### PR TITLE
Federation controller: handle label sync

### DIFF
--- a/config/crds/hive_v1alpha1_clusterdeployment.yaml
+++ b/config/crds/hive_v1alpha1_clusterdeployment.yaml
@@ -17,37 +17,62 @@ spec:
     openAPIV3Schema:
       properties:
         apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
           properties:
             baseDomain:
+              description: BaseDomain is the base domain to which the cluster should
+                belong.
               type: string
             clusterName:
+              description: ClusterName is the friendly name of the cluster. It is
+                used for subdomains, some resource tagging, and other instances where
+                a friendly name for the cluster is useful.
               type: string
             compute:
+              description: Compute is the list of MachinePools containing compute
+                nodes that need to be installed.
               items:
                 properties:
                   name:
+                    description: Name is the name of the machine pool.
                     type: string
                   platform:
+                    description: Platform is configuration for machine pool specific
+                      to the platfrom.
                     properties:
                       aws:
+                        description: AWS is the configuration used when installing
+                          on AWS.
                         properties:
                           iamRoleName:
+                            description: IAMRoleName defines the IAM role associated
+                              with the ec2 instance.
                             type: string
                           rootVolume:
+                            description: EC2RootVolume defines the storage for ec2
+                              instance.
                             properties:
                               iops:
+                                description: IOPS defines the iops for the instance.
                                 format: int64
                                 type: integer
                               size:
+                                description: Size defines the size of the instance.
                                 format: int64
                                 type: integer
                               type:
+                                description: Type defines the type of the instance.
                                 type: string
                             required:
                             - iops
@@ -55,8 +80,12 @@ spec:
                             - type
                             type: object
                           type:
+                            description: InstanceType defines the ec2 instance type.
+                              eg. m4-large
                             type: string
                           zones:
+                            description: Zones is list of availability zones that
+                              can be used.
                             items:
                               type: string
                             type: array
@@ -66,27 +95,42 @@ spec:
                         - rootVolume
                         type: object
                       libvirt:
+                        description: Libvirt is the configuration used when installing
+                          on libvirt.
                         properties:
                           image:
+                            description: Image is the URL to the OS image. E.g. "http://aos-ostree.rhev-ci-vms.eng.rdu2.redhat.com/rhcos/images/cloud/latest/rhcos-qemu.qcow2.gz"
                             type: string
                           imagePool:
+                            description: ImagePool is the name of the libvirt storage
+                              pool to which the storage volume containing the OS image
+                              belongs.
                             type: string
                           imageVolume:
+                            description: ImageVolume is the name of the libvirt storage
+                              volume containing the OS image.
                             type: string
                         required:
                         - image
                         type: object
                       openstack:
+                        description: OpenStack is the configuration used when installing
+                          on OpenStack.
                         properties:
                           rootVolume:
+                            description: OpenStackRootVolume defines the storage for
+                              Nova instance.
                             properties:
                               iops:
+                                description: IOPS defines the iops for the instance.
                                 format: int64
                                 type: integer
                               size:
+                                description: Size defines the size of the instance.
                                 format: int64
                                 type: integer
                               type:
+                                description: Type defines the type of the instance.
                                 type: string
                             required:
                             - iops
@@ -94,6 +138,8 @@ spec:
                             - type
                             type: object
                           type:
+                            description: FlavorName defines the OpenStack Nova flavor.
+                              eg. m1.large
                             type: string
                         required:
                         - type
@@ -101,6 +147,8 @@ spec:
                         type: object
                     type: object
                   replicas:
+                    description: Replicas is the count of machines for this machine
+                      pool. Default is 1.
                     format: int64
                     type: integer
                 required:
@@ -110,24 +158,37 @@ spec:
                 type: object
               type: array
             controlPlane:
+              description: ControlPlane is the MachinePool containing control plane
+                nodes that need to be installed.
               properties:
                 name:
+                  description: Name is the name of the machine pool.
                   type: string
                 platform:
+                  description: Platform is configuration for machine pool specific
+                    to the platfrom.
                   properties:
                     aws:
+                      description: AWS is the configuration used when installing on
+                        AWS.
                       properties:
                         iamRoleName:
+                          description: IAMRoleName defines the IAM role associated
+                            with the ec2 instance.
                           type: string
                         rootVolume:
+                          description: EC2RootVolume defines the storage for ec2 instance.
                           properties:
                             iops:
+                              description: IOPS defines the iops for the instance.
                               format: int64
                               type: integer
                             size:
+                              description: Size defines the size of the instance.
                               format: int64
                               type: integer
                             type:
+                              description: Type defines the type of the instance.
                               type: string
                           required:
                           - iops
@@ -135,8 +196,12 @@ spec:
                           - type
                           type: object
                         type:
+                          description: InstanceType defines the ec2 instance type.
+                            eg. m4-large
                           type: string
                         zones:
+                          description: Zones is list of availability zones that can
+                            be used.
                           items:
                             type: string
                           type: array
@@ -146,27 +211,42 @@ spec:
                       - rootVolume
                       type: object
                     libvirt:
+                      description: Libvirt is the configuration used when installing
+                        on libvirt.
                       properties:
                         image:
+                          description: Image is the URL to the OS image. E.g. "http://aos-ostree.rhev-ci-vms.eng.rdu2.redhat.com/rhcos/images/cloud/latest/rhcos-qemu.qcow2.gz"
                           type: string
                         imagePool:
+                          description: ImagePool is the name of the libvirt storage
+                            pool to which the storage volume containing the OS image
+                            belongs.
                           type: string
                         imageVolume:
+                          description: ImageVolume is the name of the libvirt storage
+                            volume containing the OS image.
                           type: string
                       required:
                       - image
                       type: object
                     openstack:
+                      description: OpenStack is the configuration used when installing
+                        on OpenStack.
                       properties:
                         rootVolume:
+                          description: OpenStackRootVolume defines the storage for
+                            Nova instance.
                           properties:
                             iops:
+                              description: IOPS defines the iops for the instance.
                               format: int64
                               type: integer
                             size:
+                              description: Size defines the size of the instance.
                               format: int64
                               type: integer
                             type:
+                              description: Type defines the type of the instance.
                               type: string
                           required:
                           - iops
@@ -174,6 +254,8 @@ spec:
                           - type
                           type: object
                         type:
+                          description: FlavorName defines the OpenStack Nova flavor.
+                            eg. m1.large
                           type: string
                       required:
                       - type
@@ -181,6 +263,8 @@ spec:
                       type: object
                   type: object
                 replicas:
+                  description: Replicas is the count of machines for this machine
+                    pool. Default is 1.
                   format: int64
                   type: integer
               required:
@@ -189,21 +273,38 @@ spec:
               - platform
               type: object
             images:
+              description: Images allows overriding the default images used to provision
+                and manage the cluster.
               properties:
                 hiveImage:
+                  description: HiveImage is the image used in the sidecar container
+                    to manage execution of openshift-install.
                   type: string
                 hiveImagePullPolicy:
+                  description: HiveImagePullPolicy is the pull policy for the installer
+                    image.
                   type: string
                 installerImage:
+                  description: InstallerImage is the image containing the openshift-install
+                    binary that will be used to install.
                   type: string
                 installerImagePullPolicy:
+                  description: InstallerImagePullPolicy is the pull policy for the
+                    installer image.
                   type: string
                 releaseImage:
+                  description: ReleaseImage is the image containing metadata for all
+                    components that run in the cluster, and is the primary and best
+                    way to specify what specific version of OpenShift you wish to
+                    install.
                   type: string
               type: object
             networking:
+              description: Networking defines the pod network provider in the cluster.
               properties:
                 clusterNetworks:
+                  description: ClusterNetworks is the IP address space from which
+                    to assign pod IPs.
                   items:
                     properties:
                       cidr:
@@ -217,10 +318,15 @@ spec:
                     type: object
                   type: array
                 machineCIDR:
+                  description: MachineCIDR is the IP address space from which to assign
+                    machine IPs.
                   type: string
                 serviceCIDR:
+                  description: ServiceCIDR is the IP address space from which to assign
+                    service IPs.
                   type: string
                 type:
+                  description: Type is the network type to install
                   type: string
               required:
               - machineCIDR
@@ -228,22 +334,34 @@ spec:
               - serviceCIDR
               type: object
             platform:
+              description: Platform is the configuration for the specific platform
+                upon which to perform the installation.
               properties:
                 aws:
+                  description: AWS is the configuration used when installing on AWS.
                   properties:
                     defaultMachinePlatform:
+                      description: DefaultMachinePlatform is the default configuration
+                        used when installing on AWS for machine pools which do not
+                        define their own platform configuration.
                       properties:
                         iamRoleName:
+                          description: IAMRoleName defines the IAM role associated
+                            with the ec2 instance.
                           type: string
                         rootVolume:
+                          description: EC2RootVolume defines the storage for ec2 instance.
                           properties:
                             iops:
+                              description: IOPS defines the iops for the instance.
                               format: int64
                               type: integer
                             size:
+                              description: Size defines the size of the instance.
                               format: int64
                               type: integer
                             type:
+                              description: Type defines the type of the instance.
                               type: string
                           required:
                           - iops
@@ -251,8 +369,12 @@ spec:
                           - type
                           type: object
                         type:
+                          description: InstanceType defines the ec2 instance type.
+                            eg. m4-large
                           type: string
                         zones:
+                          description: Zones is list of availability zones that can
+                            be used.
                           items:
                             type: string
                           type: array
@@ -262,39 +384,63 @@ spec:
                       - rootVolume
                       type: object
                     region:
+                      description: Region specifies the AWS region where the cluster
+                        will be created.
                       type: string
                     userTags:
+                      description: UserTags specifies additional tags for AWS resources
+                        created for the cluster.
                       type: object
                   required:
                   - region
                   type: object
                 libvirt:
+                  description: Libvirt is the configuration used when installing on
+                    libvirt.
                   properties:
                     URI:
+                      description: URI is the identifier for the libvirtd connection.  It
+                        must be reachable from both the host (where the installer
+                        is run) and the cluster (where the cluster-API controller
+                        pod will be running).
                       type: string
                     defaultMachinePlatform:
+                      description: DefaultMachinePlatform is the default configuration
+                        used when installing on AWS for machine pools which do not
+                        define their own platform configuration.
                       properties:
                         image:
+                          description: Image is the URL to the OS image. E.g. "http://aos-ostree.rhev-ci-vms.eng.rdu2.redhat.com/rhcos/images/cloud/latest/rhcos-qemu.qcow2.gz"
                           type: string
                         imagePool:
+                          description: ImagePool is the name of the libvirt storage
+                            pool to which the storage volume containing the OS image
+                            belongs.
                           type: string
                         imageVolume:
+                          description: ImageVolume is the name of the libvirt storage
+                            volume containing the OS image.
                           type: string
                       required:
                       - image
                       type: object
                     masterIPs:
+                      description: MasterIPs
                       items:
                         format: byte
                         type: string
                       type: array
                     network:
+                      description: Network
                       properties:
                         if:
+                          description: IfName is the name of the network interface.
                           type: string
                         ipRange:
+                          description: IPRange is the range of IPs to use.
                           type: string
                         name:
+                          description: Name is the name of the nework.
                           type: string
                       required:
                       - name
@@ -308,20 +454,30 @@ spec:
                   type: object
               type: object
             platformSecrets:
+              description: PlatformSecrets contains credentials and secrets for the
+                cluster infrastructure.
               properties:
                 aws:
                   properties:
                     credentials:
+                      description: Credentials refers to a secret that contains the
+                        AWS account access credentials.
                       type: object
                   required:
                   - credentials
                   type: object
               type: object
             preserveOnDelete:
+              description: PreserveOnDelete allows the user to disconnect a cluster
+                from Hive without deprovisioning it
               type: boolean
             pullSecret:
+              description: PullSecret is the reference to the secret to use when pulling
+                images.
               type: object
             sshKey:
+              description: SSHKey is the reference to the secret that contains a public
+                key to use for access to compute instances.
               type: object
           required:
           - clusterName
@@ -336,21 +492,41 @@ spec:
         status:
           properties:
             adminKubeconfigSecret:
+              description: AdminKubeconfigSecret references the secret containing
+                the admin kubeconfig for this cluster.
               type: object
             adminPasswordSecret:
+              description: AdminPasswordSecret references the secret containing the
+                admin username/password which can be used to login to this cluster.
               type: object
             apiURL:
+              description: APIURL is the URL where the cluster's API can be accessed.
               type: string
             clusterID:
+              description: ClusterID is a unique identifier for this cluster generated
+                during installation.
               type: string
             clusterVersionStatus:
+              description: ClusterVersionStatus will hold a copy of the remote cluster's
+                ClusterVersion.Status
               properties:
                 availableUpdates:
+                  description: availableUpdates contains the list of updates that
+                    are appropriate for this cluster. This list may be empty if no
+                    updates are recommended, if the update service is unavailable,
+                    or if an invalid channel has been specified.
                   items:
                     properties:
                       payload:
+                        description: payload is a container image location that contains
+                          the update. When this field is part of spec, payload is
+                          optional if version is specified and the availableUpdates
+                          field contains a matching version.
                         type: string
                       version:
+                        description: version is a semantic versioning identifying
+                          the update version. When this field is part of spec, version
+                          is optional if payload is specified.
                         type: string
                     required:
                     - version
@@ -358,18 +534,35 @@ spec:
                     type: object
                   type: array
                 conditions:
+                  description: conditions provides information about the cluster version.
+                    The condition "Available" is set to true if the desiredUpdate
+                    has been reached. The condition "Progressing" is set to true if
+                    an update is being applied. The condition "Failing" is set to
+                    true if an update is currently blocked by a temporary or permanent
+                    error. Conditions are only valid for the current desiredUpdate
+                    when metadata.generation is equal to status.generation.
                   items:
                     properties:
                       lastTransitionTime:
+                        description: lastTransitionTime is the time of the last update
+                          to the current status object.
                         format: date-time
                         type: string
                       message:
+                        description: message provides additional information about
+                          the current condition. This is only to be consumed by humans.
                         type: string
                       reason:
+                        description: reason is the reason for the condition's last
+                          transition.  Reasons are CamelCase
                         type: string
                       status:
+                        description: status of the condition, one of True, False,
+                          Unknown.
                         type: string
                       type:
+                        description: type specifies the state of the operator's reconciliation
+                          functionality.
                         type: string
                     required:
                     - type
@@ -378,32 +571,72 @@ spec:
                     type: object
                   type: array
                 desired:
+                  description: desired is the version that the cluster is reconciling
+                    towards. If the cluster is not yet fully initialized desired will
+                    be set with the information available, which may be a payload
+                    or a tag.
                   properties:
                     payload:
+                      description: payload is a container image location that contains
+                        the update. When this field is part of spec, payload is optional
+                        if version is specified and the availableUpdates field contains
+                        a matching version.
                       type: string
                     version:
+                      description: version is a semantic versioning identifying the
+                        update version. When this field is part of spec, version is
+                        optional if payload is specified.
                       type: string
                   required:
                   - version
                   - payload
                   type: object
                 generation:
+                  description: generation reports which version of the spec is being
+                    processed. If this value is not equal to metadata.generation,
+                    then the current and conditions fields have not yet been updated
+                    to reflect the latest request.
                   format: int64
                   type: integer
                 history:
+                  description: history contains a list of the most recent versions
+                    applied to the cluster. This value may be empty during cluster
+                    startup, and then will be updated when a new update is being applied.
+                    The newest update is first in the list and it is ordered by recency.
+                    Updates in the history have state Completed if the rollout completed
+                    - if an update was failing or halfway applied the state will be
+                    Partial. Only a limited amount of update history is preserved.
                   items:
                     properties:
                       completionTime:
+                        description: completionTime, if set, is when the update was
+                          fully applied. The update that is currently being applied
+                          will have a null completion time. Completion time will always
+                          be set for entries that are not the current update (usually
+                          to the started time of the next update).
                         format: date-time
                         type: string
                       payload:
+                        description: payload is a container image location that contains
+                          the update. This value is always populated.
                         type: string
                       startedTime:
+                        description: startedTime is the time at which the update was
+                          started.
                         format: date-time
                         type: string
                       state:
+                        description: state reflects whether the update was fully applied.
+                          The Partial state indicates the update is not fully applied,
+                          while the Completed state indicates the update was successfully
+                          rolled out at least once (all parts of the update successfully
+                          applied).
                         type: string
                       version:
+                        description: version is a semantic versioning identifying
+                          the update version. If the requested payload does not define
+                          a version, or if a failure occurs retrieving the payload,
+                          this value may be empty.
                         type: string
                     required:
                     - state
@@ -414,6 +647,9 @@ spec:
                     type: object
                   type: array
                 versionHash:
+                  description: versionHash is a fingerprint of the content that the
+                    cluster will be updated with. It is used by the operator to avoid
+                    unnecessary work and is for internal use only.
                   type: string
               required:
               - desired
@@ -424,10 +660,20 @@ spec:
               - availableUpdates
               type: object
             federated:
+              description: Federated is true if the cluster deployment has been federated
+                with the host cluster.
               type: boolean
+            federatedClusterRef:
+              description: FederatedClusterRef is the reference to the federated cluster
+                resource associated with this ClusterDeployment
+              type: object
             installed:
+              description: Installed is true if the installer job has successfully
+                completed for this cluster.
               type: boolean
             webConsoleURL:
+              description: WebConsoleURL is the URL for the cluster's web console
+                UI.
               type: string
           required:
           - installed

--- a/config/crds/hive_v1alpha1_dnszone.yaml
+++ b/config/crds/hive_v1alpha1_dnszone.yaml
@@ -15,24 +15,36 @@ spec:
     openAPIV3Schema:
       properties:
         apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
           properties:
             aws:
+              description: AWS specifies AWS-specific cloud configuration
               properties:
                 accountSecret:
+                  description: AccountSecret contains a reference to a secret that
+                    contains AWS credentials for CRUD operations
                   type: object
                 region:
+                  description: Region specifies the region-specific API endpoint to
+                    use
                   type: string
               required:
               - accountSecret
               - region
               type: object
             zone:
+              description: Zone is the DNS zoneto host
               type: string
           required:
           - zone
@@ -40,9 +52,13 @@ spec:
         status:
           properties:
             lastSyncGeneration:
+              description: LastSyncGeneration is the generation of the zone resource
+                that was last sync'd. This is used to know if the Object has changed
+                and we should sync immediately.
               format: int64
               type: integer
             lastSyncTimestamp:
+              description: LastSyncTimestamp is the time that the zone was last sync'd.
               format: date-time
               type: string
           required:

--- a/hack/install-federation.sh
+++ b/hack/install-federation.sh
@@ -13,6 +13,6 @@ fi
 kubectl apply --validate=false -f "${SRC_DIR}/hack/federation/deploy_federation.yaml"
 kubectl apply --validate=false -f "${SRC_DIR}/hack/federation/cluster-registry-crd.yaml"
 for filename in ${SRC_DIR}/hack/federation/federatedirectives/*.yaml; do
-  kubefed2 federate enable -f "${filename}" --federation-namespace="federation-system"
+  kubefed2 enable -f "${filename}" --federation-namespace="federation-system"
 done
-kubefed2 federate enable clusterrolebindings --federation-namespace="federation-system"
+kubefed2 enable clusterrolebindings --federation-namespace="federation-system"

--- a/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
@@ -124,7 +124,7 @@ type ClusterDeploymentStatus struct {
 	Federated bool `json:"federated,omitempty"`
 
 	// FederatedClusterRef is the reference to the federated cluster resource associated with
-	// this ClusterDeployment
+	// this ClusterDeployment.
 	FederatedClusterRef *corev1.ObjectReference `json:"federatedClusterRef,omitempty"`
 
 	// AdminKubeconfigSecret references the secret containing the admin kubeconfig for this cluster.

--- a/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
@@ -123,6 +123,10 @@ type ClusterDeploymentStatus struct {
 	// Federated is true if the cluster deployment has been federated with the host cluster.
 	Federated bool `json:"federated,omitempty"`
 
+	// FederatedClusterRef is the reference to the federated cluster resource associated with
+	// this ClusterDeployment
+	FederatedClusterRef *corev1.ObjectReference `json:"federatedClusterRef,omitempty"`
+
 	// AdminKubeconfigSecret references the secret containing the admin kubeconfig for this cluster.
 	AdminKubeconfigSecret corev1.LocalObjectReference `json:"adminKubeconfigSecret,omitempty"`
 

--- a/pkg/controller/federation/clusterdeployment_federation_controller.go
+++ b/pkg/controller/federation/clusterdeployment_federation_controller.go
@@ -23,11 +23,11 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/clientcmd"
 	crv1alpha1 "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
 
@@ -56,6 +56,9 @@ const (
 	adminKubeconfigKey = "kubeconfig"
 
 	federatedClustersCRDName = "federatedclusters.core.federation.k8s.io"
+
+	clusterDeploymentNamespaceAnnotation = "hive.openshift.io/cluster-deployment-namespace"
+	clusterDeploymentNameAnnotation      = "hive.openshift.io/cluster-deployment-name"
 )
 
 // Add creates a new ClusterDeployment Federation Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
@@ -66,10 +69,14 @@ func Add(mgr manager.Manager) error {
 
 // NewReconciler returns a new reconcile.Reconciler
 func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileClusterDeploymentFederation{
+	reconciler := &ReconcileClusterDeploymentFederation{
 		Client: mgr.GetClient(),
 		scheme: mgr.GetScheme(),
 	}
+	reconciler.isFederationInstalled = reconciler.isFederatedClusterCRDPresent
+	reconciler.joinCluster = reconciler.federateTargetCluster
+
+	return reconciler
 }
 
 // AddToManager adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -86,15 +93,6 @@ func AddToManager(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	// Watch for jobs created for a ClusterDeployment:
-	err = c.Watch(&source.Kind{Type: &batchv1.Job{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &hivev1.ClusterDeployment{},
-	})
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -104,6 +102,10 @@ var _ reconcile.Reconciler = &ReconcileClusterDeploymentFederation{}
 type ReconcileClusterDeploymentFederation struct {
 	client.Client
 	scheme *runtime.Scheme
+
+	// functions pointers used in unit testing
+	isFederationInstalled func() (bool, error)
+	joinCluster           func(*hivev1.ClusterDeployment, log.FieldLogger) error
 }
 
 // Reconcile reads that state of the cluster for a ClusterDeployment object and federates it if it's installed
@@ -159,53 +161,26 @@ func (r *ReconcileClusterDeploymentFederation) Reconcile(request reconcile.Reque
 
 	// If already federated, skip
 	if cd.Status.Federated {
-		cdLog.Debug("cluster already federated, nothing to do")
+		// If already federated, ensure federated cluster is in sync
+		// with the cluster deployment
+		err = r.updateFederatedCluster(cd, cdLog)
+		if err != nil {
+			cdLog.WithError(err).Error("cannot update federated cluster")
+			return reconcile.Result{}, err
+		}
 		return reconcile.Result{}, nil
 	}
 
 	cdLog.Info("reconciling cluster deployment for federation")
 
-	// Obtain cluster's kubeconfig secret
-	kubeconfig, err := r.loadSecretData(cd.Status.AdminKubeconfigSecret.Name, cd.Namespace, adminKubeconfigKey)
-	if err != nil {
-		cdLog.WithError(err).Error("error retrieving kubeconfig for cluster")
-		return reconcile.Result{}, err
+	if cd.Status.FederatedClusterRef == nil || len(cd.Status.FederatedClusterRef.Name) == 0 {
+		cdLog.Debugf("setting federated cluster name reference")
+		return reconcile.Result{}, r.setFederatedClusterRef(cd, cdLog)
 	}
 
-	hostConfig, err := config.GetConfig()
-	if err != nil {
-		cdLog.WithError(err).Error("cannot obtain host client configuration")
-		return reconcile.Result{}, err
-	}
+	r.joinCluster(cd, cdLog)
 
-	targetConfig, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeconfig))
-	if err != nil {
-		cdLog.WithError(err).Error("cannot create target cluster client config")
-		return reconcile.Result{}, err
-	}
-
-	name := federatedClusterName(cd)
-
-	err = kubefed2.JoinCluster(hostConfig,
-		targetConfig,
-		federationutil.DefaultFederationSystemNamespace,
-		federationutil.MulticlusterPublicNamespace,
-		"hive", /* hostContext */
-		name,   /* clusterName */
-		name,   /* secretName */
-		true,   /* addToRegistry */
-		false,  /* limitedScope */
-		false,  /* dryRun */
-		true)   /* idempotent */
-
-	if err != nil {
-		cdLog.WithError(err).Error("Federating cluster failed")
-		// TODO: Until the join command is idempotent, returning error here will only
-		// result in a quick backoff loop.
-		return reconcile.Result{}, nil
-	}
-
-	err = r.updateClusterDeploymentStatus(cd, cdLog)
+	err = r.setClusterFederated(cd, cdLog)
 	if err != nil {
 		cdLog.WithError(err).Errorf("error updating cluster deployment status")
 		return reconcile.Result{}, err
@@ -213,6 +188,44 @@ func (r *ReconcileClusterDeploymentFederation) Reconcile(request reconcile.Reque
 
 	cdLog.Debugf("reconcile complete")
 	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileClusterDeploymentFederation) federateTargetCluster(cd *hivev1.ClusterDeployment, cdLog log.FieldLogger) error {
+	// Obtain cluster's kubeconfig secret
+	kubeconfig, err := r.loadSecretData(cd.Status.AdminKubeconfigSecret.Name, cd.Namespace, adminKubeconfigKey)
+	if err != nil {
+		cdLog.WithError(err).Error("error retrieving kubeconfig for cluster")
+		return err
+	}
+
+	hostConfig, err := config.GetConfig()
+	if err != nil {
+		cdLog.WithError(err).Error("cannot obtain host client configuration")
+		return err
+	}
+
+	targetConfig, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeconfig))
+	if err != nil {
+		cdLog.WithError(err).Error("cannot create target cluster client config")
+		return err
+	}
+
+	err = kubefed2.JoinCluster(hostConfig,
+		targetConfig,
+		federationutil.DefaultFederationSystemNamespace,
+		federationutil.MulticlusterPublicNamespace,
+		"hive", /* hostContext */
+		cd.Status.FederatedClusterRef.Name, /* clusterName */
+		cd.Status.FederatedClusterRef.Name, /* secretName */
+		true,  /* addToRegistry */
+		false, /* limitedScope */
+		false, /* dryRun */
+		true)  /* idempotent */
+
+	if err != nil {
+		cdLog.WithError(err).Error("Federating cluster failed")
+	}
+	return err
 }
 
 func (r *ReconcileClusterDeploymentFederation) loadSecretData(secretName, namespace, dataKey string) (string, error) {
@@ -229,35 +242,48 @@ func (r *ReconcileClusterDeploymentFederation) loadSecretData(secretName, namesp
 }
 
 func (r *ReconcileClusterDeploymentFederation) syncDeletedClusterDeployment(cd *hivev1.ClusterDeployment, cdLog log.FieldLogger) (reconcile.Result, error) {
-
 	// Delete the federated cluster
+	if cd.Status.FederatedClusterRef != nil {
+		err := r.removeFederatedResources(cd.Status.FederatedClusterRef, cdLog)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	// Remove finalizer from ClusterDeployment
+	err := r.removeFederationFinalizer(cd, cdLog)
+	return reconcile.Result{}, err
+}
+
+func (r *ReconcileClusterDeploymentFederation) removeFederatedResources(ref *corev1.ObjectReference, cdLog log.FieldLogger) error {
+	name := ref.Name
+	namespace := ref.Namespace
 	federatedCluster := &fedv1alpha1.FederatedCluster{}
-	name := federatedClusterName(cd)
-	err := r.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: federationutil.DefaultFederationSystemNamespace}, federatedCluster)
+	err := r.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, federatedCluster)
 	if err != nil && !errors.IsNotFound(err) {
 		cdLog.WithError(err).Error("cannot retrieve federated cluster for cleanup")
-		return reconcile.Result{}, err
+		return err
 	}
 	if err == nil {
 		err = r.Delete(context.TODO(), federatedCluster)
 		if err != nil {
 			cdLog.WithError(err).Error("cannot delete federated cluster for cleanup")
-			return reconcile.Result{}, err
+			return err
 		}
 	}
 
 	// Delete the secret for the federated cluster
 	federatedClusterSecret := &corev1.Secret{}
-	err = r.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: federationutil.DefaultFederationSystemNamespace}, federatedClusterSecret)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, federatedClusterSecret)
 	if err != nil && !errors.IsNotFound(err) {
 		cdLog.WithError(err).Error("cannot retrieve federated cluster secret for cleanup")
-		return reconcile.Result{}, err
+		return err
 	}
 	if err == nil {
 		err = r.Delete(context.TODO(), federatedClusterSecret)
 		if err != nil {
 			cdLog.WithError(err).Error("cannot delete federated cluster secret for cleanup")
-			return reconcile.Result{}, err
+			return err
 		}
 	}
 
@@ -266,23 +292,20 @@ func (r *ReconcileClusterDeploymentFederation) syncDeletedClusterDeployment(cd *
 	err = r.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: federationutil.MulticlusterPublicNamespace}, clusterRegistryCluster)
 	if err != nil && !errors.IsNotFound(err) {
 		cdLog.WithError(err).Error("cannot retrieve clusterregistry cluster for cleanup")
-		return reconcile.Result{}, err
+		return err
 	}
 	if err == nil {
 		err = r.Delete(context.TODO(), clusterRegistryCluster)
 		if err != nil {
 			cdLog.WithError(err).Error("cannot delete clusterregistry cluster for cleanup")
-			return reconcile.Result{}, err
+			return err
 		}
 	}
 
-	// Remove finalizer from ClusterDeployment
-	err = r.removeFederationFinalizer(cd, cdLog)
-
-	return reconcile.Result{}, err
+	return nil
 }
 
-func (r *ReconcileClusterDeploymentFederation) updateClusterDeploymentStatus(cd *hivev1.ClusterDeployment, cdLog log.FieldLogger) error {
+func (r *ReconcileClusterDeploymentFederation) setClusterFederated(cd *hivev1.ClusterDeployment, cdLog log.FieldLogger) error {
 	cdLog.Debug("updating cluster deployment status")
 	origCD := cd
 	cd = cd.DeepCopy()
@@ -303,7 +326,53 @@ func (r *ReconcileClusterDeploymentFederation) updateClusterDeploymentStatus(cd 
 	return nil
 }
 
-func (r *ReconcileClusterDeploymentFederation) isFederationInstalled() (bool, error) {
+func (r *ReconcileClusterDeploymentFederation) setFederatedClusterRef(cd *hivev1.ClusterDeployment, cdLog log.FieldLogger) error {
+
+	cd.Status.FederatedClusterRef = &corev1.ObjectReference{
+		Name:      federatedClusterName(cd),
+		Namespace: federationutil.DefaultFederationSystemNamespace,
+	}
+
+	err := r.Status().Update(context.TODO(), cd)
+	if err != nil {
+		cdLog.WithError(err).Errorf("error setting federated cluster reference")
+		return err
+	}
+	return nil
+}
+
+func (r *ReconcileClusterDeploymentFederation) updateFederatedCluster(cd *hivev1.ClusterDeployment, cdLog log.FieldLogger) error {
+	clusterRef := cd.Status.FederatedClusterRef
+	if clusterRef == nil {
+		err := fmt.Errorf("invalid federated clusterdeployment, clusterRef is nil")
+		cdLog.WithError(err).Error("cannot update federated cluster")
+		return err
+	}
+	federatedCluster := &fedv1alpha1.FederatedCluster{}
+	err := r.Get(context.TODO(), types.NamespacedName{Namespace: clusterRef.Namespace, Name: clusterRef.Name}, federatedCluster)
+	if err != nil {
+		cdLog.WithError(err).Error("cannot fetch federated cluster")
+	}
+
+	original := federatedCluster.DeepCopy()
+
+	if federatedCluster.Annotations == nil {
+		federatedCluster.Annotations = map[string]string{}
+	}
+
+	federatedCluster.Annotations[clusterDeploymentNamespaceAnnotation] = cd.Namespace
+	federatedCluster.Annotations[clusterDeploymentNameAnnotation] = cd.Name
+
+	federatedCluster.Labels = cd.Labels
+
+	if !reflect.DeepEqual(federatedCluster.ObjectMeta, original.ObjectMeta) {
+		return r.Update(context.TODO(), federatedCluster)
+	}
+
+	return nil
+}
+
+func (r *ReconcileClusterDeploymentFederation) isFederatedClusterCRDPresent() (bool, error) {
 	crd := &apiextv1.CustomResourceDefinition{}
 	err := r.Get(context.TODO(), types.NamespacedName{Name: federatedClustersCRDName}, crd)
 	if err != nil && !errors.IsNotFound(err) {
@@ -333,5 +402,5 @@ func (r *ReconcileClusterDeploymentFederation) removeFederationFinalizer(cd *hiv
 }
 
 func federatedClusterName(cd *hivev1.ClusterDeployment) string {
-	return fmt.Sprintf("%s-%s", cd.Namespace, cd.Name)
+	return fmt.Sprintf("%s-%s", cd.Name, rand.String(8))
 }

--- a/pkg/controller/federation/clusterdeployment_federation_controller_test.go
+++ b/pkg/controller/federation/clusterdeployment_federation_controller_test.go
@@ -1,0 +1,308 @@
+package federation
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	fedv1alpha1 "github.com/kubernetes-sigs/federation-v2/pkg/apis/core/v1alpha1"
+	federationutil "github.com/kubernetes-sigs/federation-v2/pkg/controller/util"
+	"github.com/openshift/hive/pkg/apis"
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+	crv1alpha1 "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
+)
+
+const (
+	testName      = "test-cluster-deployment"
+	testNamespace = "test-namespace"
+	testAMI       = "ami-totallyfake"
+
+	testFedClusterName      = "test-federated-cluster"
+	testFedClusterNamespace = federationutil.DefaultFederationSystemNamespace
+)
+
+var (
+	testLabels = map[string]string{
+		"one":   "1",
+		"two":   "2",
+		"three": "3",
+	}
+)
+
+func TestReconcile(t *testing.T) {
+	apis.AddToScheme(scheme.Scheme)
+	fedv1alpha1.AddToScheme(scheme.Scheme)
+	crv1alpha1.AddToScheme(scheme.Scheme)
+
+	tests := []struct {
+		name                      string
+		federationNotInstalled    bool
+		existing                  []runtime.Object
+		expectJoinClusterCalled   bool
+		validateClusterDeployment func(*testing.T, *hivev1.ClusterDeployment)
+		validateFederatedCluster  func(*testing.T, *fedv1alpha1.FederatedCluster)
+	}{
+		{
+			name: "federation not installed -> noop",
+			federationNotInstalled:    true,
+			existing:                  []runtime.Object{testClusterDeployment()},
+			validateClusterDeployment: isSameCD(testClusterDeployment()),
+		},
+		{
+			name:                      "cluster not installed -> noop",
+			existing:                  []runtime.Object{testClusterDeployment()},
+			validateClusterDeployment: isSameCD(testClusterDeployment()),
+		},
+		{
+			name:                      "cluster deployment installed, no finalizer -> finalized should be added",
+			existing:                  []runtime.Object{installed(testClusterDeployment())},
+			validateClusterDeployment: hasFinalizer,
+		},
+		{
+			name:                      "cluster deployment installed, with finalizer -> fed clusterref should be added",
+			existing:                  []runtime.Object{withFinalizer(installed(testClusterDeployment()))},
+			validateClusterDeployment: hasFedClusterRef,
+		},
+		{
+			name:                      "cluster deployment installed, with fed cluster ref -> should be federated",
+			existing:                  []runtime.Object{withFedClusterRef(withFinalizer(installed(testClusterDeployment())))},
+			validateClusterDeployment: isFederated,
+			expectJoinClusterCalled:   true,
+		},
+		{
+			name: "cluster deployment federated -> fed cluster should get annotations and labels set",
+			existing: []runtime.Object{
+				federated(withFedClusterRef(withFinalizer(installed(testClusterDeployment())))),
+				testFederatedCluster(),
+			},
+			validateFederatedCluster: hasAnnotationsAndLabels,
+		},
+		{
+			name: "cluster deployment with finalizer is deleted -> finalizer should be removed",
+			existing: []runtime.Object{
+				withDeletionTimestamp(withFinalizer(installed(testClusterDeployment()))),
+			},
+			validateClusterDeployment: hasNoFinalizer,
+		},
+		{
+			name: "federated cluster deployment with finalizer is deleted -> finalizer should be removed",
+			existing: []runtime.Object{
+				withDeletionTimestamp(federated(withFedClusterRef(withFinalizer(installed(testClusterDeployment()))))),
+				testFederatedCluster(),
+				testFederationSecret(),
+				testClusterRegistryCluster(),
+			},
+			validateClusterDeployment: hasNoFinalizer,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := fake.NewFakeClient(test.existing...)
+			joinClusterCalled := false
+			r := &ReconcileClusterDeploymentFederation{
+				Client: client,
+				scheme: scheme.Scheme,
+				isFederationInstalled: func() (bool, error) {
+					return !test.federationNotInstalled, nil
+				},
+				joinCluster: func(*hivev1.ClusterDeployment, log.FieldLogger) error {
+					joinClusterCalled = true
+					return nil
+				},
+			}
+			cdName := types.NamespacedName{Name: testName, Namespace: testNamespace}
+			_, err := r.Reconcile(reconcile.Request{
+				NamespacedName: cdName,
+			})
+			if err != nil {
+				t.Errorf("unexpected error from Reconcile: %v", err)
+				return
+			}
+			if test.expectJoinClusterCalled && !joinClusterCalled {
+				t.Errorf("joinCluster was not called")
+			}
+			if test.validateClusterDeployment != nil {
+				cd := &hivev1.ClusterDeployment{}
+				err := client.Get(context.TODO(), cdName, cd)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+					return
+				}
+				test.validateClusterDeployment(t, cd)
+			}
+			if test.validateFederatedCluster != nil {
+				cd := &hivev1.ClusterDeployment{}
+				err := client.Get(context.TODO(), cdName, cd)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+					return
+				}
+				if cd.Status.FederatedClusterRef == nil {
+					t.Errorf("federated cluster reference is nil")
+					return
+				}
+				fcName := types.NamespacedName{Name: cd.Status.FederatedClusterRef.Name, Namespace: cd.Status.FederatedClusterRef.Namespace}
+				fc := &fedv1alpha1.FederatedCluster{}
+				err = client.Get(context.TODO(), fcName, fc)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+					return
+				}
+				test.validateFederatedCluster(t, fc)
+			}
+		})
+	}
+}
+
+func testClusterDeployment() *hivev1.ClusterDeployment {
+	cd := &hivev1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testName,
+			Namespace:  testNamespace,
+			Finalizers: []string{hivev1.FinalizerDeprovision},
+			UID:        types.UID("1234"),
+			Labels:     testLabels,
+		},
+		Spec: hivev1.ClusterDeploymentSpec{
+			ClusterName: testName,
+			SSHKey: &corev1.LocalObjectReference{
+				Name: "key-secret",
+			},
+			ControlPlane: hivev1.MachinePool{},
+			Compute:      []hivev1.MachinePool{},
+			PullSecret: corev1.LocalObjectReference{
+				Name: "pull-secret",
+			},
+			Platform: hivev1.Platform{
+				AWS: &hivev1.AWSPlatform{
+					Region: "us-east-1",
+				},
+			},
+			Networking: hivev1.Networking{
+				Type: hivev1.NetworkTypeOpenshiftSDN,
+			},
+			PlatformSecrets: hivev1.PlatformSecrets{
+				AWS: &hivev1.AWSPlatformSecrets{
+					Credentials: corev1.LocalObjectReference{
+						Name: "aws-credentials",
+					},
+				},
+			},
+		},
+		Status: hivev1.ClusterDeploymentStatus{
+			ClusterID: "cluster-id",
+		},
+	}
+	controllerutils.FixupEmptyClusterVersionFields(&cd.Status.ClusterVersionStatus)
+	return cd
+}
+
+func testFederatedCluster() *fedv1alpha1.FederatedCluster {
+	fc := &fedv1alpha1.FederatedCluster{}
+	fc.Name = testFedClusterName
+	fc.Namespace = testFedClusterNamespace
+	return fc
+}
+
+func testFederationSecret() *corev1.Secret {
+	secret := &corev1.Secret{}
+	secret.Name = testFedClusterName
+	secret.Namespace = testFedClusterNamespace
+	return secret
+}
+
+func testClusterRegistryCluster() *crv1alpha1.Cluster {
+	cluster := &crv1alpha1.Cluster{}
+	cluster.Name = testFedClusterName
+	cluster.Namespace = federationutil.MulticlusterPublicNamespace
+	return cluster
+}
+
+func installed(cd *hivev1.ClusterDeployment) *hivev1.ClusterDeployment {
+	cd.Status.Installed = true
+	cd.Status.AdminKubeconfigSecret.Name = "admin-kubeconfig-secret"
+	return cd
+}
+
+func withFinalizer(cd *hivev1.ClusterDeployment) *hivev1.ClusterDeployment {
+	controllerutils.AddFinalizer(cd, hivev1.FinalizerFederation)
+	return cd
+}
+
+func withFedClusterRef(cd *hivev1.ClusterDeployment) *hivev1.ClusterDeployment {
+	cd.Status.FederatedClusterRef = &corev1.ObjectReference{
+		Name:      testFedClusterName,
+		Namespace: testFedClusterNamespace,
+	}
+	return cd
+}
+
+func federated(cd *hivev1.ClusterDeployment) *hivev1.ClusterDeployment {
+	cd.Status.Federated = true
+	return cd
+}
+
+func withDeletionTimestamp(cd *hivev1.ClusterDeployment) *hivev1.ClusterDeployment {
+	now := metav1.Now()
+	cd.DeletionTimestamp = &now
+	return cd
+}
+
+func isSameCD(cd *hivev1.ClusterDeployment) func(*testing.T, *hivev1.ClusterDeployment) {
+	return func(t *testing.T, cd2 *hivev1.ClusterDeployment) {
+		if !reflect.DeepEqual(cd, cd2) {
+			t.Errorf("unexpected cluster deployment: %#v", cd2)
+		}
+	}
+}
+
+func hasFedClusterRef(t *testing.T, cd *hivev1.ClusterDeployment) {
+	if cd.Status.FederatedClusterRef == nil || cd.Status.FederatedClusterRef.Name == "" {
+		t.Errorf("federated cluster ref is not set")
+	}
+}
+
+func hasFinalizer(t *testing.T, cd *hivev1.ClusterDeployment) {
+	if !controllerutils.HasFinalizer(cd, hivev1.FinalizerFederation) {
+		t.Errorf("missing federation finalizer")
+	}
+}
+
+func hasNoFinalizer(t *testing.T, cd *hivev1.ClusterDeployment) {
+	if controllerutils.HasFinalizer(cd, hivev1.FinalizerFederation) {
+		t.Errorf("finalizer should not be present")
+	}
+}
+
+func isFederated(t *testing.T, cd *hivev1.ClusterDeployment) {
+	if !cd.Status.Federated {
+		t.Errorf("cluster deployment is not federated")
+	}
+}
+
+func hasAnnotationsAndLabels(t *testing.T, fc *fedv1alpha1.FederatedCluster) {
+	if fc.Annotations == nil {
+		t.Errorf("federated cluster has no annotations")
+		return
+	}
+	name := fc.Annotations[clusterDeploymentNameAnnotation]
+	namespace := fc.Annotations[clusterDeploymentNamespaceAnnotation]
+	if name != testName || namespace != testNamespace {
+		t.Errorf("federated cluster name and/or namespace annotations have unexpected values: %s/%s", namespace, name)
+	}
+	if !reflect.DeepEqual(fc.Labels, testLabels) {
+		t.Errorf("federated cluster labels do not have the expected values: %v", fc.Labels)
+	}
+}


### PR DESCRIPTION
Adds field to ClusterDeployment status to keep track of corresponding FederatedCluster resource. Synchronizes labels from ClusterDeployment to FederatedCluster resource.
Adds unit tests to federation controller.