### PR TITLE
Remove non-worker pool when generating install config for installer.

### DIFF
--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -383,7 +383,7 @@ func (r *ReconcileRemoteMachineSet) generateInstallConfigFromClusterDeployment(c
 		return nil, err
 	}
 
-	ic, err := install.GenerateInstallConfig(cd, sshKey, pullSecret)
+	ic, err := install.GenerateInstallConfig(cd, sshKey, pullSecret, false)
 	if err != nil {
 		cdLog.WithError(err).Error("unable to generate install config")
 		return nil, err

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -54,7 +54,7 @@ func GenerateInstallerJob(
 
 	cdLog.Debug("generating installer job")
 
-	ic, err := GenerateInstallConfig(cd, sshKey, pullSecret)
+	ic, err := GenerateInstallConfig(cd, sshKey, pullSecret, true)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Allow adding non-worker compute pools when initially creating clusterdeployment. The installer will error with extra pools but we can try to make them later when syncing machinesets.