### PR TITLE
adding https prefix to web console url

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -416,7 +416,7 @@ func (r *ReconcileClusterDeployment) setAdminKubeconfigStatus(cd *hivev1.Cluster
 			return err
 		}
 		cdLog.Debugf("read remote route object: %s", routeObject)
-		cd.Status.WebConsoleURL = routeObject.Spec.Host
+		cd.Status.WebConsoleURL = "https://" + routeObject.Spec.Host
 	}
 
 	// Update remote cluster's version into our status

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -538,7 +538,7 @@ func testRemoteClusterAPIClientBuilder(secretData string) (client.Client, error)
 			Namespace: remoteClusterRouteObjectNamespace,
 		},
 	}
-	remoteClusterRouteObject.Spec.Host = "https://bar-api.clusters.example.com:6443/console"
+	remoteClusterRouteObject.Spec.Host = "bar-api.clusters.example.com:6443/console"
 
 	remoteClient := fake.NewFakeClient(remoteClusterVersion, remoteClusterRouteObject)
 	return remoteClient, nil


### PR DESCRIPTION
1) Adding the missed https:// prefix from the web console url.