### PR TITLE
Add multistage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 as builder
+RUN mkdir -p /go/src/github.com/openshift/hive
+WORKDIR /go/src/github.com/openshift/hive
+COPY . .
+RUN go build -o bin/manager github.com/openshift/hive/cmd/manager
+RUN go build -o bin/hiveutil github.com/openshift/hive/contrib/cmd/hiveutil
+RUN go build -o bin/hiveadmission github.com/openshift/hive/cmd/hiveadmission
+
+FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+COPY --from=builder /go/src/github.com/openshift/hive/bin/manager /opt/services/
+COPY --from=builder /go/src/github.com/openshift/hive/bin/hiveadmission /opt/services/
+COPY --from=builder /go/src/github.com/openshift/hive/bin/hiveutil /usr/bin
+ENTRYPOINT ["/opt/services/manager"]

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@ BINDIR = bin
 SRC_DIRS = pkg contrib
 GOFILES = $(shell find $(SRC_DIRS) -name '*.go')
 VERIFY_IMPORTS_CONFIG = build/verify-imports/import-rules.yaml
-DOCKER_CMD ?= docker
 
+# To use docker build, specify BUILD_CMD="docker build"
+BUILD_CMD ?= imagebuilder
 
 
 # Image URL to use all building/pushing image targets
@@ -124,14 +125,8 @@ generate:
 
 # Build the docker image
 .PHONY: docker-build
-docker-build: manager hiveutil hiveadmission
-	$(eval build_path := ./build/hive)
-	$(eval tmp_build_path := "$(build_path)/tmp")
-	mkdir -p $(tmp_build_path)
-	cp $(build_path)/Dockerfile $(tmp_build_path)
-	cp ./bin/* $(tmp_build_path)
-	$(DOCKER_CMD) build -t ${IMG} $(tmp_build_path)
-	rm -rf $(tmp_build_path)
+docker-build: generate
+	$(BUILD_CMD) -t ${IMG} .
 
 # Push the docker image
 .PHONY: docker-push
@@ -140,11 +135,5 @@ docker-push:
 
 # Build the image with buildah
 .PHONY: buildah-build
-buildah-build: manager hiveutil hiveadmission
-	$(eval build_path := ./build/hive)
-	$(eval tmp_build_path := "$(build_path)/tmp")
-	mkdir -p $(tmp_build_path)
-	cp $(build_path)/Dockerfile $(tmp_build_path)
-	cp ./bin/* $(tmp_build_path)
-	BUILDAH_ISOLATION=chroot sudo buildah bud --tag ${IMG} $(tmp_build_path)
-	rm -rf $(tmp_build_path)
+buildah-build: generate
+	BUILDAH_ISOLATION=chroot sudo buildah bud --tag ${IMG} .


### PR DESCRIPTION
Simplify image building by using a single multi-stage Dockerfile. Existing Dockerfile will be removed in a follow-up PR after modifying CI config.