### PR TITLE
Fix installer release image override var name.

### DIFF
--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -130,7 +130,7 @@ func GenerateInstallerJob(
 	if cd.Spec.Images.ReleaseImage != "" {
 		env = append(env, []corev1.EnvVar{
 			{
-				Name:  "_OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE",
+				Name:  "OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE",
 				Value: cd.Spec.Images.ReleaseImage,
 			},
 		}...)


### PR DESCRIPTION
Appears this has been changed back to not have an underscore prefix:

https://github.com/openshift/installer/blob/master/pkg/asset/ignition/bootstrap/bootstrap.go#L148