### PR TITLE
Add code generation requirements to API types

### DIFF
--- a/pkg/apis/hive/v1alpha1/register.go
+++ b/pkg/apis/hive/v1alpha1/register.go
@@ -35,4 +35,12 @@ var (
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
+
+	// AddToScheme is a shortcut for SchemeBuilder.AddToScheme
+	AddToScheme = SchemeBuilder.AddToScheme
 )
+
+// Resource takes an unqualified resource and returns a Group qualified GroupResource
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}


### PR DESCRIPTION
The tools that generate Go clients from Kubernetes API expect the
the existence of the `AddToScheme` and `Resource` functions in the API
package, otherwise compilation of the generated code fails. But the Hive
API doesn't define these functions. This patch adds them.