### PR TITLE
Fix lack of debug logging in sd-dev cluster.

### DIFF
--- a/config/overlays/sd-dev/image_patch.yaml
+++ b/config/overlays/sd-dev/image_patch.yaml
@@ -11,3 +11,14 @@ spec:
       - image: quay.io/twiest/hive-controller:20181119
         name: manager
         imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+        command:
+          - /opt/services/manager
+          - --log-level
+          - debug


### PR DESCRIPTION
When replacing with Kustomize it replaces the whole stanza, not just the
properties we specified, and our debug logging command was lost.