### PR TITLE
Fix missing config.openshift.io type in scheme.

### DIFF
--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -41,6 +41,11 @@ func BuildClusterAPIClientFromKubeconfig(kubeconfigData string) (client.Client, 
 	if err != nil {
 		return nil, err
 	}
+
+	if err := openshiftapiv1.Install(scheme); err != nil {
+		return nil, err
+	}
+
 	return client.New(cfg, client.Options{
 		Scheme: scheme,
 	})


### PR DESCRIPTION
Fixes this error:


ERRO[0143] error fetching remote clusterversion object   clusterDeployment=dgoodwin1 error="no kind is registered for the type v1.ClusterVersion" job=dgoodwin1-install namespace=openshift-hive

Any idea what happened here @joelddiaz or @csrwng  ? I don't understand why this would show up suddenly.