### PR TITLE
Remove AMIs from API.

### DIFF
--- a/config/crds/hive_v1alpha1_clusterdeployment.yaml
+++ b/config/crds/hive_v1alpha1_clusterdeployment.yaml
@@ -37,8 +37,6 @@ spec:
                     properties:
                       aws:
                         properties:
-                          amiID:
-                            type: string
                           iamRoleName:
                             type: string
                           rootVolume:
@@ -119,8 +117,6 @@ spec:
                   properties:
                     aws:
                       properties:
-                        amiID:
-                          type: string
                         iamRoleName:
                           type: string
                         rootVolume:
@@ -237,8 +233,6 @@ spec:
                   properties:
                     defaultMachinePlatform:
                       properties:
-                        amiID:
-                          type: string
                         iamRoleName:
                           type: string
                         rootVolume:

--- a/pkg/apis/hive/v1alpha1/machinepools.go
+++ b/pkg/apis/hive/v1alpha1/machinepools.go
@@ -32,9 +32,6 @@ type AWSMachinePoolPlatform struct {
 	// Zones is list of availability zones that can be used.
 	Zones []string `json:"zones,omitempty"`
 
-	// AMIID defines the AMI that should be used.
-	AMIID string `json:"amiID,omitempty"`
-
 	// InstanceType defines the ec2 instance type.
 	// eg. m4-large
 	InstanceType string `json:"type"`

--- a/pkg/controller/clusterdeployment/aws.go
+++ b/pkg/controller/clusterdeployment/aws.go
@@ -25,12 +25,20 @@ import (
 	"github.com/openshift/installer/pkg/rhcos"
 )
 
+const (
+	hiveDefaultAMIAnnotation = "hive.openshift.io/default-AMI"
+)
+
 func isDefaultAMISet(cd *hivev1.ClusterDeployment) bool {
-	defaultAMIKnown := false
-	if cd.Spec.Platform.AWS.DefaultMachinePlatform != nil && cd.Spec.Platform.AWS.DefaultMachinePlatform.AMIID != "" {
-		defaultAMIKnown = true
+	defaultAMI, ok := cd.Annotations[hiveDefaultAMIAnnotation]
+	if ok && defaultAMI != "" {
+		return true
 	}
-	return defaultAMIKnown
+	return false
+}
+
+func setDefaultAMI(cd *hivev1.ClusterDeployment, ami string) {
+	cd.Annotations[hiveDefaultAMIAnnotation] = ami
 }
 
 // lookupAMI uses installer code to lookup the latest AMI from the RHCOS webapp.

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -147,7 +147,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 			},
 			validate: func(c client.Client, t *testing.T) {
 				cd := getCD(c)
-				if cd == nil || cd.Spec.Platform.AWS.DefaultMachinePlatform.AMIID != testAMI {
+				if cd == nil || cd.Annotations[hiveDefaultAMIAnnotation] != testAMI {
 					t.Errorf("did not get expected default AMI")
 				}
 			},
@@ -394,11 +394,13 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 func testClusterDeployment() *hivev1.ClusterDeployment {
 	return &hivev1.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        testName,
-			Namespace:   testNamespace,
-			Finalizers:  []string{hivev1.FinalizerDeprovision},
-			UID:         types.UID("1234"),
-			Annotations: map[string]string{},
+			Name:       testName,
+			Namespace:  testNamespace,
+			Finalizers: []string{hivev1.FinalizerDeprovision},
+			UID:        types.UID("1234"),
+			Annotations: map[string]string{
+				hiveDefaultAMIAnnotation: testAMI,
+			},
 		},
 		Spec: hivev1.ClusterDeploymentSpec{
 			ClusterName: testClusterName,
@@ -413,9 +415,6 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 			Platform: hivev1.Platform{
 				AWS: &hivev1.AWSPlatform{
 					Region: "us-east-1",
-					DefaultMachinePlatform: &hivev1.AWSMachinePoolPlatform{
-						AMIID: testAMI,
-					},
 				},
 			},
 			Networking: hivev1.Networking{
@@ -465,7 +464,7 @@ func testExpiredClusterDeployment() *hivev1.ClusterDeployment {
 
 func testNoDefaultAMIClusterDeployment() *hivev1.ClusterDeployment {
 	cd := testClusterDeployment()
-	cd.Spec.Platform.AWS.DefaultMachinePlatform.AMIID = ""
+	cd.Annotations[hiveDefaultAMIAnnotation] = ""
 	return cd
 }
 

--- a/pkg/controller/remotemachineset/remotemachineset_controller_test.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller_test.go
@@ -282,7 +282,6 @@ func testMachinePool(name string, replicas int, iamRoleName string, zones []stri
 		Replicas: &mpReplicas,
 		Platform: hivev1.MachinePoolPlatform{
 			AWS: &hivev1.AWSMachinePoolPlatform{
-				AMIID:        testAMI,
 				InstanceType: "m4.large",
 				IAMRoleName:  iamRoleName,
 			},
@@ -320,11 +319,13 @@ func testMachineSet(name string, replicas int) *capiv1.MachineSet {
 func testClusterDeployment(computePools []hivev1.MachinePool) *hivev1.ClusterDeployment {
 	return &hivev1.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        testName,
-			Namespace:   testNamespace,
-			Finalizers:  []string{hivev1.FinalizerDeprovision},
-			UID:         types.UID("1234"),
-			Annotations: map[string]string{},
+			Name:       testName,
+			Namespace:  testNamespace,
+			Finalizers: []string{hivev1.FinalizerDeprovision},
+			UID:        types.UID("1234"),
+			Annotations: map[string]string{
+				hiveDefaultAMIAnnotation: testAMI,
+			},
 		},
 		Spec: hivev1.ClusterDeploymentSpec{
 			SSHKey: &corev1.LocalObjectReference{
@@ -339,9 +340,6 @@ func testClusterDeployment(computePools []hivev1.MachinePool) *hivev1.ClusterDep
 			Platform: hivev1.Platform{
 				AWS: &hivev1.AWSPlatform{
 					Region: "us-east-1",
-					DefaultMachinePlatform: &hivev1.AWSMachinePoolPlatform{
-						AMIID: testAMI,
-					},
 				},
 			},
 			Networking: hivev1.Networking{

--- a/pkg/install/convertconfig_test.go
+++ b/pkg/install/convertconfig_test.go
@@ -39,19 +39,20 @@ func init() {
 }
 
 const (
-	testName        = "foo"
-	testNamespace   = "default"
-	testClusterID   = "foo"
-	testAMI         = "ami-totallyfake"
-	adminPassword   = "adminpassword"
-	adminSSHKey     = "adminSSH"
-	pullSecret      = "pullSecret"
-	awsInstanceType = "fake-aws-type"
-	awsRegion       = "us-east-1"
-	iamRoleName     = "rolename"
-	ec2VolIOPS      = 100
-	ec2VolSize      = 500
-	ec2VolType      = "sometype"
+	testName                 = "foo"
+	testNamespace            = "default"
+	testClusterID            = "foo"
+	testAMI                  = "ami-totallyfake"
+	adminPassword            = "adminpassword"
+	adminSSHKey              = "adminSSH"
+	pullSecret               = "pullSecret"
+	awsInstanceType          = "fake-aws-type"
+	awsRegion                = "us-east-1"
+	iamRoleName              = "rolename"
+	ec2VolIOPS               = 100
+	ec2VolSize               = 500
+	ec2VolType               = "sometype"
+	hiveDefaultAMIAnnotation = "hive.openshift.io/default-AMI"
 )
 
 var (
@@ -61,6 +62,11 @@ var (
 func buildValidClusterDeployment() *hivev1.ClusterDeployment {
 	replicas := int64(3)
 	return &hivev1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				hiveDefaultAMIAnnotation: testAMI,
+			},
+		},
 		Spec: hivev1.ClusterDeploymentSpec{
 			BaseDomain: "test.example.com",
 			SSHKey: &corev1.LocalObjectReference{
@@ -109,7 +115,6 @@ func buildValidClusterDeployment() *hivev1.ClusterDeployment {
 							Size: ec2VolSize,
 							Type: ec2VolType,
 						},
-						AMIID: testAMI,
 						Zones: []string{"us-east-1a", "us-east-1b"},
 					},
 				},


### PR DESCRIPTION
This feature was broken after we merged validation that you cannot
change anything outside of spec.Compute. Rather than adding another
exception, this moves the default AMI pinning to an annotation, as the
entire feature is not going to be needed once we implement the design
for OS image lifecycle, so the sooner it's out of the API the better.

CC @jhernand 

I think this will roll out to opshive smoothly. We will lose the AMI that was pinned when that cluster deployment was created. The controller's will realize this and lookup the latest RHCOS image as soon as they sync the CD again. That will then be stored in the annotaton. It's very possible it will be different than the previous image, and when we sync machine sets it would then be set in-cluster. However that would only take effect for new machines,  i.e. if a node was deleted or scaled up, and in either case it should still work. This should mean we do not need to clear all cluster deployments Monday.