### PR TITLE
awstagdeprovision: Fix bucket name in debug output

### DIFF
--- a/contrib/pkg/awstagdeprovision/awstagdeprovision.go
+++ b/contrib/pkg/awstagdeprovision/awstagdeprovision.go
@@ -966,7 +966,7 @@ func bucketsToAWSObjects(buckets []*s3.Bucket, s3Client *s3.S3, logger log.Field
 			Bucket: bucket.Name,
 		})
 		if err != nil {
-			logger.Debugf("error getting tags for bucket %s: %v, skipping...", bucket.Name, err)
+			logger.Debugf("error getting tags for bucket %s: %v, skipping...", *bucket.Name, err)
 			continue
 		}
 


### PR DESCRIPTION
Dereference the bucket name string pointer when formatting the "error getting tags" debug output.  Neglecting to do so produces error messages like the following:

    DEBUG error getting tags for bucket %!s(*string=0xc420433708): [...]

* `contrib/pkg/awstagdeprovision/awstagdeprovision.go` (`bucketsToAWSObjects`): Dereference `bucket.Name`.