### PR TITLE
Add annotation to try install only one time

### DIFF
--- a/config/templates/cluster-deployment.yaml
+++ b/config/templates/cluster-deployment.yaml
@@ -46,6 +46,10 @@ parameters:
   displayName: OpenShift Release Image
   description: The release image for the version of OpenShift you wish to install.
   value: quay.io/openshift-release-dev/ocp-release:4.0.0-0.1
+- name: TRY_INSTALL_ONCE
+  displayName: Try Install Only Once
+  description: If set, install will only be tried once.
+  value: "false"
 
 objects:
 - apiVersion: v1
@@ -80,6 +84,7 @@ objects:
       controller-tools.k8s.io: "1.0"
     annotations:
       hive.openshift.io/delete-after: "8h"
+      hive.openshift.io/try-install-once: "${TRY_INSTALL_ONCE}"
     name: ${CLUSTER_NAME}
   spec:
     platformSecrets:


### PR DESCRIPTION
If annotation is present, generated job will not do a backoff and pods created by it will not restart on failure.
The default clusterdeployment template will allow passing TRY_INSTALL_ONCE=true to enable this behavior.