### PR TITLE
Sync AWS credential secret keys with installer.

### DIFF
--- a/config/templates/cluster-deployment.yaml
+++ b/config/templates/cluster-deployment.yaml
@@ -58,8 +58,8 @@ objects:
     name: ${CLUSTER_NAME}-aws-creds
   type: Opaque
   stringData:
-    awsAccessKeyId: ${AWS_ACCESS_KEY_ID}
-    awsSecretAccessKey: ${AWS_SECRET_ACCESS_KEY}
+    aws_access_key_id: ${AWS_ACCESS_KEY_ID}
+    aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
 
 - apiVersion: v1
   kind: Secret

--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -41,8 +41,8 @@ import (
 )
 
 const (
-	awsCredsSecretIDKey     = "awsAccessKeyId"
-	awsCredsSecretAccessKey = "awsSecretAccessKey"
+	awsCredsSecretIDKey     = "aws_access_key_id"
+	awsCredsSecretAccessKey = "aws_secret_access_key"
 )
 
 //go:generate mockgen -source=./client.go -destination=./mock/client_generated.go -package=mock

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -126,7 +126,7 @@ func GenerateInstallerJob(
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: cd.Spec.PlatformSecrets.AWS.Credentials,
-						Key:                  "awsAccessKeyId",
+						Key:                  "aws_access_key_id",
 					},
 				},
 			},
@@ -135,7 +135,7 @@ func GenerateInstallerJob(
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: cd.Spec.PlatformSecrets.AWS.Credentials,
-						Key:                  "awsSecretAccessKey",
+						Key:                  "aws_secret_access_key",
 					},
 				},
 			},


### PR DESCRIPTION
Installer was using this format instead, it's more consistent with
~/.aws/credentials and we're soon to have code that will need to read
both, preferably we should sync on the format.

CC @jhernand this will affect you next time we roll out Hive. There are some more disruptive API changes coming, we'll try to land them all at once and summarize them together.