### PR TITLE
Fix bugs resulting from use of generate name.

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -342,7 +342,7 @@ func (r *ReconcileClusterDeployment) updateClusterDeploymentStatus(cd *hivev1.Cl
 		if err != nil {
 			return err
 		}
-		cluster, ok := config.Clusters[cd.Name]
+		cluster, ok := config.Clusters[cd.Spec.Config.ClusterID]
 		if !ok {
 			return fmt.Errorf("error parsing admin kubeconfig secret data")
 		}

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -43,22 +43,23 @@ import (
 )
 
 const (
-	testName              = "foo"
-	installJobName        = "foo-install"
-	uninstallJobName      = "foo-uninstall"
+	testName              = "foo-lqmsh"
+	testClusterID         = "bar"
+	installJobName        = "foo-lqmsh-install"
+	uninstallJobName      = "foo-lqmsh-uninstall"
 	testNamespace         = "default"
-	metadataName          = "foo-metadata"
+	metadataName          = "foo-lqmsh-metadata"
 	adminPasswordSecret   = "admin-password"
 	sshKeySecret          = "ssh-key"
 	pullSecretSecret      = "pull-secret"
 	testUUID              = "fakeUUID"
 	testAMI               = "ami-totallyfake"
-	adminKubeconfigSecret = "foo-admin-kubeconfig"
+	adminKubeconfigSecret = "foo-lqmsh-admin-kubeconfig"
 	adminKubeconfig       = `clusters:
 - cluster:
     certificate-authority-data: JUNK
-    server: https://foo-api.clusters.example.com:6443
-  name: foo
+    server: https://bar-api.clusters.example.com:6443
+  name: bar
 `
 )
 
@@ -181,8 +182,8 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 			},
 			validate: func(c client.Client, t *testing.T) {
 				cd := getCD(c)
-				assert.Equal(t, cd.Status.APIURL, "https://foo-api.clusters.example.com:6443")
-				assert.Equal(t, cd.Status.WebConsoleURL, "https://foo-api.clusters.example.com:6443/console")
+				assert.Equal(t, cd.Status.APIURL, "https://bar-api.clusters.example.com:6443")
+				assert.Equal(t, cd.Status.WebConsoleURL, "https://bar-api.clusters.example.com:6443/console")
 			},
 		},
 		{
@@ -309,6 +310,7 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 		Spec: hivev1.ClusterDeploymentSpec{
 			ClusterUUID: testUUID,
 			Config: hivev1.InstallConfig{
+				ClusterID: testClusterID,
 				Admin: hivev1.Admin{
 					Email: "user@example.com",
 					Password: corev1.LocalObjectReference{

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -333,7 +333,7 @@ func GenerateUninstallerJob(
 				"--cluster-name",
 				cd.Name,
 				fmt.Sprintf("tectonicClusterID=%s", cd.Spec.ClusterUUID),
-				fmt.Sprintf("kubernetes.io/cluster/%s=owned", cd.Name),
+				fmt.Sprintf("kubernetes.io/cluster/%s=owned", cd.Spec.Config.ClusterID),
 			},
 		},
 	}


### PR DESCRIPTION
We had never tested use of generate name, and were inconsistently using
the cluster deployment name, vs it's spec.config.clusterID.

So far this has surfaced in parsing the cluster name out of kubeconfigs,
and in the arguments we pass to uninstall jobs for the kube cluster ID
tag.