### PR TITLE
Add kubeconfig secret and API/console URLs to cluster deployment status.

### DIFF
--- a/config/crds/hive_v1alpha1_clusterdeployment.yaml
+++ b/config/crds/hive_v1alpha1_clusterdeployment.yaml
@@ -11,6 +11,8 @@ spec:
     kind: ClusterDeployment
     plural: clusterdeployments
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -270,10 +272,19 @@ spec:
           type: object
         status:
           properties:
+            adminKubeconfigSecret:
+              type: object
+            apiURL:
+              type: string
             installed:
               type: boolean
+            webConsoleURL:
+              type: string
           required:
           - installed
+          - adminKubeconfigSecret
+          - apiURL
+          - webConsoleURL
           type: object
   version: v1alpha1
 status:

--- a/contrib/pkg/installmanager/installmanager_test.go
+++ b/contrib/pkg/installmanager/installmanager_test.go
@@ -139,6 +139,19 @@ func TestInstallManager(t *testing.T) {
 			}
 			_, ok = adminKubeconfig.Data["kubeconfig"]
 			assert.True(t, ok)
+
+			// Ensure we set a status reference to the admin kubeconfig secret:
+			cd := &hivev1.ClusterDeployment{}
+			err = fakeClient.Get(context.Background(),
+				types.NamespacedName{
+					Namespace: testNamespace,
+					Name:      testClusterName,
+				},
+				cd)
+			if !assert.NoError(t, err) {
+				t.Fail()
+			}
+			assert.Equal(t, adminKubeconfig.Name, cd.Status.AdminKubeconfigSecret.Name)
 		})
 	}
 }

--- a/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
@@ -82,6 +82,15 @@ type ClusterDeploymentStatus struct {
 
 	// Installed is true if the installer job has successfully completed for this cluster.
 	Installed bool `json:"installed"`
+
+	// AdminKubeconfigSecret references the secret containing the admin kubeconfig for this cluster.
+	AdminKubeconfigSecret corev1.LocalObjectReference `json:"adminKubeconfigSecret"`
+
+	// APIURL is the URL where the cluster's API can be accessed.
+	APIURL string `json:"apiURL"`
+
+	// WebConsoleURL is the URL for the cluster's web console UI.
+	WebConsoleURL string `json:"webConsoleURL"`
 }
 
 // +genclient
@@ -89,6 +98,7 @@ type ClusterDeploymentStatus struct {
 
 // ClusterDeployment is the Schema for the clusterdeployments API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 type ClusterDeployment struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Install manager will now explicitly link to the secret where it uploaded
the admin kubeconfig after installation, rather than this being an
assumed name.

Also extracts the server URL from the admin kubeconfig, and stores a
link to the API and web console in status.

Includes a short term hack that will let this roll out to any persistent
environments by populating the admin kubeconfig secret name based on the
current assumption. We can remove this shortly.

CC @jhernand 
Fixes: https://github.com/openshift/hive/issues/73