### PR TITLE
Add controller to update clusterversion status

### DIFF
--- a/pkg/controller/add_clusterversion.go
+++ b/pkg/controller/add_clusterversion.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/openshift/hive/pkg/controller/clusterversion"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, clusterversion.Add)
+}

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -42,7 +42,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	openshiftapiv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
@@ -417,22 +416,6 @@ func (r *ReconcileClusterDeployment) setAdminKubeconfigStatus(cd *hivev1.Cluster
 		}
 		cdLog.Debugf("read remote route object: %s", routeObject)
 		cd.Status.WebConsoleURL = "https://" + routeObject.Spec.Host
-	}
-
-	// Update remote cluster's version into our status
-	if cd.Status.AdminKubeconfigSecret.Name != "" {
-		remoteClusterVersion := &openshiftapiv1.ClusterVersion{}
-		err = remoteClusterAPIClient.Get(context.Background(),
-			types.NamespacedName{Name: clusterVersionObjectName},
-			remoteClusterVersion)
-		if err != nil {
-			cdLog.WithError(err).Error("error fetching remote clusterversion object")
-			return err
-		}
-
-		cdLog.Debugf("remote cluster version status: %+v", remoteClusterVersion.Status)
-		controllerutils.FixupEmptyClusterVersionFields(&remoteClusterVersion.Status)
-		remoteClusterVersion.Status.DeepCopyInto(&cd.Status.ClusterVersionStatus)
 	}
 	return nil
 }

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -201,25 +201,6 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 			},
 		},
 		{
-			name: "Fetch remote cluster version status into clusterdeployment status",
-			existing: []runtime.Object{
-				func() *hivev1.ClusterDeployment {
-					cd := testClusterDeployment()
-					cd.Status.AdminKubeconfigSecret = corev1.LocalObjectReference{Name: adminKubeconfigSecret}
-					return cd
-				}(),
-				testInstallJob(),
-				testSecret(adminKubeconfigSecret, "kubeconfig", adminKubeconfig),
-				testSecret(adminPasswordSecret, adminCredsSecretPasswordKey, "password"),
-				testSecret(pullSecretSecret, pullSecretKey, "{}"),
-				testSecret(sshKeySecret, adminSSHKeySecretKey, "fakesshkey"),
-			},
-			validate: func(c client.Client, t *testing.T) {
-				cd := getCD(c)
-				assert.Equal(t, "4.0.0", cd.Status.ClusterVersionStatus.History[0].Version)
-			},
-		},
-		{
 			name: "Completed install job",
 			existing: []runtime.Object{
 				testClusterDeployment(),

--- a/pkg/controller/clusterversion/clusterversion_controller.go
+++ b/pkg/controller/clusterversion/clusterversion_controller.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterversion
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	openshiftapiv1 "github.com/openshift/api/config/v1"
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+)
+
+const (
+	clusterVersionObjectName = "version"
+	clusterVersionUnknown    = "undef"
+	adminKubeconfigKey       = "kubeconfig"
+)
+
+var (
+	clusterVersionUpdateInterval = 30 * time.Second
+)
+
+// Add creates a new ClusterDeployment Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return AddToManager(mgr, NewReconciler(mgr))
+}
+
+// NewReconciler returns a new reconcile.Reconciler
+func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileClusterVersion{
+		Client: mgr.GetClient(),
+		scheme: mgr.GetScheme(),
+		remoteClusterAPIClientBuilder: controllerutils.BuildClusterAPIClientFromKubeconfig,
+	}
+}
+
+// AddToManager adds a new Controller to mgr with r as the reconcile.Reconciler
+func AddToManager(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("clusterversion-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to ClusterDeployment
+	err = c.Watch(&source.Kind{Type: &hivev1.ClusterDeployment{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileClusterVersion{}
+
+// ReconcileClusterVersion reconciles a ClusterDeployment object
+type ReconcileClusterVersion struct {
+	client.Client
+	scheme *runtime.Scheme
+	// remoteClusterAPIClientBuilder is a function pointer to the function that builds a client for the
+	// remote cluster's cluster-api
+	remoteClusterAPIClientBuilder func(string) (client.Client, error)
+}
+
+// Reconcile reads that state of the cluster for a ClusterDeployment object and syncs the remote ClusterVersion status
+// if the remote cluster is available.
+func (r *ReconcileClusterVersion) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	// Fetch the ClusterDeployment instance
+	cd := &hivev1.ClusterDeployment{}
+	err := r.Get(context.TODO(), request.NamespacedName, cd)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Object not found, return.  Created objects are automatically garbage collected.
+			// For additional cleanup logic use finalizers.
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+	cdLog := log.WithFields(log.Fields{
+		"clusterDeployment": cd.Name,
+		"namespace":         cd.Namespace,
+		"controller":        "clusterversion",
+	})
+	cdLog.Info("reconciling cluster version")
+
+	// If the clusterdeployment is deleted, do not reconcile.
+	if cd.DeletionTimestamp != nil {
+		return reconcile.Result{}, nil
+	}
+
+	if len(cd.Status.AdminKubeconfigSecret.Name) == 0 {
+		return reconcile.Result{}, nil
+	}
+
+	adminKubeconfigSecret := &corev1.Secret{}
+	err = r.Get(context.Background(), types.NamespacedName{Namespace: cd.Namespace, Name: cd.Status.AdminKubeconfigSecret.Name}, adminKubeconfigSecret)
+	if err != nil {
+		cdLog.WithError(err).WithField("secret", fmt.Sprintf("%s/%s", cd.Status.AdminKubeconfigSecret.Name, cd.Namespace)).Error("cannot read secret")
+		return reconcile.Result{}, err
+	}
+	remoteClient, err := r.remoteClusterAPIClientBuilder(string(adminKubeconfigSecret.Data[adminKubeconfigKey]))
+	if err != nil {
+		cdLog.WithError(err).Error("error building remote cluster-api client connection")
+		return reconcile.Result{}, err
+	}
+
+	clusterVersion := &openshiftapiv1.ClusterVersion{}
+	err = remoteClient.Get(context.Background(), types.NamespacedName{Name: clusterVersionObjectName}, clusterVersion)
+	if err != nil {
+		cdLog.WithError(err).Error("error fetching remote clusterversion object")
+		return reconcile.Result{}, err
+	}
+
+	err = r.updateClusterVersionStatus(cd, clusterVersion, cdLog)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	cdLog.Debug("reconcile complete")
+	return reconcile.Result{Requeue: true, RequeueAfter: clusterVersionUpdateInterval}, nil
+}
+
+func (r *ReconcileClusterVersion) updateClusterVersionStatus(cd *hivev1.ClusterDeployment, clusterVersion *openshiftapiv1.ClusterVersion, cdLog log.FieldLogger) error {
+	origCD := cd.DeepCopy()
+	cdLog.WithField("clusterversion.status", clusterVersion.Status).Debug("remote cluster version status")
+	controllerutils.FixupEmptyClusterVersionFields(&clusterVersion.Status)
+	clusterVersion.Status.DeepCopyInto(&cd.Status.ClusterVersionStatus)
+
+	if reflect.DeepEqual(cd.Status, origCD.Status) {
+		cdLog.Debug("status has not changed, nothing to update")
+		return nil
+	}
+
+	// Update cluster deployment status if changed:
+	cdLog.Infof("status has changed, updating cluster deployment")
+	err := r.Status().Update(context.TODO(), cd)
+	if err != nil {
+		cdLog.WithError(err).Error("error updating cluster deployment status")
+		return err
+	}
+	return nil
+}

--- a/pkg/controller/clusterversion/clusterversion_controller_test.go
+++ b/pkg/controller/clusterversion/clusterversion_controller_test.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterversion
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/hive/pkg/apis"
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+)
+
+const (
+	testName              = "foo-lqmsh"
+	testClusterName       = "bar"
+	testClusterID         = "testFooClusterUUID"
+	installJobName        = "foo-lqmsh-install"
+	uninstallJobName      = "foo-lqmsh-uninstall"
+	testNamespace         = "default"
+	metadataName          = "foo-lqmsh-metadata"
+	adminPasswordSecret   = "admin-password"
+	sshKeySecret          = "ssh-key"
+	pullSecretSecret      = "pull-secret"
+	testUUID              = "fakeUUID"
+	testAMI               = "ami-totallyfake"
+	adminKubeconfigSecret = "foo-lqmsh-admin-kubeconfig"
+	adminKubeconfig       = `clusters:
+- cluster:
+    certificate-authority-data: JUNK
+    server: https://bar-api.clusters.example.com:6443
+  name: bar
+`
+	testRemoteClusterCurrentVersion = "4.0.0"
+	remoteClusterVersionObjectName  = "version"
+
+	remoteClusterRouteObjectName      = "console"
+	remoteClusterRouteObjectNamespace = "openshift-console"
+)
+
+func init() {
+	log.SetLevel(log.DebugLevel)
+}
+
+func TestClusterVersionReconcile(t *testing.T) {
+	apis.AddToScheme(scheme.Scheme)
+	configv1.Install(scheme.Scheme)
+
+	tests := []struct {
+		name        string
+		existing    []runtime.Object
+		expectError bool
+		validate    func(*testing.T, *hivev1.ClusterDeployment)
+	}{
+		{
+			// no cluster deployment, no error expected
+			name: "clusterdeployment doesn't exist",
+		},
+		{
+			name: "deleted clusterdeployment",
+			existing: []runtime.Object{
+				testDeletedClusterDeployment(),
+			},
+		},
+		{
+			name: "no admin kubeconfig secret",
+			existing: []runtime.Object{
+				testClusterDeployment(),
+			},
+			expectError: true,
+		},
+		{
+			name: "needs update",
+			existing: []runtime.Object{
+				testClusterDeployment(),
+				testKubeconfigSecret(),
+			},
+			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
+				expected := testRemoteClusterVersionStatus()
+				controllerutils.FixupEmptyClusterVersionFields(&expected)
+				if !reflect.DeepEqual(cd.Status.ClusterVersionStatus, expected) {
+					t.Errorf("did not get expected clusterversion status. Expected: \n%#v\nGot: \n%#v", expected, cd.Status.ClusterVersionStatus)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fakeClient := fake.NewFakeClient(test.existing...)
+			rcd := &ReconcileClusterVersion{
+				Client: fakeClient,
+				scheme: scheme.Scheme,
+				remoteClusterAPIClientBuilder: testRemoteClusterAPIClientBuilder,
+			}
+
+			namespacedName := types.NamespacedName{
+				Name:      testName,
+				Namespace: testNamespace,
+			}
+
+			_, err := rcd.Reconcile(reconcile.Request{NamespacedName: namespacedName})
+
+			if test.validate != nil {
+				cd := &hivev1.ClusterDeployment{}
+				err := fakeClient.Get(context.TODO(), namespacedName, cd)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+					return
+				}
+				test.validate(t, cd)
+			}
+
+			if err != nil && !test.expectError {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if err == nil && test.expectError {
+				t.Errorf("Expected error but got none")
+			}
+		})
+	}
+}
+
+func testClusterDeployment() *hivev1.ClusterDeployment {
+	cd := &hivev1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testName,
+			Namespace:  testNamespace,
+			Finalizers: []string{hivev1.FinalizerDeprovision},
+			UID:        types.UID("1234"),
+		},
+		Spec: hivev1.ClusterDeploymentSpec{
+			ClusterName: testClusterName,
+			SSHKey: &corev1.LocalObjectReference{
+				Name: sshKeySecret,
+			},
+			ControlPlane: hivev1.MachinePool{},
+			Compute:      []hivev1.MachinePool{},
+			PullSecret: corev1.LocalObjectReference{
+				Name: pullSecretSecret,
+			},
+			Platform: hivev1.Platform{
+				AWS: &hivev1.AWSPlatform{
+					Region: "us-east-1",
+				},
+			},
+			Networking: hivev1.Networking{
+				Type: hivev1.NetworkTypeOpenshiftSDN,
+			},
+			PlatformSecrets: hivev1.PlatformSecrets{
+				AWS: &hivev1.AWSPlatformSecrets{
+					Credentials: corev1.LocalObjectReference{
+						Name: "aws-credentials",
+					},
+				},
+			},
+		},
+		Status: hivev1.ClusterDeploymentStatus{
+			ClusterID: testClusterID,
+			AdminKubeconfigSecret: corev1.LocalObjectReference{
+				Name: "kubeconfig-secret",
+			},
+		},
+	}
+	controllerutils.FixupEmptyClusterVersionFields(&cd.Status.ClusterVersionStatus)
+	return cd
+}
+
+func testDeletedClusterDeployment() *hivev1.ClusterDeployment {
+	cd := testClusterDeployment()
+	now := metav1.Now()
+	cd.DeletionTimestamp = &now
+	return cd
+}
+
+func testKubeconfigSecret() *corev1.Secret {
+	return testSecret("kubeconfig-secret", "kubeconfig", "KUBECONFIG-DATA")
+}
+
+func testSecret(name, key, value string) *corev1.Secret {
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Data: map[string][]byte{
+			key: []byte(value),
+		},
+	}
+	return s
+}
+
+func testRemoteClusterAPIClientBuilder(secretData string) (client.Client, error) {
+	remoteClusterVersion := &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: remoteClusterVersionObjectName,
+		},
+	}
+	remoteClusterVersion.Status = testRemoteClusterVersionStatus()
+
+	remoteClient := fake.NewFakeClient(remoteClusterVersion)
+	return remoteClient, nil
+}
+
+func testRemoteClusterVersionStatus() configv1.ClusterVersionStatus {
+	zeroTime := metav1.NewTime(time.Unix(0, 0))
+	status := configv1.ClusterVersionStatus{
+		History: []configv1.UpdateHistory{
+			{
+				State:          configv1.CompletedUpdate,
+				Version:        testRemoteClusterCurrentVersion,
+				Payload:        "TESTPAYLOAD",
+				CompletionTime: &zeroTime,
+			},
+		},
+		Generation:  123456789,
+		VersionHash: "TESTVERSIONHASH",
+	}
+	return status
+}

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -17,6 +17,8 @@ limitations under the License.
 package utils
 
 import (
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/clientcmd"
@@ -75,6 +77,16 @@ func FixupEmptyClusterVersionFields(clusterVersionStatus *openshiftapiv1.Cluster
 
 	if clusterVersionStatus.History == nil {
 		clusterVersionStatus.History = []openshiftapiv1.UpdateHistory{}
+	}
+
+	// The CompletionTime is clearly optional, but it is not labeled with
+	// omitempty in the Openshift API.
+	// TODO: Fix upstream
+	for i, h := range clusterVersionStatus.History {
+		if h.CompletionTime == nil {
+			zero := metav1.NewTime(time.Unix(0, 0))
+			clusterVersionStatus.History[i].CompletionTime = &zero
+		}
 	}
 }
 


### PR DESCRIPTION
Moves the code to update the cluster version status on a cluster deployment to its own controller so that it can be updated on an interval over the life of a cluster.

Adds fix to FixupEmptyClusterVersionFields so that it can set a value on History.CompletionTime and avoid a validation error.