### PR TITLE
Change Hive repo to be compatible w/ OpenShift CI.

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openshift/origin-release:golang-GO_VERSION
+FROM openshift/origin-release:golang-1.10
 
 # Install the golint, use this to check our source for niceness
 RUN go get -u github.com/golang/lint/golint
@@ -26,11 +26,5 @@ RUN export version=1.0.1 && \
     cd /tmp && \
     curl -L -O https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_amd64.tar.gz && \
     tar -zxvf /tmp/kubebuilder_${version}_linux_amd64.tar.gz && \
-    mv kubebuilder_${version}_linux_amd64 /usr/local/kubebuilder
-
-
-# Create the full dir tree that we'll mount our src into when we run the image
-RUN mkdir -p /go/src/github.com/openshift/hive
-
-# Default to our src dir
-WORKDIR /go/src/github.com/openshift/hive
+    mv kubebuilder_${version}_linux_amd64 /usr/local/kubebuilder && \
+    rm /tmp/kubebuilder_${version}_linux_amd64.tar.gz

--- a/build/hive/Dockerfile
+++ b/build/hive/Dockerfile
@@ -12,14 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This image is meant to be used only for CI as a base for
-# verification tests and unit tests.
-# It combines the builder image (images/builder-image) and the
-# hive source.
+FROM BASEIMAGE
 
-FROM    builder-base
-RUN     mkdir -p /go/src/github.com/openshift/hive && \
-        cd /go/src/github.com/openshift/hive
-WORKDIR /go/src/github.com/openshift/hive
-COPY    . .
-RUN     chmod -R og+w /go
+COPY manager opt/services/
+COPY hiveutil /usr/bin
+
+ENTRYPOINT ["/opt/services/manager"]


### PR DESCRIPTION
- [x] Remove test-image per release team best practices.
- [x] Remove kubebuilder tar file during container build (smaller image size)
- [x] Add Dockerfile to generate release docker image.
- [x] Test with ci-operator locally.