### PR TITLE
[WIP]: use controlPlane and compute in install-config.yaml

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -445,6 +445,14 @@
   version = "v1.1.5"
 
 [[projects]]
+  branch = "master"
+  digest = "1:cf68a79fd02ab0f6942b9567d03d054b6568212fcc22de2a4afdefd096923749"
+  name = "github.com/kballard/go-shellquote"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "95032a82bc518f77982ea72343cc1ade730072f0"
+
+[[projects]]
   digest = "1:4059c14e87a2de3a434430340521b5feece186c1469eff0834c29a63870de3ed"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
@@ -507,12 +515,36 @@
   revision = "81af80346b1a01caae0cbc27fd3c1ba5b11e189f"
 
 [[projects]]
+  digest = "1:9785a54031460a402fab4e4bbb3124c8dd9e9f7b1982109fef605cb91632d480"
+  name = "github.com/mattn/go-colorable"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "efa589957cd060542a26d2dd7832fd6a6c6c3ade"
+  version = "v0.1.0"
+
+[[projects]]
+  digest = "1:bffa444ca07c69c599ae5876bc18b25bfd5fa85b297ca10a25594d284a7e9c5d"
+  name = "github.com/mattn/go-isatty"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c"
+  version = "v0.0.4"
+
+[[projects]]
   digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
   pruneopts = "NUT"
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:063d55b87e200bced5e2be658cc70acafb4c5bbc4afa04d4b82f66298b73d089"
+  name = "github.com/mgutz/ansi"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "9520e82c474b0a04dd04f8a40959027271bab992"
 
 [[projects]]
   digest = "1:2f42fa12d6911c7b7659738758631bec870b7e9b4c6be5444f963cdcfccc191f"
@@ -614,21 +646,25 @@
   source = "github.com/csrwng/generic-admission-server"
 
 [[projects]]
-  digest = "1:c942a2c49ace42720fc6d8739c2af36c0cedd954f393b0bba0407a515002fd81"
+  branch = "separate_control_plane_machine_pool"
+  digest = "1:3c9e9f52fd4196dbb983a17564bcb9d4dfcd357c1f7606a15983394eb67f13e6"
   name = "github.com/openshift/installer"
   packages = [
+    "pkg/asset/installconfig/aws",
     "pkg/asset/machines/aws",
     "pkg/destroy/aws",
     "pkg/ipnet",
     "pkg/rhcos",
     "pkg/types",
     "pkg/types/aws",
+    "pkg/types/aws/validation",
     "pkg/types/libvirt",
     "pkg/types/none",
     "pkg/types/openstack",
   ]
   pruneopts = "NUT"
-  revision = "7af6b141c34dd133f104b61b64c78d82e57f3d52"
+  revision = "05cc74b5b542c91a77f78e0f3b09715a36b6c437"
+  source = "github.com/staebler/installer"
 
 [[projects]]
   branch = "master"
@@ -978,6 +1014,18 @@
   pruneopts = "NUT"
   revision = "8dea3dc473e90c8179e519d91302d0597c0ca1d1"
   version = "v1.15.0"
+
+[[projects]]
+  digest = "1:acce65b46e283672291c073e642b3cadbb2817d4689a2f8babc5bad08724c99c"
+  name = "gopkg.in/AlecAivazis/survey.v1"
+  packages = [
+    ".",
+    "core",
+    "terminal",
+  ]
+  pruneopts = "NUT"
+  revision = "ee72c28b95a5ff3e227cfd403f556f0ef4b07ca5"
+  version = "v1.8.2"
 
 [[projects]]
   digest = "1:1b91ae0dc69a41d4c2ed23ea5cffb721ea63f5037ca4b81e6d6771fbb8f45129"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,7 +60,8 @@ version="v1.4.7"
 
 [[constraint]]
   name = "github.com/openshift/installer"
-  revision = "7af6b141c34dd133f104b61b64c78d82e57f3d52"
+  branch = "separate_control_plane_machine_pool"
+  source = "github.com/staebler/installer"
 
 [[constraint]]
   name = "github.com/openshift/generic-admission-server"

--- a/contrib/cmd/hiveutil/awstagdeprovision.go
+++ b/contrib/cmd/hiveutil/awstagdeprovision.go
@@ -48,7 +48,6 @@ func NewDeprovisionAWSWithTagsCommand() *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVar(&logLevel, "loglevel", "info", "log level, one of: debug, info, warn, error, fatal, panic")
 	flags.StringVar(&opt.Region, "region", "us-east-1", "AWS region to use")
-	flags.StringVar(&opt.ClusterName, "cluster-name", "", "Name that cluster was installed with")
 	return cmd
 }
 

--- a/contrib/pkg/installmanager/installmanager.go
+++ b/contrib/pkg/installmanager/installmanager.go
@@ -328,7 +328,6 @@ func runUninstaller(clusterName, region, clusterID string, logger log.FieldLogge
 	uninstaller := &aws.ClusterUninstaller{
 		Filters:     filters,
 		Region:      region,
-		ClusterName: clusterName,
 		Logger:      logger,
 	}
 

--- a/pkg/awsclient/mock/client_generated.go
+++ b/pkg/awsclient/mock/client_generated.go
@@ -40,7 +40,6 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 
 // DescribeAvailabilityZones mocks base method
 func (m *MockClient) DescribeAvailabilityZones(arg0 *ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAvailabilityZones", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeAvailabilityZonesOutput)
 	ret1, _ := ret[1].(error)
@@ -49,13 +48,11 @@ func (m *MockClient) DescribeAvailabilityZones(arg0 *ec2.DescribeAvailabilityZon
 
 // DescribeAvailabilityZones indicates an expected call of DescribeAvailabilityZones
 func (mr *MockClientMockRecorder) DescribeAvailabilityZones(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAvailabilityZones", reflect.TypeOf((*MockClient)(nil).DescribeAvailabilityZones), arg0)
 }
 
 // DescribeImages mocks base method
 func (m *MockClient) DescribeImages(arg0 *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeImages", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeImagesOutput)
 	ret1, _ := ret[1].(error)
@@ -64,13 +61,11 @@ func (m *MockClient) DescribeImages(arg0 *ec2.DescribeImagesInput) (*ec2.Describ
 
 // DescribeImages indicates an expected call of DescribeImages
 func (mr *MockClientMockRecorder) DescribeImages(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImages", reflect.TypeOf((*MockClient)(nil).DescribeImages), arg0)
 }
 
 // DescribeVpcs mocks base method
 func (m *MockClient) DescribeVpcs(arg0 *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcs", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVpcsOutput)
 	ret1, _ := ret[1].(error)
@@ -79,13 +74,11 @@ func (m *MockClient) DescribeVpcs(arg0 *ec2.DescribeVpcsInput) (*ec2.DescribeVpc
 
 // DescribeVpcs indicates an expected call of DescribeVpcs
 func (mr *MockClientMockRecorder) DescribeVpcs(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcs", reflect.TypeOf((*MockClient)(nil).DescribeVpcs), arg0)
 }
 
 // DescribeSubnets mocks base method
 func (m *MockClient) DescribeSubnets(arg0 *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSubnets", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeSubnetsOutput)
 	ret1, _ := ret[1].(error)
@@ -94,13 +87,11 @@ func (m *MockClient) DescribeSubnets(arg0 *ec2.DescribeSubnetsInput) (*ec2.Descr
 
 // DescribeSubnets indicates an expected call of DescribeSubnets
 func (mr *MockClientMockRecorder) DescribeSubnets(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubnets", reflect.TypeOf((*MockClient)(nil).DescribeSubnets), arg0)
 }
 
 // DescribeSecurityGroups mocks base method
 func (m *MockClient) DescribeSecurityGroups(arg0 *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSecurityGroups", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeSecurityGroupsOutput)
 	ret1, _ := ret[1].(error)
@@ -109,13 +100,11 @@ func (m *MockClient) DescribeSecurityGroups(arg0 *ec2.DescribeSecurityGroupsInpu
 
 // DescribeSecurityGroups indicates an expected call of DescribeSecurityGroups
 func (mr *MockClientMockRecorder) DescribeSecurityGroups(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecurityGroups", reflect.TypeOf((*MockClient)(nil).DescribeSecurityGroups), arg0)
 }
 
 // RunInstances mocks base method
 func (m *MockClient) RunInstances(arg0 *ec2.RunInstancesInput) (*ec2.Reservation, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunInstances", arg0)
 	ret0, _ := ret[0].(*ec2.Reservation)
 	ret1, _ := ret[1].(error)
@@ -124,13 +113,11 @@ func (m *MockClient) RunInstances(arg0 *ec2.RunInstancesInput) (*ec2.Reservation
 
 // RunInstances indicates an expected call of RunInstances
 func (mr *MockClientMockRecorder) RunInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunInstances", reflect.TypeOf((*MockClient)(nil).RunInstances), arg0)
 }
 
 // DescribeInstances mocks base method
 func (m *MockClient) DescribeInstances(arg0 *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstances", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -139,13 +126,11 @@ func (m *MockClient) DescribeInstances(arg0 *ec2.DescribeInstancesInput) (*ec2.D
 
 // DescribeInstances indicates an expected call of DescribeInstances
 func (mr *MockClientMockRecorder) DescribeInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstances", reflect.TypeOf((*MockClient)(nil).DescribeInstances), arg0)
 }
 
 // TerminateInstances mocks base method
 func (m *MockClient) TerminateInstances(arg0 *ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TerminateInstances", arg0)
 	ret0, _ := ret[0].(*ec2.TerminateInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -154,13 +139,11 @@ func (m *MockClient) TerminateInstances(arg0 *ec2.TerminateInstancesInput) (*ec2
 
 // TerminateInstances indicates an expected call of TerminateInstances
 func (mr *MockClientMockRecorder) TerminateInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateInstances", reflect.TypeOf((*MockClient)(nil).TerminateInstances), arg0)
 }
 
 // RegisterInstancesWithLoadBalancer mocks base method
 func (m *MockClient) RegisterInstancesWithLoadBalancer(arg0 *elb.RegisterInstancesWithLoadBalancerInput) (*elb.RegisterInstancesWithLoadBalancerOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterInstancesWithLoadBalancer", arg0)
 	ret0, _ := ret[0].(*elb.RegisterInstancesWithLoadBalancerOutput)
 	ret1, _ := ret[1].(error)
@@ -169,13 +152,11 @@ func (m *MockClient) RegisterInstancesWithLoadBalancer(arg0 *elb.RegisterInstanc
 
 // RegisterInstancesWithLoadBalancer indicates an expected call of RegisterInstancesWithLoadBalancer
 func (mr *MockClientMockRecorder) RegisterInstancesWithLoadBalancer(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterInstancesWithLoadBalancer", reflect.TypeOf((*MockClient)(nil).RegisterInstancesWithLoadBalancer), arg0)
 }
 
 // CreateAccessKey mocks base method
 func (m *MockClient) CreateAccessKey(arg0 *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAccessKey", arg0)
 	ret0, _ := ret[0].(*iam.CreateAccessKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -184,13 +165,11 @@ func (m *MockClient) CreateAccessKey(arg0 *iam.CreateAccessKeyInput) (*iam.Creat
 
 // CreateAccessKey indicates an expected call of CreateAccessKey
 func (mr *MockClientMockRecorder) CreateAccessKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccessKey", reflect.TypeOf((*MockClient)(nil).CreateAccessKey), arg0)
 }
 
 // CreateUser mocks base method
 func (m *MockClient) CreateUser(arg0 *iam.CreateUserInput) (*iam.CreateUserOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateUser", arg0)
 	ret0, _ := ret[0].(*iam.CreateUserOutput)
 	ret1, _ := ret[1].(error)
@@ -199,13 +178,11 @@ func (m *MockClient) CreateUser(arg0 *iam.CreateUserInput) (*iam.CreateUserOutpu
 
 // CreateUser indicates an expected call of CreateUser
 func (mr *MockClientMockRecorder) CreateUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockClient)(nil).CreateUser), arg0)
 }
 
 // DeleteAccessKey mocks base method
 func (m *MockClient) DeleteAccessKey(arg0 *iam.DeleteAccessKeyInput) (*iam.DeleteAccessKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAccessKey", arg0)
 	ret0, _ := ret[0].(*iam.DeleteAccessKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -214,13 +191,11 @@ func (m *MockClient) DeleteAccessKey(arg0 *iam.DeleteAccessKeyInput) (*iam.Delet
 
 // DeleteAccessKey indicates an expected call of DeleteAccessKey
 func (mr *MockClientMockRecorder) DeleteAccessKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccessKey", reflect.TypeOf((*MockClient)(nil).DeleteAccessKey), arg0)
 }
 
 // DeleteUser mocks base method
 func (m *MockClient) DeleteUser(arg0 *iam.DeleteUserInput) (*iam.DeleteUserOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteUser", arg0)
 	ret0, _ := ret[0].(*iam.DeleteUserOutput)
 	ret1, _ := ret[1].(error)
@@ -229,13 +204,11 @@ func (m *MockClient) DeleteUser(arg0 *iam.DeleteUserInput) (*iam.DeleteUserOutpu
 
 // DeleteUser indicates an expected call of DeleteUser
 func (mr *MockClientMockRecorder) DeleteUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*MockClient)(nil).DeleteUser), arg0)
 }
 
 // DeleteUserPolicy mocks base method
 func (m *MockClient) DeleteUserPolicy(arg0 *iam.DeleteUserPolicyInput) (*iam.DeleteUserPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteUserPolicy", arg0)
 	ret0, _ := ret[0].(*iam.DeleteUserPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -244,13 +217,11 @@ func (m *MockClient) DeleteUserPolicy(arg0 *iam.DeleteUserPolicyInput) (*iam.Del
 
 // DeleteUserPolicy indicates an expected call of DeleteUserPolicy
 func (mr *MockClientMockRecorder) DeleteUserPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserPolicy", reflect.TypeOf((*MockClient)(nil).DeleteUserPolicy), arg0)
 }
 
 // GetUser mocks base method
 func (m *MockClient) GetUser(arg0 *iam.GetUserInput) (*iam.GetUserOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUser", arg0)
 	ret0, _ := ret[0].(*iam.GetUserOutput)
 	ret1, _ := ret[1].(error)
@@ -259,13 +230,11 @@ func (m *MockClient) GetUser(arg0 *iam.GetUserInput) (*iam.GetUserOutput, error)
 
 // GetUser indicates an expected call of GetUser
 func (mr *MockClientMockRecorder) GetUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockClient)(nil).GetUser), arg0)
 }
 
 // ListAccessKeys mocks base method
 func (m *MockClient) ListAccessKeys(arg0 *iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAccessKeys", arg0)
 	ret0, _ := ret[0].(*iam.ListAccessKeysOutput)
 	ret1, _ := ret[1].(error)
@@ -274,13 +243,11 @@ func (m *MockClient) ListAccessKeys(arg0 *iam.ListAccessKeysInput) (*iam.ListAcc
 
 // ListAccessKeys indicates an expected call of ListAccessKeys
 func (mr *MockClientMockRecorder) ListAccessKeys(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccessKeys", reflect.TypeOf((*MockClient)(nil).ListAccessKeys), arg0)
 }
 
 // ListUserPolicies mocks base method
 func (m *MockClient) ListUserPolicies(arg0 *iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListUserPolicies", arg0)
 	ret0, _ := ret[0].(*iam.ListUserPoliciesOutput)
 	ret1, _ := ret[1].(error)
@@ -289,13 +256,11 @@ func (m *MockClient) ListUserPolicies(arg0 *iam.ListUserPoliciesInput) (*iam.Lis
 
 // ListUserPolicies indicates an expected call of ListUserPolicies
 func (mr *MockClientMockRecorder) ListUserPolicies(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserPolicies", reflect.TypeOf((*MockClient)(nil).ListUserPolicies), arg0)
 }
 
 // PutUserPolicy mocks base method
 func (m *MockClient) PutUserPolicy(arg0 *iam.PutUserPolicyInput) (*iam.PutUserPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutUserPolicy", arg0)
 	ret0, _ := ret[0].(*iam.PutUserPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -304,13 +269,11 @@ func (m *MockClient) PutUserPolicy(arg0 *iam.PutUserPolicyInput) (*iam.PutUserPo
 
 // PutUserPolicy indicates an expected call of PutUserPolicy
 func (mr *MockClientMockRecorder) PutUserPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutUserPolicy", reflect.TypeOf((*MockClient)(nil).PutUserPolicy), arg0)
 }
 
 // CreateBucket mocks base method
 func (m *MockClient) CreateBucket(arg0 *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateBucket", arg0)
 	ret0, _ := ret[0].(*s3.CreateBucketOutput)
 	ret1, _ := ret[1].(error)
@@ -319,13 +282,11 @@ func (m *MockClient) CreateBucket(arg0 *s3.CreateBucketInput) (*s3.CreateBucketO
 
 // CreateBucket indicates an expected call of CreateBucket
 func (mr *MockClientMockRecorder) CreateBucket(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBucket", reflect.TypeOf((*MockClient)(nil).CreateBucket), arg0)
 }
 
 // DeleteBucket mocks base method
 func (m *MockClient) DeleteBucket(arg0 *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteBucket", arg0)
 	ret0, _ := ret[0].(*s3.DeleteBucketOutput)
 	ret1, _ := ret[1].(error)
@@ -334,13 +295,11 @@ func (m *MockClient) DeleteBucket(arg0 *s3.DeleteBucketInput) (*s3.DeleteBucketO
 
 // DeleteBucket indicates an expected call of DeleteBucket
 func (mr *MockClientMockRecorder) DeleteBucket(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBucket", reflect.TypeOf((*MockClient)(nil).DeleteBucket), arg0)
 }
 
 // ListBuckets mocks base method
 func (m *MockClient) ListBuckets(arg0 *s3.ListBucketsInput) (*s3.ListBucketsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListBuckets", arg0)
 	ret0, _ := ret[0].(*s3.ListBucketsOutput)
 	ret1, _ := ret[1].(error)
@@ -349,13 +308,11 @@ func (m *MockClient) ListBuckets(arg0 *s3.ListBucketsInput) (*s3.ListBucketsOutp
 
 // ListBuckets indicates an expected call of ListBuckets
 func (mr *MockClientMockRecorder) ListBuckets(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBuckets", reflect.TypeOf((*MockClient)(nil).ListBuckets), arg0)
 }
 
 // GetS3API mocks base method
 func (m *MockClient) GetS3API() s3iface.S3API {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetS3API")
 	ret0, _ := ret[0].(s3iface.S3API)
 	return ret0
@@ -363,13 +320,11 @@ func (m *MockClient) GetS3API() s3iface.S3API {
 
 // GetS3API indicates an expected call of GetS3API
 func (mr *MockClientMockRecorder) GetS3API() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetS3API", reflect.TypeOf((*MockClient)(nil).GetS3API))
 }
 
 // CreateHostedZone mocks base method
 func (m *MockClient) CreateHostedZone(input *route53.CreateHostedZoneInput) (*route53.CreateHostedZoneOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateHostedZone", input)
 	ret0, _ := ret[0].(*route53.CreateHostedZoneOutput)
 	ret1, _ := ret[1].(error)
@@ -378,13 +333,11 @@ func (m *MockClient) CreateHostedZone(input *route53.CreateHostedZoneInput) (*ro
 
 // CreateHostedZone indicates an expected call of CreateHostedZone
 func (mr *MockClientMockRecorder) CreateHostedZone(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateHostedZone", reflect.TypeOf((*MockClient)(nil).CreateHostedZone), input)
 }
 
 // DeleteHostedZone mocks base method
 func (m *MockClient) DeleteHostedZone(input *route53.DeleteHostedZoneInput) (*route53.DeleteHostedZoneOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteHostedZone", input)
 	ret0, _ := ret[0].(*route53.DeleteHostedZoneOutput)
 	ret1, _ := ret[1].(error)
@@ -393,13 +346,11 @@ func (m *MockClient) DeleteHostedZone(input *route53.DeleteHostedZoneInput) (*ro
 
 // DeleteHostedZone indicates an expected call of DeleteHostedZone
 func (mr *MockClientMockRecorder) DeleteHostedZone(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteHostedZone", reflect.TypeOf((*MockClient)(nil).DeleteHostedZone), input)
 }
 
 // ListHostedZones mocks base method
 func (m *MockClient) ListHostedZones(input *route53.ListHostedZonesInput) (*route53.ListHostedZonesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListHostedZones", input)
 	ret0, _ := ret[0].(*route53.ListHostedZonesOutput)
 	ret1, _ := ret[1].(error)
@@ -408,6 +359,5 @@ func (m *MockClient) ListHostedZones(input *route53.ListHostedZonesInput) (*rout
 
 // ListHostedZones indicates an expected call of ListHostedZones
 func (mr *MockClientMockRecorder) ListHostedZones(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListHostedZones", reflect.TypeOf((*MockClient)(nil).ListHostedZones), input)
 }

--- a/pkg/controller/dnszone/dnszone_controller_test.go
+++ b/pkg/controller/dnszone/dnszone_controller_test.go
@@ -82,8 +82,8 @@ func TestReconcileOldStyle(t *testing.T) {
 			key:  "namespace/somezone",
 		},
 		{
-			name: "DNSZone found, Create hostedzone as no corresponding route53 hostedzone exists",
-			key:  validDNSZone.Namespace + "/" + validDNSZone.Name,
+			name:                     "DNSZone found, Create hostedzone as no corresponding route53 hostedzone exists",
+			key:                      validDNSZone.Namespace + "/" + validDNSZone.Name,
 			expectHostedZoneCreation: true,
 			dnsZone:                  validDNSZone.DeepCopy(),
 			listHostedZonesOutput: &route53.ListHostedZonesOutput{
@@ -95,8 +95,8 @@ func TestReconcileOldStyle(t *testing.T) {
 			},
 		},
 		{
-			name: "DNSZone found, Status Generation doesn't match object generation (sync needed)",
-			key:  validDNSZone.Namespace + "/" + validDNSZone.Name,
+			name:                     "DNSZone found, Status Generation doesn't match object generation (sync needed)",
+			key:                      validDNSZone.Namespace + "/" + validDNSZone.Name,
 			expectHostedZoneCreation: true,
 			dnsZone:                  validDNSZoneGensDontMatch.DeepCopy(),
 			listHostedZonesOutput:    &route53.ListHostedZonesOutput{},
@@ -113,9 +113,9 @@ func TestReconcileOldStyle(t *testing.T) {
 			key:     validDNSZone.Namespace + "/" + validDNSZone.Name,
 		},
 		{
-			name:    "DNSZone found, Status Generation Timestamp outside sync period (sync needed)",
-			dnsZone: validDNSZoneGenTimestampSyncNeeded.DeepCopy(),
-			key:     validDNSZone.Namespace + "/" + validDNSZone.Name,
+			name:                     "DNSZone found, Status Generation Timestamp outside sync period (sync needed)",
+			dnsZone:                  validDNSZoneGenTimestampSyncNeeded.DeepCopy(),
+			key:                      validDNSZone.Namespace + "/" + validDNSZone.Name,
 			expectHostedZoneCreation: true,
 			listHostedZonesOutput:    &route53.ListHostedZonesOutput{},
 		},

--- a/pkg/controller/dnszone/zonereconciler_test.go
+++ b/pkg/controller/dnszone/zonereconciler_test.go
@@ -92,7 +92,7 @@ func TestReconcile(t *testing.T) {
 		LastSyncTimestampCheck     func(timeToCheck *metav1.Time, start, end time.Time) bool
 	}{
 		{
-			name: "DNSZone found, No corresponding route53 hostedzone",
+			name:                     "DNSZone found, No corresponding route53 hostedzone",
 			expectHostedZoneCreation: true,
 			dnsZone:                  validDNSZone.DeepCopy(),
 			listHostedZonesOutput: &route53.ListHostedZonesOutput{

--- a/vendor/github.com/kballard/go-shellquote/LICENSE
+++ b/vendor/github.com/kballard/go-shellquote/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 2014 Kevin Ballard
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/kballard/go-shellquote/doc.go
+++ b/vendor/github.com/kballard/go-shellquote/doc.go
@@ -1,0 +1,3 @@
+// Shellquote provides utilities for joining/splitting strings using sh's
+// word-splitting rules.
+package shellquote

--- a/vendor/github.com/kballard/go-shellquote/quote.go
+++ b/vendor/github.com/kballard/go-shellquote/quote.go
@@ -1,0 +1,102 @@
+package shellquote
+
+import (
+	"bytes"
+	"strings"
+	"unicode/utf8"
+)
+
+// Join quotes each argument and joins them with a space.
+// If passed to /bin/sh, the resulting string will be split back into the
+// original arguments.
+func Join(args ...string) string {
+	var buf bytes.Buffer
+	for i, arg := range args {
+		if i != 0 {
+			buf.WriteByte(' ')
+		}
+		quote(arg, &buf)
+	}
+	return buf.String()
+}
+
+const (
+	specialChars      = "\\'\"`${[|&;<>()*?!"
+	extraSpecialChars = " \t\n"
+	prefixChars       = "~"
+)
+
+func quote(word string, buf *bytes.Buffer) {
+	// We want to try to produce a "nice" output. As such, we will
+	// backslash-escape most characters, but if we encounter a space, or if we
+	// encounter an extra-special char (which doesn't work with
+	// backslash-escaping) we switch over to quoting the whole word. We do this
+	// with a space because it's typically easier for people to read multi-word
+	// arguments when quoted with a space rather than with ugly backslashes
+	// everywhere.
+	origLen := buf.Len()
+
+	if len(word) == 0 {
+		// oops, no content
+		buf.WriteString("''")
+		return
+	}
+
+	cur, prev := word, word
+	atStart := true
+	for len(cur) > 0 {
+		c, l := utf8.DecodeRuneInString(cur)
+		cur = cur[l:]
+		if strings.ContainsRune(specialChars, c) || (atStart && strings.ContainsRune(prefixChars, c)) {
+			// copy the non-special chars up to this point
+			if len(cur) < len(prev) {
+				buf.WriteString(prev[0 : len(prev)-len(cur)-l])
+			}
+			buf.WriteByte('\\')
+			buf.WriteRune(c)
+			prev = cur
+		} else if strings.ContainsRune(extraSpecialChars, c) {
+			// start over in quote mode
+			buf.Truncate(origLen)
+			goto quote
+		}
+		atStart = false
+	}
+	if len(prev) > 0 {
+		buf.WriteString(prev)
+	}
+	return
+
+quote:
+	// quote mode
+	// Use single-quotes, but if we find a single-quote in the word, we need
+	// to terminate the string, emit an escaped quote, and start the string up
+	// again
+	inQuote := false
+	for len(word) > 0 {
+		i := strings.IndexRune(word, '\'')
+		if i == -1 {
+			break
+		}
+		if i > 0 {
+			if !inQuote {
+				buf.WriteByte('\'')
+				inQuote = true
+			}
+			buf.WriteString(word[0:i])
+		}
+		word = word[i+1:]
+		if inQuote {
+			buf.WriteByte('\'')
+			inQuote = false
+		}
+		buf.WriteString("\\'")
+	}
+	if len(word) > 0 {
+		if !inQuote {
+			buf.WriteByte('\'')
+		}
+		buf.WriteString(word)
+		buf.WriteByte('\'')
+	}
+}

--- a/vendor/github.com/kballard/go-shellquote/unquote.go
+++ b/vendor/github.com/kballard/go-shellquote/unquote.go
@@ -1,0 +1,156 @@
+package shellquote
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"unicode/utf8"
+)
+
+var (
+	UnterminatedSingleQuoteError = errors.New("Unterminated single-quoted string")
+	UnterminatedDoubleQuoteError = errors.New("Unterminated double-quoted string")
+	UnterminatedEscapeError      = errors.New("Unterminated backslash-escape")
+)
+
+var (
+	splitChars        = " \n\t"
+	singleChar        = '\''
+	doubleChar        = '"'
+	escapeChar        = '\\'
+	doubleEscapeChars = "$`\"\n\\"
+)
+
+// Split splits a string according to /bin/sh's word-splitting rules. It
+// supports backslash-escapes, single-quotes, and double-quotes. Notably it does
+// not support the $'' style of quoting. It also doesn't attempt to perform any
+// other sort of expansion, including brace expansion, shell expansion, or
+// pathname expansion.
+//
+// If the given input has an unterminated quoted string or ends in a
+// backslash-escape, one of UnterminatedSingleQuoteError,
+// UnterminatedDoubleQuoteError, or UnterminatedEscapeError is returned.
+func Split(input string) (words []string, err error) {
+	var buf bytes.Buffer
+	words = make([]string, 0)
+
+	for len(input) > 0 {
+		// skip any splitChars at the start
+		c, l := utf8.DecodeRuneInString(input)
+		if strings.ContainsRune(splitChars, c) {
+			input = input[l:]
+			continue
+		} else if c == escapeChar {
+			// Look ahead for escaped newline so we can skip over it
+			next := input[l:]
+			if len(next) == 0 {
+				err = UnterminatedEscapeError
+				return
+			}
+			c2, l2 := utf8.DecodeRuneInString(next)
+			if c2 == '\n' {
+				input = next[l2:]
+				continue
+			}
+		}
+
+		var word string
+		word, input, err = splitWord(input, &buf)
+		if err != nil {
+			return
+		}
+		words = append(words, word)
+	}
+	return
+}
+
+func splitWord(input string, buf *bytes.Buffer) (word string, remainder string, err error) {
+	buf.Reset()
+
+raw:
+	{
+		cur := input
+		for len(cur) > 0 {
+			c, l := utf8.DecodeRuneInString(cur)
+			cur = cur[l:]
+			if c == singleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto single
+			} else if c == doubleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto double
+			} else if c == escapeChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto escape
+			} else if strings.ContainsRune(splitChars, c) {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				return buf.String(), cur, nil
+			}
+		}
+		if len(input) > 0 {
+			buf.WriteString(input)
+			input = ""
+		}
+		goto done
+	}
+
+escape:
+	{
+		if len(input) == 0 {
+			return "", "", UnterminatedEscapeError
+		}
+		c, l := utf8.DecodeRuneInString(input)
+		if c == '\n' {
+			// a backslash-escaped newline is elided from the output entirely
+		} else {
+			buf.WriteString(input[:l])
+		}
+		input = input[l:]
+	}
+	goto raw
+
+single:
+	{
+		i := strings.IndexRune(input, singleChar)
+		if i == -1 {
+			return "", "", UnterminatedSingleQuoteError
+		}
+		buf.WriteString(input[0:i])
+		input = input[i+1:]
+		goto raw
+	}
+
+double:
+	{
+		cur := input
+		for len(cur) > 0 {
+			c, l := utf8.DecodeRuneInString(cur)
+			cur = cur[l:]
+			if c == doubleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto raw
+			} else if c == escapeChar {
+				// bash only supports certain escapes in double-quoted strings
+				c2, l2 := utf8.DecodeRuneInString(cur)
+				cur = cur[l2:]
+				if strings.ContainsRune(doubleEscapeChars, c2) {
+					buf.WriteString(input[0 : len(input)-len(cur)-l-l2])
+					if c2 == '\n' {
+						// newline is special, skip the backslash entirely
+					} else {
+						buf.WriteRune(c2)
+					}
+					input = cur
+				}
+			}
+		}
+		return "", "", UnterminatedDoubleQuoteError
+	}
+
+done:
+	return buf.String(), input, nil
+}

--- a/vendor/github.com/mattn/go-colorable/LICENSE
+++ b/vendor/github.com/mattn/go-colorable/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Yasuhiro Matsumoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/mattn/go-colorable/colorable_appengine.go
+++ b/vendor/github.com/mattn/go-colorable/colorable_appengine.go
@@ -1,0 +1,29 @@
+// +build appengine
+
+package colorable
+
+import (
+	"io"
+	"os"
+
+	_ "github.com/mattn/go-isatty"
+)
+
+// NewColorable return new instance of Writer which handle escape sequence.
+func NewColorable(file *os.File) io.Writer {
+	if file == nil {
+		panic("nil passed instead of *os.File to NewColorable()")
+	}
+
+	return file
+}
+
+// NewColorableStdout return new instance of Writer which handle escape sequence for stdout.
+func NewColorableStdout() io.Writer {
+	return os.Stdout
+}
+
+// NewColorableStderr return new instance of Writer which handle escape sequence for stderr.
+func NewColorableStderr() io.Writer {
+	return os.Stderr
+}

--- a/vendor/github.com/mattn/go-colorable/colorable_others.go
+++ b/vendor/github.com/mattn/go-colorable/colorable_others.go
@@ -1,0 +1,30 @@
+// +build !windows
+// +build !appengine
+
+package colorable
+
+import (
+	"io"
+	"os"
+
+	_ "github.com/mattn/go-isatty"
+)
+
+// NewColorable return new instance of Writer which handle escape sequence.
+func NewColorable(file *os.File) io.Writer {
+	if file == nil {
+		panic("nil passed instead of *os.File to NewColorable()")
+	}
+
+	return file
+}
+
+// NewColorableStdout return new instance of Writer which handle escape sequence for stdout.
+func NewColorableStdout() io.Writer {
+	return os.Stdout
+}
+
+// NewColorableStderr return new instance of Writer which handle escape sequence for stderr.
+func NewColorableStderr() io.Writer {
+	return os.Stderr
+}

--- a/vendor/github.com/mattn/go-colorable/colorable_windows.go
+++ b/vendor/github.com/mattn/go-colorable/colorable_windows.go
@@ -1,0 +1,980 @@
+// +build windows
+// +build !appengine
+
+package colorable
+
+import (
+	"bytes"
+	"io"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"github.com/mattn/go-isatty"
+)
+
+const (
+	foregroundBlue      = 0x1
+	foregroundGreen     = 0x2
+	foregroundRed       = 0x4
+	foregroundIntensity = 0x8
+	foregroundMask      = (foregroundRed | foregroundBlue | foregroundGreen | foregroundIntensity)
+	backgroundBlue      = 0x10
+	backgroundGreen     = 0x20
+	backgroundRed       = 0x40
+	backgroundIntensity = 0x80
+	backgroundMask      = (backgroundRed | backgroundBlue | backgroundGreen | backgroundIntensity)
+)
+
+const (
+	genericRead  = 0x80000000
+	genericWrite = 0x40000000
+)
+
+const (
+	consoleTextmodeBuffer = 0x1
+)
+
+type wchar uint16
+type short int16
+type dword uint32
+type word uint16
+
+type coord struct {
+	x short
+	y short
+}
+
+type smallRect struct {
+	left   short
+	top    short
+	right  short
+	bottom short
+}
+
+type consoleScreenBufferInfo struct {
+	size              coord
+	cursorPosition    coord
+	attributes        word
+	window            smallRect
+	maximumWindowSize coord
+}
+
+type consoleCursorInfo struct {
+	size    dword
+	visible int32
+}
+
+var (
+	kernel32                       = syscall.NewLazyDLL("kernel32.dll")
+	procGetConsoleScreenBufferInfo = kernel32.NewProc("GetConsoleScreenBufferInfo")
+	procSetConsoleTextAttribute    = kernel32.NewProc("SetConsoleTextAttribute")
+	procSetConsoleCursorPosition   = kernel32.NewProc("SetConsoleCursorPosition")
+	procFillConsoleOutputCharacter = kernel32.NewProc("FillConsoleOutputCharacterW")
+	procFillConsoleOutputAttribute = kernel32.NewProc("FillConsoleOutputAttribute")
+	procGetConsoleCursorInfo       = kernel32.NewProc("GetConsoleCursorInfo")
+	procSetConsoleCursorInfo       = kernel32.NewProc("SetConsoleCursorInfo")
+	procSetConsoleTitle            = kernel32.NewProc("SetConsoleTitleW")
+	procCreateConsoleScreenBuffer  = kernel32.NewProc("CreateConsoleScreenBuffer")
+)
+
+// Writer provide colorable Writer to the console
+type Writer struct {
+	out       io.Writer
+	handle    syscall.Handle
+	althandle syscall.Handle
+	oldattr   word
+	oldpos    coord
+	rest      bytes.Buffer
+}
+
+// NewColorable return new instance of Writer which handle escape sequence from File.
+func NewColorable(file *os.File) io.Writer {
+	if file == nil {
+		panic("nil passed instead of *os.File to NewColorable()")
+	}
+
+	if isatty.IsTerminal(file.Fd()) {
+		var csbi consoleScreenBufferInfo
+		handle := syscall.Handle(file.Fd())
+		procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+		return &Writer{out: file, handle: handle, oldattr: csbi.attributes, oldpos: coord{0, 0}}
+	}
+	return file
+}
+
+// NewColorableStdout return new instance of Writer which handle escape sequence for stdout.
+func NewColorableStdout() io.Writer {
+	return NewColorable(os.Stdout)
+}
+
+// NewColorableStderr return new instance of Writer which handle escape sequence for stderr.
+func NewColorableStderr() io.Writer {
+	return NewColorable(os.Stderr)
+}
+
+var color256 = map[int]int{
+	0:   0x000000,
+	1:   0x800000,
+	2:   0x008000,
+	3:   0x808000,
+	4:   0x000080,
+	5:   0x800080,
+	6:   0x008080,
+	7:   0xc0c0c0,
+	8:   0x808080,
+	9:   0xff0000,
+	10:  0x00ff00,
+	11:  0xffff00,
+	12:  0x0000ff,
+	13:  0xff00ff,
+	14:  0x00ffff,
+	15:  0xffffff,
+	16:  0x000000,
+	17:  0x00005f,
+	18:  0x000087,
+	19:  0x0000af,
+	20:  0x0000d7,
+	21:  0x0000ff,
+	22:  0x005f00,
+	23:  0x005f5f,
+	24:  0x005f87,
+	25:  0x005faf,
+	26:  0x005fd7,
+	27:  0x005fff,
+	28:  0x008700,
+	29:  0x00875f,
+	30:  0x008787,
+	31:  0x0087af,
+	32:  0x0087d7,
+	33:  0x0087ff,
+	34:  0x00af00,
+	35:  0x00af5f,
+	36:  0x00af87,
+	37:  0x00afaf,
+	38:  0x00afd7,
+	39:  0x00afff,
+	40:  0x00d700,
+	41:  0x00d75f,
+	42:  0x00d787,
+	43:  0x00d7af,
+	44:  0x00d7d7,
+	45:  0x00d7ff,
+	46:  0x00ff00,
+	47:  0x00ff5f,
+	48:  0x00ff87,
+	49:  0x00ffaf,
+	50:  0x00ffd7,
+	51:  0x00ffff,
+	52:  0x5f0000,
+	53:  0x5f005f,
+	54:  0x5f0087,
+	55:  0x5f00af,
+	56:  0x5f00d7,
+	57:  0x5f00ff,
+	58:  0x5f5f00,
+	59:  0x5f5f5f,
+	60:  0x5f5f87,
+	61:  0x5f5faf,
+	62:  0x5f5fd7,
+	63:  0x5f5fff,
+	64:  0x5f8700,
+	65:  0x5f875f,
+	66:  0x5f8787,
+	67:  0x5f87af,
+	68:  0x5f87d7,
+	69:  0x5f87ff,
+	70:  0x5faf00,
+	71:  0x5faf5f,
+	72:  0x5faf87,
+	73:  0x5fafaf,
+	74:  0x5fafd7,
+	75:  0x5fafff,
+	76:  0x5fd700,
+	77:  0x5fd75f,
+	78:  0x5fd787,
+	79:  0x5fd7af,
+	80:  0x5fd7d7,
+	81:  0x5fd7ff,
+	82:  0x5fff00,
+	83:  0x5fff5f,
+	84:  0x5fff87,
+	85:  0x5fffaf,
+	86:  0x5fffd7,
+	87:  0x5fffff,
+	88:  0x870000,
+	89:  0x87005f,
+	90:  0x870087,
+	91:  0x8700af,
+	92:  0x8700d7,
+	93:  0x8700ff,
+	94:  0x875f00,
+	95:  0x875f5f,
+	96:  0x875f87,
+	97:  0x875faf,
+	98:  0x875fd7,
+	99:  0x875fff,
+	100: 0x878700,
+	101: 0x87875f,
+	102: 0x878787,
+	103: 0x8787af,
+	104: 0x8787d7,
+	105: 0x8787ff,
+	106: 0x87af00,
+	107: 0x87af5f,
+	108: 0x87af87,
+	109: 0x87afaf,
+	110: 0x87afd7,
+	111: 0x87afff,
+	112: 0x87d700,
+	113: 0x87d75f,
+	114: 0x87d787,
+	115: 0x87d7af,
+	116: 0x87d7d7,
+	117: 0x87d7ff,
+	118: 0x87ff00,
+	119: 0x87ff5f,
+	120: 0x87ff87,
+	121: 0x87ffaf,
+	122: 0x87ffd7,
+	123: 0x87ffff,
+	124: 0xaf0000,
+	125: 0xaf005f,
+	126: 0xaf0087,
+	127: 0xaf00af,
+	128: 0xaf00d7,
+	129: 0xaf00ff,
+	130: 0xaf5f00,
+	131: 0xaf5f5f,
+	132: 0xaf5f87,
+	133: 0xaf5faf,
+	134: 0xaf5fd7,
+	135: 0xaf5fff,
+	136: 0xaf8700,
+	137: 0xaf875f,
+	138: 0xaf8787,
+	139: 0xaf87af,
+	140: 0xaf87d7,
+	141: 0xaf87ff,
+	142: 0xafaf00,
+	143: 0xafaf5f,
+	144: 0xafaf87,
+	145: 0xafafaf,
+	146: 0xafafd7,
+	147: 0xafafff,
+	148: 0xafd700,
+	149: 0xafd75f,
+	150: 0xafd787,
+	151: 0xafd7af,
+	152: 0xafd7d7,
+	153: 0xafd7ff,
+	154: 0xafff00,
+	155: 0xafff5f,
+	156: 0xafff87,
+	157: 0xafffaf,
+	158: 0xafffd7,
+	159: 0xafffff,
+	160: 0xd70000,
+	161: 0xd7005f,
+	162: 0xd70087,
+	163: 0xd700af,
+	164: 0xd700d7,
+	165: 0xd700ff,
+	166: 0xd75f00,
+	167: 0xd75f5f,
+	168: 0xd75f87,
+	169: 0xd75faf,
+	170: 0xd75fd7,
+	171: 0xd75fff,
+	172: 0xd78700,
+	173: 0xd7875f,
+	174: 0xd78787,
+	175: 0xd787af,
+	176: 0xd787d7,
+	177: 0xd787ff,
+	178: 0xd7af00,
+	179: 0xd7af5f,
+	180: 0xd7af87,
+	181: 0xd7afaf,
+	182: 0xd7afd7,
+	183: 0xd7afff,
+	184: 0xd7d700,
+	185: 0xd7d75f,
+	186: 0xd7d787,
+	187: 0xd7d7af,
+	188: 0xd7d7d7,
+	189: 0xd7d7ff,
+	190: 0xd7ff00,
+	191: 0xd7ff5f,
+	192: 0xd7ff87,
+	193: 0xd7ffaf,
+	194: 0xd7ffd7,
+	195: 0xd7ffff,
+	196: 0xff0000,
+	197: 0xff005f,
+	198: 0xff0087,
+	199: 0xff00af,
+	200: 0xff00d7,
+	201: 0xff00ff,
+	202: 0xff5f00,
+	203: 0xff5f5f,
+	204: 0xff5f87,
+	205: 0xff5faf,
+	206: 0xff5fd7,
+	207: 0xff5fff,
+	208: 0xff8700,
+	209: 0xff875f,
+	210: 0xff8787,
+	211: 0xff87af,
+	212: 0xff87d7,
+	213: 0xff87ff,
+	214: 0xffaf00,
+	215: 0xffaf5f,
+	216: 0xffaf87,
+	217: 0xffafaf,
+	218: 0xffafd7,
+	219: 0xffafff,
+	220: 0xffd700,
+	221: 0xffd75f,
+	222: 0xffd787,
+	223: 0xffd7af,
+	224: 0xffd7d7,
+	225: 0xffd7ff,
+	226: 0xffff00,
+	227: 0xffff5f,
+	228: 0xffff87,
+	229: 0xffffaf,
+	230: 0xffffd7,
+	231: 0xffffff,
+	232: 0x080808,
+	233: 0x121212,
+	234: 0x1c1c1c,
+	235: 0x262626,
+	236: 0x303030,
+	237: 0x3a3a3a,
+	238: 0x444444,
+	239: 0x4e4e4e,
+	240: 0x585858,
+	241: 0x626262,
+	242: 0x6c6c6c,
+	243: 0x767676,
+	244: 0x808080,
+	245: 0x8a8a8a,
+	246: 0x949494,
+	247: 0x9e9e9e,
+	248: 0xa8a8a8,
+	249: 0xb2b2b2,
+	250: 0xbcbcbc,
+	251: 0xc6c6c6,
+	252: 0xd0d0d0,
+	253: 0xdadada,
+	254: 0xe4e4e4,
+	255: 0xeeeeee,
+}
+
+// `\033]0;TITLESTR\007`
+func doTitleSequence(er *bytes.Reader) error {
+	var c byte
+	var err error
+
+	c, err = er.ReadByte()
+	if err != nil {
+		return err
+	}
+	if c != '0' && c != '2' {
+		return nil
+	}
+	c, err = er.ReadByte()
+	if err != nil {
+		return err
+	}
+	if c != ';' {
+		return nil
+	}
+	title := make([]byte, 0, 80)
+	for {
+		c, err = er.ReadByte()
+		if err != nil {
+			return err
+		}
+		if c == 0x07 || c == '\n' {
+			break
+		}
+		title = append(title, c)
+	}
+	if len(title) > 0 {
+		title8, err := syscall.UTF16PtrFromString(string(title))
+		if err == nil {
+			procSetConsoleTitle.Call(uintptr(unsafe.Pointer(title8)))
+		}
+	}
+	return nil
+}
+
+// Write write data on console
+func (w *Writer) Write(data []byte) (n int, err error) {
+	var csbi consoleScreenBufferInfo
+	procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
+
+	handle := w.handle
+
+	var er *bytes.Reader
+	if w.rest.Len() > 0 {
+		var rest bytes.Buffer
+		w.rest.WriteTo(&rest)
+		w.rest.Reset()
+		rest.Write(data)
+		er = bytes.NewReader(rest.Bytes())
+	} else {
+		er = bytes.NewReader(data)
+	}
+	var bw [1]byte
+loop:
+	for {
+		c1, err := er.ReadByte()
+		if err != nil {
+			break loop
+		}
+		if c1 != 0x1b {
+			bw[0] = c1
+			w.out.Write(bw[:])
+			continue
+		}
+		c2, err := er.ReadByte()
+		if err != nil {
+			break loop
+		}
+
+		switch c2 {
+		case '>':
+			continue
+		case ']':
+			w.rest.WriteByte(c1)
+			w.rest.WriteByte(c2)
+			er.WriteTo(&w.rest)
+			if bytes.IndexByte(w.rest.Bytes(), 0x07) == -1 {
+				break loop
+			}
+			er = bytes.NewReader(w.rest.Bytes()[2:])
+			err := doTitleSequence(er)
+			if err != nil {
+				break loop
+			}
+			w.rest.Reset()
+			continue
+		// https://github.com/mattn/go-colorable/issues/27
+		case '7':
+			procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+			w.oldpos = csbi.cursorPosition
+			continue
+		case '8':
+			procSetConsoleCursorPosition.Call(uintptr(handle), *(*uintptr)(unsafe.Pointer(&w.oldpos)))
+			continue
+		case 0x5b:
+			// execute part after switch
+		default:
+			continue
+		}
+
+		w.rest.WriteByte(c1)
+		w.rest.WriteByte(c2)
+		er.WriteTo(&w.rest)
+
+		var buf bytes.Buffer
+		var m byte
+		for i, c := range w.rest.Bytes()[2:] {
+			if ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || c == '@' {
+				m = c
+				er = bytes.NewReader(w.rest.Bytes()[2+i+1:])
+				w.rest.Reset()
+				break
+			}
+			buf.Write([]byte(string(c)))
+		}
+		if m == 0 {
+			break loop
+		}
+
+		switch m {
+		case 'A':
+			n, err = strconv.Atoi(buf.String())
+			if err != nil {
+				continue
+			}
+			procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+			csbi.cursorPosition.y -= short(n)
+			procSetConsoleCursorPosition.Call(uintptr(handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
+		case 'B':
+			n, err = strconv.Atoi(buf.String())
+			if err != nil {
+				continue
+			}
+			procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+			csbi.cursorPosition.y += short(n)
+			procSetConsoleCursorPosition.Call(uintptr(handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
+		case 'C':
+			n, err = strconv.Atoi(buf.String())
+			if err != nil {
+				continue
+			}
+			procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+			csbi.cursorPosition.x += short(n)
+			procSetConsoleCursorPosition.Call(uintptr(handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
+		case 'D':
+			n, err = strconv.Atoi(buf.String())
+			if err != nil {
+				continue
+			}
+			procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+			csbi.cursorPosition.x -= short(n)
+			if csbi.cursorPosition.x < 0 {
+				csbi.cursorPosition.x = 0
+			}
+			procSetConsoleCursorPosition.Call(uintptr(handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
+		case 'E':
+			n, err = strconv.Atoi(buf.String())
+			if err != nil {
+				continue
+			}
+			procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+			csbi.cursorPosition.x = 0
+			csbi.cursorPosition.y += short(n)
+			procSetConsoleCursorPosition.Call(uintptr(handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
+		case 'F':
+			n, err = strconv.Atoi(buf.String())
+			if err != nil {
+				continue
+			}
+			procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+			csbi.cursorPosition.x = 0
+			csbi.cursorPosition.y -= short(n)
+			procSetConsoleCursorPosition.Call(uintptr(handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
+		case 'G':
+			n, err = strconv.Atoi(buf.String())
+			if err != nil {
+				continue
+			}
+			procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+			csbi.cursorPosition.x = short(n - 1)
+			procSetConsoleCursorPosition.Call(uintptr(handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
+		case 'H', 'f':
+			procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+			if buf.Len() > 0 {
+				token := strings.Split(buf.String(), ";")
+				switch len(token) {
+				case 1:
+					n1, err := strconv.Atoi(token[0])
+					if err != nil {
+						continue
+					}
+					csbi.cursorPosition.y = short(n1 - 1)
+				case 2:
+					n1, err := strconv.Atoi(token[0])
+					if err != nil {
+						continue
+					}
+					n2, err := strconv.Atoi(token[1])
+					if err != nil {
+						continue
+					}
+					csbi.cursorPosition.x = short(n2 - 1)
+					csbi.cursorPosition.y = short(n1 - 1)
+				}
+			} else {
+				csbi.cursorPosition.y = 0
+			}
+			procSetConsoleCursorPosition.Call(uintptr(handle), *(*uintptr)(unsafe.Pointer(&csbi.cursorPosition)))
+		case 'J':
+			n := 0
+			if buf.Len() > 0 {
+				n, err = strconv.Atoi(buf.String())
+				if err != nil {
+					continue
+				}
+			}
+			var count, written dword
+			var cursor coord
+			procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+			switch n {
+			case 0:
+				cursor = coord{x: csbi.cursorPosition.x, y: csbi.cursorPosition.y}
+				count = dword(csbi.size.x) - dword(csbi.cursorPosition.x) + dword(csbi.size.y-csbi.cursorPosition.y)*dword(csbi.size.x)
+			case 1:
+				cursor = coord{x: csbi.window.left, y: csbi.window.top}
+				count = dword(csbi.size.x) - dword(csbi.cursorPosition.x) + dword(csbi.window.top-csbi.cursorPosition.y)*dword(csbi.size.x)
+			case 2:
+				cursor = coord{x: csbi.window.left, y: csbi.window.top}
+				count = dword(csbi.size.x) - dword(csbi.cursorPosition.x) + dword(csbi.size.y-csbi.cursorPosition.y)*dword(csbi.size.x)
+			}
+			procFillConsoleOutputCharacter.Call(uintptr(handle), uintptr(' '), uintptr(count), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&written)))
+			procFillConsoleOutputAttribute.Call(uintptr(handle), uintptr(csbi.attributes), uintptr(count), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&written)))
+		case 'K':
+			n := 0
+			if buf.Len() > 0 {
+				n, err = strconv.Atoi(buf.String())
+				if err != nil {
+					continue
+				}
+			}
+			procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+			var cursor coord
+			var count, written dword
+			switch n {
+			case 0:
+				cursor = coord{x: csbi.cursorPosition.x, y: csbi.cursorPosition.y}
+				count = dword(csbi.size.x - csbi.cursorPosition.x)
+			case 1:
+				cursor = coord{x: csbi.window.left, y: csbi.cursorPosition.y}
+				count = dword(csbi.size.x - csbi.cursorPosition.x)
+			case 2:
+				cursor = coord{x: csbi.window.left, y: csbi.cursorPosition.y}
+				count = dword(csbi.size.x)
+			}
+			procFillConsoleOutputCharacter.Call(uintptr(handle), uintptr(' '), uintptr(count), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&written)))
+			procFillConsoleOutputAttribute.Call(uintptr(handle), uintptr(csbi.attributes), uintptr(count), *(*uintptr)(unsafe.Pointer(&cursor)), uintptr(unsafe.Pointer(&written)))
+		case 'm':
+			procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+			attr := csbi.attributes
+			cs := buf.String()
+			if cs == "" {
+				procSetConsoleTextAttribute.Call(uintptr(handle), uintptr(w.oldattr))
+				continue
+			}
+			token := strings.Split(cs, ";")
+			for i := 0; i < len(token); i++ {
+				ns := token[i]
+				if n, err = strconv.Atoi(ns); err == nil {
+					switch {
+					case n == 0 || n == 100:
+						attr = w.oldattr
+					case 1 <= n && n <= 5:
+						attr |= foregroundIntensity
+					case n == 7:
+						attr = ((attr & foregroundMask) << 4) | ((attr & backgroundMask) >> 4)
+					case n == 22 || n == 25:
+						attr |= foregroundIntensity
+					case n == 27:
+						attr = ((attr & foregroundMask) << 4) | ((attr & backgroundMask) >> 4)
+					case 30 <= n && n <= 37:
+						attr &= backgroundMask
+						if (n-30)&1 != 0 {
+							attr |= foregroundRed
+						}
+						if (n-30)&2 != 0 {
+							attr |= foregroundGreen
+						}
+						if (n-30)&4 != 0 {
+							attr |= foregroundBlue
+						}
+					case n == 38: // set foreground color.
+						if i < len(token)-2 && (token[i+1] == "5" || token[i+1] == "05") {
+							if n256, err := strconv.Atoi(token[i+2]); err == nil {
+								if n256foreAttr == nil {
+									n256setup()
+								}
+								attr &= backgroundMask
+								attr |= n256foreAttr[n256]
+								i += 2
+							}
+						} else if len(token) == 5 && token[i+1] == "2" {
+							var r, g, b int
+							r, _ = strconv.Atoi(token[i+2])
+							g, _ = strconv.Atoi(token[i+3])
+							b, _ = strconv.Atoi(token[i+4])
+							i += 4
+							if r > 127 {
+								attr |= foregroundRed
+							}
+							if g > 127 {
+								attr |= foregroundGreen
+							}
+							if b > 127 {
+								attr |= foregroundBlue
+							}
+						} else {
+							attr = attr & (w.oldattr & backgroundMask)
+						}
+					case n == 39: // reset foreground color.
+						attr &= backgroundMask
+						attr |= w.oldattr & foregroundMask
+					case 40 <= n && n <= 47:
+						attr &= foregroundMask
+						if (n-40)&1 != 0 {
+							attr |= backgroundRed
+						}
+						if (n-40)&2 != 0 {
+							attr |= backgroundGreen
+						}
+						if (n-40)&4 != 0 {
+							attr |= backgroundBlue
+						}
+					case n == 48: // set background color.
+						if i < len(token)-2 && token[i+1] == "5" {
+							if n256, err := strconv.Atoi(token[i+2]); err == nil {
+								if n256backAttr == nil {
+									n256setup()
+								}
+								attr &= foregroundMask
+								attr |= n256backAttr[n256]
+								i += 2
+							}
+						} else if len(token) == 5 && token[i+1] == "2" {
+							var r, g, b int
+							r, _ = strconv.Atoi(token[i+2])
+							g, _ = strconv.Atoi(token[i+3])
+							b, _ = strconv.Atoi(token[i+4])
+							i += 4
+							if r > 127 {
+								attr |= backgroundRed
+							}
+							if g > 127 {
+								attr |= backgroundGreen
+							}
+							if b > 127 {
+								attr |= backgroundBlue
+							}
+						} else {
+							attr = attr & (w.oldattr & foregroundMask)
+						}
+					case n == 49: // reset foreground color.
+						attr &= foregroundMask
+						attr |= w.oldattr & backgroundMask
+					case 90 <= n && n <= 97:
+						attr = (attr & backgroundMask)
+						attr |= foregroundIntensity
+						if (n-90)&1 != 0 {
+							attr |= foregroundRed
+						}
+						if (n-90)&2 != 0 {
+							attr |= foregroundGreen
+						}
+						if (n-90)&4 != 0 {
+							attr |= foregroundBlue
+						}
+					case 100 <= n && n <= 107:
+						attr = (attr & foregroundMask)
+						attr |= backgroundIntensity
+						if (n-100)&1 != 0 {
+							attr |= backgroundRed
+						}
+						if (n-100)&2 != 0 {
+							attr |= backgroundGreen
+						}
+						if (n-100)&4 != 0 {
+							attr |= backgroundBlue
+						}
+					}
+					procSetConsoleTextAttribute.Call(uintptr(handle), uintptr(attr))
+				}
+			}
+		case 'h':
+			var ci consoleCursorInfo
+			cs := buf.String()
+			if cs == "5>" {
+				procGetConsoleCursorInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&ci)))
+				ci.visible = 0
+				procSetConsoleCursorInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&ci)))
+			} else if cs == "?25" {
+				procGetConsoleCursorInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&ci)))
+				ci.visible = 1
+				procSetConsoleCursorInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&ci)))
+			} else if cs == "?1049" {
+				if w.althandle == 0 {
+					h, _, _ := procCreateConsoleScreenBuffer.Call(uintptr(genericRead|genericWrite), 0, 0, uintptr(consoleTextmodeBuffer), 0, 0)
+					w.althandle = syscall.Handle(h)
+					if w.althandle != 0 {
+						handle = w.althandle
+					}
+				}
+			}
+		case 'l':
+			var ci consoleCursorInfo
+			cs := buf.String()
+			if cs == "5>" {
+				procGetConsoleCursorInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&ci)))
+				ci.visible = 1
+				procSetConsoleCursorInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&ci)))
+			} else if cs == "?25" {
+				procGetConsoleCursorInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&ci)))
+				ci.visible = 0
+				procSetConsoleCursorInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&ci)))
+			} else if cs == "?1049" {
+				if w.althandle != 0 {
+					syscall.CloseHandle(w.althandle)
+					w.althandle = 0
+					handle = w.handle
+				}
+			}
+		case 's':
+			procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+			w.oldpos = csbi.cursorPosition
+		case 'u':
+			procSetConsoleCursorPosition.Call(uintptr(handle), *(*uintptr)(unsafe.Pointer(&w.oldpos)))
+		}
+	}
+
+	return len(data), nil
+}
+
+type consoleColor struct {
+	rgb       int
+	red       bool
+	green     bool
+	blue      bool
+	intensity bool
+}
+
+func (c consoleColor) foregroundAttr() (attr word) {
+	if c.red {
+		attr |= foregroundRed
+	}
+	if c.green {
+		attr |= foregroundGreen
+	}
+	if c.blue {
+		attr |= foregroundBlue
+	}
+	if c.intensity {
+		attr |= foregroundIntensity
+	}
+	return
+}
+
+func (c consoleColor) backgroundAttr() (attr word) {
+	if c.red {
+		attr |= backgroundRed
+	}
+	if c.green {
+		attr |= backgroundGreen
+	}
+	if c.blue {
+		attr |= backgroundBlue
+	}
+	if c.intensity {
+		attr |= backgroundIntensity
+	}
+	return
+}
+
+var color16 = []consoleColor{
+	{0x000000, false, false, false, false},
+	{0x000080, false, false, true, false},
+	{0x008000, false, true, false, false},
+	{0x008080, false, true, true, false},
+	{0x800000, true, false, false, false},
+	{0x800080, true, false, true, false},
+	{0x808000, true, true, false, false},
+	{0xc0c0c0, true, true, true, false},
+	{0x808080, false, false, false, true},
+	{0x0000ff, false, false, true, true},
+	{0x00ff00, false, true, false, true},
+	{0x00ffff, false, true, true, true},
+	{0xff0000, true, false, false, true},
+	{0xff00ff, true, false, true, true},
+	{0xffff00, true, true, false, true},
+	{0xffffff, true, true, true, true},
+}
+
+type hsv struct {
+	h, s, v float32
+}
+
+func (a hsv) dist(b hsv) float32 {
+	dh := a.h - b.h
+	switch {
+	case dh > 0.5:
+		dh = 1 - dh
+	case dh < -0.5:
+		dh = -1 - dh
+	}
+	ds := a.s - b.s
+	dv := a.v - b.v
+	return float32(math.Sqrt(float64(dh*dh + ds*ds + dv*dv)))
+}
+
+func toHSV(rgb int) hsv {
+	r, g, b := float32((rgb&0xFF0000)>>16)/256.0,
+		float32((rgb&0x00FF00)>>8)/256.0,
+		float32(rgb&0x0000FF)/256.0
+	min, max := minmax3f(r, g, b)
+	h := max - min
+	if h > 0 {
+		if max == r {
+			h = (g - b) / h
+			if h < 0 {
+				h += 6
+			}
+		} else if max == g {
+			h = 2 + (b-r)/h
+		} else {
+			h = 4 + (r-g)/h
+		}
+	}
+	h /= 6.0
+	s := max - min
+	if max != 0 {
+		s /= max
+	}
+	v := max
+	return hsv{h: h, s: s, v: v}
+}
+
+type hsvTable []hsv
+
+func toHSVTable(rgbTable []consoleColor) hsvTable {
+	t := make(hsvTable, len(rgbTable))
+	for i, c := range rgbTable {
+		t[i] = toHSV(c.rgb)
+	}
+	return t
+}
+
+func (t hsvTable) find(rgb int) consoleColor {
+	hsv := toHSV(rgb)
+	n := 7
+	l := float32(5.0)
+	for i, p := range t {
+		d := hsv.dist(p)
+		if d < l {
+			l, n = d, i
+		}
+	}
+	return color16[n]
+}
+
+func minmax3f(a, b, c float32) (min, max float32) {
+	if a < b {
+		if b < c {
+			return a, c
+		} else if a < c {
+			return a, b
+		} else {
+			return c, b
+		}
+	} else {
+		if a < c {
+			return b, c
+		} else if b < c {
+			return b, a
+		} else {
+			return c, a
+		}
+	}
+}
+
+var n256foreAttr []word
+var n256backAttr []word
+
+func n256setup() {
+	n256foreAttr = make([]word, 256)
+	n256backAttr = make([]word, 256)
+	t := toHSVTable(color16)
+	for i, rgb := range color256 {
+		c := t.find(rgb)
+		n256foreAttr[i] = c.foregroundAttr()
+		n256backAttr[i] = c.backgroundAttr()
+	}
+}

--- a/vendor/github.com/mattn/go-colorable/noncolorable.go
+++ b/vendor/github.com/mattn/go-colorable/noncolorable.go
@@ -1,0 +1,55 @@
+package colorable
+
+import (
+	"bytes"
+	"io"
+)
+
+// NonColorable hold writer but remove escape sequence.
+type NonColorable struct {
+	out io.Writer
+}
+
+// NewNonColorable return new instance of Writer which remove escape sequence from Writer.
+func NewNonColorable(w io.Writer) io.Writer {
+	return &NonColorable{out: w}
+}
+
+// Write write data on console
+func (w *NonColorable) Write(data []byte) (n int, err error) {
+	er := bytes.NewReader(data)
+	var bw [1]byte
+loop:
+	for {
+		c1, err := er.ReadByte()
+		if err != nil {
+			break loop
+		}
+		if c1 != 0x1b {
+			bw[0] = c1
+			w.out.Write(bw[:])
+			continue
+		}
+		c2, err := er.ReadByte()
+		if err != nil {
+			break loop
+		}
+		if c2 != 0x5b {
+			continue
+		}
+
+		var buf bytes.Buffer
+		for {
+			c, err := er.ReadByte()
+			if err != nil {
+				break loop
+			}
+			if ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || c == '@' {
+				break
+			}
+			buf.Write([]byte(string(c)))
+		}
+	}
+
+	return len(data), nil
+}

--- a/vendor/github.com/mattn/go-isatty/LICENSE
+++ b/vendor/github.com/mattn/go-isatty/LICENSE
@@ -1,0 +1,9 @@
+Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
+
+MIT License (Expat)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/mattn/go-isatty/doc.go
+++ b/vendor/github.com/mattn/go-isatty/doc.go
@@ -1,0 +1,2 @@
+// Package isatty implements interface to isatty
+package isatty

--- a/vendor/github.com/mattn/go-isatty/isatty_appengine.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_appengine.go
@@ -1,0 +1,15 @@
+// +build appengine
+
+package isatty
+
+// IsTerminal returns true if the file descriptor is terminal which
+// is always false on on appengine classic which is a sandboxed PaaS.
+func IsTerminal(fd uintptr) bool {
+	return false
+}
+
+// IsCygwinTerminal() return true if the file descriptor is a cygwin or msys2
+// terminal. This is also always false on this environment.
+func IsCygwinTerminal(fd uintptr) bool {
+	return false
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_bsd.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_bsd.go
@@ -1,0 +1,18 @@
+// +build darwin freebsd openbsd netbsd dragonfly
+// +build !appengine
+
+package isatty
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const ioctlReadTermios = syscall.TIOCGETA
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_linux.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_linux.go
@@ -1,0 +1,18 @@
+// +build linux
+// +build !appengine,!ppc64,!ppc64le
+
+package isatty
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const ioctlReadTermios = syscall.TCGETS
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_linux_ppc64x.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_linux_ppc64x.go
@@ -1,0 +1,19 @@
+// +build linux
+// +build ppc64 ppc64le
+
+package isatty
+
+import (
+	"unsafe"
+
+	syscall "golang.org/x/sys/unix"
+)
+
+const ioctlReadTermios = syscall.TCGETS
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_others.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_others.go
@@ -1,0 +1,10 @@
+// +build !windows
+// +build !appengine
+
+package isatty
+
+// IsCygwinTerminal return true if the file descriptor is a cygwin or msys2
+// terminal. This is also always false on this environment.
+func IsCygwinTerminal(fd uintptr) bool {
+	return false
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_solaris.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_solaris.go
@@ -1,0 +1,16 @@
+// +build solaris
+// +build !appengine
+
+package isatty
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+// see: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c
+func IsTerminal(fd uintptr) bool {
+	var termio unix.Termio
+	err := unix.IoctlSetTermio(int(fd), unix.TCGETA, &termio)
+	return err == nil
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_windows.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_windows.go
@@ -1,0 +1,94 @@
+// +build windows
+// +build !appengine
+
+package isatty
+
+import (
+	"strings"
+	"syscall"
+	"unicode/utf16"
+	"unsafe"
+)
+
+const (
+	fileNameInfo uintptr = 2
+	fileTypePipe         = 3
+)
+
+var (
+	kernel32                         = syscall.NewLazyDLL("kernel32.dll")
+	procGetConsoleMode               = kernel32.NewProc("GetConsoleMode")
+	procGetFileInformationByHandleEx = kernel32.NewProc("GetFileInformationByHandleEx")
+	procGetFileType                  = kernel32.NewProc("GetFileType")
+)
+
+func init() {
+	// Check if GetFileInformationByHandleEx is available.
+	if procGetFileInformationByHandleEx.Find() != nil {
+		procGetFileInformationByHandleEx = nil
+	}
+}
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var st uint32
+	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, fd, uintptr(unsafe.Pointer(&st)), 0)
+	return r != 0 && e == 0
+}
+
+// Check pipe name is used for cygwin/msys2 pty.
+// Cygwin/MSYS2 PTY has a name like:
+//   \{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-master
+func isCygwinPipeName(name string) bool {
+	token := strings.Split(name, "-")
+	if len(token) < 5 {
+		return false
+	}
+
+	if token[0] != `\msys` && token[0] != `\cygwin` {
+		return false
+	}
+
+	if token[1] == "" {
+		return false
+	}
+
+	if !strings.HasPrefix(token[2], "pty") {
+		return false
+	}
+
+	if token[3] != `from` && token[3] != `to` {
+		return false
+	}
+
+	if token[4] != "master" {
+		return false
+	}
+
+	return true
+}
+
+// IsCygwinTerminal() return true if the file descriptor is a cygwin or msys2
+// terminal.
+func IsCygwinTerminal(fd uintptr) bool {
+	if procGetFileInformationByHandleEx == nil {
+		return false
+	}
+
+	// Cygwin/msys's pty is a pipe.
+	ft, _, e := syscall.Syscall(procGetFileType.Addr(), 1, fd, 0, 0)
+	if ft != fileTypePipe || e != 0 {
+		return false
+	}
+
+	var buf [2 + syscall.MAX_PATH]uint16
+	r, _, e := syscall.Syscall6(procGetFileInformationByHandleEx.Addr(),
+		4, fd, fileNameInfo, uintptr(unsafe.Pointer(&buf)),
+		uintptr(len(buf)*2), 0, 0)
+	if r == 0 || e != 0 {
+		return false
+	}
+
+	l := *(*uint32)(unsafe.Pointer(&buf))
+	return isCygwinPipeName(string(utf16.Decode(buf[2 : 2+l/2])))
+}

--- a/vendor/github.com/mgutz/ansi/LICENSE
+++ b/vendor/github.com/mgutz/ansi/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+Copyright (c) 2013 Mario L. Gutierrez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/vendor/github.com/mgutz/ansi/ansi.go
+++ b/vendor/github.com/mgutz/ansi/ansi.go
@@ -1,0 +1,285 @@
+package ansi
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	black = iota
+	red
+	green
+	yellow
+	blue
+	magenta
+	cyan
+	white
+	defaultt = 9
+
+	normalIntensityFG = 30
+	highIntensityFG   = 90
+	normalIntensityBG = 40
+	highIntensityBG   = 100
+
+	start         = "\033["
+	bold          = "1;"
+	blink         = "5;"
+	underline     = "4;"
+	inverse       = "7;"
+	strikethrough = "9;"
+
+	// Reset is the ANSI reset escape sequence
+	Reset = "\033[0m"
+	// DefaultBG is the default background
+	DefaultBG = "\033[49m"
+	// DefaultFG is the default foreground
+	DefaultFG = "\033[39m"
+)
+
+// Black FG
+var Black string
+
+// Red FG
+var Red string
+
+// Green FG
+var Green string
+
+// Yellow FG
+var Yellow string
+
+// Blue FG
+var Blue string
+
+// Magenta FG
+var Magenta string
+
+// Cyan FG
+var Cyan string
+
+// White FG
+var White string
+
+// LightBlack FG
+var LightBlack string
+
+// LightRed FG
+var LightRed string
+
+// LightGreen FG
+var LightGreen string
+
+// LightYellow FG
+var LightYellow string
+
+// LightBlue FG
+var LightBlue string
+
+// LightMagenta FG
+var LightMagenta string
+
+// LightCyan FG
+var LightCyan string
+
+// LightWhite FG
+var LightWhite string
+
+var (
+	plain = false
+	// Colors maps common color names to their ANSI color code.
+	Colors = map[string]int{
+		"black":   black,
+		"red":     red,
+		"green":   green,
+		"yellow":  yellow,
+		"blue":    blue,
+		"magenta": magenta,
+		"cyan":    cyan,
+		"white":   white,
+		"default": defaultt,
+	}
+)
+
+func init() {
+	for i := 0; i < 256; i++ {
+		Colors[strconv.Itoa(i)] = i
+	}
+
+	Black = ColorCode("black")
+	Red = ColorCode("red")
+	Green = ColorCode("green")
+	Yellow = ColorCode("yellow")
+	Blue = ColorCode("blue")
+	Magenta = ColorCode("magenta")
+	Cyan = ColorCode("cyan")
+	White = ColorCode("white")
+	LightBlack = ColorCode("black+h")
+	LightRed = ColorCode("red+h")
+	LightGreen = ColorCode("green+h")
+	LightYellow = ColorCode("yellow+h")
+	LightBlue = ColorCode("blue+h")
+	LightMagenta = ColorCode("magenta+h")
+	LightCyan = ColorCode("cyan+h")
+	LightWhite = ColorCode("white+h")
+}
+
+// ColorCode returns the ANSI color color code for style.
+func ColorCode(style string) string {
+	return colorCode(style).String()
+}
+
+// Gets the ANSI color code for a style.
+func colorCode(style string) *bytes.Buffer {
+	buf := bytes.NewBufferString("")
+	if plain || style == "" {
+		return buf
+	}
+	if style == "reset" {
+		buf.WriteString(Reset)
+		return buf
+	} else if style == "off" {
+		return buf
+	}
+
+	foregroundBackground := strings.Split(style, ":")
+	foreground := strings.Split(foregroundBackground[0], "+")
+	fgKey := foreground[0]
+	fg := Colors[fgKey]
+	fgStyle := ""
+	if len(foreground) > 1 {
+		fgStyle = foreground[1]
+	}
+
+	bg, bgStyle := "", ""
+
+	if len(foregroundBackground) > 1 {
+		background := strings.Split(foregroundBackground[1], "+")
+		bg = background[0]
+		if len(background) > 1 {
+			bgStyle = background[1]
+		}
+	}
+
+	buf.WriteString(start)
+	base := normalIntensityFG
+	if len(fgStyle) > 0 {
+		if strings.Contains(fgStyle, "b") {
+			buf.WriteString(bold)
+		}
+		if strings.Contains(fgStyle, "B") {
+			buf.WriteString(blink)
+		}
+		if strings.Contains(fgStyle, "u") {
+			buf.WriteString(underline)
+		}
+		if strings.Contains(fgStyle, "i") {
+			buf.WriteString(inverse)
+		}
+		if strings.Contains(fgStyle, "s") {
+			buf.WriteString(strikethrough)
+		}
+		if strings.Contains(fgStyle, "h") {
+			base = highIntensityFG
+		}
+	}
+
+	// if 256-color
+	n, err := strconv.Atoi(fgKey)
+	if err == nil {
+		fmt.Fprintf(buf, "38;5;%d;", n)
+	} else {
+		fmt.Fprintf(buf, "%d;", base+fg)
+	}
+
+	base = normalIntensityBG
+	if len(bg) > 0 {
+		if strings.Contains(bgStyle, "h") {
+			base = highIntensityBG
+		}
+		// if 256-color
+		n, err := strconv.Atoi(bg)
+		if err == nil {
+			fmt.Fprintf(buf, "48;5;%d;", n)
+		} else {
+			fmt.Fprintf(buf, "%d;", base+Colors[bg])
+		}
+	}
+
+	// remove last ";"
+	buf.Truncate(buf.Len() - 1)
+	buf.WriteRune('m')
+	return buf
+}
+
+// Color colors a string based on the ANSI color code for style.
+func Color(s, style string) string {
+	if plain || len(style) < 1 {
+		return s
+	}
+	buf := colorCode(style)
+	buf.WriteString(s)
+	buf.WriteString(Reset)
+	return buf.String()
+}
+
+// ColorFunc creates a closure to avoid computation ANSI color code.
+func ColorFunc(style string) func(string) string {
+	if style == "" {
+		return func(s string) string {
+			return s
+		}
+	}
+	color := ColorCode(style)
+	return func(s string) string {
+		if plain || s == "" {
+			return s
+		}
+		buf := bytes.NewBufferString(color)
+		buf.WriteString(s)
+		buf.WriteString(Reset)
+		result := buf.String()
+		return result
+	}
+}
+
+// DisableColors disables ANSI color codes. The default is false (colors are on).
+func DisableColors(disable bool) {
+	plain = disable
+	if plain {
+		Black = ""
+		Red = ""
+		Green = ""
+		Yellow = ""
+		Blue = ""
+		Magenta = ""
+		Cyan = ""
+		White = ""
+		LightBlack = ""
+		LightRed = ""
+		LightGreen = ""
+		LightYellow = ""
+		LightBlue = ""
+		LightMagenta = ""
+		LightCyan = ""
+		LightWhite = ""
+	} else {
+		Black = ColorCode("black")
+		Red = ColorCode("red")
+		Green = ColorCode("green")
+		Yellow = ColorCode("yellow")
+		Blue = ColorCode("blue")
+		Magenta = ColorCode("magenta")
+		Cyan = ColorCode("cyan")
+		White = ColorCode("white")
+		LightBlack = ColorCode("black+h")
+		LightRed = ColorCode("red+h")
+		LightGreen = ColorCode("green+h")
+		LightYellow = ColorCode("yellow+h")
+		LightBlue = ColorCode("blue+h")
+		LightMagenta = ColorCode("magenta+h")
+		LightCyan = ColorCode("cyan+h")
+		LightWhite = ColorCode("white+h")
+	}
+}

--- a/vendor/github.com/mgutz/ansi/doc.go
+++ b/vendor/github.com/mgutz/ansi/doc.go
@@ -1,0 +1,65 @@
+/*
+Package ansi is a small, fast library to create ANSI colored strings and codes.
+
+Installation
+
+    # this installs the color viewer and the package
+    go get -u github.com/mgutz/ansi/cmd/ansi-mgutz
+
+Example
+
+	// colorize a string, SLOW
+	msg := ansi.Color("foo", "red+b:white")
+
+	// create a closure to avoid recalculating ANSI code compilation
+	phosphorize := ansi.ColorFunc("green+h:black")
+	msg = phosphorize("Bring back the 80s!")
+	msg2 := phospohorize("Look, I'm a CRT!")
+
+	// cache escape codes and build strings manually
+	lime := ansi.ColorCode("green+h:black")
+	reset := ansi.ColorCode("reset")
+
+	fmt.Println(lime, "Bring back the 80s!", reset)
+
+Other examples
+
+	Color(s, "red")            // red
+	Color(s, "red+b")          // red bold
+	Color(s, "red+B")          // red blinking
+	Color(s, "red+u")          // red underline
+	Color(s, "red+bh")         // red bold bright
+	Color(s, "red:white")      // red on white
+	Color(s, "red+b:white+h")  // red bold on white bright
+	Color(s, "red+B:white+h")  // red blink on white bright
+
+To view color combinations, from terminal
+
+	ansi-mgutz
+
+Style format
+
+	"foregroundColor+attributes:backgroundColor+attributes"
+
+Colors
+
+	black
+	red
+	green
+	yellow
+	blue
+	magenta
+	cyan
+	white
+
+Attributes
+
+	b = bold foreground
+	B = Blink foreground
+	u = underline foreground
+	h = high intensity (bright) foreground, background
+	i = inverse
+
+Wikipedia ANSI escape codes [Colors](http://en.wikipedia.org/wiki/ANSI_escape_code#Colors)
+*/
+package ansi

--- a/vendor/github.com/mgutz/ansi/print.go
+++ b/vendor/github.com/mgutz/ansi/print.go
@@ -1,0 +1,57 @@
+package ansi
+
+import (
+	"fmt"
+	"sort"
+
+	colorable "github.com/mattn/go-colorable"
+)
+
+// PrintStyles prints all style combinations to the terminal.
+func PrintStyles() {
+	// for compatibility with Windows, not needed for *nix
+	stdout := colorable.NewColorableStdout()
+
+	bgColors := []string{
+		"",
+		":black",
+		":red",
+		":green",
+		":yellow",
+		":blue",
+		":magenta",
+		":cyan",
+		":white",
+	}
+
+	keys := make([]string, 0, len(Colors))
+	for k := range Colors {
+		keys = append(keys, k)
+	}
+
+	sort.Sort(sort.StringSlice(keys))
+
+	for _, fg := range keys {
+		for _, bg := range bgColors {
+			fmt.Fprintln(stdout, padColor(fg, []string{"" + bg, "+b" + bg, "+bh" + bg, "+u" + bg}))
+			fmt.Fprintln(stdout, padColor(fg, []string{"+s" + bg, "+i" + bg}))
+			fmt.Fprintln(stdout, padColor(fg, []string{"+uh" + bg, "+B" + bg, "+Bb" + bg /* backgrounds */, "" + bg + "+h"}))
+			fmt.Fprintln(stdout, padColor(fg, []string{"+b" + bg + "+h", "+bh" + bg + "+h", "+u" + bg + "+h", "+uh" + bg + "+h"}))
+		}
+	}
+}
+
+func pad(s string, length int) string {
+	for len(s) < length {
+		s += " "
+	}
+	return s
+}
+
+func padColor(color string, styles []string) string {
+	buffer := ""
+	for _, style := range styles {
+		buffer += Color(pad(color+style, 20), color+style)
+	}
+	return buffer
+}

--- a/vendor/github.com/openshift/installer/pkg/asset/installconfig/aws/aws.go
+++ b/vendor/github.com/openshift/installer/pkg/asset/installconfig/aws/aws.go
@@ -1,0 +1,163 @@
+// Package aws collects AWS-specific configuration.
+package aws
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/defaults"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	survey "gopkg.in/AlecAivazis/survey.v1"
+
+	"github.com/openshift/installer/pkg/types/aws"
+	"github.com/openshift/installer/pkg/types/aws/validation"
+)
+
+// Platform collects AWS-specific configuration.
+func Platform() (*aws.Platform, error) {
+	longRegions := make([]string, 0, len(validation.Regions))
+	shortRegions := make([]string, 0, len(validation.Regions))
+	for id, location := range validation.Regions {
+		longRegions = append(longRegions, fmt.Sprintf("%s (%s)", id, location))
+		shortRegions = append(shortRegions, id)
+	}
+	regionTransform := survey.TransformString(func(s string) string {
+		return strings.SplitN(s, " ", 2)[0]
+	})
+
+	defaultRegion := "us-east-1"
+	_, ok := validation.Regions[defaultRegion]
+	if !ok {
+		panic(fmt.Sprintf("installer bug: invalid default AWS region %q", defaultRegion))
+	}
+
+	ssn, err := GetSession()
+	if err != nil {
+		return nil, err
+	}
+
+	defaultRegionPointer := ssn.Config.Region
+	if defaultRegionPointer != nil && *defaultRegionPointer != "" {
+		_, ok := validation.Regions[*defaultRegionPointer]
+		if ok {
+			defaultRegion = *defaultRegionPointer
+		} else {
+			logrus.Warnf("Unrecognized AWS region %q, defaulting to %s", *defaultRegionPointer, defaultRegion)
+		}
+	}
+
+	sort.Strings(longRegions)
+	sort.Strings(shortRegions)
+
+	var region string
+	err = survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Select{
+				Message: "Region",
+				Help:    "The AWS region to be used for installation.",
+				Default: fmt.Sprintf("%s (%s)", defaultRegion, validation.Regions[defaultRegion]),
+				Options: longRegions,
+			},
+			Validate: survey.ComposeValidators(survey.Required, func(ans interface{}) error {
+				choice := regionTransform(ans).(string)
+				i := sort.SearchStrings(shortRegions, choice)
+				if i == len(shortRegions) || shortRegions[i] != choice {
+					return errors.Errorf("invalid region %q", choice)
+				}
+				return nil
+			}),
+			Transform: regionTransform,
+		},
+	}, &region)
+	if err != nil {
+		return nil, err
+	}
+
+	return &aws.Platform{
+		Region: region,
+	}, nil
+}
+
+// GetSession returns an AWS session by checking credentials
+// and, if no creds are found, asks for them and stores them on disk in a config file
+func GetSession() (*session.Session, error) {
+	ssn := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
+	ssn.Config.Credentials = credentials.NewChainCredentials([]credentials.Provider{
+		&credentials.EnvProvider{},
+		&credentials.SharedCredentialsProvider{},
+	})
+	_, err := ssn.Config.Credentials.Get()
+	if err == credentials.ErrNoValidProvidersFoundInChain {
+		err = getCredentials()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ssn, nil
+}
+
+func getCredentials() error {
+	var keyID string
+	err := survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Input{
+				Message: "AWS Access Key ID",
+				Help:    "The AWS access key ID to use for installation (this is not your username).\nhttps://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html",
+			},
+		},
+	}, &keyID)
+	if err != nil {
+		return err
+	}
+
+	var secretKey string
+	err = survey.Ask([]*survey.Question{
+		{
+			Prompt: &survey.Password{
+				Message: "AWS Secret Access Key",
+				Help:    "The AWS secret access key corresponding to your access key ID (this is not your password).",
+			},
+		},
+	}, &secretKey)
+	if err != nil {
+		return err
+	}
+
+	tmpl, err := template.New("aws-credentials").Parse(`# Created by openshift-install
+# https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
+[default]
+aws_access_key_id={{.KeyID}}
+aws_secret_access_key={{.SecretKey}}
+`)
+	if err != nil {
+		return err
+	}
+
+	path := defaults.SharedCredentialsFilename()
+	logrus.Infof("Writing AWS credentials to %q (https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)", path)
+	err = os.MkdirAll(filepath.Dir(path), 0700)
+	if err != nil {
+		return err
+	}
+
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return tmpl.Execute(file, map[string]string{
+		"KeyID":     keyID,
+		"SecretKey": secretKey,
+	})
+}

--- a/vendor/github.com/openshift/installer/pkg/asset/installconfig/aws/basedomain.go
+++ b/vendor/github.com/openshift/installer/pkg/asset/installconfig/aws/basedomain.go
@@ -1,0 +1,80 @@
+package aws
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	survey "gopkg.in/AlecAivazis/survey.v1"
+)
+
+// IsForbidden returns true if and only if the input error is an HTTP
+// 403 error from the AWS API.
+func IsForbidden(err error) bool {
+	requestError, ok := err.(awserr.RequestFailure)
+	return ok && requestError.StatusCode() == http.StatusForbidden
+}
+
+// GetBaseDomain returns a base domain chosen from among the account's
+// public routes.
+func GetBaseDomain() (string, error) {
+	session, err := GetSession()
+	if err != nil {
+		return "", err
+	}
+
+	client := route53.New(session)
+	publicZoneMap := map[string]struct{}{}
+	exists := struct{}{}
+	input := route53.ListHostedZonesInput{}
+	for i := 0; true; i++ {
+		logrus.Debugf("listing AWS hosted zones (page %d)", i)
+		response, err := client.ListHostedZones(&input)
+		if err != nil {
+			return "", errors.Wrap(err, "list hosted zones")
+		}
+
+		for _, zone := range response.HostedZones {
+			if !*zone.Config.PrivateZone {
+				publicZoneMap[strings.TrimSuffix(*zone.Name, ".")] = exists
+			}
+		}
+
+		if !*response.IsTruncated {
+			break
+		}
+
+		input.Marker = response.NextMarker
+	}
+
+	publicZones := make([]string, 0, len(publicZoneMap))
+	for name := range publicZoneMap {
+		publicZones = append(publicZones, name)
+	}
+	sort.Strings(publicZones)
+	if len(publicZones) == 0 {
+		return "", errors.New("no public Route 53 hosted zones found")
+	}
+
+	var domain string
+	if err := survey.AskOne(&survey.Select{
+		Message: "Base Domain",
+		Help:    "The base domain of the cluster. All DNS records will be sub-domains of this base and will also include the cluster name.\n\nIf you don't see you intended base-domain listed, create a new public Route53 hosted zone and rerun the installer.",
+		Options: publicZones,
+	}, &domain, func(ans interface{}) error {
+		choice := ans.(string)
+		i := sort.SearchStrings(publicZones, choice)
+		if i == len(publicZones) || publicZones[i] != choice {
+			return errors.Errorf("invalid base domain %q", choice)
+		}
+		return nil
+	}); err != nil {
+		return "", errors.Wrap(err, "failed UserInput for base domain")
+	}
+
+	return domain, nil
+}

--- a/vendor/github.com/openshift/installer/pkg/asset/machines/aws/zones.go
+++ b/vendor/github.com/openshift/installer/pkg/asset/machines/aws/zones.go
@@ -4,13 +4,16 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	awsutil "github.com/openshift/installer/pkg/asset/installconfig/aws"
 )
 
 // AvailabilityZones retrieves a list of availability zones for the given region.
 func AvailabilityZones(region string) ([]string, error) {
-	ec2Client := ec2Client(region)
+	ec2Client, err := ec2Client(region)
+	if err != nil {
+		return nil, err
+	}
 	zones, err := fetchAvailabilityZones(ec2Client, region)
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch availability zones: %v", err)
@@ -18,14 +21,14 @@ func AvailabilityZones(region string) ([]string, error) {
 	return zones, nil
 }
 
-func ec2Client(region string) *ec2.EC2 {
-	ssn := session.Must(session.NewSessionWithOptions(session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-		Config: aws.Config{
-			Region: aws.String(region),
-		},
-	}))
-	return ec2.New(ssn)
+func ec2Client(region string) (*ec2.EC2, error) {
+	ssn, err := awsutil.GetSession()
+	if err != nil {
+		return nil, err
+	}
+
+	client := ec2.New(ssn, aws.NewConfig().WithRegion(region))
+	return client, nil
 }
 
 func fetchAvailabilityZones(client *ec2.EC2, region string) ([]string, error) {

--- a/vendor/github.com/openshift/installer/pkg/destroy/aws/aws.go
+++ b/vendor/github.com/openshift/installer/pkg/destroy/aws/aws.go
@@ -47,18 +47,14 @@ type ClusterUninstaller struct {
 	//   }
 	//
 	// will match resources with (a:b and c:d) or d:e.
-	Filters     []Filter // filter(s) we will be searching for
-	Logger      logrus.FieldLogger
-	Region      string
-	ClusterName string
+	Filters []Filter // filter(s) we will be searching for
+	Logger  logrus.FieldLogger
+	Region  string
 }
 
 func (o *ClusterUninstaller) validate() error {
 	if len(o.Filters) == 0 {
 		return errors.Errorf("you must specify at least one tag filter")
-	}
-	if len(o.ClusterName) == 0 {
-		return errors.Errorf("you must specify cluster-name")
 	}
 	return nil
 }
@@ -143,6 +139,7 @@ func (o *ClusterUninstaller) Run() error {
 				if err != nil {
 					err = errors.Wrapf(err, "get tagged resources")
 					o.Logger.Info(err)
+					matched = true
 					loopError = err
 				}
 			}

--- a/vendor/github.com/openshift/installer/pkg/types/aws/machinepool.go
+++ b/vendor/github.com/openshift/installer/pkg/types/aws/machinepool.go
@@ -10,10 +10,6 @@ type MachinePool struct {
 	// eg. m4-large
 	InstanceType string `json:"type"`
 
-	// IAMRoleName defines the IAM role associated
-	// with the ec2 instance.
-	IAMRoleName string `json:"iamRoleName"`
-
 	// EC2RootVolume defines the storage for ec2 instance.
 	EC2RootVolume `json:"rootVolume"`
 }
@@ -30,9 +26,6 @@ func (a *MachinePool) Set(required *MachinePool) {
 
 	if required.InstanceType != "" {
 		a.InstanceType = required.InstanceType
-	}
-	if required.IAMRoleName != "" {
-		a.IAMRoleName = required.IAMRoleName
 	}
 
 	if required.EC2RootVolume.IOPS != 0 {

--- a/vendor/github.com/openshift/installer/pkg/types/aws/validation/machinepool.go
+++ b/vendor/github.com/openshift/installer/pkg/types/aws/validation/machinepool.go
@@ -1,0 +1,19 @@
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/openshift/installer/pkg/types/aws"
+)
+
+// ValidateMachinePool checks that the specified machine pool is valid.
+func ValidateMachinePool(p *aws.MachinePool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if p.IOPS < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("iops"), p.IOPS, "Storage IOPS must be positive"))
+	}
+	if p.Size < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("size"), p.IOPS, "Storage size must be positive"))
+	}
+	return allErrs
+}

--- a/vendor/github.com/openshift/installer/pkg/types/aws/validation/platform.go
+++ b/vendor/github.com/openshift/installer/pkg/types/aws/validation/platform.go
@@ -1,0 +1,58 @@
+package validation
+
+import (
+	"sort"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/openshift/installer/pkg/types/aws"
+)
+
+var (
+	// Regions is a map of the known AWS regions. The key of the map is
+	// the short name of the region. The value of the map is the long
+	// name of the region.
+	Regions = map[string]string{
+		"ap-northeast-1": "Tokyo",
+		"ap-northeast-2": "Seoul",
+		"ap-northeast-3": "Osaka-Local",
+		"ap-south-1":     "Mumbai",
+		"ap-southeast-1": "Singapore",
+		"ap-southeast-2": "Sydney",
+		"ca-central-1":   "Central",
+		"cn-north-1":     "Beijing",
+		"cn-northwest-1": "Ningxia",
+		"eu-central-1":   "Frankfurt",
+		"eu-west-1":      "Ireland",
+		"eu-west-2":      "London",
+		"eu-west-3":      "Paris",
+		"sa-east-1":      "São Paulo",
+		"us-east-1":      "N. Virginia",
+		"us-east-2":      "Ohio",
+		"us-west-1":      "N. California",
+		"us-west-2":      "Oregon",
+	}
+
+	validRegionValues = func() []string {
+		validValues := make([]string, len(Regions))
+		i := 0
+		for r := range Regions {
+			validValues[i] = r
+			i++
+		}
+		sort.Strings(validValues)
+		return validValues
+	}()
+)
+
+// ValidatePlatform checks that the specified platform is valid.
+func ValidatePlatform(p *aws.Platform, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if _, ok := Regions[p.Region]; !ok {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("region"), p.Region, validRegionValues))
+	}
+	if p.DefaultMachinePlatform != nil {
+		allErrs = append(allErrs, ValidateMachinePool(p.DefaultMachinePlatform, fldPath.Child("defaultMachinePlatform"))...)
+	}
+	return allErrs
+}

--- a/vendor/github.com/openshift/installer/pkg/types/machinepools.go
+++ b/vendor/github.com/openshift/installer/pkg/types/machinepools.go
@@ -9,11 +9,12 @@ import (
 // MachinePool is a pool of machines to be installed.
 type MachinePool struct {
 	// Name is the name of the machine pool.
+	// For the control plane machine pool, the name will always be "master".
+	// For the compute machine pools, the only valid name is "worker".
 	Name string `json:"name"`
 
 	// Replicas is the count of machines for this machine pool.
-	// Default is 1.
-	Replicas *int64 `json:"replicas"`
+	Replicas *int64 `json:"replicas,omitempty"`
 
 	// Platform is configuration for machine pool specific to the platfrom.
 	Platform MachinePoolPlatform `json:"platform"`

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/LICENSE
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Alec Aivazis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/confirm.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/confirm.go
@@ -1,0 +1,138 @@
+package survey
+
+import (
+	"fmt"
+	"regexp"
+
+	"gopkg.in/AlecAivazis/survey.v1/core"
+)
+
+// Confirm is a regular text input that accept yes/no answers. Response type is a bool.
+type Confirm struct {
+	core.Renderer
+	Message string
+	Default bool
+	Help    string
+}
+
+// data available to the templates when processing
+type ConfirmTemplateData struct {
+	Confirm
+	Answer   string
+	ShowHelp bool
+}
+
+// Templates with Color formatting. See Documentation: https://github.com/mgutz/ansi#style-format
+var ConfirmQuestionTemplate = `
+{{- if .ShowHelp }}{{- color "cyan"}}{{ HelpIcon }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- color "green+hb"}}{{ QuestionIcon }} {{color "reset"}}
+{{- color "default+hb"}}{{ .Message }} {{color "reset"}}
+{{- if .Answer}}
+  {{- color "cyan"}}{{.Answer}}{{color "reset"}}{{"\n"}}
+{{- else }}
+  {{- if and .Help (not .ShowHelp)}}{{color "cyan"}}[{{ HelpInputRune }} for help]{{color "reset"}} {{end}}
+  {{- color "white"}}{{if .Default}}(Y/n) {{else}}(y/N) {{end}}{{color "reset"}}
+{{- end}}`
+
+// the regex for answers
+var (
+	yesRx = regexp.MustCompile("^(?i:y(?:es)?)$")
+	noRx  = regexp.MustCompile("^(?i:n(?:o)?)$")
+)
+
+func yesNo(t bool) string {
+	if t {
+		return "Yes"
+	}
+	return "No"
+}
+
+func (c *Confirm) getBool(showHelp bool) (bool, error) {
+	cursor := c.NewCursor()
+	rr := c.NewRuneReader()
+	rr.SetTermMode()
+	defer rr.RestoreTermMode()
+
+	// start waiting for input
+	for {
+		line, err := rr.ReadLine(0)
+		if err != nil {
+			return false, err
+		}
+		// move back up a line to compensate for the \n echoed from terminal
+		cursor.PreviousLine(1)
+		val := string(line)
+
+		// get the answer that matches the
+		var answer bool
+		switch {
+		case yesRx.Match([]byte(val)):
+			answer = true
+		case noRx.Match([]byte(val)):
+			answer = false
+		case val == "":
+			answer = c.Default
+		case val == string(core.HelpInputRune) && c.Help != "":
+			err := c.Render(
+				ConfirmQuestionTemplate,
+				ConfirmTemplateData{Confirm: *c, ShowHelp: true},
+			)
+			if err != nil {
+				// use the default value and bubble up
+				return c.Default, err
+			}
+			showHelp = true
+			continue
+		default:
+			// we didnt get a valid answer, so print error and prompt again
+			if err := c.Error(fmt.Errorf("%q is not a valid answer, please try again.", val)); err != nil {
+				return c.Default, err
+			}
+			err := c.Render(
+				ConfirmQuestionTemplate,
+				ConfirmTemplateData{Confirm: *c, ShowHelp: showHelp},
+			)
+			if err != nil {
+				// use the default value and bubble up
+				return c.Default, err
+			}
+			continue
+		}
+		return answer, nil
+	}
+	// should not get here
+	return c.Default, nil
+}
+
+/*
+Prompt prompts the user with a simple text field and expects a reply followed
+by a carriage return.
+
+	likesPie := false
+	prompt := &survey.Confirm{ Message: "What is your name?" }
+	survey.AskOne(prompt, &likesPie, nil)
+*/
+func (c *Confirm) Prompt() (interface{}, error) {
+	// render the question template
+	err := c.Render(
+		ConfirmQuestionTemplate,
+		ConfirmTemplateData{Confirm: *c},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	// get input and return
+	return c.getBool(false)
+}
+
+// Cleanup overwrite the line with the finalized formatted version
+func (c *Confirm) Cleanup(val interface{}) error {
+	// if the value was previously true
+	ans := yesNo(val.(bool))
+	// render the template
+	return c.Render(
+		ConfirmQuestionTemplate,
+		ConfirmTemplateData{Confirm: *c, Answer: ans},
+	)
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/core/renderer.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/core/renderer.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
+)
+
+type Renderer struct {
+	stdio          terminal.Stdio
+	lineCount      int
+	errorLineCount int
+}
+
+var ErrorTemplate = `{{color "red"}}{{ ErrorIcon }} Sorry, your reply was invalid: {{.Error}}{{color "reset"}}
+`
+
+func (r *Renderer) WithStdio(stdio terminal.Stdio) {
+	r.stdio = stdio
+}
+
+func (r *Renderer) Stdio() terminal.Stdio {
+	return r.stdio
+}
+
+func (r *Renderer) NewRuneReader() *terminal.RuneReader {
+	return terminal.NewRuneReader(r.stdio)
+}
+
+func (r *Renderer) NewCursor() *terminal.Cursor {
+	return &terminal.Cursor{
+		In:  r.stdio.In,
+		Out: r.stdio.Out,
+	}
+}
+
+func (r *Renderer) Error(invalid error) error {
+	// since errors are printed on top we need to reset the prompt
+	// as well as any previous error print
+	r.resetPrompt(r.lineCount + r.errorLineCount)
+	// we just cleared the prompt lines
+	r.lineCount = 0
+	out, err := RunTemplate(ErrorTemplate, invalid)
+	if err != nil {
+		return err
+	}
+	// keep track of how many lines are printed so we can clean up later
+	r.errorLineCount = strings.Count(out, "\n")
+
+	// send the message to the user
+	fmt.Fprint(terminal.NewAnsiStdout(r.stdio.Out), out)
+	return nil
+}
+
+func (r *Renderer) resetPrompt(lines int) {
+	// clean out current line in case tmpl didnt end in newline
+	cursor := r.NewCursor()
+	cursor.HorizontalAbsolute(0)
+	terminal.EraseLine(r.stdio.Out, terminal.ERASE_LINE_ALL)
+	// clean up what we left behind last time
+	for i := 0; i < lines; i++ {
+		cursor.PreviousLine(1)
+		terminal.EraseLine(r.stdio.Out, terminal.ERASE_LINE_ALL)
+	}
+}
+
+func (r *Renderer) Render(tmpl string, data interface{}) error {
+	r.resetPrompt(r.lineCount)
+	// render the template summarizing the current state
+	out, err := RunTemplate(tmpl, data)
+	if err != nil {
+		return err
+	}
+
+	// keep track of how many lines are printed so we can clean up later
+	r.lineCount = strings.Count(out, "\n")
+
+	// print the summary
+	fmt.Fprint(terminal.NewAnsiStdout(r.stdio.Out), out)
+
+	// nothing went wrong
+	return nil
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/core/template.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/core/template.go
@@ -1,0 +1,120 @@
+package core
+
+import (
+	"bytes"
+	"sync"
+	"text/template"
+
+	"github.com/mgutz/ansi"
+)
+
+var DisableColor = false
+
+var (
+	// HelpInputRune is the rune which the user should enter to trigger
+	// more detailed question help
+	HelpInputRune = '?'
+
+	// ErrorIcon will be be shown before an error
+	ErrorIcon = "X"
+
+	// HelpIcon will be shown before more detailed question help
+	HelpIcon = "?"
+	// QuestionIcon will be shown before a question Message
+	QuestionIcon = "?"
+
+	// MarkedOptionIcon will be prepended before a selected multiselect option
+	MarkedOptionIcon = "[x]"
+	// UnmarkedOptionIcon will be prepended before an unselected multiselect option
+	UnmarkedOptionIcon = "[ ]"
+
+	// SelectFocusIcon is prepended to an option to signify the user is
+	// currently focusing that option
+	SelectFocusIcon = ">"
+)
+
+/*
+  SetFancyIcons changes the err, help, marked, and focus input icons to their
+  fancier forms. These forms may not be compatible with most terminals.
+  This function will not touch the QuestionIcon as its fancy and non fancy form
+  are the same.
+*/
+func SetFancyIcons() {
+	ErrorIcon = "✘"
+	HelpIcon = "ⓘ"
+	// QuestionIcon fancy and non-fancy form are the same
+
+	MarkedOptionIcon = "◉"
+	UnmarkedOptionIcon = "◯"
+
+	SelectFocusIcon = "❯"
+}
+
+var TemplateFuncs = map[string]interface{}{
+	// Templates with Color formatting. See Documentation: https://github.com/mgutz/ansi#style-format
+	"color": func(color string) string {
+		if DisableColor {
+			return ""
+		}
+		return ansi.ColorCode(color)
+	},
+	"HelpInputRune": func() string {
+		return string(HelpInputRune)
+	},
+	"ErrorIcon": func() string {
+		return ErrorIcon
+	},
+	"HelpIcon": func() string {
+		return HelpIcon
+	},
+	"QuestionIcon": func() string {
+		return QuestionIcon
+	},
+	"MarkedOptionIcon": func() string {
+		return MarkedOptionIcon
+	},
+	"UnmarkedOptionIcon": func() string {
+		return UnmarkedOptionIcon
+	},
+	"SelectFocusIcon": func() string {
+		return SelectFocusIcon
+	},
+}
+
+var (
+	memoizedGetTemplate = map[string]*template.Template{}
+
+	memoMutex = &sync.RWMutex{}
+)
+
+func getTemplate(tmpl string) (*template.Template, error) {
+	memoMutex.RLock()
+	if t, ok := memoizedGetTemplate[tmpl]; ok {
+		memoMutex.RUnlock()
+		return t, nil
+	}
+	memoMutex.RUnlock()
+
+	t, err := template.New("prompt").Funcs(TemplateFuncs).Parse(tmpl)
+	if err != nil {
+		return nil, err
+	}
+
+	memoMutex.Lock()
+	memoizedGetTemplate[tmpl] = t
+	memoMutex.Unlock()
+	return t, nil
+}
+
+func RunTemplate(tmpl string, data interface{}) (string, error) {
+	t, err := getTemplate(tmpl)
+	if err != nil {
+		return "", err
+	}
+	buf := bytes.NewBufferString("")
+	err = t.Execute(buf, data)
+	if err != nil {
+		return "", err
+	}
+	return buf.String(), err
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/core/write.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/core/write.go
@@ -1,0 +1,246 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+// the tag used to denote the name of the question
+const tagName = "survey"
+
+// add a few interfaces so users can configure how the prompt values are set
+type settable interface {
+	WriteAnswer(field string, value interface{}) error
+}
+
+func WriteAnswer(t interface{}, name string, v interface{}) (err error) {
+	// if the field is a custom type
+	if s, ok := t.(settable); ok {
+		// use the interface method
+		return s.WriteAnswer(name, v)
+	}
+
+	// the target to write to
+	target := reflect.ValueOf(t)
+	// the value to write from
+	value := reflect.ValueOf(v)
+
+	// make sure we are writing to a pointer
+	if target.Kind() != reflect.Ptr {
+		return errors.New("you must pass a pointer as the target of a Write operation")
+	}
+	// the object "inside" of the target pointer
+	elem := target.Elem()
+
+	// handle the special types
+	switch elem.Kind() {
+	// if we are writing to a struct
+	case reflect.Struct:
+		// get the name of the field that matches the string we  were given
+		fieldIndex, err := findFieldIndex(elem, name)
+		// if something went wrong
+		if err != nil {
+			// bubble up
+			return err
+		}
+		field := elem.Field(fieldIndex)
+		// handle references to the settable interface aswell
+		if s, ok := field.Interface().(settable); ok {
+			// use the interface method
+			return s.WriteAnswer(name, v)
+		}
+		if field.CanAddr() {
+			if s, ok := field.Addr().Interface().(settable); ok {
+				// use the interface method
+				return s.WriteAnswer(name, v)
+			}
+		}
+
+		// copy the value over to the normal struct
+		return copy(field, value)
+	case reflect.Map:
+		mapType := reflect.TypeOf(t).Elem()
+		if mapType.Key().Kind() != reflect.String || mapType.Elem().Kind() != reflect.Interface {
+			return errors.New("answer maps must be of type map[string]interface")
+		}
+		mt := *t.(*map[string]interface{})
+		mt[name] = value.Interface()
+		return nil
+	}
+	// otherwise just copy the value to the target
+	return copy(elem, value)
+}
+
+// BUG(AlecAivazis): the current implementation might cause weird conflicts if there are
+// two fields with same name that only differ by casing.
+func findFieldIndex(s reflect.Value, name string) (int, error) {
+	// the type of the value
+	sType := s.Type()
+
+	// first look for matching tags so we can overwrite matching field names
+	for i := 0; i < sType.NumField(); i++ {
+		// the field we are current scanning
+		field := sType.Field(i)
+
+		// the value of the survey tag
+		tag := field.Tag.Get(tagName)
+		// if the tag matches the name we are looking for
+		if tag != "" && tag == name {
+			// then we found our index
+			return i, nil
+		}
+	}
+
+	// then look for matching names
+	for i := 0; i < sType.NumField(); i++ {
+		// the field we are current scanning
+		field := sType.Field(i)
+
+		// if the name of the field matches what we're looking for
+		if strings.ToLower(field.Name) == strings.ToLower(name) {
+			return i, nil
+		}
+	}
+
+	// we didn't find the field
+	return -1, fmt.Errorf("could not find field matching %v", name)
+}
+
+// isList returns true if the element is something we can Len()
+func isList(v reflect.Value) bool {
+	switch v.Type().Kind() {
+	case reflect.Array, reflect.Slice:
+		return true
+	default:
+		return false
+	}
+}
+
+// Write takes a value and copies it to the target
+func copy(t reflect.Value, v reflect.Value) (err error) {
+	// if something ends up panicing we need to catch it in a deferred func
+	defer func() {
+		if r := recover(); r != nil {
+			// if we paniced with an error
+			if _, ok := r.(error); ok {
+				// cast the result to an error object
+				err = r.(error)
+			} else if _, ok := r.(string); ok {
+				// otherwise we could have paniced with a string so wrap it in an error
+				err = errors.New(r.(string))
+			}
+		}
+	}()
+
+	// if we are copying from a string result to something else
+	if v.Kind() == reflect.String && v.Type() != t.Type() {
+		var castVal interface{}
+		var casterr error
+		vString := v.Interface().(string)
+
+		switch t.Kind() {
+		case reflect.Bool:
+			castVal, casterr = strconv.ParseBool(vString)
+		case reflect.Int:
+			castVal, casterr = strconv.Atoi(vString)
+		case reflect.Int8:
+			var val64 int64
+			val64, casterr = strconv.ParseInt(vString, 10, 8)
+			if casterr == nil {
+				castVal = int8(val64)
+			}
+		case reflect.Int16:
+			var val64 int64
+			val64, casterr = strconv.ParseInt(vString, 10, 16)
+			if casterr == nil {
+				castVal = int16(val64)
+			}
+		case reflect.Int32:
+			var val64 int64
+			val64, casterr = strconv.ParseInt(vString, 10, 32)
+			if casterr == nil {
+				castVal = int32(val64)
+			}
+		case reflect.Int64:
+			castVal, casterr = strconv.ParseInt(vString, 10, 64)
+		case reflect.Uint:
+			var val64 uint64
+			val64, casterr = strconv.ParseUint(vString, 10, 8)
+			if casterr == nil {
+				castVal = uint(val64)
+			}
+		case reflect.Uint8:
+			var val64 uint64
+			val64, casterr = strconv.ParseUint(vString, 10, 8)
+			if casterr == nil {
+				castVal = uint8(val64)
+			}
+		case reflect.Uint16:
+			var val64 uint64
+			val64, casterr = strconv.ParseUint(vString, 10, 16)
+			if casterr == nil {
+				castVal = uint16(val64)
+			}
+		case reflect.Uint32:
+			var val64 uint64
+			val64, casterr = strconv.ParseUint(vString, 10, 32)
+			if casterr == nil {
+				castVal = uint32(val64)
+			}
+		case reflect.Uint64:
+			castVal, casterr = strconv.ParseUint(vString, 10, 64)
+		case reflect.Float32:
+			var val64 float64
+			val64, casterr = strconv.ParseFloat(vString, 32)
+			if casterr == nil {
+				castVal = float32(val64)
+			}
+		case reflect.Float64:
+			castVal, casterr = strconv.ParseFloat(vString, 64)
+		default:
+			return fmt.Errorf("Unable to convert from string to type %s", t.Kind())
+		}
+
+		if casterr != nil {
+			return casterr
+		}
+
+		t.Set(reflect.ValueOf(castVal))
+		return
+	}
+
+	// if we are copying from one slice or array to another
+	if isList(v) && isList(t) {
+		// loop over every item in the desired value
+		for i := 0; i < v.Len(); i++ {
+			// write to the target given its kind
+			switch t.Kind() {
+			// if its a slice
+			case reflect.Slice:
+				// an object of the correct type
+				obj := reflect.Indirect(reflect.New(t.Type().Elem()))
+
+				// write the appropriate value to the obj and catch any errors
+				if err := copy(obj, v.Index(i)); err != nil {
+					return err
+				}
+
+				// just append the value to the end
+				t.Set(reflect.Append(t, obj))
+			// otherwise it could be an array
+			case reflect.Array:
+				// set the index to the appropriate value
+				copy(t.Slice(i, i+1).Index(0), v.Index(i))
+			}
+		}
+	} else {
+		// set the value to the target
+		t.Set(v)
+	}
+
+	// we're done
+	return
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/editor.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/editor.go
@@ -1,0 +1,205 @@
+package survey
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"runtime"
+
+	shellquote "github.com/kballard/go-shellquote"
+	"gopkg.in/AlecAivazis/survey.v1/core"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
+)
+
+/*
+Editor launches an instance of the users preferred editor on a temporary file.
+The editor to use is determined by reading the $VISUAL or $EDITOR environment
+variables. If neither of those are present, notepad (on Windows) or vim
+(others) is used.
+The launch of the editor is triggered by the enter key. Since the response may
+be long, it will not be echoed as Input does, instead, it print <Received>.
+Response type is a string.
+
+	message := ""
+	prompt := &survey.Editor{ Message: "What is your commit message?" }
+	survey.AskOne(prompt, &message, nil)
+*/
+type Editor struct {
+	core.Renderer
+	Message       string
+	Default       string
+	Help          string
+	Editor        string
+	HideDefault   bool
+	AppendDefault bool
+}
+
+// data available to the templates when processing
+type EditorTemplateData struct {
+	Editor
+	Answer     string
+	ShowAnswer bool
+	ShowHelp   bool
+}
+
+// Templates with Color formatting. See Documentation: https://github.com/mgutz/ansi#style-format
+var EditorQuestionTemplate = `
+{{- if .ShowHelp }}{{- color "cyan"}}{{ HelpIcon }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- color "green+hb"}}{{ QuestionIcon }} {{color "reset"}}
+{{- color "default+hb"}}{{ .Message }} {{color "reset"}}
+{{- if .ShowAnswer}}
+  {{- color "cyan"}}{{.Answer}}{{color "reset"}}{{"\n"}}
+{{- else }}
+  {{- if and .Help (not .ShowHelp)}}{{color "cyan"}}[{{ HelpInputRune }} for help]{{color "reset"}} {{end}}
+  {{- if and .Default (not .HideDefault)}}{{color "white"}}({{.Default}}) {{color "reset"}}{{end}}
+  {{- color "cyan"}}[Enter to launch editor] {{color "reset"}}
+{{- end}}`
+
+var (
+	bom    = []byte{0xef, 0xbb, 0xbf}
+	editor = "vim"
+)
+
+func init() {
+	if runtime.GOOS == "windows" {
+		editor = "notepad"
+	}
+	if v := os.Getenv("VISUAL"); v != "" {
+		editor = v
+	} else if e := os.Getenv("EDITOR"); e != "" {
+		editor = e
+	}
+}
+
+func (e *Editor) PromptAgain(invalid interface{}, err error) (interface{}, error) {
+	initialValue := invalid.(string)
+	return e.prompt(initialValue)
+}
+
+func (e *Editor) Prompt() (interface{}, error) {
+	initialValue := ""
+	if e.Default != "" && e.AppendDefault {
+		initialValue = e.Default
+	}
+	return e.prompt(initialValue)
+}
+
+func (e *Editor) prompt(initialValue string) (interface{}, error) {
+	// render the template
+	err := e.Render(
+		EditorQuestionTemplate,
+		EditorTemplateData{Editor: *e},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	// start reading runes from the standard in
+	rr := e.NewRuneReader()
+	rr.SetTermMode()
+	defer rr.RestoreTermMode()
+
+	cursor := e.NewCursor()
+	cursor.Hide()
+	defer cursor.Show()
+
+	for {
+		r, _, err := rr.ReadRune()
+		if err != nil {
+			return "", err
+		}
+		if r == '\r' || r == '\n' {
+			break
+		}
+		if r == terminal.KeyInterrupt {
+			return "", terminal.InterruptErr
+		}
+		if r == terminal.KeyEndTransmission {
+			break
+		}
+		if r == core.HelpInputRune && e.Help != "" {
+			err = e.Render(
+				EditorQuestionTemplate,
+				EditorTemplateData{Editor: *e, ShowHelp: true},
+			)
+			if err != nil {
+				return "", err
+			}
+		}
+		continue
+	}
+
+	// prepare the temp file
+	f, err := ioutil.TempFile("", "survey")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(f.Name())
+
+	// write utf8 BOM header
+	// The reason why we do this is because notepad.exe on Windows determines the
+	// encoding of an "empty" text file by the locale, for example, GBK in China,
+	// while golang string only handles utf8 well. However, a text file with utf8
+	// BOM header is not considered "empty" on Windows, and the encoding will then
+	// be determined utf8 by notepad.exe, instead of GBK or other encodings.
+	if _, err := f.Write(bom); err != nil {
+		return "", err
+	}
+
+	// write initial value
+	if _, err := f.WriteString(initialValue); err != nil {
+		return "", err
+	}
+
+	// close the fd to prevent the editor unable to save file
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+
+	// check is input editor exist
+	if e.Editor != "" {
+		editor = e.Editor
+	}
+
+	stdio := e.Stdio()
+
+	args, err := shellquote.Split(editor)
+	if err != nil {
+		return "", err
+	}
+	args = append(args, f.Name())
+
+	// open the editor
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdin = stdio.In
+	cmd.Stdout = stdio.Out
+	cmd.Stderr = stdio.Err
+	cursor.Show()
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	// raw is a BOM-unstripped UTF8 byte slice
+	raw, err := ioutil.ReadFile(f.Name())
+	if err != nil {
+		return "", err
+	}
+
+	// strip BOM header
+	text := string(bytes.TrimPrefix(raw, bom))
+
+	// check length, return default value on empty
+	if len(text) == 0 && !e.AppendDefault {
+		return e.Default, nil
+	}
+
+	return text, nil
+}
+
+func (e *Editor) Cleanup(val interface{}) error {
+	return e.Render(
+		EditorQuestionTemplate,
+		EditorTemplateData{Editor: *e, Answer: "<Received>", ShowAnswer: true},
+	)
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/filter.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/filter.go
@@ -1,0 +1,13 @@
+package survey
+
+import "strings"
+
+var DefaultFilterFn = func(filter string, options []string) (answer []string) {
+	filter = strings.ToLower(filter)
+	for _, o := range options {
+		if strings.Contains(strings.ToLower(o), filter) {
+			answer = append(answer, o)
+		}
+	}
+	return answer
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/input.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/input.go
@@ -1,0 +1,97 @@
+package survey
+
+import (
+	"gopkg.in/AlecAivazis/survey.v1/core"
+)
+
+/*
+Input is a regular text input that prints each character the user types on the screen
+and accepts the input with the enter key. Response type is a string.
+
+	name := ""
+	prompt := &survey.Input{ Message: "What is your name?" }
+	survey.AskOne(prompt, &name, nil)
+*/
+type Input struct {
+	core.Renderer
+	Message string
+	Default string
+	Help    string
+}
+
+// data available to the templates when processing
+type InputTemplateData struct {
+	Input
+	Answer     string
+	ShowAnswer bool
+	ShowHelp   bool
+}
+
+// Templates with Color formatting. See Documentation: https://github.com/mgutz/ansi#style-format
+var InputQuestionTemplate = `
+{{- if .ShowHelp }}{{- color "cyan"}}{{ HelpIcon }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- color "green+hb"}}{{ QuestionIcon }} {{color "reset"}}
+{{- color "default+hb"}}{{ .Message }} {{color "reset"}}
+{{- if .ShowAnswer}}
+  {{- color "cyan"}}{{.Answer}}{{color "reset"}}{{"\n"}}
+{{- else }}
+  {{- if and .Help (not .ShowHelp)}}{{color "cyan"}}[{{ HelpInputRune }} for help]{{color "reset"}} {{end}}
+  {{- if .Default}}{{color "white"}}({{.Default}}) {{color "reset"}}{{end}}
+{{- end}}`
+
+func (i *Input) Prompt() (interface{}, error) {
+	// render the template
+	err := i.Render(
+		InputQuestionTemplate,
+		InputTemplateData{Input: *i},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	// start reading runes from the standard in
+	rr := i.NewRuneReader()
+	rr.SetTermMode()
+	defer rr.RestoreTermMode()
+
+	cursor := i.NewCursor()
+
+	line := []rune{}
+	// get the next line
+	for {
+		line, err = rr.ReadLine(0)
+		if err != nil {
+			return string(line), err
+		}
+		// terminal will echo the \n so we need to jump back up one row
+		cursor.PreviousLine(1)
+
+		if string(line) == string(core.HelpInputRune) && i.Help != "" {
+			err = i.Render(
+				InputQuestionTemplate,
+				InputTemplateData{Input: *i, ShowHelp: true},
+			)
+			if err != nil {
+				return "", err
+			}
+			continue
+		}
+		break
+	}
+
+	// if the line is empty
+	if line == nil || len(line) == 0 {
+		// use the default value
+		return i.Default, err
+	}
+
+	// we're done
+	return string(line), err
+}
+
+func (i *Input) Cleanup(val interface{}) error {
+	return i.Render(
+		InputQuestionTemplate,
+		InputTemplateData{Input: *i, Answer: val.(string), ShowAnswer: true},
+	)
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/multiline.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/multiline.go
@@ -1,0 +1,104 @@
+package survey
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/AlecAivazis/survey.v1/core"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
+)
+
+type Multiline struct {
+	core.Renderer
+	Message string
+	Default string
+	Help    string
+}
+
+// data available to the templates when processing
+type MultilineTemplateData struct {
+	Multiline
+	Answer     string
+	ShowAnswer bool
+	ShowHelp   bool
+}
+
+// Templates with Color formatting. See Documentation: https://github.com/mgutz/ansi#style-format
+var MultilineQuestionTemplate = `
+{{- if .ShowHelp }}{{- color "cyan"}}{{ HelpIcon }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- color "green+hb"}}{{ QuestionIcon }} {{color "reset"}}
+{{- color "default+hb"}}{{ .Message }} {{color "reset"}}
+{{- if .ShowAnswer}}
+  {{- "\n"}}{{color "cyan"}}{{.Answer}}{{color "reset"}}
+  {{- if .Answer }}{{ "\n" }}{{ end }}
+{{- else }}
+  {{- if .Default}}{{color "white"}}({{.Default}}) {{color "reset"}}{{end}}
+  {{- color "cyan"}}[Enter 2 empty lines to finish]{{color "reset"}}
+{{- end}}`
+
+func (i *Multiline) Prompt() (interface{}, error) {
+	// render the template
+	err := i.Render(
+		MultilineQuestionTemplate,
+		MultilineTemplateData{Multiline: *i},
+	)
+	if err != nil {
+		return "", err
+	}
+	fmt.Println()
+
+	// start reading runes from the standard in
+	rr := i.NewRuneReader()
+	rr.SetTermMode()
+	defer rr.RestoreTermMode()
+
+	cursor := i.NewCursor()
+
+	multiline := make([]string, 0)
+
+	emptyOnce := false
+	// get the next line
+	for {
+		line := []rune{}
+		line, err = rr.ReadLine(0)
+		if err != nil {
+			return string(line), err
+		}
+
+		if string(line) == "" {
+			if emptyOnce {
+				numLines := len(multiline) + 2
+				cursor.PreviousLine(numLines)
+				for j := 0; j < numLines; j++ {
+					terminal.EraseLine(i.Stdio().Out, terminal.ERASE_LINE_ALL)
+					cursor.NextLine(1)
+				}
+				cursor.PreviousLine(numLines)
+				break
+			}
+			emptyOnce = true
+		} else {
+			emptyOnce = false
+		}
+		multiline = append(multiline, string(line))
+	}
+
+	val := strings.Join(multiline, "\n")
+	val = strings.TrimSpace(val)
+
+	// if the line is empty
+	if len(val) == 0 {
+		// use the default value
+		return i.Default, err
+	}
+
+	// we're done
+	return val, err
+}
+
+func (i *Multiline) Cleanup(val interface{}) error {
+	return i.Render(
+		MultilineQuestionTemplate,
+		MultilineTemplateData{Multiline: *i, Answer: val.(string), ShowAnswer: true},
+	)
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/multiselect.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/multiselect.go
@@ -1,0 +1,248 @@
+package survey
+
+import (
+	"errors"
+	"strings"
+
+	"gopkg.in/AlecAivazis/survey.v1/core"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
+)
+
+/*
+MultiSelect is a prompt that presents a list of various options to the user
+for them to select using the arrow keys and enter. Response type is a slice of strings.
+
+	days := []string{}
+	prompt := &survey.MultiSelect{
+		Message: "What days do you prefer:",
+		Options: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
+	}
+	survey.AskOne(prompt, &days, nil)
+*/
+type MultiSelect struct {
+	core.Renderer
+	Message       string
+	Options       []string
+	Default       []string
+	Help          string
+	PageSize      int
+	VimMode       bool
+	FilterMessage string
+	FilterFn      func(string, []string) []string
+	filter        string
+	selectedIndex int
+	checked       map[string]bool
+	showingHelp   bool
+}
+
+// data available to the templates when processing
+type MultiSelectTemplateData struct {
+	MultiSelect
+	Answer        string
+	ShowAnswer    bool
+	Checked       map[string]bool
+	SelectedIndex int
+	ShowHelp      bool
+	PageEntries   []string
+}
+
+var MultiSelectQuestionTemplate = `
+{{- if .ShowHelp }}{{- color "cyan"}}{{ HelpIcon }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- color "green+hb"}}{{ QuestionIcon }} {{color "reset"}}
+{{- color "default+hb"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
+{{- if .ShowAnswer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
+{{- else }}
+	{{- "  "}}{{- color "cyan"}}[Use arrows to move, type to filter{{- if and .Help (not .ShowHelp)}}, {{ HelpInputRune }} for more help{{end}}]{{color "reset"}}
+  {{- "\n"}}
+  {{- range $ix, $option := .PageEntries}}
+    {{- if eq $ix $.SelectedIndex}}{{color "cyan"}}{{ SelectFocusIcon }}{{color "reset"}}{{else}} {{end}}
+    {{- if index $.Checked $option}}{{color "green"}} {{ MarkedOptionIcon }} {{else}}{{color "default+hb"}} {{ UnmarkedOptionIcon }} {{end}}
+    {{- color "reset"}}
+    {{- " "}}{{$option}}{{"\n"}}
+  {{- end}}
+{{- end}}`
+
+// OnChange is called on every keypress.
+func (m *MultiSelect) OnChange(line []rune, pos int, key rune) (newLine []rune, newPos int, ok bool) {
+	options := m.filterOptions()
+	oldFilter := m.filter
+
+	if key == terminal.KeyArrowUp || (m.VimMode && key == 'k') {
+		// if we are at the top of the list
+		if m.selectedIndex == 0 {
+			// go to the bottom
+			m.selectedIndex = len(options) - 1
+		} else {
+			// decrement the selected index
+			m.selectedIndex--
+		}
+	} else if key == terminal.KeyArrowDown || (m.VimMode && key == 'j') {
+		// if we are at the bottom of the list
+		if m.selectedIndex == len(options)-1 {
+			// start at the top
+			m.selectedIndex = 0
+		} else {
+			// increment the selected index
+			m.selectedIndex++
+		}
+		// if the user pressed down and there is room to move
+	} else if key == terminal.KeySpace {
+		if m.selectedIndex < len(options) {
+			if old, ok := m.checked[options[m.selectedIndex]]; !ok {
+				// otherwise just invert the current value
+				m.checked[options[m.selectedIndex]] = true
+			} else {
+				// otherwise just invert the current value
+				m.checked[options[m.selectedIndex]] = !old
+			}
+			m.filter = ""
+		}
+		// only show the help message if we have one to show
+	} else if key == core.HelpInputRune && m.Help != "" {
+		m.showingHelp = true
+	} else if key == terminal.KeyEscape {
+		m.VimMode = !m.VimMode
+	} else if key == terminal.KeyDeleteWord || key == terminal.KeyDeleteLine {
+		m.filter = ""
+	} else if key == terminal.KeyDelete || key == terminal.KeyBackspace {
+		if m.filter != "" {
+			m.filter = m.filter[0 : len(m.filter)-1]
+		}
+	} else if key >= terminal.KeySpace {
+		m.filter += string(key)
+		m.VimMode = false
+	}
+
+	m.FilterMessage = ""
+	if m.filter != "" {
+		m.FilterMessage = " " + m.filter
+	}
+	if oldFilter != m.filter {
+		// filter changed
+		options = m.filterOptions()
+		if len(options) > 0 && len(options) <= m.selectedIndex {
+			m.selectedIndex = len(options) - 1
+		}
+	}
+	// paginate the options
+
+	// TODO if we have started filtering and were looking at the end of a list
+	// and we have modified the filter then we should move the page back!
+	opts, idx := paginate(m.PageSize, options, m.selectedIndex)
+
+	// render the options
+	m.Render(
+		MultiSelectQuestionTemplate,
+		MultiSelectTemplateData{
+			MultiSelect:   *m,
+			SelectedIndex: idx,
+			Checked:       m.checked,
+			ShowHelp:      m.showingHelp,
+			PageEntries:   opts,
+		},
+	)
+
+	// if we are not pressing ent
+	return line, 0, true
+}
+
+func (m *MultiSelect) filterOptions() []string {
+	if m.filter == "" {
+		return m.Options
+	}
+	if m.FilterFn != nil {
+		return m.FilterFn(m.filter, m.Options)
+	}
+	return DefaultFilterFn(m.filter, m.Options)
+}
+
+func (m *MultiSelect) Prompt() (interface{}, error) {
+	// compute the default state
+	m.checked = make(map[string]bool)
+	// if there is a default
+	if len(m.Default) > 0 {
+		for _, dflt := range m.Default {
+			for _, opt := range m.Options {
+				// if the option corresponds to the default
+				if opt == dflt {
+					// we found our initial value
+					m.checked[opt] = true
+					// stop looking
+					break
+				}
+			}
+		}
+	}
+
+	// if there are no options to render
+	if len(m.Options) == 0 {
+		// we failed
+		return "", errors.New("please provide options to select from")
+	}
+
+	// paginate the options
+	opts, idx := paginate(m.PageSize, m.Options, m.selectedIndex)
+
+	cursor := m.NewCursor()
+	cursor.Hide()       // hide the cursor
+	defer cursor.Show() // show the cursor when we're done
+
+	// ask the question
+	err := m.Render(
+		MultiSelectQuestionTemplate,
+		MultiSelectTemplateData{
+			MultiSelect:   *m,
+			SelectedIndex: idx,
+			Checked:       m.checked,
+			PageEntries:   opts,
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	rr := m.NewRuneReader()
+	rr.SetTermMode()
+	defer rr.RestoreTermMode()
+
+	// start waiting for input
+	for {
+		r, _, _ := rr.ReadRune()
+		if r == '\r' || r == '\n' {
+			break
+		}
+		if r == terminal.KeyInterrupt {
+			return "", terminal.InterruptErr
+		}
+		if r == terminal.KeyEndTransmission {
+			break
+		}
+		m.OnChange(nil, 0, r)
+	}
+	m.filter = ""
+	m.FilterMessage = ""
+
+	answers := []string{}
+	for _, option := range m.Options {
+		if val, ok := m.checked[option]; ok && val {
+			answers = append(answers, option)
+		}
+	}
+
+	return answers, nil
+}
+
+// Cleanup removes the options section, and renders the ask like a normal question.
+func (m *MultiSelect) Cleanup(val interface{}) error {
+	// execute the output summary template with the answer
+	return m.Render(
+		MultiSelectQuestionTemplate,
+		MultiSelectTemplateData{
+			MultiSelect:   *m,
+			SelectedIndex: m.selectedIndex,
+			Checked:       m.checked,
+			Answer:        strings.Join(val.([]string), ", "),
+			ShowAnswer:    true,
+		},
+	)
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/password.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/password.go
@@ -1,0 +1,86 @@
+package survey
+
+import (
+	"fmt"
+
+	"gopkg.in/AlecAivazis/survey.v1/core"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
+)
+
+/*
+Password is like a normal Input but the text shows up as *'s and there is no default. Response
+type is a string.
+
+	password := ""
+	prompt := &survey.Password{ Message: "Please type your password" }
+	survey.AskOne(prompt, &password, nil)
+*/
+type Password struct {
+	core.Renderer
+	Message string
+	Help    string
+}
+
+type PasswordTemplateData struct {
+	Password
+	ShowHelp bool
+}
+
+// Templates with Color formatting. See Documentation: https://github.com/mgutz/ansi#style-format
+var PasswordQuestionTemplate = `
+{{- if .ShowHelp }}{{- color "cyan"}}{{ HelpIcon }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- color "green+hb"}}{{ QuestionIcon }} {{color "reset"}}
+{{- color "default+hb"}}{{ .Message }} {{color "reset"}}
+{{- if and .Help (not .ShowHelp)}}{{color "cyan"}}[{{ HelpInputRune }} for help]{{color "reset"}} {{end}}`
+
+func (p *Password) Prompt() (line interface{}, err error) {
+	// render the question template
+	out, err := core.RunTemplate(
+		PasswordQuestionTemplate,
+		PasswordTemplateData{Password: *p},
+	)
+	fmt.Fprint(terminal.NewAnsiStdout(p.Stdio().Out), out)
+	if err != nil {
+		return "", err
+	}
+
+	rr := p.NewRuneReader()
+	rr.SetTermMode()
+	defer rr.RestoreTermMode()
+
+	// no help msg?  Just return any response
+	if p.Help == "" {
+		line, err := rr.ReadLine('*')
+		return string(line), err
+	}
+
+	cursor := p.NewCursor()
+
+	// process answers looking for help prompt answer
+	for {
+		line, err := rr.ReadLine('*')
+		if err != nil {
+			return string(line), err
+		}
+
+		if string(line) == string(core.HelpInputRune) {
+			// terminal will echo the \n so we need to jump back up one row
+			cursor.PreviousLine(1)
+
+			err = p.Render(
+				PasswordQuestionTemplate,
+				PasswordTemplateData{Password: *p, ShowHelp: true},
+			)
+			if err != nil {
+				return "", err
+			}
+			continue
+		}
+		return string(line), err
+	}
+}
+
+// Cleanup hides the string with a fixed number of characters.
+func (prompt *Password) Cleanup(val interface{}) error {
+	return nil
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/select.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/select.go
@@ -1,0 +1,266 @@
+package survey
+
+import (
+	"errors"
+	"gopkg.in/AlecAivazis/survey.v1/core"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
+)
+
+/*
+Select is a prompt that presents a list of various options to the user
+for them to select using the arrow keys and enter. Response type is a string.
+
+	color := ""
+	prompt := &survey.Select{
+		Message: "Choose a color:",
+		Options: []string{"red", "blue", "green"},
+	}
+	survey.AskOne(prompt, &color, nil)
+*/
+type Select struct {
+	core.Renderer
+	Message       string
+	Options       []string
+	Default       string
+	Help          string
+	PageSize      int
+	VimMode       bool
+	FilterMessage string
+	FilterFn      func(string, []string) []string
+	filter        string
+	selectedIndex int
+	useDefault    bool
+	showingHelp   bool
+}
+
+// the data available to the templates when processing
+type SelectTemplateData struct {
+	Select
+	PageEntries   []string
+	SelectedIndex int
+	Answer        string
+	ShowAnswer    bool
+	ShowHelp      bool
+}
+
+var SelectQuestionTemplate = `
+{{- if .ShowHelp }}{{- color "cyan"}}{{ HelpIcon }} {{ .Help }}{{color "reset"}}{{"\n"}}{{end}}
+{{- color "green+hb"}}{{ QuestionIcon }} {{color "reset"}}
+{{- color "default+hb"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
+{{- if .ShowAnswer}}{{color "cyan"}} {{.Answer}}{{color "reset"}}{{"\n"}}
+{{- else}}
+  {{- "  "}}{{- color "cyan"}}[Use arrows to move, type to filter{{- if and .Help (not .ShowHelp)}}, {{ HelpInputRune }} for more help{{end}}]{{color "reset"}}
+  {{- "\n"}}
+  {{- range $ix, $choice := .PageEntries}}
+    {{- if eq $ix $.SelectedIndex}}{{color "cyan+b"}}{{ SelectFocusIcon }} {{else}}{{color "default+hb"}}  {{end}}
+    {{- $choice}}
+    {{- color "reset"}}{{"\n"}}
+  {{- end}}
+{{- end}}`
+
+// OnChange is called on every keypress.
+func (s *Select) OnChange(line []rune, pos int, key rune) (newLine []rune, newPos int, ok bool) {
+	options := s.filterOptions()
+	oldFilter := s.filter
+
+	// if the user pressed the enter key
+	if key == terminal.KeyEnter {
+		if s.selectedIndex < len(options) {
+			return []rune(options[s.selectedIndex]), 0, true
+		}
+		// if the user pressed the up arrow or 'k' to emulate vim
+	} else if key == terminal.KeyArrowUp || (s.VimMode && key == 'k') {
+		s.useDefault = false
+
+		// if we are at the top of the list
+		if s.selectedIndex == 0 {
+			// start from the button
+			s.selectedIndex = len(options) - 1
+		} else {
+			// otherwise we are not at the top of the list so decrement the selected index
+			s.selectedIndex--
+		}
+		// if the user pressed down or 'j' to emulate vim
+	} else if key == terminal.KeyArrowDown || (s.VimMode && key == 'j') {
+		s.useDefault = false
+		// if we are at the bottom of the list
+		if s.selectedIndex == len(options)-1 {
+			// start from the top
+			s.selectedIndex = 0
+		} else {
+			// increment the selected index
+			s.selectedIndex++
+		}
+		// only show the help message if we have one
+	} else if key == core.HelpInputRune && s.Help != "" {
+		s.showingHelp = true
+		// if the user wants to toggle vim mode on/off
+	} else if key == terminal.KeyEscape {
+		s.VimMode = !s.VimMode
+		// if the user hits any of the keys that clear the filter
+	} else if key == terminal.KeyDeleteWord || key == terminal.KeyDeleteLine {
+		s.filter = ""
+		// if the user is deleting a character in the filter
+	} else if key == terminal.KeyDelete || key == terminal.KeyBackspace {
+		// if there is content in the filter to delete
+		if s.filter != "" {
+			// subtract a line from the current filter
+			s.filter = s.filter[0 : len(s.filter)-1]
+			// we removed the last value in the filter
+		}
+	} else if key >= terminal.KeySpace {
+		s.filter += string(key)
+		// make sure vim mode is disabled
+		s.VimMode = false
+		// make sure that we use the current value in the filtered list
+		s.useDefault = false
+	}
+
+	s.FilterMessage = ""
+	if s.filter != "" {
+		s.FilterMessage = " " + s.filter
+	}
+	if oldFilter != s.filter {
+		// filter changed
+		options = s.filterOptions()
+		if len(options) > 0 && len(options) <= s.selectedIndex {
+			s.selectedIndex = len(options) - 1
+		}
+	}
+
+	// figure out the options and index to render
+
+	// TODO if we have started filtering and were looking at the end of a list
+	// and we have modified the filter then we should move the page back!
+	opts, idx := paginate(s.PageSize, options, s.selectedIndex)
+
+	// render the options
+	s.Render(
+		SelectQuestionTemplate,
+		SelectTemplateData{
+			Select:        *s,
+			SelectedIndex: idx,
+			ShowHelp:      s.showingHelp,
+			PageEntries:   opts,
+		},
+	)
+
+	// if we are not pressing ent
+	if len(options) <= s.selectedIndex {
+		return []rune{}, 0, false
+	}
+	return []rune(options[s.selectedIndex]), 0, true
+}
+
+func (s *Select) filterOptions() []string {
+	if s.filter == "" {
+		return s.Options
+	}
+	if s.FilterFn != nil {
+		return s.FilterFn(s.filter, s.Options)
+	}
+	return DefaultFilterFn(s.filter, s.Options)
+}
+
+func (s *Select) Prompt() (interface{}, error) {
+	// if there are no options to render
+	if len(s.Options) == 0 {
+		// we failed
+		return "", errors.New("please provide options to select from")
+	}
+
+	// start off with the first option selected
+	sel := 0
+	// if there is a default
+	if s.Default != "" {
+		// find the choice
+		for i, opt := range s.Options {
+			// if the option corresponds to the default
+			if opt == s.Default {
+				// we found our initial value
+				sel = i
+				// stop looking
+				break
+			}
+		}
+	}
+	// save the selected index
+	s.selectedIndex = sel
+
+	// figure out the options and index to render
+	opts, idx := paginate(s.PageSize, s.Options, sel)
+
+	// ask the question
+	err := s.Render(
+		SelectQuestionTemplate,
+		SelectTemplateData{
+			Select:        *s,
+			PageEntries:   opts,
+			SelectedIndex: idx,
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	// by default, use the default value
+	s.useDefault = true
+
+	rr := s.NewRuneReader()
+	rr.SetTermMode()
+	defer rr.RestoreTermMode()
+
+	cursor := s.NewCursor()
+	cursor.Hide()       // hide the cursor
+	defer cursor.Show() // show the cursor when we're done
+
+	// start waiting for input
+	for {
+		r, _, err := rr.ReadRune()
+		if err != nil {
+			return "", err
+		}
+		if r == '\r' || r == '\n' {
+			break
+		}
+		if r == terminal.KeyInterrupt {
+			return "", terminal.InterruptErr
+		}
+		if r == terminal.KeyEndTransmission {
+			break
+		}
+		s.OnChange(nil, 0, r)
+	}
+	options := s.filterOptions()
+	s.filter = ""
+	s.FilterMessage = ""
+
+	var val string
+	// if we are supposed to use the default value
+	if s.useDefault || s.selectedIndex >= len(options) {
+		// if there is a default value
+		if s.Default != "" {
+			// use the default value
+			val = s.Default
+		} else if len(options) > 0 {
+			// there is no default value so use the first
+			val = options[0]
+		}
+		// otherwise the selected index points to the value
+	} else if s.selectedIndex < len(options) {
+		// the
+		val = options[s.selectedIndex]
+	}
+	return val, err
+}
+
+func (s *Select) Cleanup(val interface{}) error {
+	return s.Render(
+		SelectQuestionTemplate,
+		SelectTemplateData{
+			Select:     *s,
+			Answer:     val.(string),
+			ShowAnswer: true,
+		},
+	)
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/survey.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/survey.go
@@ -1,0 +1,255 @@
+package survey
+
+import (
+	"errors"
+	"io"
+	"os"
+
+	"gopkg.in/AlecAivazis/survey.v1/core"
+	"gopkg.in/AlecAivazis/survey.v1/terminal"
+)
+
+// PageSize is the default maximum number of items to show in select/multiselect prompts
+var PageSize = 7
+
+// DefaultAskOptions is the default options on ask, using the OS stdio.
+var DefaultAskOptions = AskOptions{
+	Stdio: terminal.Stdio{
+		In:  os.Stdin,
+		Out: os.Stdout,
+		Err: os.Stderr,
+	},
+}
+
+// Validator is a function passed to a Question after a user has provided a response.
+// If the function returns an error, then the user will be prompted again for another
+// response.
+type Validator func(ans interface{}) error
+
+// Transformer is a function passed to a Question after a user has provided a response.
+// The function can be used to implement a custom logic that will result to return
+// a different representation of the given answer.
+//
+// Look `TransformString`, `ToLower` `Title` and `ComposeTransformers` for more.
+type Transformer func(ans interface{}) (newAns interface{})
+
+// Question is the core data structure for a survey questionnaire.
+type Question struct {
+	Name      string
+	Prompt    Prompt
+	Validate  Validator
+	Transform Transformer
+}
+
+// Prompt is the primary interface for the objects that can take user input
+// and return a response.
+type Prompt interface {
+	Prompt() (interface{}, error)
+	Cleanup(interface{}) error
+	Error(error) error
+}
+
+// PromptAgainer Interface for Prompts that support prompting again after invalid input
+type PromptAgainer interface {
+	PromptAgain(invalid interface{}, err error) (interface{}, error)
+}
+
+// AskOpt allows setting optional ask options.
+type AskOpt func(options *AskOptions) error
+
+// AskOptions provides additional options on ask.
+type AskOptions struct {
+	Stdio terminal.Stdio
+}
+
+// WithStdio specifies the standard input, output and error files survey
+// interacts with. By default, these are os.Stdin, os.Stdout, and os.Stderr.
+func WithStdio(in terminal.FileReader, out terminal.FileWriter, err io.Writer) AskOpt {
+	return func(options *AskOptions) error {
+		options.Stdio.In = in
+		options.Stdio.Out = out
+		options.Stdio.Err = err
+		return nil
+	}
+}
+
+type wantsStdio interface {
+	WithStdio(terminal.Stdio)
+}
+
+/*
+AskOne performs the prompt for a single prompt and asks for validation if required.
+Response types should be something that can be casted from the response type designated
+in the documentation. For example:
+
+	name := ""
+	prompt := &survey.Input{
+		Message: "name",
+	}
+
+	survey.AskOne(prompt, &name, nil)
+
+*/
+func AskOne(p Prompt, response interface{}, v Validator, opts ...AskOpt) error {
+	err := Ask([]*Question{{Prompt: p, Validate: v}}, response, opts...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+/*
+Ask performs the prompt loop, asking for validation when appropriate. The response
+type can be one of two options. If a struct is passed, the answer will be written to
+the field whose name matches the Name field on the corresponding question. Field types
+should be something that can be casted from the response type designated in the
+documentation. Note, a survey tag can also be used to identify a Otherwise, a
+map[string]interface{} can be passed, responses will be written to the key with the
+matching name. For example:
+
+	qs := []*survey.Question{
+		{
+			Name:     "name",
+			Prompt:   &survey.Input{Message: "What is your name?"},
+			Validate: survey.Required,
+			Transform: survey.Title,
+		},
+	}
+
+	answers := struct{ Name string }{}
+
+
+	err := survey.Ask(qs, &answers)
+*/
+func Ask(qs []*Question, response interface{}, opts ...AskOpt) error {
+
+	options := DefaultAskOptions
+	for _, opt := range opts {
+		if err := opt(&options); err != nil {
+			return err
+		}
+	}
+
+	// if we weren't passed a place to record the answers
+	if response == nil {
+		// we can't go any further
+		return errors.New("cannot call Ask() with a nil reference to record the answers")
+	}
+
+	// go over every question
+	for _, q := range qs {
+		// If Prompt implements controllable stdio, pass in specified stdio.
+		if p, ok := q.Prompt.(wantsStdio); ok {
+			p.WithStdio(options.Stdio)
+		}
+
+		// grab the user input and save it
+		ans, err := q.Prompt.Prompt()
+		// if there was a problem
+		if err != nil {
+			return err
+		}
+
+		// if there is a validate handler for this question
+		if q.Validate != nil {
+			// wait for a valid response
+			for invalid := q.Validate(ans); invalid != nil; invalid = q.Validate(ans) {
+				err := q.Prompt.Error(invalid)
+				// if there was a problem
+				if err != nil {
+					return err
+				}
+
+				// ask for more input
+				if promptAgainer, ok := q.Prompt.(PromptAgainer); ok {
+					ans, err = promptAgainer.PromptAgain(ans, invalid)
+				} else {
+					ans, err = q.Prompt.Prompt()
+				}
+				// if there was a problem
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		if q.Transform != nil {
+			// check if we have a transformer available, if so
+			// then try to acquire the new representation of the
+			// answer, if the resulting answer is not nil.
+			if newAns := q.Transform(ans); newAns != nil {
+				ans = newAns
+			}
+		}
+
+		// tell the prompt to cleanup with the validated value
+		q.Prompt.Cleanup(ans)
+
+		// if something went wrong
+		if err != nil {
+			// stop listening
+			return err
+		}
+
+		// add it to the map
+		err = core.WriteAnswer(response, q.Name, ans)
+		// if something went wrong
+		if err != nil {
+			return err
+		}
+
+	}
+
+	// return the response
+	return nil
+}
+
+// paginate returns a single page of choices given the page size, the total list of
+// possible choices, and the current selected index in the total list.
+func paginate(page int, choices []string, sel int) ([]string, int) {
+	// the number of elements to show in a single page
+	var pageSize int
+	// if the select has a specific page size
+	if page != 0 {
+		// use the specified one
+		pageSize = page
+		// otherwise the select does not have a page size
+	} else {
+		// use the package default
+		pageSize = PageSize
+	}
+
+	var start, end, cursor int
+
+	if len(choices) < pageSize {
+		// if we dont have enough options to fill a page
+		start = 0
+		end = len(choices)
+		cursor = sel
+
+	} else if sel < pageSize/2 {
+		// if we are in the first half page
+		start = 0
+		end = pageSize
+		cursor = sel
+
+	} else if len(choices)-sel-1 < pageSize/2 {
+		// if we are in the last half page
+		start = len(choices) - pageSize
+		end = len(choices)
+		cursor = sel - start
+
+	} else {
+		// somewhere in the middle
+		above := pageSize / 2
+		below := pageSize - above
+
+		cursor = pageSize / 2
+		start = sel - above
+		end = sel + below
+	}
+
+	// return the subset we care about and the index
+	return choices[start:end], cursor
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/LICENSE.txt
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright (c) 2014 Takashi Kokubun
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/buffered_reader.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/buffered_reader.go
@@ -1,0 +1,22 @@
+package terminal
+
+import (
+	"bytes"
+	"io"
+)
+
+type BufferedReader struct {
+	In     io.Reader
+	Buffer *bytes.Buffer
+}
+
+func (br *BufferedReader) Read(p []byte) (int, error) {
+	n, err := br.Buffer.Read(p)
+	if err != nil && err != io.EOF {
+		return n, err
+	} else if err == nil {
+		return n, nil
+	}
+
+	return br.In.Read(p[n:])
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/cursor.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/cursor.go
@@ -1,0 +1,174 @@
+// +build !windows
+
+package terminal
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+var COORDINATE_SYSTEM_BEGIN Short = 1
+
+var dsrPattern = regexp.MustCompile(`\x1b\[(\d+);(\d+)R$`)
+
+type Cursor struct {
+	In  FileReader
+	Out FileWriter
+}
+
+// Up moves the cursor n cells to up.
+func (c *Cursor) Up(n int) {
+	fmt.Fprintf(c.Out, "\x1b[%dA", n)
+}
+
+// Down moves the cursor n cells to down.
+func (c *Cursor) Down(n int) {
+	fmt.Fprintf(c.Out, "\x1b[%dB", n)
+}
+
+// Forward moves the cursor n cells to right.
+func (c *Cursor) Forward(n int) {
+	fmt.Fprintf(c.Out, "\x1b[%dC", n)
+}
+
+// Back moves the cursor n cells to left.
+func (c *Cursor) Back(n int) {
+	fmt.Fprintf(c.Out, "\x1b[%dD", n)
+}
+
+// NextLine moves cursor to beginning of the line n lines down.
+func (c *Cursor) NextLine(n int) {
+	fmt.Fprintf(c.Out, "\x1b[%dE", n)
+}
+
+// PreviousLine moves cursor to beginning of the line n lines up.
+func (c *Cursor) PreviousLine(n int) {
+	fmt.Fprintf(c.Out, "\x1b[%dF", n)
+}
+
+// HorizontalAbsolute moves cursor horizontally to x.
+func (c *Cursor) HorizontalAbsolute(x int) {
+	fmt.Fprintf(c.Out, "\x1b[%dG", x)
+}
+
+// Show shows the cursor.
+func (c *Cursor) Show() {
+	fmt.Fprint(c.Out, "\x1b[?25h")
+}
+
+// Hide hide the cursor.
+func (c *Cursor) Hide() {
+	fmt.Fprint(c.Out, "\x1b[?25l")
+}
+
+// Move moves the cursor to a specific x,y location.
+func (c *Cursor) Move(x int, y int) {
+	fmt.Fprintf(c.Out, "\x1b[%d;%df", x, y)
+}
+
+// Save saves the current position
+func (c *Cursor) Save() {
+	fmt.Fprint(c.Out, "\x1b7")
+}
+
+// Restore restores the saved position of the cursor
+func (c *Cursor) Restore() {
+	fmt.Fprint(c.Out, "\x1b8")
+}
+
+// for comparability purposes between windows
+// in unix we need to print out a new line on some terminals
+func (c *Cursor) MoveNextLine(cur *Coord, terminalSize *Coord) {
+	if cur.Y == terminalSize.Y {
+		fmt.Fprintln(c.Out)
+	}
+	c.NextLine(1)
+}
+
+// Location returns the current location of the cursor in the terminal
+func (c *Cursor) Location(buf *bytes.Buffer) (*Coord, error) {
+	// ANSI escape sequence for DSR - Device Status Report
+	// https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_sequences
+	fmt.Fprint(c.Out, "\x1b[6n")
+
+	// There may be input in Stdin prior to CursorLocation so make sure we don't
+	// drop those bytes.
+	var loc []int
+	var match string
+	for loc == nil {
+		// Reports the cursor position (CPR) to the application as (as though typed at
+		// the keyboard) ESC[n;mR, where n is the row and m is the column.
+		reader := bufio.NewReader(c.In)
+		text, err := reader.ReadSlice('R')
+		if err != nil {
+			return nil, err
+		}
+
+		loc = dsrPattern.FindStringIndex(string(text))
+		if loc == nil {
+			// Stdin contains R that doesn't match DSR.
+			buf.Write(text)
+		} else {
+			buf.Write(text[:loc[0]])
+			match = string(text[loc[0]:loc[1]])
+		}
+	}
+
+	matches := dsrPattern.FindStringSubmatch(string(match))
+	if len(matches) != 3 {
+		return nil, fmt.Errorf("incorrect number of matches: %d", len(matches))
+	}
+
+	col, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return nil, err
+	}
+
+	row, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return nil, err
+	}
+
+	return &Coord{Short(col), Short(row)}, nil
+}
+
+func (cur Coord) CursorIsAtLineEnd(size *Coord) bool {
+	return cur.X == size.X
+}
+
+func (cur Coord) CursorIsAtLineBegin() bool {
+	return cur.X == COORDINATE_SYSTEM_BEGIN
+}
+
+// Size returns the height and width of the terminal.
+func (c *Cursor) Size(buf *bytes.Buffer) (*Coord, error) {
+	// the general approach here is to move the cursor to the very bottom
+	// of the terminal, ask for the current location and then move the
+	// cursor back where we started
+
+	// hide the cursor (so it doesn't blink when getting the size of the terminal)
+	c.Hide()
+	// save the current location of the cursor
+	c.Save()
+
+	// move the cursor to the very bottom of the terminal
+	c.Move(999, 999)
+
+	// ask for the current location
+	bottom, err := c.Location(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	// move back where we began
+	c.Restore()
+
+	// show the cursor
+	c.Show()
+	// sice the bottom was calcuated in the lower right corner, it
+	// is the dimensions we are looking for
+	return bottom, nil
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/cursor_windows.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/cursor_windows.go
@@ -1,0 +1,138 @@
+package terminal
+
+import (
+	"bytes"
+	"syscall"
+	"unsafe"
+)
+
+var COORDINATE_SYSTEM_BEGIN Short = 0
+
+// shared variable to save the cursor location from CursorSave()
+var cursorLoc Coord
+
+type Cursor struct {
+	In  FileReader
+	Out FileWriter
+}
+
+func (c *Cursor) Up(n int) {
+	c.cursorMove(0, n)
+}
+
+func (c *Cursor) Down(n int) {
+	c.cursorMove(0, -1*n)
+}
+
+func (c *Cursor) Forward(n int) {
+	c.cursorMove(n, 0)
+}
+
+func (c *Cursor) Back(n int) {
+	c.cursorMove(-1*n, 0)
+}
+
+// save the cursor location
+func (c *Cursor) Save() {
+	cursorLoc, _ = c.Location(nil)
+}
+
+func (c *Cursor) Restore() {
+	handle := syscall.Handle(c.Out.Fd())
+	// restore it to the original position
+	procSetConsoleCursorPosition.Call(uintptr(handle), uintptr(*(*int32)(unsafe.Pointer(&cursorLoc))))
+}
+
+func (cur Coord) CursorIsAtLineEnd(size *Coord) bool {
+	return cur.X == size.X
+}
+
+func (cur Coord) CursorIsAtLineBegin() bool {
+	return cur.X == 0
+}
+
+func (c *Cursor) cursorMove(x int, y int) {
+	handle := syscall.Handle(c.Out.Fd())
+
+	var csbi consoleScreenBufferInfo
+	procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+
+	var cursor Coord
+	cursor.X = csbi.cursorPosition.X + Short(x)
+	cursor.Y = csbi.cursorPosition.Y + Short(y)
+
+	procSetConsoleCursorPosition.Call(uintptr(handle), uintptr(*(*int32)(unsafe.Pointer(&cursor))))
+}
+
+func (c *Cursor) NextLine(n int) {
+	c.Up(n)
+	c.HorizontalAbsolute(0)
+}
+
+func (c *Cursor) PreviousLine(n int) {
+	c.Down(n)
+	c.HorizontalAbsolute(0)
+}
+
+// for comparability purposes between windows
+// in windows we don't have to print out a new line
+func (c *Cursor) MoveNextLine(cur Coord, terminalSize *Coord) {
+	c.NextLine(1)
+}
+
+func (c *Cursor) HorizontalAbsolute(x int) {
+	handle := syscall.Handle(c.Out.Fd())
+
+	var csbi consoleScreenBufferInfo
+	procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+
+	var cursor Coord
+	cursor.X = Short(x)
+	cursor.Y = csbi.cursorPosition.Y
+
+	if csbi.size.X < cursor.X {
+		cursor.X = csbi.size.X
+	}
+
+	procSetConsoleCursorPosition.Call(uintptr(handle), uintptr(*(*int32)(unsafe.Pointer(&cursor))))
+}
+
+func (c *Cursor) Show() {
+	handle := syscall.Handle(c.Out.Fd())
+
+	var cci consoleCursorInfo
+	procGetConsoleCursorInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&cci)))
+	cci.visible = 1
+
+	procSetConsoleCursorInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&cci)))
+}
+
+func (c *Cursor) Hide() {
+	handle := syscall.Handle(c.Out.Fd())
+
+	var cci consoleCursorInfo
+	procGetConsoleCursorInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&cci)))
+	cci.visible = 0
+
+	procSetConsoleCursorInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&cci)))
+}
+
+func (c *Cursor) Location(buf *bytes.Buffer) (Coord, error) {
+	handle := syscall.Handle(c.Out.Fd())
+
+	var csbi consoleScreenBufferInfo
+	procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+
+	return csbi.cursorPosition, nil
+}
+
+func (c *Cursor) Size(buf *bytes.Buffer) (*Coord, error) {
+	handle := syscall.Handle(c.Out.Fd())
+
+	var csbi consoleScreenBufferInfo
+	procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+	// windows' coordinate system begins at (0, 0)
+	csbi.size.X--
+	csbi.size.Y--
+	return &csbi.size, nil
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/display.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/display.go
@@ -1,0 +1,9 @@
+package terminal
+
+type EraseLineMode int
+
+const (
+	ERASE_LINE_END EraseLineMode = iota
+	ERASE_LINE_START
+	ERASE_LINE_ALL
+)

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/display_posix.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/display_posix.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package terminal
+
+import (
+	"fmt"
+)
+
+func EraseLine(out FileWriter, mode EraseLineMode) {
+	fmt.Fprintf(out, "\x1b[%dK", mode)
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/display_windows.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/display_windows.go
@@ -1,0 +1,27 @@
+package terminal
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+func EraseLine(out FileWriter, mode EraseLineMode) {
+	handle := syscall.Handle(out.Fd())
+
+	var csbi consoleScreenBufferInfo
+	procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+
+	var w uint32
+	var x Short
+	cursor := csbi.cursorPosition
+	switch mode {
+	case ERASE_LINE_END:
+		x = csbi.size.X
+	case ERASE_LINE_START:
+		x = 0
+	case ERASE_LINE_ALL:
+		cursor.X = 0
+		x = csbi.size.X
+	}
+	procFillConsoleOutputCharacter.Call(uintptr(handle), uintptr(' '), uintptr(x), uintptr(*(*int32)(unsafe.Pointer(&cursor))), uintptr(unsafe.Pointer(&w)))
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/error.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/error.go
@@ -1,0 +1,9 @@
+package terminal
+
+import (
+	"errors"
+)
+
+var (
+	InterruptErr = errors.New("interrupt")
+)

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/output.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/output.go
@@ -1,0 +1,19 @@
+// +build !windows
+
+package terminal
+
+import (
+	"io"
+)
+
+// Returns special stdout, which converts escape sequences to Windows API calls
+// on Windows environment.
+func NewAnsiStdout(out FileWriter) io.Writer {
+	return out
+}
+
+// Returns special stderr, which converts escape sequences to Windows API calls
+// on Windows environment.
+func NewAnsiStderr(out FileWriter) io.Writer {
+	return out
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/output_windows.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/output_windows.go
@@ -1,0 +1,227 @@
+package terminal
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"github.com/mattn/go-isatty"
+)
+
+var (
+	cursorFunctions = map[rune]func(c *Cursor) func(int){
+		'A': func(c *Cursor) func(int) { return c.Up },
+		'B': func(c *Cursor) func(int) { return c.Down },
+		'C': func(c *Cursor) func(int) { return c.Forward },
+		'D': func(c *Cursor) func(int) { return c.Back },
+		'E': func(c *Cursor) func(int) { return c.NextLine },
+		'F': func(c *Cursor) func(int) { return c.PreviousLine },
+		'G': func(c *Cursor) func(int) { return c.HorizontalAbsolute },
+	}
+)
+
+const (
+	foregroundBlue      = 0x1
+	foregroundGreen     = 0x2
+	foregroundRed       = 0x4
+	foregroundIntensity = 0x8
+	foregroundMask      = (foregroundRed | foregroundBlue | foregroundGreen | foregroundIntensity)
+	backgroundBlue      = 0x10
+	backgroundGreen     = 0x20
+	backgroundRed       = 0x40
+	backgroundIntensity = 0x80
+	backgroundMask      = (backgroundRed | backgroundBlue | backgroundGreen | backgroundIntensity)
+)
+
+type Writer struct {
+	out     FileWriter
+	handle  syscall.Handle
+	orgAttr word
+}
+
+func NewAnsiStdout(out FileWriter) io.Writer {
+	var csbi consoleScreenBufferInfo
+	if !isatty.IsTerminal(out.Fd()) {
+		return out
+	}
+	handle := syscall.Handle(out.Fd())
+	procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+	return &Writer{out: out, handle: handle, orgAttr: csbi.attributes}
+}
+
+func NewAnsiStderr(out FileWriter) io.Writer {
+	var csbi consoleScreenBufferInfo
+	if !isatty.IsTerminal(out.Fd()) {
+		return out
+	}
+	handle := syscall.Handle(out.Fd())
+	procGetConsoleScreenBufferInfo.Call(uintptr(handle), uintptr(unsafe.Pointer(&csbi)))
+	return &Writer{out: out, handle: handle, orgAttr: csbi.attributes}
+}
+
+func (w *Writer) Write(data []byte) (n int, err error) {
+	r := bytes.NewReader(data)
+
+	for {
+		ch, size, err := r.ReadRune()
+		if err != nil {
+			break
+		}
+		n += size
+
+		switch ch {
+		case '\x1b':
+			size, err = w.handleEscape(r)
+			n += size
+			if err != nil {
+				break
+			}
+		default:
+			fmt.Fprint(w.out, string(ch))
+		}
+	}
+	return
+}
+
+func (w *Writer) handleEscape(r *bytes.Reader) (n int, err error) {
+	buf := make([]byte, 0, 10)
+	buf = append(buf, "\x1b"...)
+
+	// Check '[' continues after \x1b
+	ch, size, err := r.ReadRune()
+	if err != nil {
+		fmt.Fprint(w.out, string(buf))
+		return
+	}
+	n += size
+	if ch != '[' {
+		fmt.Fprint(w.out, string(buf))
+		return
+	}
+
+	// Parse escape code
+	var code rune
+	argBuf := make([]byte, 0, 10)
+	for {
+		ch, size, err = r.ReadRune()
+		if err != nil {
+			fmt.Fprint(w.out, string(buf))
+			return
+		}
+		n += size
+		if ('a' <= ch && ch <= 'z') || ('A' <= ch && ch <= 'Z') {
+			code = ch
+			break
+		}
+		argBuf = append(argBuf, string(ch)...)
+	}
+
+	w.applyEscapeCode(buf, string(argBuf), code)
+	return
+}
+
+func (w *Writer) applyEscapeCode(buf []byte, arg string, code rune) {
+	c := &Cursor{Out: w.out}
+
+	switch arg + string(code) {
+	case "?25h":
+		c.Show()
+		return
+	case "?25l":
+		c.Hide()
+		return
+	}
+
+	if f, ok := cursorFunctions[code]; ok {
+		if n, err := strconv.Atoi(arg); err == nil {
+			f(c)(n)
+			return
+		}
+	}
+
+	switch code {
+	case 'm':
+		w.applySelectGraphicRendition(arg)
+	default:
+		buf = append(buf, string(code)...)
+		fmt.Fprint(w.out, string(buf))
+	}
+}
+
+// Original implementation: https://github.com/mattn/go-colorable
+func (w *Writer) applySelectGraphicRendition(arg string) {
+	if arg == "" {
+		procSetConsoleTextAttribute.Call(uintptr(w.handle), uintptr(w.orgAttr))
+		return
+	}
+
+	var csbi consoleScreenBufferInfo
+	procGetConsoleScreenBufferInfo.Call(uintptr(w.handle), uintptr(unsafe.Pointer(&csbi)))
+	attr := csbi.attributes
+
+	for _, param := range strings.Split(arg, ";") {
+		n, err := strconv.Atoi(param)
+		if err != nil {
+			continue
+		}
+
+		switch {
+		case n == 0 || n == 100:
+			attr = w.orgAttr
+		case 1 <= n && n <= 5:
+			attr |= foregroundIntensity
+		case 30 <= n && n <= 37:
+			attr = (attr & backgroundMask)
+			if (n-30)&1 != 0 {
+				attr |= foregroundRed
+			}
+			if (n-30)&2 != 0 {
+				attr |= foregroundGreen
+			}
+			if (n-30)&4 != 0 {
+				attr |= foregroundBlue
+			}
+		case 40 <= n && n <= 47:
+			attr = (attr & foregroundMask)
+			if (n-40)&1 != 0 {
+				attr |= backgroundRed
+			}
+			if (n-40)&2 != 0 {
+				attr |= backgroundGreen
+			}
+			if (n-40)&4 != 0 {
+				attr |= backgroundBlue
+			}
+		case 90 <= n && n <= 97:
+			attr = (attr & backgroundMask)
+			attr |= foregroundIntensity
+			if (n-90)&1 != 0 {
+				attr |= foregroundRed
+			}
+			if (n-90)&2 != 0 {
+				attr |= foregroundGreen
+			}
+			if (n-90)&4 != 0 {
+				attr |= foregroundBlue
+			}
+		case 100 <= n && n <= 107:
+			attr = (attr & foregroundMask)
+			attr |= backgroundIntensity
+			if (n-100)&1 != 0 {
+				attr |= backgroundRed
+			}
+			if (n-100)&2 != 0 {
+				attr |= backgroundGreen
+			}
+			if (n-100)&4 != 0 {
+				attr |= backgroundBlue
+			}
+		}
+	}
+
+	procSetConsoleTextAttribute.Call(uintptr(w.handle), uintptr(attr))
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/runereader.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/runereader.go
@@ -1,0 +1,316 @@
+package terminal
+
+import (
+	"fmt"
+	"unicode"
+)
+
+type RuneReader struct {
+	stdio  Stdio
+	cursor *Cursor
+	state  runeReaderState
+}
+
+func NewRuneReader(stdio Stdio) *RuneReader {
+	return &RuneReader{
+		stdio: stdio,
+		state: newRuneReaderState(stdio.In),
+	}
+}
+
+func (rr *RuneReader) printChar(char rune, mask rune) {
+	// if we don't need to mask the input
+	if mask == 0 {
+		// just print the character the user pressed
+		fmt.Fprintf(rr.stdio.Out, "%c", char)
+	} else {
+		// otherwise print the mask we were given
+		fmt.Fprintf(rr.stdio.Out, "%c", mask)
+	}
+}
+
+func (rr *RuneReader) ReadLine(mask rune) ([]rune, error) {
+	line := []rune{}
+	// we only care about horizontal displacements from the origin so start counting at 0
+	index := 0
+
+	cursor := &Cursor{
+		In:  rr.stdio.In,
+		Out: rr.stdio.Out,
+	}
+
+	// we get the terminal width and height (if resized after this point the property might become invalid)
+	terminalSize, _ := cursor.Size(rr.Buffer())
+	// we set the current location of the cursor once
+	cursorCurrent, _ := cursor.Location(rr.Buffer())
+
+	for {
+		// wait for some input
+		r, _, err := rr.ReadRune()
+		if err != nil {
+			return line, err
+		}
+		// increment cursor location
+		cursorCurrent.X++
+
+		// if the user pressed enter or some other newline/termination like ctrl+d
+		if r == '\r' || r == '\n' || r == KeyEndTransmission {
+			// delete what's printed out on the console screen (cleanup)
+			for index > 0 {
+				if cursorCurrent.CursorIsAtLineBegin() {
+					EraseLine(rr.stdio.Out, ERASE_LINE_END)
+					cursor.PreviousLine(1)
+					cursor.Forward(int(terminalSize.X))
+					cursorCurrent.X = terminalSize.X
+					cursorCurrent.Y--
+
+				} else {
+					cursor.Back(1)
+					cursorCurrent.X--
+				}
+				index--
+			}
+			// move the cursor the a new line
+			cursor.MoveNextLine(cursorCurrent, terminalSize)
+
+			// we're done processing the input
+			return line, nil
+		}
+		// if the user interrupts (ie with ctrl+c)
+		if r == KeyInterrupt {
+			// go to the beginning of the next line
+			fmt.Fprint(rr.stdio.Out, "\r\n")
+
+			// we're done processing the input, and treat interrupt like an error
+			return line, InterruptErr
+		}
+
+		// allow for backspace/delete editing of inputs
+		if r == KeyBackspace || r == KeyDelete {
+			// and we're not at the beginning of the line
+			if index > 0 && len(line) > 0 {
+				// if we are at the end of the word
+				if index == len(line) {
+					// just remove the last letter from the internal representation
+					line = line[:len(line)-1]
+					// go back one
+					if cursorCurrent.X == 1 {
+						cursor.PreviousLine(1)
+						cursor.Forward(int(terminalSize.X))
+					} else {
+						cursor.Back(1)
+					}
+
+					// clear the rest of the line
+					EraseLine(rr.stdio.Out, ERASE_LINE_END)
+				} else {
+					// we need to remove a character from the middle of the word
+
+					// remove the current index from the list
+					line = append(line[:index-1], line[index:]...)
+
+					// save the current position of the cursor, as we have to move the cursor one back to erase the current symbol
+					// and then move the cursor for each symbol in line[index-1:] to print it out, afterwards we want to restore
+					// the cursor to its previous location.
+					cursor.Save()
+
+					// clear the rest of the line
+					cursor.Back(1)
+
+					// print what comes after
+					for _, char := range line[index-1:] {
+						//Erase symbols which are left over from older print
+						EraseLine(rr.stdio.Out, ERASE_LINE_END)
+						// print characters to the new line appropriately
+						rr.printChar(char, mask)
+
+					}
+					// erase what's left over from last print
+					if cursorCurrent.Y < terminalSize.Y {
+						cursor.NextLine(1)
+						EraseLine(rr.stdio.Out, ERASE_LINE_END)
+					}
+					// restore cursor
+					cursor.Restore()
+					if cursorCurrent.CursorIsAtLineBegin() {
+						cursor.PreviousLine(1)
+						cursor.Forward(int(terminalSize.X))
+					} else {
+						cursor.Back(1)
+					}
+				}
+
+				// decrement the index
+				index--
+			} else {
+				// otherwise the user pressed backspace while at the beginning of the line
+				soundBell(rr.stdio.Out)
+			}
+
+			// we're done processing this key
+			continue
+		}
+
+		// if the left arrow is pressed
+		if r == KeyArrowLeft {
+			// if we have space to the left
+			if index > 0 {
+				//move the cursor to the prev line if necessary
+				if cursorCurrent.CursorIsAtLineBegin() {
+					cursor.PreviousLine(1)
+					cursor.Forward(int(terminalSize.X))
+				} else {
+					cursor.Back(1)
+				}
+				//decrement the index
+				index--
+
+			} else {
+				// otherwise we are at the beginning of where we started reading lines
+				// sound the bell
+				soundBell(rr.stdio.Out)
+			}
+
+			// we're done processing this key press
+			continue
+		}
+
+		// if the right arrow is pressed
+		if r == KeyArrowRight {
+			// if we have space to the right
+			if index < len(line) {
+				// move the cursor to the next line if necessary
+				if cursorCurrent.CursorIsAtLineEnd(terminalSize) {
+					cursor.NextLine(1)
+				} else {
+					cursor.Forward(1)
+				}
+				index++
+
+			} else {
+				// otherwise we are at the end of the word and can't go past
+				// sound the bell
+				soundBell(rr.stdio.Out)
+			}
+
+			// we're done processing this key press
+			continue
+		}
+		// the user pressed one of the special keys
+		if r == SpecialKeyHome {
+			for index > 0 {
+				if cursorCurrent.CursorIsAtLineBegin() {
+					cursor.PreviousLine(1)
+					cursor.Forward(int(terminalSize.X))
+					cursorCurrent.X = terminalSize.X
+					cursorCurrent.Y--
+
+				} else {
+					cursor.Back(1)
+					cursorCurrent.X--
+				}
+				index--
+			}
+			continue
+			// user pressed end
+		} else if r == SpecialKeyEnd {
+			for index != len(line) {
+				if cursorCurrent.CursorIsAtLineEnd(terminalSize) {
+					cursor.NextLine(1)
+					cursorCurrent.X = COORDINATE_SYSTEM_BEGIN
+					cursorCurrent.Y++
+
+				} else {
+					cursor.Forward(1)
+					cursorCurrent.X++
+				}
+				index++
+			}
+			continue
+			// user pressed forward delete key
+		} else if r == SpecialKeyDelete {
+			// if index at the end of the line nothing to delete
+			if index != len(line) {
+				// save the current position of the cursor, as we have to  erase the current symbol
+				// and then move the cursor for each symbol in line[index:] to print it out, afterwards we want to restore
+				// the cursor to its previous location.
+				cursor.Save()
+				// remove the symbol after the cursor
+				line = append(line[:index], line[index+1:]...)
+				// print the updated line
+				for _, char := range line[index:] {
+					EraseLine(rr.stdio.Out, ERASE_LINE_END)
+					// print out the character
+					rr.printChar(char, mask)
+				}
+				// erase what's left on last line
+				if cursorCurrent.Y < terminalSize.Y {
+					cursor.NextLine(1)
+					EraseLine(rr.stdio.Out, ERASE_LINE_END)
+				}
+				// restore cursor
+				cursor.Restore()
+				if len(line) == 0 || index == len(line) {
+					EraseLine(rr.stdio.Out, ERASE_LINE_END)
+				}
+			}
+			continue
+		}
+
+		// if the letter is another escape sequence
+		if unicode.IsControl(r) || r == IgnoreKey {
+			// ignore it
+			continue
+		}
+
+		// the user pressed a regular key
+
+		// if we are at the end of the line
+		if index == len(line) {
+			// just append the character at the end of the line
+			line = append(line, r)
+			// save the location of the cursor
+			index++
+			// print out the character
+			rr.printChar(r, mask)
+		} else {
+			// we are in the middle of the word so we need to insert the character the user pressed
+			line = append(line[:index], append([]rune{r}, line[index:]...)...)
+			// save the current position of the cursor, as we have to move the cursor back to erase the current symbol
+			// and then move for each symbol in line[index:] to print it out, afterwards we want to restore
+			// cursor's location to its previous one.
+			cursor.Save()
+			EraseLine(rr.stdio.Out, ERASE_LINE_END)
+			// remove the symbol after the cursor
+			// print the updated line
+			for _, char := range line[index:] {
+				EraseLine(rr.stdio.Out, ERASE_LINE_END)
+				// print out the character
+				rr.printChar(char, mask)
+				cursorCurrent.X++
+			}
+			// if we are at the last line, we want to visually insert a new line and append to it.
+			if cursorCurrent.CursorIsAtLineEnd(terminalSize) && cursorCurrent.Y == terminalSize.Y {
+				// add a new line to the terminal
+				fmt.Fprintln(rr.stdio.Out)
+				// restore the position of the cursor horizontally
+				cursor.Restore()
+				// restore the position of the cursor vertically
+				cursor.Up(1)
+			} else {
+				// restore cursor
+				cursor.Restore()
+			}
+			// check if cursor needs to move to next line
+			cursorCurrent, _ = cursor.Location(rr.Buffer())
+			if cursorCurrent.CursorIsAtLineEnd(terminalSize) {
+				cursor.NextLine(1)
+			} else {
+				cursor.Forward(1)
+			}
+			// increment the index
+			index++
+
+		}
+	}
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/runereader_bsd.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/runereader_bsd.go
@@ -1,0 +1,13 @@
+// copied from: https://github.com/golang/crypto/blob/master/ssh/terminal/util_bsd.go
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package terminal
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TIOCGETA
+const ioctlWriteTermios = syscall.TIOCSETA

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/runereader_linux.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/runereader_linux.go
@@ -1,0 +1,12 @@
+// copied from https://github.com/golang/crypto/blob/master/ssh/terminal/util_linux.go
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package terminal
+
+// These constants are declared here, rather than importing
+// them from the syscall package as some syscall packages, even
+// on linux, for example gccgo, do not declare them.
+const ioctlReadTermios = 0x5401  // syscall.TCGETS
+const ioctlWriteTermios = 0x5402 // syscall.TCSETS

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/runereader_posix.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/runereader_posix.go
@@ -1,0 +1,111 @@
+// +build !windows
+
+// The terminal mode manipulation code is derived heavily from:
+// https://github.com/golang/crypto/blob/master/ssh/terminal/util.go:
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package terminal
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+type runeReaderState struct {
+	term   syscall.Termios
+	reader *bufio.Reader
+	buf    *bytes.Buffer
+}
+
+func newRuneReaderState(input FileReader) runeReaderState {
+	buf := new(bytes.Buffer)
+	return runeReaderState{
+		reader: bufio.NewReader(&BufferedReader{
+			In:     input,
+			Buffer: buf,
+		}),
+		buf: buf,
+	}
+}
+
+func (rr *RuneReader) Buffer() *bytes.Buffer {
+	return rr.state.buf
+}
+
+// For reading runes we just want to disable echo.
+func (rr *RuneReader) SetTermMode() error {
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(rr.stdio.In.Fd()), ioctlReadTermios, uintptr(unsafe.Pointer(&rr.state.term)), 0, 0, 0); err != 0 {
+		return err
+	}
+
+	newState := rr.state.term
+	newState.Lflag &^= syscall.ECHO | syscall.ECHONL | syscall.ICANON | syscall.ISIG
+
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(rr.stdio.In.Fd()), ioctlWriteTermios, uintptr(unsafe.Pointer(&newState)), 0, 0, 0); err != 0 {
+		return err
+	}
+
+	return nil
+}
+
+func (rr *RuneReader) RestoreTermMode() error {
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(rr.stdio.In.Fd()), ioctlWriteTermios, uintptr(unsafe.Pointer(&rr.state.term)), 0, 0, 0); err != 0 {
+		return err
+	}
+	return nil
+}
+
+func (rr *RuneReader) ReadRune() (rune, int, error) {
+	r, size, err := rr.state.reader.ReadRune()
+	if err != nil {
+		return r, size, err
+	}
+
+	// parse ^[ sequences to look for arrow keys
+	if r == '\033' {
+		if rr.state.reader.Buffered() == 0 {
+			// no more characters so must be `Esc` key
+			return KeyEscape, 1, nil
+		}
+		r, size, err = rr.state.reader.ReadRune()
+		if err != nil {
+			return r, size, err
+		}
+		if r != '[' {
+			return r, size, fmt.Errorf("Unexpected Escape Sequence: %q", []rune{'\033', r})
+		}
+		r, size, err = rr.state.reader.ReadRune()
+		if err != nil {
+			return r, size, err
+		}
+		switch r {
+		case 'D':
+			return KeyArrowLeft, 1, nil
+		case 'C':
+			return KeyArrowRight, 1, nil
+		case 'A':
+			return KeyArrowUp, 1, nil
+		case 'B':
+			return KeyArrowDown, 1, nil
+		case 'H': // Home button
+			return SpecialKeyHome, 1, nil
+		case 'F': // End button
+			return SpecialKeyEnd, 1, nil
+		case '3': // Delete Button
+			// discard the following '~' key from buffer
+			rr.state.reader.Discard(1)
+			return SpecialKeyDelete, 1, nil
+		default:
+			// discard the following '~' key from buffer
+			rr.state.reader.Discard(1)
+			return IgnoreKey, 1, nil
+		}
+		return r, size, fmt.Errorf("Unknown Escape Sequence: %q", []rune{'\033', '[', r})
+	}
+	return r, size, err
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/runereader_windows.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/runereader_windows.go
@@ -1,0 +1,142 @@
+package terminal
+
+import (
+	"bytes"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	dll              = syscall.NewLazyDLL("kernel32.dll")
+	setConsoleMode   = dll.NewProc("SetConsoleMode")
+	getConsoleMode   = dll.NewProc("GetConsoleMode")
+	readConsoleInput = dll.NewProc("ReadConsoleInputW")
+)
+
+const (
+	EVENT_KEY = 0x0001
+
+	// key codes for arrow keys
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/dd375731(v=vs.85).aspx
+	VK_DELETE = 0x2E
+	VK_END    = 0x23
+	VK_HOME   = 0x24
+	VK_LEFT   = 0x25
+	VK_UP     = 0x26
+	VK_RIGHT  = 0x27
+	VK_DOWN   = 0x28
+
+	RIGHT_CTRL_PRESSED = 0x0004
+	LEFT_CTRL_PRESSED  = 0x0008
+
+	ENABLE_ECHO_INPUT      uint32 = 0x0004
+	ENABLE_LINE_INPUT      uint32 = 0x0002
+	ENABLE_PROCESSED_INPUT uint32 = 0x0001
+)
+
+type inputRecord struct {
+	eventType uint16
+	padding   uint16
+	event     [16]byte
+}
+
+type keyEventRecord struct {
+	bKeyDown          int32
+	wRepeatCount      uint16
+	wVirtualKeyCode   uint16
+	wVirtualScanCode  uint16
+	unicodeChar       uint16
+	wdControlKeyState uint32
+}
+
+type runeReaderState struct {
+	term uint32
+}
+
+func newRuneReaderState(input FileReader) runeReaderState {
+	return runeReaderState{}
+}
+
+func (rr *RuneReader) Buffer() *bytes.Buffer {
+	return nil
+}
+
+func (rr *RuneReader) SetTermMode() error {
+	r, _, err := getConsoleMode.Call(uintptr(rr.stdio.In.Fd()), uintptr(unsafe.Pointer(&rr.state.term)))
+	// windows return 0 on error
+	if r == 0 {
+		return err
+	}
+
+	newState := rr.state.term
+	newState &^= ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT | ENABLE_PROCESSED_INPUT
+	r, _, err = setConsoleMode.Call(uintptr(rr.stdio.In.Fd()), uintptr(newState))
+	// windows return 0 on error
+	if r == 0 {
+		return err
+	}
+	return nil
+}
+
+func (rr *RuneReader) RestoreTermMode() error {
+	r, _, err := setConsoleMode.Call(uintptr(rr.stdio.In.Fd()), uintptr(rr.state.term))
+	// windows return 0 on error
+	if r == 0 {
+		return err
+	}
+	return nil
+}
+
+func (rr *RuneReader) ReadRune() (rune, int, error) {
+	ir := &inputRecord{}
+	bytesRead := 0
+	for {
+		rv, _, e := readConsoleInput.Call(rr.stdio.In.Fd(), uintptr(unsafe.Pointer(ir)), 1, uintptr(unsafe.Pointer(&bytesRead)))
+		// windows returns non-zero to indicate success
+		if rv == 0 && e != nil {
+			return 0, 0, e
+		}
+
+		if ir.eventType != EVENT_KEY {
+			continue
+		}
+
+		// the event data is really a c struct union, so here we have to do an usafe
+		// cast to put the data into the keyEventRecord (since we have already verified
+		// above that this event does correspond to a key event
+		key := (*keyEventRecord)(unsafe.Pointer(&ir.event[0]))
+		// we only care about key down events
+		if key.bKeyDown == 0 {
+			continue
+		}
+		if key.wdControlKeyState&(LEFT_CTRL_PRESSED|RIGHT_CTRL_PRESSED) != 0 && key.unicodeChar == 'C' {
+			return KeyInterrupt, bytesRead, nil
+		}
+		// not a normal character so look up the input sequence from the
+		// virtual key code mappings (VK_*)
+		if key.unicodeChar == 0 {
+			switch key.wVirtualKeyCode {
+			case VK_DOWN:
+				return KeyArrowDown, bytesRead, nil
+			case VK_LEFT:
+				return KeyArrowLeft, bytesRead, nil
+			case VK_RIGHT:
+				return KeyArrowRight, bytesRead, nil
+			case VK_UP:
+				return KeyArrowUp, bytesRead, nil
+			case VK_DELETE:
+				return SpecialKeyDelete, bytesRead, nil
+			case VK_HOME:
+				return SpecialKeyHome, bytesRead, nil
+			case VK_END:
+				return SpecialKeyEnd, bytesRead, nil
+			default:
+				// not a virtual key that we care about so just continue on to
+				// the next input key
+				continue
+			}
+		}
+		r := rune(key.unicodeChar)
+		return r, bytesRead, nil
+	}
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/sequences.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/sequences.go
@@ -1,0 +1,30 @@
+package terminal
+
+import (
+	"fmt"
+	"io"
+)
+
+const (
+	KeyArrowLeft       = '\x02'
+	KeyArrowRight      = '\x06'
+	KeyArrowUp         = '\x10'
+	KeyArrowDown       = '\x0e'
+	KeySpace           = ' '
+	KeyEnter           = '\r'
+	KeyBackspace       = '\b'
+	KeyDelete          = '\x7f'
+	KeyInterrupt       = '\x03'
+	KeyEndTransmission = '\x04'
+	KeyEscape          = '\x1b'
+	KeyDeleteWord      = '\x17' // Ctrl+W
+	KeyDeleteLine      = '\x18' // Ctrl+X
+	SpecialKeyHome     = '\x01'
+	SpecialKeyEnd      = '\x11'
+	SpecialKeyDelete   = '\x12'
+	IgnoreKey          = '\000'
+)
+
+func soundBell(out io.Writer) {
+	fmt.Fprint(out, "\a")
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/stdio.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/stdio.go
@@ -1,0 +1,24 @@
+package terminal
+
+import (
+	"io"
+)
+
+// Stdio is the standard input/output the terminal reads/writes with.
+type Stdio struct {
+	In  FileReader
+	Out FileWriter
+	Err io.Writer
+}
+
+// FileWriter provides a minimal interface for Stdin.
+type FileWriter interface {
+	io.Writer
+	Fd() uintptr
+}
+
+// FileReader provides a minimal interface for Stdout.
+type FileReader interface {
+	io.Reader
+	Fd() uintptr
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/syscall_windows.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/syscall_windows.go
@@ -1,0 +1,39 @@
+package terminal
+
+import (
+	"syscall"
+)
+
+var (
+	kernel32                       = syscall.NewLazyDLL("kernel32.dll")
+	procGetConsoleScreenBufferInfo = kernel32.NewProc("GetConsoleScreenBufferInfo")
+	procSetConsoleTextAttribute    = kernel32.NewProc("SetConsoleTextAttribute")
+	procSetConsoleCursorPosition   = kernel32.NewProc("SetConsoleCursorPosition")
+	procFillConsoleOutputCharacter = kernel32.NewProc("FillConsoleOutputCharacterW")
+	procGetConsoleCursorInfo       = kernel32.NewProc("GetConsoleCursorInfo")
+	procSetConsoleCursorInfo       = kernel32.NewProc("SetConsoleCursorInfo")
+)
+
+type wchar uint16
+type dword uint32
+type word uint16
+
+type smallRect struct {
+	left   Short
+	top    Short
+	right  Short
+	bottom Short
+}
+
+type consoleScreenBufferInfo struct {
+	size              Coord
+	cursorPosition    Coord
+	attributes        word
+	window            smallRect
+	maximumWindowSize Coord
+}
+
+type consoleCursorInfo struct {
+	size    dword
+	visible int32
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/terminal.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/terminal/terminal.go
@@ -1,0 +1,8 @@
+package terminal
+
+type Short int16
+
+type Coord struct {
+	X Short
+	Y Short
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/transform.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/transform.go
@@ -1,0 +1,76 @@
+package survey
+
+import (
+	"reflect"
+	"strings"
+)
+
+// TransformString returns a `Transformer` based on the "f"
+// function which accepts a string representation of the answer
+// and returns a new one, transformed, answer.
+// Take for example the functions inside the std `strings` package,
+// they can be converted to a compatible `Transformer` by using this function,
+// i.e: `TransformString(strings.Title)`, `TransformString(strings.ToUpper)`.
+//
+// Note that `TransformString` is just a helper, `Transformer` can be used
+// to transform any type of answer.
+func TransformString(f func(s string) string) Transformer {
+	return func(ans interface{}) interface{} {
+		// if the answer value passed in is the zero value of the appropriate type
+		if isZero(reflect.ValueOf(ans)) {
+			// skip this `Transformer` by returning a nil value.
+			// The original answer will be not affected,
+			// see survey.go#L125.
+			return nil
+		}
+
+		// "ans" is never nil here, so we don't have to check that
+		// see survey.go#L97 for more.
+		// Make sure that the the answer's value was a typeof string.
+		s, ok := ans.(string)
+		if !ok {
+			return nil
+		}
+
+		return f(s)
+	}
+}
+
+// ToLower is a `Transformer`.
+// It receives an answer value
+// and returns a copy of the "ans"
+// with all Unicode letters mapped to their lower case.
+//
+// Note that if "ans" is not a string then it will
+// return a nil value, meaning that the above answer
+// will not be affected by this call at all.
+func ToLower(ans interface{}) interface{} {
+	transformer := TransformString(strings.ToLower)
+	return transformer(ans)
+}
+
+// Title is a `Transformer`.
+// It receives an answer value
+// and returns a copy of the "ans"
+// with all Unicode letters that begin words
+// mapped to their title case.
+//
+// Note that if "ans" is not a string then it will
+// return a nil value, meaning that the above answer
+// will not be affected by this call at all.
+func Title(ans interface{}) interface{} {
+	transformer := TransformString(strings.Title)
+	return transformer(ans)
+}
+
+// ComposeTransformers is a variadic function used to create one transformer from many.
+func ComposeTransformers(transformers ...Transformer) Transformer {
+	// return a transformer that calls each one sequentially
+	return func(ans interface{}) interface{} {
+		// execute each transformer
+		for _, t := range transformers {
+			ans = t(ans)
+		}
+		return ans
+	}
+}

--- a/vendor/gopkg.in/AlecAivazis/survey.v1/validate.go
+++ b/vendor/gopkg.in/AlecAivazis/survey.v1/validate.go
@@ -1,0 +1,87 @@
+package survey
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+// Required does not allow an empty value
+func Required(val interface{}) error {
+	// the reflect value of the result
+	value := reflect.ValueOf(val)
+
+	// if the value passed in is the zero value of the appropriate type
+	if isZero(value) && value.Kind() != reflect.Bool {
+		return errors.New("Value is required")
+	}
+	return nil
+}
+
+// MaxLength requires that the string is no longer than the specified value
+func MaxLength(length int) Validator {
+	// return a validator that checks the length of the string
+	return func(val interface{}) error {
+		if str, ok := val.(string); ok {
+			// if the string is longer than the given value
+			if len([]rune(str)) > length {
+				// yell loudly
+				return fmt.Errorf("value is too long. Max length is %v", length)
+			}
+		} else {
+			// otherwise we cannot convert the value into a string and cannot enforce length
+			return fmt.Errorf("cannot enforce length on response of type %v", reflect.TypeOf(val).Name())
+		}
+
+		// the input is fine
+		return nil
+	}
+}
+
+// MinLength requires that the string is longer or equal in length to the specified value
+func MinLength(length int) Validator {
+	// return a validator that checks the length of the string
+	return func(val interface{}) error {
+		if str, ok := val.(string); ok {
+			// if the string is shorter than the given value
+			if len([]rune(str)) < length {
+				// yell loudly
+				return fmt.Errorf("value is too short. Min length is %v", length)
+			}
+		} else {
+			// otherwise we cannot convert the value into a string and cannot enforce length
+			return fmt.Errorf("cannot enforce length on response of type %v", reflect.TypeOf(val).Name())
+		}
+
+		// the input is fine
+		return nil
+	}
+}
+
+// ComposeValidators is a variadic function used to create one validator from many.
+func ComposeValidators(validators ...Validator) Validator {
+	// return a validator that calls each one sequentially
+	return func(val interface{}) error {
+		// execute each validator
+		for _, validator := range validators {
+			// if the answer's value is not valid
+			if err := validator(val); err != nil {
+				// return the error
+				return err
+			}
+		}
+		// we passed all validators, the answer is valid
+		return nil
+	}
+}
+
+// isZero returns true if the passed value is the zero object
+func isZero(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Slice, reflect.Map:
+		return v.Len() == 0
+	}
+
+	// compare the types directly with more general coverage
+	return reflect.DeepEqual(v.Interface(), reflect.Zero(v.Type()).Interface())
+}


### PR DESCRIPTION
The `machines` field in install-config.yaml will be replaced with `controlPlane` and `compute` fields. This PR brings in the latest openshift/installer version, which includes those changes.