### PR TITLE
Fix bugs uncovered when rolling out to opshive

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ This method uses the latest published Hive image on the CI registry: `registry.s
   export CLUSTER_NAME="${USER}"
   export SSH_PUB_KEY="$(ssh-keygen -y -f ~/.ssh/libra.pem)"
   export PULL_SECRET="$(cat ${HOME}/config.json)"
-  export HIVE_IMAGE="quay.io/twiest/hive-controller:20190116"
+  export HIVE_IMAGE="quay.io/twiest/hive-controller:20190128"
   export HIVE_IMAGE_PULL_POLICY="Always"
-  export INSTALLER_IMAGE="quay.io/twiest/installer:20190116"
+  export INSTALLER_IMAGE="quay.io/twiest/installer:20190128"
   export INSTALLER_IMAGE_PULL_POLICY="Always"
 
   oc process -f config/templates/cluster-deployment.yaml \

--- a/config/overlays/sd-dev/image_patch.yaml
+++ b/config/overlays/sd-dev/image_patch.yaml
@@ -9,7 +9,7 @@ spec:
       containers:
       # Run from a defined image published to quay as necessary for SD's needs:
       - name: manager
-        image: quay.io/twiest/hive-controller:20190116
+        image: quay.io/twiest/hive-controller:20190128
         imagePullPolicy: Always
         resources:
           limits:
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
       - name: hiveadmission
-        image: quay.io/twiest/hive-controller:20190116
+        image: quay.io/twiest/hive-controller:20190128
         imagePullPolicy: Always
         command:
         - "/opt/services/hiveadmission"

--- a/pkg/controller/clusterdeployment/aws.go
+++ b/pkg/controller/clusterdeployment/aws.go
@@ -38,6 +38,9 @@ func isDefaultAMISet(cd *hivev1.ClusterDeployment) bool {
 }
 
 func setDefaultAMI(cd *hivev1.ClusterDeployment, ami string) {
+	if cd.Annotations == nil {
+		cd.Annotations = map[string]string{}
+	}
 	cd.Annotations[hiveDefaultAMIAnnotation] = ami
 }
 

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -397,7 +397,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 }
 
 func testClusterDeployment() *hivev1.ClusterDeployment {
-	return &hivev1.ClusterDeployment{
+	cd := &hivev1.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       testName,
 			Namespace:  testNamespace,
@@ -437,6 +437,8 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 			ClusterID: testClusterID,
 		},
 	}
+	controllerutils.FixupEmptyClusterVersionFields(&cd.Status.ClusterVersionStatus)
+	return cd
 }
 
 func testClusterDeploymentWithoutFinalizer() *hivev1.ClusterDeployment {


### PR DESCRIPTION
Generally related to pre-existing cluster deployments without some fields set, possibly worse on 3.10.