### PR TITLE
Fix networking in cluster deployment template.

### DIFF
--- a/config/templates/cluster-deployment.yaml
+++ b/config/templates/cluster-deployment.yaml
@@ -45,8 +45,7 @@ parameters:
 - name: OPENSHIFT_RELEASE_IMAGE
   displayName: OpenShift Release Image
   description: The release image for the version of OpenShift you wish to install.
-  # 0.0.6
-  value: quay.io/openshift-release-dev/ocp-release:4.0.0-5
+  value: quay.io/openshift-release-dev/ocp-release:4.0.0-0.1
 
 objects:
 - apiVersion: v1
@@ -99,10 +98,10 @@ objects:
     baseDomain: ${BASE_DOMAIN}
     networking:
       type: OpenshiftSDN
-      serviceCIDR: "10.3.0.0/16"
+      serviceCIDR: "172.30.0.0/16"
       machineCIDR: "10.0.0.0/16"
       clusterNetworks:
-        - cidr: "10.2.0.0/16"
+        - cidr: "10.128.0.0/14"
           hostSubnetLength: 9
     platform:
       aws:


### PR DESCRIPTION
For some reason our clusters started failing to come up properly this
week. Comparing a working CLI run to our install config, these changes
in the networking CIDRs showed up, and appeared to correct the problem.

Also updated to a newer default release image.