### PR TITLE
store cluster version into clusterdeployment status

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1476,6 +1476,7 @@
     "github.com/golang/mock/gomock",
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
+    "github.com/openshift/api/config/v1",
     "github.com/openshift/cluster-network-operator/pkg/apis/networkoperator/v1",
     "github.com/openshift/generic-admission-server/pkg/cmd",
     "github.com/openshift/installer/pkg/asset/machines/aws",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -68,3 +68,7 @@ version="v1.4.7"
 [[constraint]]
   name = "k8s.io/apiserver"
   version="kubernetes-1.11.2"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/openshift/api"

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 
 	_ "github.com/openshift/generic-admission-server/pkg/cmd"
+	openshiftapiv1 "github.com/openshift/api/config/v1"
 )
 
 const (
@@ -75,6 +76,10 @@ func NewRootCommand() *cobra.Command {
 
 			// Setup Scheme for all resources
 			if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
+				log.Fatal(err)
+			}
+
+			if err := openshiftapiv1.Install(mgr.GetScheme()); err != nil {
 				log.Fatal(err)
 			}
 

--- a/config/crds/hive_v1alpha1_clusterdeployment.yaml
+++ b/config/crds/hive_v1alpha1_clusterdeployment.yaml
@@ -265,6 +265,62 @@ spec:
               type: object
             apiURL:
               type: string
+            clusterVersionStatus:
+              properties:
+                availableUpdates:
+                  items:
+                    properties:
+                      payload:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                    - version
+                    - payload
+                    type: object
+                  type: array
+                conditions:
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - type
+                    - status
+                    - lastTransitionTime
+                    type: object
+                  type: array
+                current:
+                  properties:
+                    payload:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - version
+                  - payload
+                  type: object
+                generation:
+                  format: int64
+                  type: integer
+                versionHash:
+                  type: string
+              required:
+              - current
+              - generation
+              - versionHash
+              - conditions
+              - availableUpdates
+              type: object
             installed:
               type: boolean
             webConsoleURL:
@@ -272,6 +328,7 @@ spec:
           required:
           - installed
           - adminKubeconfigSecret
+          - clusterVersionStatus
           - apiURL
           - webConsoleURL
           type: object

--- a/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	openshiftapiv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -85,6 +86,9 @@ type ClusterDeploymentStatus struct {
 
 	// AdminKubeconfigSecret references the secret containing the admin kubeconfig for this cluster.
 	AdminKubeconfigSecret corev1.LocalObjectReference `json:"adminKubeconfigSecret"`
+
+	// ClusterVersionStatus will hold a copy of the remote cluster's ClusterVersion.Status
+	ClusterVersionStatus openshiftapiv1.ClusterVersionStatus `json:"clusterVersionStatus"`
 
 	// APIURL is the URL where the cluster's API can be accessed.
 	APIURL string `json:"apiURL"`

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// BuildClusterAPIClientFromKubeconfig will return a kubeclient usin the provided kubeconfig
+func BuildClusterAPIClientFromKubeconfig(kubeconfigData string) (client.Client, error) {
+	config, err := clientcmd.Load([]byte(kubeconfigData))
+	if err != nil {
+		return nil, err
+	}
+	kubeConfig := clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{})
+	cfg, err := kubeConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return client.New(cfg, client.Options{})
+}


### PR DESCRIPTION
when we have a kubeconfig for the remote cluster, fetch the ClusterVersion.Status and store it in ClusterDeployment.Status.ClusterVersionStatus

handle nil values for fields in clusterVersion.Status (so we can pass object validation)

update test cases to work with new need to mock up remote ClusterVersion object
    
refactor the building of a remotecluster kubeclient (and update remotemachineset controller accordingly)

build on top of https://github.com/openshift/hive/pull/127 to get beyond the gomock issues