### PR TITLE
Make ClusterDeployment.spec mostly immutable

### DIFF
--- a/cmd/hiveadmission/main.go
+++ b/cmd/hiveadmission/main.go
@@ -29,5 +29,8 @@ func main() {
 	// TODO: figure out a way to combine logrus and glog logging levels. The team has decided that hardcoding this is ok for now.
 	log.SetLevel(log.InfoLevel)
 
-	admissionCmd.RunAdmissionServer(&hivevalidatingwebhooks.DNSZoneValidatingAdmissionHook{})
+	admissionCmd.RunAdmissionServer(
+		&hivevalidatingwebhooks.DNSZoneValidatingAdmissionHook{},
+		&hivevalidatingwebhooks.ClusterDeploymentValidatingAdmissionHook{},
+	)
 }

--- a/config/hiveadmission/hiveadmission.yaml
+++ b/config/hiveadmission/hiveadmission.yaml
@@ -69,6 +69,10 @@ spec:
             scheme: HTTPS
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
       volumes:
       - name: serving-cert
         secret:

--- a/config/samples/hive_v1alpha1_clusterdeployment.yaml
+++ b/config/samples/hive_v1alpha1_clusterdeployment.yaml
@@ -3,7 +3,53 @@ kind: ClusterDeployment
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: clusterdeployment-sample
+  annotations:
+    hive.openshift.io/delete-after: "8h"
+  name: foo
 spec:
-  # Add fields here
-  foo: bar
+  preserveOnDelete: false
+  clusterName: foo
+  baseDomain: bar.baz
+  networking:
+    type: OpenshiftSDN
+    serviceCIDR: "10.3.0.0/16"
+    machineCIDR: "10.0.0.0/16"
+    podCIDR: "10.2.0.0/16"
+
+  controlPlane:
+    name: master
+    replicas: 3
+    platform:
+      aws:
+        type: m4.large
+        iamRoleName: ""
+        rootVolume:
+          iops: 100 # TODO
+          size: 22
+          type: gp2
+
+  compute:
+  - name: worker
+    replicas: 3
+    platform:
+      aws:
+        type: m4.large
+        iamRoleName: ""
+        rootVolume:
+          iops: 100 # TODO
+          size: 22
+          type: gp2
+
+  platform:
+    aws:
+      region: us-east-1
+      vpcID: ""
+      vpcCIDRBlock: 10.0.0.0/16
+
+  platformSecrets:
+    aws:
+      credentials:
+        name: "foo-aws-creds"
+
+  pullSecret:
+    name: "foo-pull-secret"

--- a/config/templates/hiveadmission.yaml
+++ b/config/templates/hiveadmission.yaml
@@ -66,3 +66,29 @@ objects:
       resources:
       - dnszones
     failurePolicy: Fail
+
+# register to intercept ClusterDeployment object creates and updates
+- apiVersion: admissionregistration.k8s.io/v1beta1
+  kind: ValidatingWebhookConfiguration
+  metadata:
+    name: clusterdeployments.admission.hive.openshift.io
+  webhooks:
+  - name: clusterdeployments.admission.hive.openshift.io
+    clientConfig:
+      service:
+        # reach the webhook via the registered aggregated API
+        namespace: default
+        name: kubernetes
+        path: /apis/admission.hive.openshift.io/v1alpha1/clusterdeployments
+      caBundle: ${KUBE_CA}
+    rules:
+    - operations:
+      - CREATE
+      - UPDATE
+      apiGroups:
+      - hive.openshift.io
+      apiVersions:
+      - v1alpha1
+      resources:
+      - clusterdeployments
+    failurePolicy: Fail

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook.go
@@ -19,62 +19,66 @@ package validatingwebhooks
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/sirupsen/logrus"
-	"strings"
-
-	"net/http"
-
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
-
-	dnsvalidation "k8s.io/apimachinery/pkg/util/validation"
-
+	log "github.com/sirupsen/logrus"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
+	"net/http"
+	"reflect"
 )
 
 const (
-	dnsZoneGroup    = "hive.openshift.io"
-	dnsZoneVersion  = "v1alpha1"
-	dnsZoneResource = "dnszones"
+	clusterDeploymentGroup    = "hive.openshift.io"
+	clusterDeploymentVersion  = "v1alpha1"
+	clusterDeploymentResource = "clusterdeployments"
+
+	clusterDeploymentAdmissionGroup    = "admission.hive.openshift.io"
+	clusterDeploymentAdmissionVersion  = "v1alpha1"
+	clusterDeploymentAdmissionResource = "clusterdeployments"
 )
 
-// DNSZoneValidatingAdmissionHook is a struct that is used to reference what code should be run by the generic-admission-server.
-type DNSZoneValidatingAdmissionHook struct{}
+var (
+	mutableFields = []string{"Compute"}
+)
+
+// ClusterDeploymentValidatingAdmissionHook is a struct that is used to reference what code should be run by the generic-admission-server.
+type ClusterDeploymentValidatingAdmissionHook struct{}
 
 // ValidatingResource is called by generic-admission-server on startup to register the returned REST resource through which the
 //                    webhook is accessed by the kube apiserver.
-// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.hive.openshift.io/v1alpha1/dnszones".
+// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.hive.openshift.io/v1alpha1/clusterdeployments".
 //              When the kube apiserver calls this registered REST resource, the generic-admission-server calls the Validate() method below.
-func (a *DNSZoneValidatingAdmissionHook) ValidatingResource() (plural schema.GroupVersionResource, singular string) {
+func (a *ClusterDeploymentValidatingAdmissionHook) ValidatingResource() (plural schema.GroupVersionResource, singular string) {
 	log.WithFields(log.Fields{
-		"group":    "admission.hive.openshift.io",
-		"version":  "v1alpha1",
-		"resource": "dnszones",
+		"group":    clusterDeploymentAdmissionGroup,
+		"version":  clusterDeploymentAdmissionVersion,
+		"resource": clusterDeploymentAdmissionResource,
 	}).Info("Registering validation REST resource")
-	// NOTE: This GVR is meant to be different than the DNSZone CRD GVR which has group "hive.openshift.io".
+
+	// NOTE: This GVR is meant to be different than the ClusterDeployment CRD GVR which has group "hive.openshift.io".
 	return schema.GroupVersionResource{
-			Group:    "admission.hive.openshift.io",
-			Version:  "v1alpha1",
-			Resource: "dnszones",
+			Group:    clusterDeploymentAdmissionGroup,
+			Version:  clusterDeploymentAdmissionVersion,
+			Resource: clusterDeploymentAdmissionResource,
 		},
-		"dnszone"
+		"clusterdeployment"
 }
 
 // Initialize is called by generic-admission-server on startup to setup any special initialization that your webhook needs.
-func (a *DNSZoneValidatingAdmissionHook) Initialize(kubeClientConfig *rest.Config, stopCh <-chan struct{}) error {
+func (a *ClusterDeploymentValidatingAdmissionHook) Initialize(kubeClientConfig *rest.Config, stopCh <-chan struct{}) error {
 	log.WithFields(log.Fields{
-		"group":    "admission.hive.openshift.io",
-		"version":  "v1alpha1",
-		"resource": "dnszones",
+		"group":    clusterDeploymentAdmissionGroup,
+		"version":  clusterDeploymentAdmissionVersion,
+		"resource": clusterDeploymentAdmissionResource,
 	}).Info("Initializing validation REST resource")
 	return nil // No initialization needed right now.
 }
 
 // Validate is called by generic-admission-server when the registered REST resource above is called with an admission request.
 // Usually it's the kube apiserver that is making the admission validation request.
-func (a *DNSZoneValidatingAdmissionHook) Validate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *ClusterDeploymentValidatingAdmissionHook) Validate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -86,7 +90,7 @@ func (a *DNSZoneValidatingAdmissionHook) Validate(admissionSpec *admissionv1beta
 	if !a.shouldValidate(admissionSpec) {
 		contextLogger.Info("Skipping validation for request")
 		// The request object isn't something that this validator should validate.
-		// Therefore, we say that it's allowed.
+		// Therefore, we say that it's Allowed.
 		return &admissionv1beta1.AdmissionResponse{
 			Allowed: true,
 		}
@@ -111,7 +115,7 @@ func (a *DNSZoneValidatingAdmissionHook) Validate(admissionSpec *admissionv1beta
 
 // shouldValidate explicitly checks if the request should validated. For example, this webhook may have accidentally been registered to check
 // the validity of some other type of object with a different GVR.
-func (a *DNSZoneValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1beta1.AdmissionRequest) bool {
+func (a *ClusterDeploymentValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1beta1.AdmissionRequest) bool {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -120,17 +124,17 @@ func (a *DNSZoneValidatingAdmissionHook) shouldValidate(admissionSpec *admission
 		"method":    "shouldValidate",
 	})
 
-	if admissionSpec.Resource.Group != dnsZoneGroup {
+	if admissionSpec.Resource.Group != clusterDeploymentGroup {
 		contextLogger.Debug("Returning False, not our group")
 		return false
 	}
 
-	if admissionSpec.Resource.Version != dnsZoneVersion {
+	if admissionSpec.Resource.Version != clusterDeploymentVersion {
 		contextLogger.Debug("Returning False, it's our group, but not the right version")
 		return false
 	}
 
-	if admissionSpec.Resource.Resource != dnsZoneResource {
+	if admissionSpec.Resource.Resource != clusterDeploymentResource {
 		contextLogger.Debug("Returning False, it's our group and version, but not the right resource")
 		return false
 	}
@@ -140,8 +144,8 @@ func (a *DNSZoneValidatingAdmissionHook) shouldValidate(admissionSpec *admission
 	return true
 }
 
-// validateCreate specifically validates create operations for DNSZone objects.
-func (a *DNSZoneValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+// validateCreate specifically validates create operations for ClusterDeployment objects.
+func (a *ClusterDeploymentValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -150,7 +154,7 @@ func (a *DNSZoneValidatingAdmissionHook) validateCreate(admissionSpec *admission
 		"method":    "validateCreate",
 	})
 
-	newObject := &hivev1.DNSZone{}
+	newObject := &hivev1.ClusterDeployment{}
 	err := json.Unmarshal(admissionSpec.Object.Raw, newObject)
 	if err != nil {
 		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
@@ -168,18 +172,7 @@ func (a *DNSZoneValidatingAdmissionHook) validateCreate(admissionSpec *admission
 		contextLogger.Data["object.Name"] = newObject.Name
 	}
 
-	strErrs := dnsvalidation.IsDNS1123Subdomain(newObject.Spec.Zone)
-	if len(strErrs) != 0 {
-		message := fmt.Sprintf("Failed validation: %v", strings.Join(strErrs, ";"))
-		contextLogger.Infof(message)
-		return &admissionv1beta1.AdmissionResponse{
-			Allowed: false,
-			Result: &metav1.Status{
-				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
-				Message: message,
-			},
-		}
-	}
+	// TODO: Put Create Validation Here (or in openAPIV3Schema validation section of crd)
 
 	// If we get here, then all checks passed, so the object is valid.
 	contextLogger.Info("Successful validation")
@@ -188,8 +181,8 @@ func (a *DNSZoneValidatingAdmissionHook) validateCreate(admissionSpec *admission
 	}
 }
 
-// validateUpdate specifically validates update operations for DNSZone objects.
-func (a *DNSZoneValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+// validateUpdate specifically validates update operations for ClusterDeployment objects.
+func (a *ClusterDeploymentValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -198,7 +191,7 @@ func (a *DNSZoneValidatingAdmissionHook) validateUpdate(admissionSpec *admission
 		"method":    "validateUpdate",
 	})
 
-	newObject := &hivev1.DNSZone{}
+	newObject := &hivev1.ClusterDeployment{}
 	err := json.Unmarshal(admissionSpec.Object.Raw, newObject)
 	if err != nil {
 		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
@@ -216,7 +209,7 @@ func (a *DNSZoneValidatingAdmissionHook) validateUpdate(admissionSpec *admission
 		contextLogger.Data["object.Name"] = newObject.Name
 	}
 
-	oldObject := &hivev1.DNSZone{}
+	oldObject := &hivev1.ClusterDeployment{}
 	err = json.Unmarshal(admissionSpec.OldObject.Raw, oldObject)
 	if err != nil {
 		contextLogger.Errorf("Failed unmarshaling OldObject: %v", err.Error())
@@ -234,8 +227,8 @@ func (a *DNSZoneValidatingAdmissionHook) validateUpdate(admissionSpec *admission
 		contextLogger.Data["oldObject.Name"] = oldObject.Name
 	}
 
-	if oldObject.Spec.Zone != newObject.Spec.Zone {
-		message := "DNSZone.Spec.Zone is immutable"
+	if hasChangedImmutableField(&oldObject.Spec, &newObject.Spec) {
+		message := fmt.Sprintf("ClusterDeployment.Spec is immutable except for %v", mutableFields)
 		contextLogger.Infof("Failed validation: %v", message)
 
 		return &admissionv1beta1.AdmissionResponse{
@@ -252,4 +245,34 @@ func (a *DNSZoneValidatingAdmissionHook) validateUpdate(admissionSpec *admission
 	return &admissionv1beta1.AdmissionResponse{
 		Allowed: true,
 	}
+}
+
+// isFieldMutable says whether the ClusterDeployment.spec field is meant to be mutable or not.
+func isFieldMutable(value string) bool {
+	for _, mutableField := range mutableFields {
+		if value == mutableField {
+			return true
+		}
+	}
+
+	return false
+}
+
+// hasChangedImmutableField determines if a ClusterDeployment.spec immutable field was changed.
+func hasChangedImmutableField(oldObject, newObject *hivev1.ClusterDeploymentSpec) bool {
+	ooElem := reflect.ValueOf(oldObject).Elem()
+	noElem := reflect.ValueOf(newObject).Elem()
+
+	for i := 0; i < ooElem.NumField(); i++ {
+		ooFieldName := ooElem.Type().Field(i).Name
+		ooValue := ooElem.Field(i).Interface()
+		noValue := noElem.Field(i).Interface()
+
+		if !isFieldMutable(ooFieldName) && !reflect.DeepEqual(ooValue, noValue) {
+			// The field isn't mutable -and- has been changed. DO NOT ALLOW.
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validatingwebhooks
+
+import (
+	"encoding/json"
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"testing"
+)
+
+var (
+	validClusterDeployment = &hivev1.ClusterDeployment{
+		Spec: hivev1.ClusterDeploymentSpec{
+			ClusterName: "SameClusterName",
+			Compute: []hivev1.MachinePool{
+				{
+					Name: "SameMachinePoolName",
+				},
+			},
+		},
+	}
+
+	// Meant to be used to compare new and old as the same values.
+	validClusterDeploymentSameValues = &hivev1.ClusterDeployment{
+		Spec: hivev1.ClusterDeploymentSpec{
+			ClusterName: "SameClusterName",
+			Compute: []hivev1.MachinePool{
+				{
+					Name: "SameMachinePoolName",
+				},
+			},
+		},
+	}
+
+	validClusterDeploymentDifferentImmutableValue = &hivev1.ClusterDeployment{
+		Spec: hivev1.ClusterDeploymentSpec{
+			ClusterName: "DifferentClusterName",
+			Compute: []hivev1.MachinePool{
+				{
+					Name: "SameMachinePoolName",
+				},
+			},
+		},
+	}
+
+	validClusterDeploymentDifferentMutableValue = &hivev1.ClusterDeployment{
+		Spec: hivev1.ClusterDeploymentSpec{
+			ClusterName: "SameClusterName",
+			Compute: []hivev1.MachinePool{
+				{
+					Name: "DifferentMachinePoolName",
+				},
+			},
+		},
+	}
+)
+
+func TestClusterDeploymentValidatingResource(t *testing.T) {
+	// Arrange
+	data := ClusterDeploymentValidatingAdmissionHook{}
+	expectedPlural := schema.GroupVersionResource{
+		Group:    "admission.hive.openshift.io",
+		Version:  "v1alpha1",
+		Resource: "clusterdeployments",
+	}
+	expectedSingular := "clusterdeployment"
+
+	// Act
+	plural, singular := data.ValidatingResource()
+
+	// Assert
+	assert.Equal(t, expectedPlural, plural)
+	assert.Equal(t, expectedSingular, singular)
+}
+
+func TestClusterDeploymentInitialize(t *testing.T) {
+	// Arrange
+	data := ClusterDeploymentValidatingAdmissionHook{}
+
+	// Act
+	err := data.Initialize(nil, nil)
+
+	// Assert
+	assert.Nil(t, err)
+}
+
+func TestClusterDeploymentValidate(t *testing.T) {
+	cases := []struct {
+		name            string
+		newObject       *hivev1.ClusterDeployment
+		newObjectRaw    []byte
+		oldObject       *hivev1.ClusterDeployment
+		oldObjectRaw    []byte
+		operation       admissionv1beta1.Operation
+		expectedAllowed bool
+		gvr             *metav1.GroupVersionResource
+	}{
+		{
+			name:            "Test Create Operation is allowed even with mismatch objects",
+			oldObject:       validClusterDeployment,
+			newObject:       nil,
+			operation:       admissionv1beta1.Create,
+			expectedAllowed: true,
+		},
+		{
+			name:            "Test Delete Operation is allowed even with mismatch objects",
+			oldObject:       validClusterDeployment,
+			newObject:       validClusterDeploymentDifferentImmutableValue,
+			operation:       admissionv1beta1.Delete,
+			expectedAllowed: true,
+		},
+		{
+			name:            "Test Update Operation is allowed with same data",
+			oldObject:       validClusterDeployment,
+			newObject:       validClusterDeploymentSameValues,
+			operation:       admissionv1beta1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name:            "Test Update Operation is allowed with different mutable data",
+			oldObject:       validClusterDeployment,
+			newObject:       validClusterDeploymentDifferentMutableValue,
+			operation:       admissionv1beta1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name:            "Test Update Operation is NOT allowed with different immutable data",
+			oldObject:       validClusterDeployment,
+			newObject:       validClusterDeploymentDifferentImmutableValue,
+			operation:       admissionv1beta1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name:            "Test unable to marshal new object during create",
+			newObjectRaw:    []byte{0},
+			operation:       admissionv1beta1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name:            "Test unable to marshal new object during update",
+			newObjectRaw:    []byte{0},
+			operation:       admissionv1beta1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name:            "Test unable to marshal old object during update",
+			oldObjectRaw:    []byte{0},
+			operation:       admissionv1beta1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "Test doesn't validate with right version and resouce, but wrong group",
+			gvr: &metav1.GroupVersionResource{
+				Group:    "not the right group",
+				Version:  "v1alpha1",
+				Resource: "clusterdeployments",
+			},
+			expectedAllowed: true,
+		},
+		{
+			name: "Test doesn't validate with right group and resource, wrong version",
+			gvr: &metav1.GroupVersionResource{
+				Group:    "hive.openshift.io",
+				Version:  "not the right version",
+				Resource: "clusterdeployments",
+			},
+			expectedAllowed: true,
+		},
+		{
+			name: "Test doesn't validate with right group and version, wrong resouce",
+			gvr: &metav1.GroupVersionResource{
+				Group:    "hive.openshift.io",
+				Version:  "v1alpha1",
+				Resource: "not the right resource",
+			},
+			expectedAllowed: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			data := ClusterDeploymentValidatingAdmissionHook{}
+
+			if tc.gvr == nil {
+				tc.gvr = &metav1.GroupVersionResource{
+					Group:    "hive.openshift.io",
+					Version:  "v1alpha1",
+					Resource: "clusterdeployments",
+				}
+			}
+
+			if tc.newObjectRaw == nil {
+				tc.newObjectRaw, _ = json.Marshal(tc.newObject)
+			}
+
+			if tc.oldObjectRaw == nil {
+				tc.oldObjectRaw, _ = json.Marshal(tc.oldObject)
+			}
+
+			request := &admissionv1beta1.AdmissionRequest{
+				Operation: tc.operation,
+				Resource:  *tc.gvr,
+				Object: runtime.RawExtension{
+					Raw: tc.newObjectRaw,
+				},
+				OldObject: runtime.RawExtension{
+					Raw: tc.oldObjectRaw,
+				},
+			}
+
+			// Act
+			response := data.Validate(request)
+
+			// Assert
+			assert.Equal(t, tc.expectedAllowed, response.Allowed)
+		})
+	}
+}


### PR DESCRIPTION
- [x] Add validation webhook for ClusterDeployment
- [x] Add aggregated api for ClusterDeployment webhook
- [x] Make ClusterDeployment.spec immutable
- [x] Change ClusterDeployment.spec.compute to be mutable
- [x] Ensure that future fields added to ClusterDeployment.spec are immutable by default
- [x] Add unit test showing that ClusterDeployment.spec.compute can be changed during an update
- [x] Add unit test showing that other fields of ClusterDeployment.spec cannot be changed during and update
- [x] Manually test on cluster that immutability is respected.
- [x] Add toleration for hiveadmission daemonset to be able to land on masters.