### PR TITLE
contrib/pkg/awstagdeprovision: Allow for OR filters

### DIFF
--- a/contrib/cmd/hiveutil/awstagdeprovision.go
+++ b/contrib/cmd/hiveutil/awstagdeprovision.go
@@ -30,11 +30,10 @@ import (
 // NewDeprovisionAWSWithTagsCommand is the entrypoint to create the 'aws-tag-deprovision' subcommand
 func NewDeprovisionAWSWithTagsCommand() *cobra.Command {
 	opt := &awstagdeprovision.ClusterUninstaller{}
-	opt.Filters = awstagdeprovision.AWSFilter{}
 	cmd := &cobra.Command{
 		Use:   "aws-tag-deprovision KEY=VALUE ...",
 		Short: "Deprovision AWS assets (as created by openshift-installer) with the given tag(s)",
-		Long:  "Deprovision AWS assets (as created by openshift-installer) with the given tag(s).  A resource matches the filter if all of the key/value pairs are in its tags.",
+		Long:  "Deprovision AWS assets (as created by openshift-installer) with the given tag(s).  A resource matches the filter if any of the key/value pairs are in its tags.",
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := completeAWSUninstaller(opt, args); err != nil {
 				log.WithError(err).Error("Cannot complete command")
@@ -54,10 +53,12 @@ func NewDeprovisionAWSWithTagsCommand() *cobra.Command {
 
 func completeAWSUninstaller(o *awstagdeprovision.ClusterUninstaller, args []string) error {
 	for _, arg := range args {
-		err := parseFilter(o.Filters, arg)
+		filter := awstagdeprovision.AWSFilter{}
+		err := parseFilter(filter, arg)
 		if err != nil {
 			return fmt.Errorf("cannot parse filter %s: %v", arg, err)
 		}
+		o.Filters = append(o.Filters, filter)
 	}
 
 	// Set log level


### PR DESCRIPTION
Builds on #46; review that first.

AWS docs for filters are a bit sparse, but [the AWS docs][1] have:

> Combining search filters
>
> In general, multiple filters with the same key field (for example, tag:Name, search, Instance State) are automatically joined with OR.  This is intentional, as the vast majority of filters would not be logical if they were joined with AND.  For example, you would get zero results for a search on Instance State=running AND Instance State=stopped.  In many cases, you can granulate the results by using complementary search terms on different key fields, where the AND rule is automatically applied instead.  If you search for tag: Name:=All values and tag:Instance State=running, you get search results that contain both those criteria.  To fine-tune your results, simply remove one filter in the string until the results fit your requirements.

Unfortunately, there seems to be no way to represent OR filters in [ec2's `Filter` structure][2].  With the approach I have here, resources that match multiple filters will be fetched multiple times, and may have parallel, racing delete attempts.  But we should be robust in the face of racing delete attempt, and hopefully one of the deletes will go through before too long ;).

It would be possible to adjust our locally-filtered types (which use `filterObjects`) to avoid this issue for those types.  I may do that in follow-up work, but for now I'm treating all of our types the same way.

[1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Filtering.html#advancedsearch
[2]: https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#Filter