### PR TITLE
InstallConfig: use secret references instead of strings

### DIFF
--- a/config/crds/hive_v1alpha1_clusterdeployment.yaml
+++ b/config/crds/hive_v1alpha1_clusterdeployment.yaml
@@ -29,9 +29,9 @@ spec:
                     email:
                       type: string
                     password:
-                      type: string
+                      type: object
                     sshKey:
-                      type: string
+                      type: object
                   required:
                   - email
                   - password
@@ -149,7 +149,7 @@ spec:
                       type: object
                   type: object
                 pullSecret:
-                  type: string
+                  type: object
               required:
               - clusterID
               - admin

--- a/config/templates/cluster-deployment.yaml
+++ b/config/templates/cluster-deployment.yaml
@@ -45,6 +45,30 @@ objects:
     awsAccessKeyId: ${AWS_ACCESS_KEY_ID}
     awsSecretAccessKey: ${AWS_SECRET_ACCESS_KEY}
 
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: ${CLUSTER_NAME}-pull-secret
+  type: kubernetes.io/dockercfg
+  stringData:
+    ".dockercfg": "${PULL_SECRET}"
+
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: ${CLUSTER_NAME}-ssh-key
+  type: Opaque
+  stringData:
+    ssh-publickey: "${SSH_KEY}"
+
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: ${CLUSTER_NAME}-admin-creds
+  type: Opaque
+  stringData:
+    password: ${ADMIKN_PASSWORD}
+
 - apiVersion: hive.openshift.io/v1alpha1
   kind: ClusterDeployment
   metadata:
@@ -59,8 +83,10 @@ objects:
     config:
       admin:
         email: ${ADMIN_EMAIL}
-        password: ${ADMIN_PASSWORD}
-        sshKey: ${SSH_KEY}
+        password:
+          name: "${CLUSTER_NAME}-admin-creds"
+        sshKey:
+          name: "${CLUSTER_NAME}-ssh-key"
       clusterID: ${CLUSTER_NAME} # TODO: what kind of ID is this
       baseDomain: ${BASE_DOMAIN}
       networking:
@@ -72,7 +98,8 @@ objects:
           region: us-east-1
           vpcID: should-not-be-required # TODO
           vpcCIDRBlock: 10.0.0.0/16
-      pullSecret: "${PULL_SECRET}"
+      pullSecret:
+        name: "${CLUSTER_NAME}-pull-secret"
       machines:
       - name: master
         replicas: 3

--- a/pkg/apis/hive/v1alpha1/installconfig.go
+++ b/pkg/apis/hive/v1alpha1/installconfig.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
+
 	"net"
 )
 
@@ -25,18 +27,18 @@ type InstallConfig struct {
 	// perform the installation.
 	Platform `json:"platform"`
 
-	// PullSecret is the secret to use when pulling images.
-	PullSecret string `json:"pullSecret"`
+	// PullSecret is the reference to the secret to use when pulling images.
+	PullSecret corev1.LocalObjectReference `json:"pullSecret"`
 }
 
 // Admin is the configuration for the admin user.
 type Admin struct {
 	// Email is the email address of the admin user.
 	Email string `json:"email"`
-	// Password is the password of the admin user.
-	Password string `json:"password"`
-	// SSHKey to use for the access to compute instances.
-	SSHKey string `json:"sshKey,omitempty"`
+	// Password is a reference to the secret that contains the password of the admin user.
+	Password corev1.LocalObjectReference `json:"password"`
+	// SSHKey is a reference to the secret that contains a public key to use for access to compute instances.
+	SSHKey *corev1.LocalObjectReference `json:"sshKey,omitempty"`
 }
 
 // Platform is the configuration for the specific platform upon which to perform

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -81,20 +81,35 @@ func GenerateInstallerJob(
 				Value: cd.Spec.Config.Admin.Email,
 			},
 			{
-				Name:  "OPENSHIFT_INSTALL_PASSWORD",
-				Value: cd.Spec.Config.Admin.Password,
+				Name: "OPENSHIFT_INSTALL_PASSWORD",
+				ValueFrom: &kapi.EnvVarSource{
+					SecretKeyRef: &kapi.SecretKeySelector{
+						LocalObjectReference: cd.Spec.Config.Admin.Password,
+						Key:                  "password",
+					},
+				},
 			},
 			{
 				Name:  "OPENSHIFT_INSTALL_PLATFORM",
 				Value: "aws",
 			},
 			{
-				Name:  "OPENSHIFT_INSTALL_PULL_SECRET",
-				Value: cd.Spec.Config.PullSecret,
+				Name: "OPENSHIFT_INSTALL_PULL_SECRET",
+				ValueFrom: &kapi.EnvVarSource{
+					SecretKeyRef: &kapi.SecretKeySelector{
+						LocalObjectReference: cd.Spec.Config.PullSecret,
+						Key:                  ".dockercfg",
+					},
+				},
 			},
 			{
-				Name:  "OPENSHIFT_INSTALL_SSH_PUB_KEY",
-				Value: cd.Spec.Config.Admin.SSHKey,
+				Name: "OPENSHIFT_INSTALL_SSH_PUB_KEY",
+				ValueFrom: &kapi.EnvVarSource{
+					SecretKeyRef: &kapi.SecretKeySelector{
+						LocalObjectReference: *cd.Spec.Config.Admin.SSHKey,
+						Key:                  "ssh-publickey",
+					},
+				},
 			},
 			{
 				Name:  "OPENSHIFT_INSTALL_AWS_REGION",


### PR DESCRIPTION
Switch to secrets for ssh public key, admin password, and image pull secret