### PR TITLE
Add operator federation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,22 @@ Install federation components:
 make install-federation
 ```
 
-### Testing Federation (alpha)
+### Federation Example
 
-1. Install Hive normally.
-2. Add cluster-admin role to Hive service account (current limitation with cli):
-  ```
-  oc adm policy add-cluster-role-to-user cluster-admin -z hive-controller-manager-service -n openshift-hive
-  ```
-3. Install federation as explained above.
+An example etcd operator deployment is included in `contrib/federation_example`.
+
+To deploy the example, run:
+
+```
+kubectl apply -f ./contrib/federation_example
+```
+
+The example artifacts install etcd-operator on a cluster with the label `etcdoperator: yes`
+
+In order to automatically install the operator on a cluster  you create with Hive,
+first create the cluster, then label its corresponding `federatedcluster` resource with
+the appropriate label:
+
+```
+kubectl label federatedcluster/CLUSTER_NAME -n federation-system etcdoperator=yes
+```

--- a/contrib/federation_example/00_namespace.yaml
+++ b/contrib/federation_example/00_namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcd-operator

--- a/contrib/federation_example/00_namespace_placement.yaml
+++ b/contrib/federation_example/00_namespace_placement.yaml
@@ -1,0 +1,9 @@
+apiVersion: primitives.federation.k8s.io/v1alpha1
+kind: FederatedNamespacePlacement
+metadata:
+  name: etcd-operator
+  namespace: etcd-operator
+spec:
+  clusterSelector:
+    matchLabels:
+      etcdoperator: "yes"

--- a/contrib/federation_example/cluster-role-binding-placement.yaml
+++ b/contrib/federation_example/cluster-role-binding-placement.yaml
@@ -1,0 +1,8 @@
+apiVersion: primitives.federation.k8s.io/v1alpha1
+kind: FederatedClusterRoleBindingPlacement
+metadata:
+  name: etcd-operator
+spec:
+  clusterSelector:
+    matchLabels:
+      etcdoperator: "yes"

--- a/contrib/federation_example/cluster-role-binding-template.yaml
+++ b/contrib/federation_example/cluster-role-binding-template.yaml
@@ -1,0 +1,14 @@
+apiVersion: primitives.federation.k8s.io/v1alpha1
+kind: FederatedClusterRoleBinding
+metadata:
+  name: etcd-operator
+spec:
+  template:
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: etcd-operator
+    subjects:
+    - kind: ServiceAccount
+      name: default
+      namespace: etcd-operator

--- a/contrib/federation_example/cluster-role-placement.yaml
+++ b/contrib/federation_example/cluster-role-placement.yaml
@@ -1,0 +1,8 @@
+apiVersion: primitives.federation.k8s.io/v1alpha1
+kind: FederatedClusterRolePlacement
+metadata:
+  name: etcd-operator
+spec:
+  clusterSelector:
+    matchLabels:
+      etcdoperator: "yes"

--- a/contrib/federation_example/cluster-role-template.yaml
+++ b/contrib/federation_example/cluster-role-template.yaml
@@ -1,0 +1,44 @@
+apiVersion: primitives.federation.k8s.io/v1alpha1
+kind: FederatedClusterRole
+metadata:
+  name: etcd-operator
+spec:
+  template:
+    rules:
+    - apiGroups:
+      - etcd.database.coreos.com
+      resources:
+      - etcdclusters
+      - etcdbackups
+      - etcdrestores
+      verbs:
+      - "*"
+    - apiGroups:
+      - apiextensions.k8s.io
+      resources:
+      - customresourcedefinitions
+      verbs:
+      - "*"
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      verbs:
+      - "*"
+    - apiGroups:
+      - apps
+      resources:
+      - deployments
+      verbs:
+      - "*"
+    # The following permissions can be removed if not using S3 backup and TLS
+    - apiGroups:
+      - ""
+      resources:
+      - secrets
+      verbs:
+      - get

--- a/contrib/federation_example/deployment-placement.yaml
+++ b/contrib/federation_example/deployment-placement.yaml
@@ -1,0 +1,9 @@
+apiVersion: primitives.federation.k8s.io/v1alpha1
+kind: FederatedDeploymentPlacement
+metadata:
+  name: etcd-operator
+  namespace: etcd-operator
+spec:
+  clusterSelector:
+    matchLabels:
+      etcdoperator: "yes"

--- a/contrib/federation_example/deployment-template.yaml
+++ b/contrib/federation_example/deployment-template.yaml
@@ -1,0 +1,36 @@
+apiVersion: primitives.federation.k8s.io/v1alpha1
+kind: FederatedDeployment
+metadata:
+  name: etcd-operator
+  namespace: etcd-operator
+spec:
+  template:
+    metadata:
+      labels:
+        name: etcd-operator
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          name: etcd-operator
+      template:
+        metadata:
+          labels:
+            name: etcd-operator
+        spec:
+          containers:
+          - name: etcd-operator
+            image: quay.io/coreos/etcd-operator:v0.9.3
+            command:
+            - etcd-operator
+            # Uncomment to act for resources in all namespaces. More information in doc/user/clusterwide.md
+            #- -cluster-wide
+            env:
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name

--- a/hack/install-federation.sh
+++ b/hack/install-federation.sh
@@ -15,3 +15,4 @@ kubectl apply --validate=false -f "${SRC_DIR}/hack/federation/cluster-registry-c
 for filename in ${SRC_DIR}/hack/federation/federatedirectives/*.yaml; do
   kubefed2 federate enable -f "${filename}" --federation-namespace="federation-system"
 done
+kubefed2 federate enable clusterrolebindings --federation-namespace="federation-system"


### PR DESCRIPTION
Example enables installation of [etcd-operator](https://github.com/coreos/etcd-operator) on target clusters.