### PR TITLE
Improve process and docs for deploying in cluster.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,8 @@ install: manifests
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 .PHONY: deploy
-deploy: manifests docker-build deploy-hiveadmission
+deploy: manifests deploy-hiveadmission
+	kubectl apply -f manifests/
 	kubectl apply -f config/crds
 	kustomize build config/default | kubectl apply -f -
 

--- a/README.md
+++ b/README.md
@@ -6,22 +6,23 @@ API driven OpenShift cluster provisioning and management
  * Install mockgen:
    * `$ go get github.com/golang/mock/gomock; go install github.com/golang/mock/mockgen`
 
-## Deploying In-Cluster
+## Deployment Options
 
-* Ensure that you have access to an OpenShift cluster and have administrator permissions. This could be oc cluster up, minishift, or an actual cluster you can oc login to.
-* Build and deploy to Minishift:
-  * `$ hack/minishift-deploy.sh`
-* Build and deploy to current kubectl context using local container image:
-   * `$ make deploy`
-* Build and deploy to current kubectl context using remote container image:
-   * `$ make deploy-sd-dev`
+### Deploying To OpenShift 4.x Using Latest Published Images
 
-## Running from Source
+This method uses the latest published Hive image on the CI registry: `registry.svc.ci.openshift.org/openshift/hive-v4.0:hive`
+
+1. Provision an OpenShift 4.0 Cluster with openshift-install.
+1. Login as a cluster admin after installation completes:
+  * `$ export KUBECONFIG=/home/dgoodwin/installdir/auth/kubeconfig`
+1. Install Hive to the openshift-hive namespace:
+  * `$ make deploy`
+
+### Running from Source
 
 * Create the ClusterDeployment and DNSZone CRDs:
-  * `$ kubectl apply -f config/crds/hive_v1alpha1_clusterdeployment.yaml`
-  * `$ kubectl apply -f config/crds/hive_v1alpha1_dnszone.yaml`
-* Run the Hive controllers from source:
+  * `$ make install`
+* Run Hive from local source:
   * `$ make run`
 
 ## Using Hive

--- a/README.md
+++ b/README.md
@@ -31,15 +31,11 @@ This method uses the latest published Hive image on the CI registry: `registry.s
   * Assuming AWS credentials set in the standard environment variables, and our usual SSH key.
   ```bash
   export CLUSTER_NAME="${USER}"
-  export ADMIN_EMAIL="${USER}@redhat.com"
-  export ADMIN_PASSWORD="letmein"
   export SSH_PUB_KEY="$(ssh-keygen -y -f ~/.ssh/libra.pem)"
   export PULL_SECRET="$(cat ${HOME}/config.json)"
 
   oc process -f config/templates/cluster-deployment.yaml \
      CLUSTER_NAME="${CLUSTER_NAME}" \
-     ADMIN_EMAIL="${ADMIN_EMAIL}" \
-     ADMIN_PASSWORD="${ADMIN_PASSWORD}" \
      SSH_KEY="${SSH_PUB_KEY}" \
      PULL_SECRET="${PULL_SECRET}" \
      AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
@@ -51,8 +47,6 @@ This method uses the latest published Hive image on the CI registry: `registry.s
   * Assuming AWS credentials set in the standard environment variables, and our usual SSH key.
   ```bash
   export CLUSTER_NAME="${USER}"
-  export ADMIN_EMAIL="${USER}@redhat.com"
-  export ADMIN_PASSWORD="letmein"
   export SSH_PUB_KEY="$(ssh-keygen -y -f ~/.ssh/libra.pem)"
   export PULL_SECRET="$(cat ${HOME}/config.json)"
   export HIVE_IMAGE="quay.io/twiest/hive-controller:20181212"
@@ -62,8 +56,6 @@ This method uses the latest published Hive image on the CI registry: `registry.s
 
   oc process -f config/templates/cluster-deployment.yaml \
      CLUSTER_NAME="${CLUSTER_NAME}" \
-     ADMIN_EMAIL="${ADMIN_EMAIL}" \
-     ADMIN_PASSWORD="${ADMIN_PASSWORD}" \
      SSH_KEY="${SSH_PUB_KEY}" \
      PULL_SECRET="${PULL_SECRET}" \
      AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \

--- a/config/hiveadmission/hiveadmission.yaml
+++ b/config/hiveadmission/hiveadmission.yaml
@@ -48,9 +48,8 @@ spec:
       serviceAccountName: hiveadmission
       containers:
       - name: hiveadmission
-        image: hive-controller:latest
-        #imagePullPolicy: IfNotPresent
-        imagePullPolicy: Never
+        image: registry.svc.ci.openshift.org/openshift/hive-v4.0:hive
+        imagePullPolicy: Always
         command:
         - "/opt/services/hiveadmission"
         - "--secure-port=9443"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -53,11 +53,9 @@ spec:
         controller-tools.k8s.io: "1.0"
     spec:
       containers:
-      # By default we are assuming a development setup with the image pushed to
-      # the local registry. Pull policy should be Never in this case, it will be
-      # modified in overrides for actual environments.
-      - image: hive-controller:latest
-        imagePullPolicy: Never
+      # By default we will use the latest CI images published from hive master:
+      - image: registry.svc.ci.openshift.org/openshift/hive-v4.0:hive
+        imagePullPolicy: Always
         name: manager
         resources:
           limits:

--- a/config/templates/cluster-deployment.yaml
+++ b/config/templates/cluster-deployment.yaml
@@ -29,11 +29,11 @@ parameters:
 - name: HIVE_IMAGE
   displayName: Hive image URL
   description: Hive image URL
-  value: "hive-controller:latest"
+  value: "registry.svc.ci.openshift.org/openshift/hive-v4.0:hive"
 - name: HIVE_IMAGE_PULL_POLICY
   displayName: Hive image pull policy
   description: Hive image pull policy
-  value: Never
+  value: Always
 - name: INSTALLER_IMAGE
   displayName: OpenShift Installer image URL
   description: OpenShift Installer image URL

--- a/manifests/00-namespace.yaml
+++ b/manifests/00-namespace.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: openshift-hive


### PR DESCRIPTION
We no longer use the oc cluster up method and thus the use of local hive
images was no longer useful.

Instead we default to latest published images on registry.ci, and a
simple make deploy to install Hive.