### PR TITLE
Add ownerref to uploaded artifacts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ manager: generate
 	go build -o bin/manager github.com/openshift/hive/cmd/manager
 
 # Build hiveutil binary
-hiveutil:
+hiveutil: generate
 	go build -o bin/hiveutil github.com/openshift/hive/contrib/cmd/hiveutil
 
 # Run against the configured Kubernetes cluster in ~/.kube/config

--- a/README.md
+++ b/README.md
@@ -37,3 +37,14 @@ API driven OpenShift cluster provisioning and management
   ```bash
   $ oc delete clusterdeployment $USER
   ```
+
+## Tips
+
+### Using the Admin Kubeconfig
+
+Once the cluster is provisioned you will see a CLUSTER_NAME-admin-kubeconfig secret. You can use this with:
+
+```bash
+kubectl get secret ${USER}-admin-kubeconfig -o json | jq ".data.kubeconfig" -r | base64 -d > ${USER}.kubeconfig
+kubectl --kubeconfig ${USER}.kubeconfig get nodes
+```

--- a/README.md
+++ b/README.md
@@ -46,5 +46,6 @@ Once the cluster is provisioned you will see a CLUSTER_NAME-admin-kubeconfig sec
 
 ```bash
 kubectl get secret ${USER}-admin-kubeconfig -o json | jq ".data.kubeconfig" -r | base64 -d > ${USER}.kubeconfig
-kubectl --kubeconfig ${USER}.kubeconfig get nodes
+export KUBECONFIG=${USER}.kubeconfig
+kubectl get nodes
 ```

--- a/config/templates/cluster-deployment.yaml
+++ b/config/templates/cluster-deployment.yaml
@@ -67,7 +67,7 @@ objects:
     name: ${CLUSTER_NAME}-admin-creds
   type: Opaque
   stringData:
-    password: ${ADMIKN_PASSWORD}
+    password: ${ADMIN_PASSWORD}
 
 - apiVersion: hive.openshift.io/v1alpha1
   kind: ClusterDeployment

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -364,6 +364,11 @@ func (r *ReconcileClusterDeployment) setupClusterInstallServiceAccount(namespace
 				Resources: []string{"secrets", "configmaps"},
 				Verbs:     []string{"create", "delete", "get", "list", "update"},
 			},
+			{
+				APIGroups: []string{"hive.openshift.io"},
+				Resources: []string{"clusterdeployments", "clusterdeployments/finalizers"},
+				Verbs:     []string{"create", "delete", "get", "list", "update"},
+			},
 		},
 	}
 	currentRole := &rbacv1.Role{}


### PR DESCRIPTION
The admin kubeconfig secret, and cluster metadata config map, should be cleaned up when a cluster is deleted.