### PR TITLE
kustomize isn't liking the wildcards

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -18,8 +18,9 @@ namePrefix: hive-
 # YAML string, with resources separated by document
 # markers ("---").
 resources:
-- ../rbac/*.yaml
-- ../manager/*.yaml
+- ../rbac/rbac_role_binding.yaml
+- ../rbac/rbac_role.yaml
+- ../manager/manager.yaml
 
 patches:
 - manager_image_patch.yaml


### PR DESCRIPTION
with kustomize version 1.0.8, it errors with

Error: loadResMapFromBasesAndResources: rawResources failed to read Resources: Load from path ../rbac/*.yaml failed: open /home/jdiaz/projects/hive/src/github.com/openshift/hive/config/rbac/*.yaml: no such file or directory

taking out the wildcards gets things working