### PR TITLE
use install-config.yaml

### DIFF
--- a/contrib/pkg/installmanager/installmanager.go
+++ b/contrib/pkg/installmanager/installmanager.go
@@ -110,7 +110,7 @@ func NewInstallManagerCommand() *cobra.Command {
 	flags.StringVar(&im.ClusterUUID, "cluster-uuid", "", "UUID to tag cloud resources with")
 	flags.StringVar(&im.Region, "region", "us-east-1", "Region installing into")
 	// This is required due to how we have to share volume and mount in our install config. The installer also deletes the workdir copy.
-	flags.StringVar(&im.InstallConfig, "install-config", "/installconfig/install-config.yml", "location of install-config.yml to copy into work-dir")
+	flags.StringVar(&im.InstallConfig, "install-config", "/installconfig/install-config.yaml", "location of install-config.yaml to copy into work-dir")
 	return cmd
 }
 
@@ -175,7 +175,7 @@ func (m *InstallManager) Run() error {
 
 	m.waitForInstallerBinaries()
 
-	dstInstallConfig := filepath.Join(m.WorkDir, "install-config.yml")
+	dstInstallConfig := filepath.Join(m.WorkDir, "install-config.yaml")
 	m.log.Debugf("copying %s to %s", m.InstallConfig, dstInstallConfig)
 	err = m.copyFile(m.InstallConfig, dstInstallConfig)
 	if err != nil {

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -258,7 +258,7 @@ func (r *ReconcileClusterDeployment) Reconcile(request reconcile.Request) (recon
 
 	cdLog = cdLog.WithField("job", job.Name)
 
-	cdLog.Debug("checking if install-config.yml config map exists")
+	cdLog.Debug("checking if install-config.yaml config map exists")
 	// Check if the ConfigMap already exists for this ClusterDeployment:
 	existingCfgMap := &kapi.ConfigMap{}
 	err = r.Get(context.TODO(), types.NamespacedName{Name: cfgMap.Name, Namespace: cfgMap.Namespace}, existingCfgMap)

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -70,7 +70,7 @@ func GenerateInstallerJob(
 		},
 		Data: map[string]string{
 			// Filename should match installer default:
-			"install-config.yml": installConfig,
+			"install-config.yaml": installConfig,
 		},
 	}
 
@@ -223,7 +223,7 @@ func GenerateInstallerJob(
 				"--log-level",
 				"debug",
 				"--install-config",
-				"/installconfig/install-config.yml",
+				"/installconfig/install-config.yaml",
 				"--cluster-uuid",
 				cd.Spec.ClusterUUID,
 				"--region",


### PR DESCRIPTION
Use install-config.yaml instead of install-config.yml. The name of the file used by openshift-install has changed and install-config.yml is deprecated.