### PR TITLE
Template for creating ClusterDeployments and spawning dummy jobs in the controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# hive
+# OpenShift Hive
 API driven OpenShift cluster provisioning and management
+
+# Create a Cluster Deployment
+
+  `$ oc process -f config/templates/cluster-deployment.yaml CLUSTER_NAME=$USER ADMIN_EMAIL="dgoodwin@redhat.com" ADMIN_PASSWORD="letmein" SSH_KEY="$(cat ~/libra.pem)" | oc apply -f -`
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # OpenShift Hive
 API driven OpenShift cluster provisioning and management
 
+# Create the ClusterDeployment Custom Resource Definition (CRD)
+
+  `$ kubectl apply -f config/crds/hive_v1alpha1_clusterdeployment.yaml --validate=false`
+
 # Create a Cluster Deployment
 
   `$ oc process -f config/templates/cluster-deployment.yaml CLUSTER_NAME=$USER ADMIN_EMAIL="dgoodwin@redhat.com" ADMIN_PASSWORD="letmein" SSH_KEY="$(cat ~/libra.pem)" | oc apply -f -`

--- a/config/crds/hive_v1alpha1_clusterdeployment.yaml
+++ b/config/crds/hive_v1alpha1_clusterdeployment.yaml
@@ -21,6 +21,98 @@ spec:
         metadata:
           type: object
         spec:
+          properties:
+            baseDomain:
+              type: string
+            clusterID:
+              type: string
+            machines:
+              items:
+                properties:
+                  name:
+                    type: string
+                  platform:
+                    properties:
+                      aws:
+                        properties:
+                          iamRoleName:
+                            type: string
+                          rootVolume:
+                            properties:
+                              iops:
+                                format: int64
+                                type: integer
+                              size:
+                                format: int64
+                                type: integer
+                              type:
+                                type: string
+                            required:
+                            - iops
+                            - size
+                            - type
+                            type: object
+                          type:
+                            type: string
+                        required:
+                        - type
+                        - iamRoleName
+                        - rootVolume
+                        type: object
+                    type: object
+                  replicas:
+                    format: int64
+                    type: integer
+                required:
+                - name
+                - replicas
+                - platform
+                type: object
+              type: array
+            networking:
+              properties:
+                podCIDR:
+                  type: string
+                serviceCIDR:
+                  type: string
+                type:
+                  type: string
+              required:
+              - type
+              - serviceCIDR
+              - podCIDR
+              type: object
+            platform:
+              properties:
+                aws:
+                  properties:
+                    credentialsSecret:
+                      type: object
+                    region:
+                      type: string
+                    sshSecret:
+                      type: object
+                    vpcCIDRBlock:
+                      type: string
+                    vpcID:
+                      type: string
+                  required:
+                  - region
+                  - vpcID
+                  - vpcCIDRBlock
+                  - sshSecret
+                  - credentialsSecret
+                  type: object
+              type: object
+            pullSecret:
+              type: string
+          required:
+          - clusterID
+          - baseDomain
+          - networking
+          - machines
+          - platform
+          - pullSecret
           type: object
         status:
           type: object
@@ -30,4 +122,3 @@ status:
     kind: ""
     plural: ""
   conditions: null
-  storedVersions: null

--- a/config/crds/hive_v1alpha1_clusterdeployment.yaml
+++ b/config/crds/hive_v1alpha1_clusterdeployment.yaml
@@ -22,97 +22,145 @@ spec:
           type: object
         spec:
           properties:
-            baseDomain:
-              type: string
-            clusterID:
-              type: string
-            machines:
-              items:
-                properties:
-                  name:
-                    type: string
-                  platform:
+            config:
+              properties:
+                admin:
+                  properties:
+                    email:
+                      type: string
+                    password:
+                      type: string
+                    sshKey:
+                      type: string
+                  required:
+                  - email
+                  - password
+                  type: object
+                baseDomain:
+                  type: string
+                clusterID:
+                  type: string
+                machines:
+                  items:
                     properties:
-                      aws:
+                      name:
+                        type: string
+                      platform:
                         properties:
-                          iamRoleName:
-                            type: string
-                          rootVolume:
+                          aws:
                             properties:
-                              iops:
-                                format: int64
-                                type: integer
-                              size:
-                                format: int64
-                                type: integer
+                              iamRoleName:
+                                type: string
+                              rootVolume:
+                                properties:
+                                  iops:
+                                    format: int64
+                                    type: integer
+                                  size:
+                                    format: int64
+                                    type: integer
+                                  type:
+                                    type: string
+                                required:
+                                - iops
+                                - size
+                                - type
+                                type: object
                               type:
                                 type: string
                             required:
-                            - iops
-                            - size
                             - type
+                            - iamRoleName
+                            - rootVolume
                             type: object
-                          type:
-                            type: string
-                        required:
-                        - type
-                        - iamRoleName
-                        - rootVolume
+                          libvirt:
+                            properties:
+                              qcowImagePath:
+                                type: string
+                            required:
+                            - qcowImagePath
+                            type: object
                         type: object
+                      replicas:
+                        format: int64
+                        type: integer
+                    required:
+                    - name
+                    - replicas
+                    - platform
                     type: object
-                  replicas:
-                    format: int64
-                    type: integer
-                required:
-                - name
-                - replicas
-                - platform
-                type: object
-              type: array
-            networking:
-              properties:
-                podCIDR:
-                  type: string
-                serviceCIDR:
-                  type: string
-                type:
-                  type: string
-              required:
-              - type
-              - serviceCIDR
-              - podCIDR
-              type: object
-            platform:
-              properties:
-                aws:
+                  type: array
+                networking:
                   properties:
-                    credentialsSecret:
-                      type: object
-                    region:
+                    podCIDR:
                       type: string
-                    sshSecret:
-                      type: object
-                    vpcCIDRBlock:
+                    serviceCIDR:
                       type: string
-                    vpcID:
+                    type:
                       type: string
                   required:
-                  - region
-                  - vpcID
-                  - vpcCIDRBlock
-                  - sshSecret
-                  - credentialsSecret
+                  - type
+                  - serviceCIDR
+                  - podCIDR
                   type: object
+                platform:
+                  properties:
+                    aws:
+                      properties:
+                        region:
+                          type: string
+                        tags:
+                          type: object
+                        vpcCIDRBlock:
+                          type: string
+                        vpcID:
+                          type: string
+                      required:
+                      - region
+                      - vpcID
+                      - vpcCIDRBlock
+                      type: object
+                    libvirt:
+                      properties:
+                        URI:
+                          type: string
+                        masterIPs:
+                          items:
+                            format: byte
+                            type: string
+                          type: array
+                        network:
+                          properties:
+                            if:
+                              type: string
+                            ipRange:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - name
+                          - if
+                          - ipRange
+                          type: object
+                      required:
+                      - URI
+                      - network
+                      - masterIPs
+                      type: object
+                  type: object
+                pullSecret:
+                  type: string
+              required:
+              - clusterID
+              - admin
+              - baseDomain
+              - networking
+              - machines
+              - platform
+              - pullSecret
               type: object
-            pullSecret:
-              type: string
           required:
-          - clusterID
-          - baseDomain
-          - networking
-          - machines
-          - platform
-          - pullSecret
+          - config
           type: object
         status:
           type: object

--- a/config/templates/cluster-deployment.yaml
+++ b/config/templates/cluster-deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: cluster-deployment-template
+
+parameters:
+- name: CLUSTER_NAME
+  displayName: Cluster Name
+  description: The name to give to the Cluster created. If using real AWS, then this name should include your username so that resources created in AWS can be identified as yours.
+  required: true
+- name: ADMIN_EMAIL
+  displayName: Admin Email
+  description: Your email address.
+  required: true
+- name: ADMIN_PASSWORD
+  displayName: Admin Password
+  description: Your password to login to the new cluster.
+  required: true
+- name: SSH_KEY
+  displayName: SSH Key
+  description: Your public SSH key to reach instances.
+  required: true
+- name: BASE_DOMAIN
+  displayName: Base DNS Domain
+  description: Base DNS domain for your cluster. Will be combined with cluster name when creating entries.
+  default: new-installer.openshift.com
+
+objects:
+- apiVersion: hive.openshift.io/v1alpha1
+  kind: ClusterDeployment
+  metadata:
+    labels:
+      controller-tools.k8s.io: "1.0"
+    name: ${CLUSTER_NAME}
+  spec:
+    config:
+      admin:
+        email: ${ADMIN_EMAIL}
+        password: ${ADMIN_PASSWORD}
+        sshKey: ${SSH_KEY}
+      clusterID: ${CLUSTER_NAME} # TODO: what kind of ID is this
+      baseDomain: ${BASE_DOMAIN}
+      networking:
+        type: openshift-sdn
+        serviceCIDR: "172.30.0.0/16"
+        podCIDR: "10.128.0.0/14"
+      platform:
+        aws:
+          region: us-east-1
+          vpcID: should-not-be-required # TODO
+          vpcCIDRBlock: 10.0.0.0/16
+      pullSecret: does-not-exist # TODO
+      machines:
+      - name: master
+        replicas: 3
+        platform:
+          aws:
+            type: m4-large
+            iamRoleName: TBD # TODO
+            rootVolume:
+              iops: 100 # TODO
+              size: 32
+              type: gp2
+      - name: worker
+        replicas: 3
+        platform:
+          aws:
+            type: m4-large
+            iamRoleName: TBD # TODO
+            rootVolume:
+              iops: 100 # TODO
+              size: 32
+              type: gp2
+

--- a/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
@@ -26,66 +26,12 @@ import (
 
 // ClusterDeploymentSpec defines the desired state of ClusterDeployment
 type ClusterDeploymentSpec struct {
-	// ClusterID is the ID of the cluster.
-	ClusterID string `json:"clusterID"`
-
-	// BaseDomain is the base domain to which the cluster should belong.
-	BaseDomain string `json:"baseDomain"`
-
-	// Networking defines the pod network provider in the cluster.
-	Networking `json:"networking"`
-
-	// Machines is the list of MachinePools that need to be installed.
-	Machines []MachinePool `json:"machines"`
-
-	// Platform is the configuration for the specific platform upon which to
-	// perform the installation.
-	Platform `json:"platform"`
-
-	// PullSecret is the secret to use when pulling images.
-	PullSecret string `json:"pullSecret"`
+	Config InstallConfig `json:"config"`
 }
 
-// Networking defines the pod network provider in the cluster.
-type Networking struct {
-	Type NetworkType `json:"type"`
-	// NOTE: Type here deviates from the installer but these should pass through fine as strings.
-	ServiceCIDR string `json:"serviceCIDR"`
-	PodCIDR     string `json:"podCIDR"`
-}
-
-// NetworkType defines the pod network provider in the cluster.
-type NetworkType string
-
-const (
-	// NetworkTypeOpenshiftSDN is used to install with SDN.
-	NetworkTypeOpenshiftSDN NetworkType = "openshift-sdn"
-	// NetworkTypeOpenshiftOVN is used to install with OVN.
-	NetworkTypeOpenshiftOVN NetworkType = "openshift-ovn"
-)
-
-// Platform is the configuration for the specific platform upon which to perform
-// the installation. Only one of the platform configuration should be set.
-type Platform struct {
-	// AWS is the configuration used when installing on AWS.
-	AWS *AWSPlatform `json:"aws,omitempty"`
-}
-
-// AWSPlatform stores all the global configuration that
+// MyAWSPlatform stores all the global configuration that
 // all machinesets use.
-type AWSPlatform struct {
-	// Region specifies the AWS region where the cluster will be created.
-	Region string `json:"region"`
-
-	// VPCID specifies the vpc to associate with the cluster.
-	// If empty, new vpc will be created.
-	// +optional
-	VPCID string `json:"vpcID"`
-
-	// VPCCIDRBlock
-	// +optional
-	VPCCIDRBlock string `json:"vpcCIDRBlock"`
-
+type MyAWSPlatform struct {
 	// SSHSecret refers to a secret that contains the ssh private key to access
 	// EC2 instances in this cluster.
 	SSHSecret corev1.LocalObjectReference `json:"sshSecret"`
@@ -93,51 +39,6 @@ type AWSPlatform struct {
 	// CredentialsSecret refers to a secret that contains the AWS account access
 	// credentials.
 	CredentialsSecret corev1.LocalObjectReference `json:"credentialsSecret"`
-}
-
-// MachinePool is a pool of machines to be installed.
-type MachinePool struct {
-	// Name is the name of the machine pool.
-	Name string `json:"name"`
-
-	// Replicas is the count of machines for this machine pool.
-	// Default is 1.
-	Replicas *int64 `json:"replicas"`
-
-	// PlatformConfig is configuration for machine pool specific to the platfrom.
-	PlatformConfig MachinePoolPlatformConfig `json:"platform"`
-}
-
-// MachinePoolPlatformConfig is the platform-specific configuration for a machine
-// pool. Only one of the platforms should be set.
-type MachinePoolPlatformConfig struct {
-	// AWS is the configuration used when installing on AWS.
-	AWS *AWSMachinePoolPlatformConfig `json:"aws,omitempty"`
-}
-
-// AWSMachinePoolPlatformConfig stores the configuration for a machine pool
-// installed on AWS.
-type AWSMachinePoolPlatformConfig struct {
-	// InstanceType defines the ec2 instance type.
-	// eg. m4-large
-	InstanceType string `json:"type"`
-
-	// IAMRoleName defines the IAM role associated
-	// with the ec2 instance.
-	IAMRoleName string `json:"iamRoleName"`
-
-	// EC2RootVolume defines the storage for ec2 instance.
-	EC2RootVolume `json:"rootVolume"`
-}
-
-// EC2RootVolume defines the storage for an ec2 instance.
-type EC2RootVolume struct {
-	// IOPS defines the iops for the instance.
-	IOPS int `json:"iops"`
-	// Size defines the size of the instance.
-	Size int `json:"size"`
-	// Type defines the type of the instance.
-	Type string `json:"type"`
 }
 
 // ClusterDeploymentStatus defines the observed state of ClusterDeployment

--- a/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
@@ -17,16 +17,127 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+// Important: Run "make" to regenerate code after modifying this file
 
 // ClusterDeploymentSpec defines the desired state of ClusterDeployment
 type ClusterDeploymentSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+	// ClusterID is the ID of the cluster.
+	ClusterID string `json:"clusterID"`
+
+	// BaseDomain is the base domain to which the cluster should belong.
+	BaseDomain string `json:"baseDomain"`
+
+	// Networking defines the pod network provider in the cluster.
+	Networking `json:"networking"`
+
+	// Machines is the list of MachinePools that need to be installed.
+	Machines []MachinePool `json:"machines"`
+
+	// Platform is the configuration for the specific platform upon which to
+	// perform the installation.
+	Platform `json:"platform"`
+
+	// PullSecret is the secret to use when pulling images.
+	PullSecret string `json:"pullSecret"`
+}
+
+// Networking defines the pod network provider in the cluster.
+type Networking struct {
+	Type NetworkType `json:"type"`
+	// NOTE: Type here deviates from the installer but these should pass through fine as strings.
+	ServiceCIDR string `json:"serviceCIDR"`
+	PodCIDR     string `json:"podCIDR"`
+}
+
+// NetworkType defines the pod network provider in the cluster.
+type NetworkType string
+
+const (
+	// NetworkTypeOpenshiftSDN is used to install with SDN.
+	NetworkTypeOpenshiftSDN NetworkType = "openshift-sdn"
+	// NetworkTypeOpenshiftOVN is used to install with OVN.
+	NetworkTypeOpenshiftOVN NetworkType = "openshift-ovn"
+)
+
+// Platform is the configuration for the specific platform upon which to perform
+// the installation. Only one of the platform configuration should be set.
+type Platform struct {
+	// AWS is the configuration used when installing on AWS.
+	AWS *AWSPlatform `json:"aws,omitempty"`
+}
+
+// AWSPlatform stores all the global configuration that
+// all machinesets use.
+type AWSPlatform struct {
+	// Region specifies the AWS region where the cluster will be created.
+	Region string `json:"region"`
+
+	// VPCID specifies the vpc to associate with the cluster.
+	// If empty, new vpc will be created.
+	// +optional
+	VPCID string `json:"vpcID"`
+
+	// VPCCIDRBlock
+	// +optional
+	VPCCIDRBlock string `json:"vpcCIDRBlock"`
+
+	// SSHSecret refers to a secret that contains the ssh private key to access
+	// EC2 instances in this cluster.
+	SSHSecret corev1.LocalObjectReference `json:"sshSecret"`
+
+	// CredentialsSecret refers to a secret that contains the AWS account access
+	// credentials.
+	CredentialsSecret corev1.LocalObjectReference `json:"credentialsSecret"`
+}
+
+// MachinePool is a pool of machines to be installed.
+type MachinePool struct {
+	// Name is the name of the machine pool.
+	Name string `json:"name"`
+
+	// Replicas is the count of machines for this machine pool.
+	// Default is 1.
+	Replicas *int64 `json:"replicas"`
+
+	// PlatformConfig is configuration for machine pool specific to the platfrom.
+	PlatformConfig MachinePoolPlatformConfig `json:"platform"`
+}
+
+// MachinePoolPlatformConfig is the platform-specific configuration for a machine
+// pool. Only one of the platforms should be set.
+type MachinePoolPlatformConfig struct {
+	// AWS is the configuration used when installing on AWS.
+	AWS *AWSMachinePoolPlatformConfig `json:"aws,omitempty"`
+}
+
+// AWSMachinePoolPlatformConfig stores the configuration for a machine pool
+// installed on AWS.
+type AWSMachinePoolPlatformConfig struct {
+	// InstanceType defines the ec2 instance type.
+	// eg. m4-large
+	InstanceType string `json:"type"`
+
+	// IAMRoleName defines the IAM role associated
+	// with the ec2 instance.
+	IAMRoleName string `json:"iamRoleName"`
+
+	// EC2RootVolume defines the storage for ec2 instance.
+	EC2RootVolume `json:"rootVolume"`
+}
+
+// EC2RootVolume defines the storage for an ec2 instance.
+type EC2RootVolume struct {
+	// IOPS defines the iops for the instance.
+	IOPS int `json:"iops"`
+	// Size defines the size of the instance.
+	Size int `json:"size"`
+	// Type defines the type of the instance.
+	Type string `json:"type"`
 }
 
 // ClusterDeploymentStatus defines the observed state of ClusterDeployment

--- a/pkg/apis/hive/v1alpha1/clusterdeployment_types_test.go
+++ b/pkg/apis/hive/v1alpha1/clusterdeployment_types_test.go
@@ -27,7 +27,12 @@ import (
 
 func TestStorageClusterDeployment(t *testing.T) {
 	key := types.NamespacedName{Name: "foo", Namespace: "default"}
-	created := &ClusterDeployment{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
+	created := &ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+		Spec: ClusterDeploymentSpec{
+			Machines: []MachinePool{},
+		},
+	}
 	g := gomega.NewGomegaWithT(t)
 
 	// Test Create

--- a/pkg/apis/hive/v1alpha1/clusterdeployment_types_test.go
+++ b/pkg/apis/hive/v1alpha1/clusterdeployment_types_test.go
@@ -30,7 +30,9 @@ func TestStorageClusterDeployment(t *testing.T) {
 	created := &ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
 		Spec: ClusterDeploymentSpec{
-			Machines: []MachinePool{},
+			Config: InstallConfig{
+				Machines: []MachinePool{},
+			},
 		},
 	}
 	g := gomega.NewGomegaWithT(t)

--- a/pkg/apis/hive/v1alpha1/installconfig.go
+++ b/pkg/apis/hive/v1alpha1/installconfig.go
@@ -1,0 +1,108 @@
+package v1alpha1
+
+import (
+	"net"
+)
+
+// InstallConfig is the configuration for an OpenShift install.
+type InstallConfig struct {
+	// ClusterID is the ID of the cluster.
+	ClusterID string `json:"clusterID"`
+
+	// Admin is the configuration for the admin user.
+	Admin Admin `json:"admin"`
+
+	// BaseDomain is the base domain to which the cluster should belong.
+	BaseDomain string `json:"baseDomain"`
+
+	// Networking defines the pod network provider in the cluster.
+	Networking `json:"networking"`
+
+	// Machines is the list of MachinePools that need to be installed.
+	Machines []MachinePool `json:"machines"`
+
+	// Platform is the configuration for the specific platform upon which to
+	// perform the installation.
+	Platform `json:"platform"`
+
+	// PullSecret is the secret to use when pulling images.
+	PullSecret string `json:"pullSecret"`
+}
+
+// Admin is the configuration for the admin user.
+type Admin struct {
+	// Email is the email address of the admin user.
+	Email string `json:"email"`
+	// Password is the password of the admin user.
+	Password string `json:"password"`
+	// SSHKey to use for the access to compute instances.
+	SSHKey string `json:"sshKey,omitempty"`
+}
+
+// Platform is the configuration for the specific platform upon which to perform
+// the installation. Only one of the platform configuration should be set.
+type Platform struct {
+	// AWS is the configuration used when installing on AWS.
+	AWS *AWSPlatform `json:"aws,omitempty"`
+	// Libvirt is the configuration used when installing on libvirt.
+	Libvirt *LibvirtPlatform `json:"libvirt,omitempty"`
+}
+
+// Networking defines the pod network provider in the cluster.
+type Networking struct {
+	Type        NetworkType `json:"type"`
+	ServiceCIDR string      `json:"serviceCIDR"`
+	PodCIDR     string      `json:"podCIDR"`
+}
+
+// NetworkType defines the pod network provider in the cluster.
+type NetworkType string
+
+const (
+	// NetworkTypeOpenshiftSDN is used to install with SDN.
+	NetworkTypeOpenshiftSDN NetworkType = "openshift-sdn"
+	// NetworkTypeOpenshiftOVN is used to install with OVN.
+	NetworkTypeOpenshiftOVN NetworkType = "openshift-ovn"
+)
+
+// AWSPlatform stores all the global configuration that
+// all machinesets use.
+type AWSPlatform struct {
+	// Region specifies the AWS region where the cluster will be created.
+	Region string `json:"region"`
+
+	// UserTags specifies additional tags for AWS resources created by the cluster.
+	UserTags map[string]string `json:"tags,omitempty"`
+
+	// VPCID specifies the vpc to associate with the cluster.
+	// If empty, new vpc will be created.
+	// +optional
+	VPCID string `json:"vpcID"`
+
+	// VPCCIDRBlock
+	// +optional
+	VPCCIDRBlock string `json:"vpcCIDRBlock"`
+}
+
+// LibvirtPlatform stores all the global configuration that
+// all machinesets use.
+type LibvirtPlatform struct {
+	// URI
+	URI string `json:"URI"`
+
+	// Network
+	Network LibvirtNetwork `json:"network"`
+
+	// MasterIPs
+	MasterIPs []net.IP `json:"masterIPs"`
+}
+
+// LibvirtNetwork is the configuration of the libvirt network.
+type LibvirtNetwork struct {
+	// Name is the name of the nework.
+	Name string `json:"name"`
+	// IfName is the name of the network interface.
+	IfName string `json:"if"`
+	// IPRange is the range of IPs to use.
+	IPRange string `json:"ipRange"`
+}

--- a/pkg/apis/hive/v1alpha1/machinepools.go
+++ b/pkg/apis/hive/v1alpha1/machinepools.go
@@ -1,0 +1,55 @@
+package v1alpha1
+
+// MachinePool is a pool of machines to be installed.
+type MachinePool struct {
+	// Name is the name of the machine pool.
+	Name string `json:"name"`
+
+	// Replicas is the count of machines for this machine pool.
+	// Default is 1.
+	Replicas *int64 `json:"replicas"`
+
+	// Platform is configuration for machine pool specific to the platfrom.
+	Platform MachinePoolPlatform `json:"platform"`
+}
+
+// MachinePoolPlatform is the platform-specific configuration for a machine
+// pool. Only one of the platforms should be set.
+type MachinePoolPlatform struct {
+	// AWS is the configuration used when installing on AWS.
+	AWS *AWSMachinePoolPlatform `json:"aws,omitempty"`
+	// Libvirt is the configuration used when installing on libvirt.
+	Libvirt *LibvirtMachinePoolPlatform `json:"libvirt,omitempty"`
+}
+
+// AWSMachinePoolPlatform stores the configuration for a machine pool
+// installed on AWS.
+type AWSMachinePoolPlatform struct {
+	// InstanceType defines the ec2 instance type.
+	// eg. m4-large
+	InstanceType string `json:"type"`
+
+	// IAMRoleName defines the IAM role associated
+	// with the ec2 instance.
+	IAMRoleName string `json:"iamRoleName"`
+
+	// EC2RootVolume defines the storage for ec2 instance.
+	EC2RootVolume `json:"rootVolume"`
+}
+
+// EC2RootVolume defines the storage for an ec2 instance.
+type EC2RootVolume struct {
+	// IOPS defines the iops for the instance.
+	IOPS int `json:"iops"`
+	// Size defines the size of the instance.
+	Size int `json:"size"`
+	// Type defines the type of the instance.
+	Type string `json:"type"`
+}
+
+// LibvirtMachinePoolPlatform stores the configuration for a machine pool
+// installed on libvirt.
+type LibvirtMachinePoolPlatform struct {
+	// QCOWImagePath
+	QCOWImagePath string `json:"qcowImagePath"`
+}


### PR DESCRIPTION
The installer's InstallConfig is not currently usable as a Kube type, so it had to be copied in, with a few minor modifications. (remove some objectmeta, change the IPNet usage to string, and critically ensure the auto-generated methods are present for Kube such as DeepCopyInto) I am pursuing what we should do with this long term with installer team, but this gets us moving now and we can change easily in future.

ClusterDeployment template allows creating with your desired admin info and SSH key.

Controller updated to create a dummy job that just passes, associated with the cluster deployment. (automatically cleaned up and triggering resyncs of the cluster deployment on job updates changes)