### PR TITLE
replace tectonicClusterID tag with openshiftClusterID

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,4 +100,4 @@ After deleting your cluster deployment you will see an uninstall job created. If
  1. You can manually run the uninstall code with hiveutil to delete AWS resources based on their tags.
     * Get your cluster UUID from the clusterdeployment.Spec.ClusterUUID.
     * `make hiveutil`
-    * `bin/hiveutil aws-tag-deprovision --loglevel=debug --cluster-name CLUSTER_NAME tectonicClusterID=CLUSTER_UUID kubernetes.io/cluster/CLUSTER_NAME=owned`
+    * `bin/hiveutil aws-tag-deprovision --loglevel=debug --cluster-name CLUSTER_NAME openshiftClusterID=CLUSTER_UUID kubernetes.io/cluster/CLUSTER_NAME=owned`

--- a/contrib/pkg/installmanager/installmanager.go
+++ b/contrib/pkg/installmanager/installmanager.go
@@ -37,7 +37,7 @@ const (
 	// relative to our WorkDir.
 	metadataRelativePath                = "metadata.json"
 	adminKubeConfigRelativePath         = "auth/kubeconfig"
-	uuidKey                             = "tectonicClusterID"
+	uuidKey                             = "openshiftClusterID"
 	kubernetesKeyPrefix                 = "kubernetes.io/cluster/"
 	metadataConfigmapStringTemplate     = "%s-metadata"
 	adminKubeConfigSecretStringTemplate = "%s-admin-kubeconfig"

--- a/contrib/pkg/installmanager/installmanager_test.go
+++ b/contrib/pkg/installmanager/installmanager_test.go
@@ -50,7 +50,7 @@ const (
 echo "Fake Installer"
 echo $@
 WORKDIR=%s
-echo '{"clusterName":"test-cluster","aws":{"region":"us-east-1","identifier":{"tectonicClusterID":"fe953108-f64c-4166-bb8e-20da7665ba00"}}}' > $WORKDIR/metadata.json
+echo '{"clusterName":"test-cluster","aws":{"region":"us-east-1","identifier":{"openshiftClusterID":"fe953108-f64c-4166-bb8e-20da7665ba00"}}}' > $WORKDIR/metadata.json
 mkdir -p $WORKDIR/auth/
 echo "fakekubeconfig" > $WORKDIR/auth/kubeconfig
 `

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -433,7 +433,7 @@ func testMetadataConfigMap() *corev1.ConfigMap {
 	metadataJSON := `{
 		"aws": {
 			"identifier": {
-				"tectonicClusterID": "testFooClusterUUID"
+				"openshiftClusterID": "testFooClusterUUID"
 			}
 		}
 	}`

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -332,7 +332,7 @@ func GenerateUninstallerJob(
 				"debug",
 				"--cluster-name",
 				cd.Name,
-				fmt.Sprintf("tectonicClusterID=%s", cd.Spec.ClusterUUID),
+				fmt.Sprintf("openshiftClusterID=%s", cd.Spec.ClusterUUID),
 				fmt.Sprintf("kubernetes.io/cluster/%s=owned", cd.Spec.Config.ClusterID),
 			},
 		},

--- a/test/integration/clusterdeployment/clusterdeployment_controller_test.go
+++ b/test/integration/clusterdeployment/clusterdeployment_controller_test.go
@@ -48,7 +48,7 @@ var jobKey = types.NamespacedName{Name: "foo-install", Namespace: "default"}
 const (
 	timeout             = time.Second * 10
 	fakeClusterUUID     = "fe953108-f64c-4166-bb8e-20da7665ba00"
-	fakeClusterMetadata = `{"clusterName":"foo","aws":{"region":"us-east-1","identifier":{"tectonicClusterID":"fe953108-f64c-4166-bb8e-20da7665ba00"}}}`
+	fakeClusterMetadata = `{"clusterName":"foo","aws":{"region":"us-east-1","identifier":{"openshiftClusterID":"fe953108-f64c-4166-bb8e-20da7665ba00"}}}`
 )
 
 func init() {


### PR DESCRIPTION
The tectonicClusterID tag is being replaced with openshiftClusterID in the installer. This change will use the new tag name.

Hold on openshift/installer#817.

/hold