### PR TITLE
Fix cdLog typos

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -237,12 +237,12 @@ func (r *ReconcileClusterDeployment) Reconcile(request reconcile.Request) (recon
 		return reconcile.Result{}, err
 	}
 
-	if err := controllerutil.SetControllerReference(cd, job, r.scheme); err != nil {
-		cdLog.Errorf("error setting controller reference on job", err)
+	if err = controllerutil.SetControllerReference(cd, job, r.scheme); err != nil {
+		cdLog.WithError(err).Error("error setting controller reference on job")
 		return reconcile.Result{}, err
 	}
-	if err := controllerutil.SetControllerReference(cd, cfgMap, r.scheme); err != nil {
-		cdLog.Errorf("error setting controller reference on config map", err)
+	if err = controllerutil.SetControllerReference(cd, cfgMap, r.scheme); err != nil {
+		cdLog.WithError(err).Error("error setting controller reference on config map")
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
When I try to run:
```
make run
```

I get errors:
```
# github.com/openshift/hive/pkg/controller/clusterdeployment
pkg/controller/clusterdeployment/clusterdeployment_controller.go:241: Entry.Errorf call has arguments but no formatting directives
pkg/controller/clusterdeployment/clusterdeployment_controller.go:245: Entry.Errorf call has arguments but no formatting directives
make: *** [Makefile:70: vet] Error 2
```

This PR fixes that.
