### PR TITLE
Lookup default AMIs.

### DIFF
--- a/pkg/apis/hive/v1alpha1/machinepools.go
+++ b/pkg/apis/hive/v1alpha1/machinepools.go
@@ -29,6 +29,12 @@ type MachinePoolPlatform struct {
 // AWSMachinePoolPlatform stores the configuration for a machine pool
 // installed on AWS.
 type AWSMachinePoolPlatform struct {
+	// Zones is list of availability zones that can be used.
+	Zones []string `json:"zones,omitempty"`
+
+	// AMIID defines the AMI that should be used.
+	AMIID string `json:"amiID,omitempty"`
+
 	// InstanceType defines the ec2 instance type.
 	// eg. m4-large
 	InstanceType string `json:"type"`

--- a/pkg/controller/clusterdeployment/aws.go
+++ b/pkg/controller/clusterdeployment/aws.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterdeployment
+
+import (
+	"context"
+	"time"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+
+	"github.com/openshift/installer/pkg/rhcos"
+)
+
+func isDefaultAMISet(cd *hivev1.ClusterDeployment) bool {
+	defaultAMIKnown := false
+	if cd.Spec.Config.Platform.AWS.DefaultMachinePlatform != nil && cd.Spec.Config.Platform.AWS.DefaultMachinePlatform.AMIID != "" {
+		defaultAMIKnown = true
+	}
+	return defaultAMIKnown
+}
+
+// lookupAMI uses installer code to lookup the latest AMI from the RHCOS webapp.
+func lookupAMI(cd *hivev1.ClusterDeployment) (string, error) {
+	// In future this will hopefully be a part of the release image, but for now we have
+	// to do a lookup via the RHCOS pipeline API. The installer does this already so we re-use their
+	// function to do so.
+	ctx, cancel := context.WithTimeout(context.TODO(), 60*time.Second)
+	defer cancel()
+	return rhcos.AMI(ctx, rhcos.DefaultChannel, cd.Spec.Config.AWS.Region)
+}

--- a/pkg/install/convertconfig.go
+++ b/pkg/install/convertconfig.go
@@ -60,6 +60,8 @@ func generateInstallConfig(cd *hivev1.ClusterDeployment, adminPassword, sshKey, 
 					Size: aws.DefaultMachinePlatform.EC2RootVolume.Size,
 					Type: aws.DefaultMachinePlatform.EC2RootVolume.Type,
 				},
+				AMIID: aws.DefaultMachinePlatform.AMIID,
+				Zones: aws.DefaultMachinePlatform.Zones,
 			}
 		}
 	}
@@ -79,6 +81,8 @@ func generateInstallConfig(cd *hivev1.ClusterDeployment, adminPassword, sshKey, 
 					Size: mp.Platform.AWS.EC2RootVolume.Size,
 					Type: mp.Platform.AWS.EC2RootVolume.Type,
 				},
+				AMIID: mp.Platform.AWS.AMIID,
+				Zones: mp.Platform.AWS.Zones,
 			}
 		}
 		machinePools = append(machinePools, newMP)

--- a/pkg/install/convertconfig_test.go
+++ b/pkg/install/convertconfig_test.go
@@ -38,6 +38,7 @@ const (
 	testName        = "foo"
 	testNamespace   = "default"
 	testClusterID   = "foo"
+	testAMI         = "ami-totallyfake"
 	adminPassword   = "adminpassword"
 	adminSSHKey     = "adminSSH"
 	pullSecret      = "pullSecret"
@@ -107,6 +108,8 @@ func buildValidClusterDeployment() *hivev1.ClusterDeployment {
 									Size: ec2VolSize,
 									Type: ec2VolType,
 								},
+								AMIID: testAMI,
+								Zones: []string{"us-east-1a", "us-east-1b"},
 							},
 						},
 					},
@@ -185,6 +188,8 @@ func buildBaseExpectedInstallConfig() *installtypes.InstallConfig {
 							Size: ec2VolSize,
 							Type: ec2VolType,
 						},
+						AMIID: testAMI,
+						Zones: []string{"us-east-1a", "us-east-1b"},
 					},
 				},
 			},


### PR DESCRIPTION
If no default machine pool AMI is set, we will lookup the latest for
RHCOS and store it there for use on any pools that do not explicitly
store their own AMI. This lookup is done with code from
openshift-install.

In future we expect the RHCOS image to use to be a part of the release
image metadata.