### PR TITLE
Stop copying terraform binary out of installer image.

### DIFF
--- a/contrib/pkg/installmanager/installmanager.go
+++ b/contrib/pkg/installmanager/installmanager.go
@@ -211,7 +211,6 @@ func (m *InstallManager) Run() error {
 func (m *InstallManager) waitForInstallerBinaries() {
 	waitForFiles := []string{
 		filepath.Join(m.WorkDir, "openshift-install"),
-		filepath.Join(m.WorkDir, "terraform"),
 	}
 	m.log.Infof("waiting for install binaries to be available: %v", waitForFiles)
 

--- a/contrib/pkg/installmanager/installmanager_test.go
+++ b/contrib/pkg/installmanager/installmanager_test.go
@@ -45,7 +45,6 @@ const (
 	testUUID        = "fake-cluster-UUID"
 
 	installerBinary     = "openshift-install"
-	terraformBinary     = "terraform"
 	fakeInstallerBinary = `#!/bin/sh
 echo "Fake Installer"
 echo $@
@@ -118,10 +117,6 @@ func TestInstallManager(t *testing.T) {
 
 			if !assert.NoError(t, writeFakeBinary(filepath.Join(tempDir, installerBinary),
 				fmt.Sprintf(fakeInstallerBinary, tempDir))) {
-				t.Fail()
-			}
-			// File contents don't matter for terraform, it won't be called because we're faking the install binary:
-			if !assert.NoError(t, writeFakeBinary(filepath.Join(tempDir, terraformBinary), "")) {
 				t.Fail()
 			}
 

--- a/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
@@ -50,7 +50,7 @@ type ClusterDeploymentSpec struct {
 
 // ProvisionImages allows overriding the default images used to provision a cluster.
 type ProvisionImages struct {
-	// InstallerImage is the image containing the openshift-install and terraform binaries that will be used to install.
+	// InstallerImage is the image containing the openshift-install binary that will be used to install.
 	InstallerImage string `json:"installerImage"`
 	// InstallerImagePullPolicy is the pull policy for the installer image.
 	InstallerImagePullPolicy corev1.PullPolicy `json:"installerImagePullPolicy"`

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -199,7 +199,7 @@ func GenerateInstallerJob(
 			ImagePullPolicy: installerImagePullPolicy,
 			Env:             env,
 			Command:         []string{"/bin/sh", "-c"},
-			Args:            []string{"cp -v /bin/openshift-install /output && cp -v /bin/terraform /output && ls -la /output"},
+			Args:            []string{"cp -v /bin/openshift-install /output && ls -la /output"},
 			VolumeMounts:    volumeMounts,
 		},
 		{


### PR DESCRIPTION
This is no longer necessary, and was recently removed from the image
meaning Hive installs are now completely blocked as we're waiting on
that binary to be copied.

Installer now vendors Terraform so the binary is not needed.