### PR TITLE
fix clusterversion.Status is more places

### DIFF
--- a/contrib/pkg/installmanager/installmanager.go
+++ b/contrib/pkg/installmanager/installmanager.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/openshift/hive/pkg/apis"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -501,6 +502,7 @@ func updateClusterDeploymentStatus(cd *hivev1.ClusterDeployment, adminKubeconfig
 	m.log.Info("updating cluster deployment status")
 	cd.Status.AdminKubeconfigSecret = corev1.LocalObjectReference{Name: adminKubeconfigSecretName}
 	cd.Status.AdminPasswordSecret = corev1.LocalObjectReference{Name: adminPasswordSecretName}
+	controllerutils.FixupEmptyClusterVersionFields(&cd.Status.ClusterVersionStatus)
 	return m.DynamicClient.Status().Update(context.Background(), cd)
 }
 

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -390,7 +390,7 @@ func (r *ReconcileClusterDeployment) updateClusterDeploymentStatus(cd *hivev1.Cl
 		}
 
 		cdLog.Debugf("remote cluster version status: %+v", remoteClusterVersion.Status)
-		fixupEmptyClusterVersionFields(&remoteClusterVersion.Status)
+		controllerutils.FixupEmptyClusterVersionFields(&remoteClusterVersion.Status)
 		remoteClusterVersion.Status.DeepCopyInto(&cd.Status.ClusterVersionStatus)
 	}
 
@@ -645,19 +645,4 @@ func DeleteFinalizer(object metav1.Object, finalizer string) {
 	finalizers := sets.NewString(object.GetFinalizers()...)
 	finalizers.Delete(finalizer)
 	object.SetFinalizers(finalizers.List())
-}
-
-func fixupEmptyClusterVersionFields(clusterVersionStatus *openshiftapiv1.ClusterVersionStatus) {
-
-	// Fetching clusterVersion object can results in nil clusterVersion.Status.AvailableUpdates
-	// and clusterVersion.Status.Conditions.
-	// Place an empty list if needed to satisfy the object validation.
-
-	if clusterVersionStatus.AvailableUpdates == nil {
-		clusterVersionStatus.AvailableUpdates = []openshiftapiv1.Update{}
-	}
-
-	if clusterVersionStatus.Conditions == nil {
-		clusterVersionStatus.Conditions = []openshiftapiv1.ClusterOperatorStatusCondition{}
-	}
 }

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -19,6 +19,8 @@ package utils
 import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openshiftapiv1 "github.com/openshift/api/config/v1"
 )
 
 // BuildClusterAPIClientFromKubeconfig will return a kubeclient usin the provided kubeconfig
@@ -34,4 +36,20 @@ func BuildClusterAPIClientFromKubeconfig(kubeconfigData string) (client.Client, 
 	}
 
 	return client.New(cfg, client.Options{})
+}
+
+// FixupEmptyClusterVersionFields will un-'nil' fields that would fail validation in the ClusterVersion.Status
+func FixupEmptyClusterVersionFields(clusterVersionStatus *openshiftapiv1.ClusterVersionStatus) {
+
+	// Fetching clusterVersion object can results in nil clusterVersion.Status.AvailableUpdates
+	// and clusterVersion.Status.Conditions.
+	// Place an empty list if needed to satisfy the object validation.
+
+	if clusterVersionStatus.AvailableUpdates == nil {
+		clusterVersionStatus.AvailableUpdates = []openshiftapiv1.Update{}
+	}
+
+	if clusterVersionStatus.Conditions == nil {
+		clusterVersionStatus.Conditions = []openshiftapiv1.ClusterOperatorStatusCondition{}
+	}
 }


### PR DESCRIPTION
move clusterversion.Status field fixing into utils and use it where necessary in installmanager

current installer seems to be failing, but the updating of the status is working now:

```
time="2018-12-12T15:06:43Z" level=info msg="uploaded cluster metadata configmap" configMapName=jdiaz-hive-metadata
time="2018-12-12T15:06:43Z" level=info msg="uploading admin kubeconfig"                                                                                         
time="2018-12-12T15:06:43Z" level=info msg="uploaded admin kubeconfig secret" secretName=jdiaz-hive-admin-kubeconfig
time="2018-12-12T15:06:43Z" level=info msg="updating cluster deployment status"
!!!!! NO ERROR LINE HERE WHILE UPDATING CLUSTERDEPLOYMENT !!!!!
time="2018-12-12T15:06:43Z" level=fatal msg="failed due to install error" error="exit status 1"
```