### PR TITLE
Fix load balancer deletion hang

### DIFF
--- a/contrib/pkg/awstagdeprovision/awstagdeprovision.go
+++ b/contrib/pkg/awstagdeprovision/awstagdeprovision.go
@@ -262,6 +262,10 @@ func tagsToMap(tags interface{}) (map[string]string, error) {
 func lbToAWSObjects(lbList []*elb.LoadBalancerDescription, elbClient *elb.ELB) ([]awsObjectWithTags, error) {
 	lbObjects := []awsObjectWithTags{}
 
+	if len(lbList) == 0 {
+		return lbObjects, nil
+	}
+
 	describeTagsInput := elb.DescribeTagsInput{}
 	// populate the list of LBs we want tags for
 	for _, lb := range lbList {


### PR DESCRIPTION
If the number of load balancers to delete is zero, `lbToAWSObjects` throws an
error which is swallowed by the caller, causing an infinite retry loop in the
exponential backoff wait.

Make the LB deletion function idempotent by correctly handling empty LB lists.