### PR TITLE
WIP: *: Extract installer from the target update payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ This method uses the latest published Hive image on the CI registry: `registry.s
   export PULL_SECRET="$(cat ${HOME}/config.json)"
   export HIVE_IMAGE="quay.io/twiest/hive-controller:20190128"
   export HIVE_IMAGE_PULL_POLICY="Always"
-  export INSTALLER_IMAGE="quay.io/twiest/installer:20190128"
-  export INSTALLER_IMAGE_PULL_POLICY="Always"
+  export OPENSHIFT_RELEASE_IMAGE="quay.io/twiest/openshift:20190128"
+  export OPENSHIFT_RELEASE_IMAGE_PULL_POLICY="Always"
 
   oc process -f config/templates/cluster-deployment.yaml \
      CLUSTER_NAME="${CLUSTER_NAME}" \
@@ -63,8 +63,8 @@ This method uses the latest published Hive image on the CI registry: `registry.s
      AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
      HIVE_IMAGE="${HIVE_IMAGE}" \
      HIVE_IMAGE_PULL_POLICY="${HIVE_IMAGE_PULL_POLICY}" \
-     INSTALLER_IMAGE="${INSTALLER_IMAGE}" \
-     INSTALLER_IMAGE_PULL_POLICY="${INSTALLER_IMAGE_PULL_POLICY}" \
+     OPENSHIFT_RELEASE_IMAGE="${OPENSHIFT_RELEASE_IMAGE}" \
+     OPENSHIFT_RELEASE_IMAGE_PULL_POLICY="${OPENSHIFT_RELEASE_IMAGE_PULL_POLICY}" \
      | oc apply -f -
   ```
   * **NOTE:** The template parameter BASE_DOMAIN (which defaults to "new-installer.openshift.com") **must** be different than the DNS base domain for the Hive cluster itself. For example, if the Hive cluster's DNS base domain is "foo.example.com", then BASE_DOMAIN **must** be set to something other than "foo.example.com".

--- a/config/crds/hive_v1alpha1_clusterdeployment.yaml
+++ b/config/crds/hive_v1alpha1_clusterdeployment.yaml
@@ -194,11 +194,9 @@ spec:
                   type: string
                 hiveImagePullPolicy:
                   type: string
-                installerImage:
-                  type: string
-                installerImagePullPolicy:
-                  type: string
                 releaseImage:
+                  type: string
+                releaseImagePullPolicy:
                   type: string
               type: object
             networking:

--- a/config/templates/cluster-deployment.yaml
+++ b/config/templates/cluster-deployment.yaml
@@ -34,18 +34,14 @@ parameters:
   displayName: Hive image pull policy
   description: Hive image pull policy
   value: Always
-- name: INSTALLER_IMAGE
-  displayName: OpenShift Installer image URL
-  description: OpenShift Installer image URL
-  value: "registry.svc.ci.openshift.org/openshift/origin-v4.0:installer"
-- name: INSTALLER_IMAGE_PULL_POLICY
-  displayName: OpenShift Installer image pull policy
-  description: OpenShift Installer image pull policy
-  value: Always
 - name: OPENSHIFT_RELEASE_IMAGE
   displayName: OpenShift Release Image
   description: The release image for the version of OpenShift you wish to install.
   value: quay.io/openshift-release-dev/ocp-release:4.0.0-0.1
+- name: OPENSHIFT_RELEASE_IMAGE_PULL_POLICY
+  displayName: OpenShift release image pull policy
+  description: OpenShift release image pull policy
+  value: Always
 - name: TRY_INSTALL_ONCE
   displayName: Try Install Only Once
   description: If set, install will only be tried once.
@@ -94,9 +90,8 @@ objects:
     images:
       hiveImage: "${HIVE_IMAGE}"
       hiveImagePullPolicy: "${HIVE_IMAGE_PULL_POLICY}"
-      installerImage: "${INSTALLER_IMAGE}"
-      installerImagePullPolicy: "${INSTALLER_IMAGE_PULL_POLICY}"
       releaseImage: "${OPENSHIFT_RELEASE_IMAGE}"
+      releaseImagePullPolicy: "${OPENSHIFT_RELEASE_IMAGE_PULL_POLICY}"
     sshKey:
       name: "${CLUSTER_NAME}-ssh-key"
     clusterName: ${CLUSTER_NAME}

--- a/docs/sd_release.md
+++ b/docs/sd_release.md
@@ -4,92 +4,75 @@
 
 The purpose of this doc is to show how to do a deployment of OpenShift Hive for Service Delivery.
 
+## Release an update payload
 
-## Build installer Image
-
-- Setup some useful variables:
-  ```shell
-  > export RELEASE_VER=$(date +%Y%m%d)
-  > export INSTALLER_GOPATH=/path/to/openshift/installer/gopath
-  > export INSTALLER_SRC=${INSTALLER_GOPATH}/src/github.com/openshift/installer
-  > export INSTALLER_IMAGE_TAG=quay.io/twiest/installer:${RELEASE_VER}
-  > export AUTHFILE=~/.docker/config.json
+- Set up some useful variables:
+  ```console
+  $ RELEASE_VER=$(date +%Y%m%d)
+  $ RELEASE_IMAGE=quay.io/twiest/openshift
+  $ RELEASE_IMAGE_TAG="${RELEASE_IMAGE}:${RELEASE_VER}"
   ```
 
-- Get the latest installer code
-  ```shell
-  > cd "${INSTALLER_SRC}"
-  > git checkout master
-  > git fetch upstream
-  > git reset --hard upstream/master
-  ```
-
-- Build the installer container
-  ```shell
-  > cd "${INSTALLER_SRC}"
-  > BUILDAH_ISOLATION=chroot sudo buildah bud --file images/installer/Dockerfile.ci --tag "${INSTALLER_IMAGE_TAG}" .
-  ```
-
-- Push the build installer image to quay
-  ```shell
-  > BUILDAH_ISOLATION=chroot sudo buildah push --authfile ${AUTHFILE} ${INSTALLER_IMAGE_TAG} docker://${INSTALLER_IMAGE_TAG}
+- Create the release:
+  ```console
+  $ oc adm release new --from-release registry.svc.ci.openshift.org/openshift/origin-release:v4.0 --to-image "${RELEASE_IMAGE_TAG}" --mirror "${RELEASE_IMAGE}"
   ```
 
 ## Build the hive-controller Image
-- Setup some useful variables:
-  ```shell
-  > export HIVE_GOPATH=/path/to/openshift/installer/gopath
-  > export HIVE_SRC=${HIVE_GOPATH}/src/github.com/openshift/hive
-  > export HIVE_IMAGE_TAG=quay.io/twiest/hive-controller:${RELEASE_VER}
-  > export AUTHFILE=~/.docker/config.json
+- Set up some useful variables:
+  ```console
+  $ HIVE_GOPATH=/path/to/openshift/installer/gopath
+  $ HIVE_SRC=${HIVE_GOPATH}/src/github.com/openshift/hive
+  $ HIVE_IMAGE_TAG=quay.io/twiest/hive-controller:${RELEASE_VER}
+  $ AUTHFILE=~/.docker/config.json
   ```
 
-- Get the latest installer code
-  ```shell
-  > cd "${HIVE_SRC}"
-  > git checkout master
-  > git fetch upstream
-  > git reset --hard upstream/master
+- Get the latest Hive code:
+  ```console
+  $ cd "${HIVE_SRC}"
+  $ git checkout master
+  $ git fetch upstream
+  $ git reset --hard upstream/master
   ```
 
-- Build the installer container
-  ```shell
-  > cd "${HIVE_SRC}"
-  > GOPATH="${HIVE_GOPATH}" IMG="${HIVE_IMAGE_TAG}" make buildah-build
+- Build the Hive container:
+  ```console
+  $ cd "${HIVE_SRC}"
+  $ GOPATH="${HIVE_GOPATH}" IMG="${HIVE_IMAGE_TAG}" make buildah-build
   ```
 
-- Push the build installer image to quay
-  ```shell
-  > BUILDAH_ISOLATION=chroot sudo buildah push --authfile ${AUTHFILE} ${HIVE_IMAGE_TAG} docker://${HIVE_IMAGE_TAG}
+- Push the Hive image to quay:
+  ```console
+  $ BUILDAH_ISOLATION=chroot sudo buildah push --authfile ${AUTHFILE} ${HIVE_IMAGE_TAG} docker://${HIVE_IMAGE_TAG}
   ```
 
 ## Change the OpenShift Hive SD Deploy to point to the new images
-- Setup some useful variables:
-  ```shell
-  > export HIVE_SD_RELEASE_BRANCH="sd-release-${RELEASE_VER}"
+- Set up some useful variables:
+  ```console
+  $ HIVE_SD_RELEASE_BRANCH="sd-release-${RELEASE_VER}"
   ```
 
 - Create branch for PR:
-  ```shell
-  > cd "${HIVE_SRC}"
-  > git checkout master
-  > git fetch upstream
-  > git reset --hard upstream/master
-  > git checkout -b "${HIVE_SD_RELEASE_BRANCH}"
-  > git push -u origin "${HIVE_SD_RELEASE_BRANCH}"
+  ```console
+  $ cd "${HIVE_SRC}"
+  $ git checkout master
+  $ git fetch upstream
+  $ git reset --hard upstream/master
+  $ git checkout -b "${HIVE_SD_RELEASE_BRANCH}"
+  $ git push -u origin "${HIVE_SD_RELEASE_BRANCH}"
   ```
 
 - Update image versions in Kustomize and README:
-  ```shell
-  > cd "${HIVE_SRC}"
-  > sed -r -i -e "s%quay.io/twiest/hive-controller:[0-9]{8}%quay.io/twiest/hive-controller:${RELEASE_VER}%" README.md config/overlays/sd-dev/image_patch.yaml
-  > sed -r -i -e "s%quay.io/twiest/installer:[0-9]{8}%quay.io/twiest/installer:${RELEASE_VER}%" README.md config/overlays/sd-dev/image_patch.yaml
+  ```console
+  $ cd "${HIVE_SRC}"
+  $ sed -r -i -e "s%quay.io/twiest/hive-controller:[0-9]{8}%${HIVE_IMAGE_TAG}%" README.md config/overlays/sd-dev/image_patch.yaml
+  $ sed -r -i -e "s%quay.io/twiest/openshift:[0-9]{8}%${RELEASE_IMAGE_TAG}%" README.md config/overlays/sd-dev/image_patch.yaml
   ```
 
 - Commit and push changes
-  ```shell
-  > git commit -a -m "Update SD image links to latest release."
-  > git push origin
+  ```console
+  $ git commit -a -m "Update SD image links to latest release."
+  $ git push origin
   ```
 
 - Create PR in github for the new release
@@ -99,9 +82,9 @@ The purpose of this doc is to show how to do a deployment of OpenShift Hive for 
 - Login using `oc` to the SD cluster (aka opshive)
 - Remove all existing Hive objects (clusterdeployments, dnszones, etc). We're not currently trying to be backwards compatible, so this is necessary.
 - Deploy the new OpenShift Hive build:
-  ```shell
-  > cd "${HIVE_SRC}"
-  > GOPATH="${HIVE_GOPATH}" make deploy-sd-dev
+  ```console
+  $ cd "${HIVE_SRC}"
+  $ GOPATH="${HIVE_GOPATH}" make deploy-sd-dev
   ```
 - Test deploying a cluster using the instructions in the README. Make sure to use the instructions that use remote images and that the remote images are the new ones that were just built.
 

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -5,7 +5,6 @@ set -e
 component=hive
 TEST_IMAGE=$(eval "echo $IMAGE_FORMAT")
 component=installer
-INSTALLER_IMAGE=$(eval "echo $IMAGE_FORMAT")
 
 ln -s $(which oc) $(pwd)/kubectl
 export PATH=$PATH:$(pwd)
@@ -56,7 +55,6 @@ oc process -f config/templates/cluster-deployment.yaml \
    AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
    AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
    BASE_DOMAIN="${BASE_DOMAIN}" \
-   INSTALLER_IMAGE="${INSTALLER_IMAGE}" \
    OPENSHIFT_RELEASE_IMAGE="" \
    TRY_INSTALL_ONCE="true" \
    | oc apply -f -

--- a/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
@@ -80,10 +80,6 @@ type ClusterDeploymentSpec struct {
 
 // ProvisionImages allows overriding the default images used to provision a cluster.
 type ProvisionImages struct {
-	// InstallerImage is the image containing the openshift-install binary that will be used to install.
-	InstallerImage string `json:"installerImage,omitempty"`
-	// InstallerImagePullPolicy is the pull policy for the installer image.
-	InstallerImagePullPolicy corev1.PullPolicy `json:"installerImagePullPolicy,omitempty"`
 	// HiveImage is the image used in the sidecar container to manage execution of openshift-install.
 	HiveImage string `json:"hiveImage,omitempty"`
 	// HiveImagePullPolicy is the pull policy for the installer image.
@@ -92,6 +88,8 @@ type ProvisionImages struct {
 	// ReleaseImage is the image containing metadata for all components that run in the cluster, and
 	// is the primary and best way to specify what specific version of OpenShift you wish to install.
 	ReleaseImage string `json:"releaseImage,omitempty"`
+	// ReleaseImagePullPolicy is the pull policy for the release image.
+	ReleaseImagePullPolicy corev1.PullPolicy `json:"releaseImagePullPolicy,omitempty"`
 }
 
 // PlatformSecrets defines the secrets to be used by various clouds.

--- a/pkg/install/convertconfig.go
+++ b/pkg/install/convertconfig.go
@@ -101,7 +101,7 @@ func GenerateInstallConfig(cd *hivev1.ClusterDeployment, sshKey, pullSecret stri
 			Name: spec.ClusterName,
 		},
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1beta1",
+			APIVersion: "v1beta1", // FIXME: from installer package
 		},
 		SSHKey:     sshKey,
 		BaseDomain: spec.BaseDomain,


### PR DESCRIPTION
Take advantage of openshift/origin@59dab63d (openshift/origin#21637) to avoid installer/update-payload mismatches.  This does not address `install-config.yaml`/installer mismatches, but it's a step in the right direction.

Also:

* Replace `shell` syntax highlighting with `console`, because these blocks have prompts.  And switch from the traditionally-`PS2` `>` to the traditionally-`PS1` `$` for those prompts.
* Stop exporting variables that are not needed by subprocesses.
* Drop `OPENSHIFT_INSTALL_*`.  This information is provided via `install-config.yaml`, and the installer ignores the environment variables since openshift/installer@6be4c253 (openshift/installer#861).

There's an outstanding FIXME while I wait for guidance about who's job it is to pull the installer image out of the update payload.  If we do that in `generate.go`, we need to vendor some not-really-designed-as-a-library origin code.  If we do it in the launched container, we need both `oc` and `podman` (or some other way to actually run the discovered installer image).