### PR TITLE
Fix GenerateName Bug in Remote Machine Set Controller, and Uninstall Missing Credentials

### DIFF
--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -143,7 +143,7 @@ func (r *ReconcileRemoteMachineSet) Reconcile(request reconcile.Request) (reconc
 		return reconcile.Result{}, nil
 	}
 
-	secretName := cd.Spec.Config.ClusterID + "-admin-kubeconfig"
+	secretName := cd.Status.AdminKubeconfigSecret.Name
 	secretData, err := r.loadSecretData(secretName, cd.Namespace, adminKubeConfigKey)
 	if err != nil {
 		cdLog.WithError(err).Error("unable to load admin kubeconfig")

--- a/pkg/controller/remotemachineset/remotemachineset_controller_test.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller_test.go
@@ -18,6 +18,7 @@ package remotemachineset
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -363,7 +364,8 @@ func testClusterDeployment(machinePools []hivev1.MachinePool) *hivev1.ClusterDep
 			},
 		},
 		Status: hivev1.ClusterDeploymentStatus{
-			Installed: true,
+			Installed:             true,
+			AdminKubeconfigSecret: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-admin-kubeconfig", testName)},
 		},
 	}
 }

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -293,7 +293,7 @@ func GenerateUninstallerJob(
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: cd.Spec.PlatformSecrets.AWS.Credentials,
-						Key:                  "awsAccessKeyId",
+						Key:                  "aws_access_key_id",
 					},
 				},
 			},
@@ -302,7 +302,7 @@ func GenerateUninstallerJob(
 				ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: cd.Spec.PlatformSecrets.AWS.Credentials,
-						Key:                  "awsSecretAccessKey",
+						Key:                  "aws_secret_access_key",
 					},
 				},
 			},


### PR DESCRIPTION
Fixes: https://github.com/openshift/hive/issues/123

Also fixes an uninstall error resulting from my recent rename of the aws cred secret properties.