### PR TITLE
initial buildah support

### DIFF
--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: IMAGE_URL
+      - image: controller:latest
         name: manager


### PR DESCRIPTION
fedora's docker version doesn't support some of the syntax in the Dockerfile generated by kubebuilder

use builah for building the container