### PR TITLE
Short name and custom printer columns for the ClusterDeployment CRD

### DIFF
--- a/config/crds/hive_v1alpha1_clusterdeployment.yaml
+++ b/config/crds/hive_v1alpha1_clusterdeployment.yaml
@@ -6,10 +6,22 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: clusterdeployments.hive.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.baseDomain
+    name: BaseDomain
+    type: string
+  - JSONPath: .status.installed
+    name: Installed
+    type: boolean
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: hive.openshift.io
   names:
     kind: ClusterDeployment
     plural: clusterdeployments
+    shortNames:
+    - cd
   scope: Namespaced
   subresources:
     status: {}

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -133,6 +133,36 @@ if [ $i -ge ${max_tries} ] ; then
   exit 10
 fi
 
+# Sanity check the cluster deployment printer
+i=1
+while [ $i -le ${max_tries} ]; do
+  if [ $i -gt 1 ]; then
+    # Don't sleep on first loop
+    echo "sleeping ${sleep_between_tries} seconds"
+    sleep ${sleep_between_tries}
+  fi
+
+  echo "Getting ClusterDeployment ${CLUSTER_NAME}. Try #${i}/${max_tries}:"
+
+  GET_BY_SHORT_NAME=$(oc get cd)
+
+  if echo "${GET_BY_SHORT_NAME}" | grep 'BASEDOMAIN' ; then
+    echo "Success"
+    break
+  else
+    echo -n "Failed, "
+  fi
+
+  i=$((i + 1))
+done
+
+if [ $i -ge ${max_tries} ] ; then
+  # Failed the maximum amount of times.
+  echo "exiting"
+  exit 10
+fi
+
+
 # Wait for the cluster deployment to be installed
 SRC_ROOT=$(git rev-parse --show-toplevel)
 

--- a/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
@@ -152,6 +152,10 @@ type ClusterDeploymentStatus struct {
 // ClusterDeployment is the Schema for the clusterdeployments API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="BaseDomain",type="string",JSONPath=".spec.baseDomain"
+// +kubebuilder:printcolumn:name="Installed",type="boolean",JSONPath=".status.installed"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:resource:path=clusterdeployments,shortName=cd
 type ClusterDeployment struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Adds the `cd` short name to the `ClusterDeployment` CRD so that we can do `kubectl get cd`.
Adds `baseDomain` and `status.installed` as custom printer columns so that the printer output looks like

```
$ kubectl get cd
NAME     BASEDOMAIN                                INSTALLED   AGE
ffranz   ffranz-cluster-deployment.openshift.com   false       4m7s
```

@csrwng @dgoodwin makes sense?