### PR TITLE
Match OpenshiftSDN -> OpenShiftSDN network type change.

### DIFF
--- a/config/templates/cluster-deployment.yaml
+++ b/config/templates/cluster-deployment.yaml
@@ -102,7 +102,7 @@ objects:
     clusterName: ${CLUSTER_NAME}
     baseDomain: ${BASE_DOMAIN}
     networking:
-      type: OpenshiftSDN
+      type: OpenShiftSDN
       serviceCIDR: "172.30.0.0/16"
       machineCIDR: "10.0.0.0/16"
       clusterNetworks:

--- a/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
@@ -195,7 +195,7 @@ type NetworkType string
 
 const (
 	// NetworkTypeOpenshiftSDN is used to install with SDN.
-	NetworkTypeOpenshiftSDN NetworkType = "OpenshiftSDN"
+	NetworkTypeOpenshiftSDN NetworkType = "OpenShiftSDN"
 	// NetworkTypeOpenshiftOVN is used to install with OVN.
 	NetworkTypeOpenshiftOVN NetworkType = "OVNKubernetes"
 )

--- a/pkg/install/convertconfig_test.go
+++ b/pkg/install/convertconfig_test.go
@@ -148,7 +148,7 @@ func buildBaseExpectedInstallConfig() *installtypes.InstallConfig {
 		PullSecret: pullSecret,
 		Networking: &installtypes.Networking{
 			// TODO: Hardcoded to match installer for now.
-			Type:        "OpenshiftSDN",
+			Type:        "OpenShiftSDN",
 			ServiceCIDR: ipnet.MustParseCIDR("172.30.0.0/16"),
 			ClusterNetworks: []installtypes.ClusterNetworkEntry{
 				{


### PR DESCRIPTION
Related to https://github.com/openshift/release/pull/2922 and maybe the cause of the cluster CI failures all day today.

I'm not strictly sure if this required to get through CI or not.

CC @jhernand this will require a change on the UHC side once this rolls out.