### PR TITLE
Fixes for running controllers in-cluster.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ BINDIR = bin
 SRC_DIRS = pkg contrib
 GOFILES = $(shell find $(SRC_DIRS) -name '*.go')
 VERIFY_IMPORTS_CONFIG = build/verify-imports/import-rules.yaml
+DOCKER_CMD ?= docker
 
 
 
@@ -111,10 +112,10 @@ docker-build: manager hiveutil
 	mkdir -p $(tmp_build_path)
 	cp $(build_path)/Dockerfile $(tmp_build_path)
 	cp ./bin/* $(tmp_build_path)
-	docker build -t ${IMG} $(tmp_build_path)
+	$(DOCKER_CMD) build -t ${IMG} $(tmp_build_path)
 	rm -rf $(tmp_build_path)
 
 # Push the docker image
 .PHONY: docker-push
 docker-push:
-	docker push ${IMG}
+	$(DOCKER_CMD) push ${IMG}

--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 # OpenShift Hive
 API driven OpenShift cluster provisioning and management
 
-## Deploying Locally
+## Deploying In-Cluster
 
-* Ensure that you have access to an OpenShift cluster and have administrator access
+* Ensure that you have access to an OpenShift cluster and have administrator permissions. This could be oc cluster up, minishift, or an actual cluster you can oc login to.
+* Build and deploy to Minishift:
+  * `$ hack/minishift-deploy.sh`
+* Build deploy to current kubectl context:
+   * `$ make deploy`
 
-* Build and provision CRDs, roles, and controller:
-   * `$ make provision`
-
-## Development Workflow
+## Running from Source
 
 * Create the ClusterDeployment CRD:
   * `$ kubectl apply -f config/crds/hive_v1alpha1_clusterdeployment.yaml --validate=false`
 * Run the Hive controllers from source:
   * `$ make run`
+
+## Using Hive
 * Create a ClusterDeployment:
   * Place the OpenShift images pull secret in a known location like `$HOME/config.json`
   * Assuming AWS credentials set in the standard environment variables, and our usual SSH key.

--- a/config/default/clusterdeployment_crd_status_patch.yaml
+++ b/config/default/clusterdeployment_crd_status_patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+ name: clusterdeployments.hive.openshift.io
+status:
+  storedVersions: []
+  conditions: []

--- a/config/default/dnszone_crd_status_patch.yaml
+++ b/config/default/dnszone_crd_status_patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: dnszones.hive.openshift.io
+status:
+  storedVersions: []
+  conditions: []

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -21,6 +21,10 @@ resources:
 - ../rbac/rbac_role_binding.yaml
 - ../rbac/rbac_role.yaml
 - ../manager/manager.yaml
+- ../crds/hive_v1alpha1_clusterdeployment.yaml
+- ../crds/hive_v1alpha1_dnszone.yaml
 
 patches:
 - manager_image_patch.yaml
+- clusterdeployment_crd_status_patch.yaml
+- dnszone_crd_status_patch.yaml

--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -60,7 +60,13 @@ rules:
   resources:
   - clusterdeployments/finalizers
   verbs:
+  - get
+  - list
+  - watch
+  - create
   - update
+  - patch
+  - delete
 - apiGroups:
   - hive.openshift.io
   resources:

--- a/hack/minishift-deploy.sh
+++ b/hack/minishift-deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+HIVE_DOCKER_CMD="docker --tls --tlscacert=$HOME/.minishift/certs/ca.pem --tlscert=$HOME/.minishift/certs/cert.pem --tlskey=$HOME/.minishift/certs/key.pem"
+eval $(minishift docker-env)
+DOCKER_CMD=$HIVE_DOCKER_CMD make docker-build
+IMG=hive-controller:latest
+minishift_registry="$(minishift openshift registry)"
+current_project="$(oc project -q)"
+#$HIVE_DOCKER_CMD login -u admin -p "$(oc whoami -t)" $minishift_registry
+#$HIVE_DOCKER_CMD tag ${IMG} $minishift_registry/$current_project/${IMG}
+#$HIVE_DOCKER_CMD push $minishift_registry/$current_project/${IMG}
+kustomize build config/default | kubectl apply -f -
+oc delete pod hive-controller-manager-0

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -35,8 +35,9 @@ func GenerateInstallerJob(
 	cd *hivev1.ClusterDeployment,
 	serviceAccountName string,
 	installerImage string,
+	installerImagePullPolicy corev1.PullPolicy,
 	hiveImage string,
-	imagePullPolicy corev1.PullPolicy) *batchv1.Job {
+	hiveImagePullPolicy corev1.PullPolicy) *batchv1.Job {
 
 	cdLog := log.WithFields(log.Fields{
 		"clusterDeployment": cd.Name,
@@ -146,7 +147,7 @@ func GenerateInstallerJob(
 		{
 			Name:            "installer",
 			Image:           installerImage,
-			ImagePullPolicy: imagePullPolicy,
+			ImagePullPolicy: installerImagePullPolicy,
 			Env:             env,
 			Command:         []string{"/bin/sh", "-c"},
 			Args:            []string{"cp -v /bin/openshift-install /output && cp -v /bin/terraform /output && ls -la /output"},
@@ -155,7 +156,7 @@ func GenerateInstallerJob(
 		{
 			Name:            "hive",
 			Image:           hiveImage,
-			ImagePullPolicy: imagePullPolicy,
+			ImagePullPolicy: hiveImagePullPolicy,
 			Env:             env,
 			Command:         []string{"/usr/bin/hiveutil"},
 			Args:            []string{"install-manager", "--work-dir", "/output", "--log-level", "debug", cd.Namespace, cd.Name},


### PR DESCRIPTION
Add a script for deploying to a minishift cluster.

Fixes CRD validation errors due to missing status fields.

Fix image pull policies for in-cluster. (always pull latest installer
image, pull latest hive image if not present)

Fixes RBAC problems in-cluster.