### PR TITLE
Set cluster api scheme in cluster api client builder.

### DIFF
--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -20,6 +20,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	capiv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
+
 	openshiftapiv1 "github.com/openshift/api/config/v1"
 )
 
@@ -35,7 +37,13 @@ func BuildClusterAPIClientFromKubeconfig(kubeconfigData string) (client.Client, 
 		return nil, err
 	}
 
-	return client.New(cfg, client.Options{})
+	scheme, err := capiv1.SchemeBuilder.Build()
+	if err != nil {
+		return nil, err
+	}
+	return client.New(cfg, client.Options{
+		Scheme: scheme,
+	})
 }
 
 // FixupEmptyClusterVersionFields will un-'nil' fields that would fail validation in the ClusterVersion.Status


### PR DESCRIPTION
Fixes error when listing machine sets.

```
time="2018-12-18T19:45:24Z" level=error msg="unable to fetch remote machine sets" clusterDeployment=abutcher controller=remotemachineset error="no kind is registered for the type v1alpha1.MachineSetList" namespace=myproject
```