### PR TITLE
Improve debug logging for e2e uninstall

### DIFF
--- a/config/templates/cluster-deployment.yaml
+++ b/config/templates/cluster-deployment.yaml
@@ -50,6 +50,10 @@ parameters:
   displayName: Try Install Only Once
   description: If set, install will only be tried once.
   value: "false"
+- name: TRY_UNINSTALL_ONCE
+  displayName: Try Uninstall Only Once
+  description: If set, uninstall will only be tried once.
+  value: "false"
 
 objects:
 - apiVersion: v1
@@ -85,6 +89,7 @@ objects:
     annotations:
       hive.openshift.io/delete-after: "8h"
       hive.openshift.io/try-install-once: "${TRY_INSTALL_ONCE}"
+      hive.openshift.io/try-uninstall-once: "${TRY_UNINSTALL_ONCE}"
     name: ${CLUSTER_NAME}
   spec:
     platformSecrets:

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -69,18 +69,19 @@ function teardown() {
 	echo "Deleting ClusterDeployment ${CLUSTER_NAME}"
 	oc delete --wait=false clusterdeployment ${CLUSTER_NAME}
 	errorOnUninstall=0
-	if ! go run "${SRC_ROOT}/contrib/cmd/waitforjob/main.go" "${CLUSTER_NAME}-uninstall"; then
+	if ! go run "${SRC_ROOT}/contrib/cmd/waitforjob/main.go" --log-level=debug --not-found-ok=true "${CLUSTER_NAME}-uninstall"; then
 		errorOnUninstall=1
 	fi
-	oc logs job/${CLUSTER_NAME}-uninstall &> "${ARTIFACT_DIR}/hive_uninstall_job.log" || true
-
-	echo "************* UNINSTALL JOB LOG *************"
-	cat "${ARTIFACT_DIR}/hive_uninstall_job.log"
-	echo ""
-	echo ""
 
 	if [[ $errorOnUninstall == 1 ]]; then
-		echo "Uninstall job failed."
+		if oc logs job/${CLUSTER_NAME}-uninstall &> "${ARTIFACT_DIR}/hive_uninstall_job.log"; then
+			echo "************* UNINSTALL JOB LOG *************"
+			cat "${ARTIFACT_DIR}/hive_uninstall_job.log"
+			echo ""
+			echo ""
+		else
+			echo "Waiting for uninstall job failed"
+		fi
 		exit 1
 	fi
 }

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -62,9 +62,27 @@ export AWS_SECRET_ACCESS_KEY="$(cat ${CLOUD_CREDS_DIR}/.awscred | awk '/aws_secr
 
 function teardown() {
 	oc logs -c hive job/${CLUSTER_NAME}-install &> "${ARTIFACT_DIR}/hive_install_job.log" || true
+	echo "************* INSTALL JOB LOG *************"
 	cat "${ARTIFACT_DIR}/hive_install_job.log"
+	echo ""
+	echo ""
 	echo "Deleting ClusterDeployment ${CLUSTER_NAME}"
-	oc delete clusterdeployment ${CLUSTER_NAME}
+	oc delete --wait=false clusterdeployment ${CLUSTER_NAME}
+	errorOnUninstall=0
+	if ! go run "${SRC_ROOT}/contrib/cmd/waitforjob/main.go" "${CLUSTER_NAME}-uninstall"; then
+		errorOnUninstall=1
+	fi
+	oc logs job/${CLUSTER_NAME}-uninstall &> "${ARTIFACT_DIR}/hive_uninstall_job.log" || true
+
+	echo "************* UNINSTALL JOB LOG *************"
+	cat "${ARTIFACT_DIR}/hive_uninstall_job.log"
+	echo ""
+	echo ""
+
+	if [[ $errorOnUninstall == 1 ]]; then
+		echo "Uninstall job failed."
+		exit 1
+	fi
 }
 trap 'teardown' EXIT
 
@@ -91,6 +109,7 @@ while [ $i -le ${max_tries} ]; do
          INSTALLER_IMAGE="${INSTALLER_IMAGE}" \
          OPENSHIFT_RELEASE_IMAGE="" \
          TRY_INSTALL_ONCE="true" \
+         TRY_UNINSTALL_ONCE="true" \
       > ${CLUSTER_DEPLOYMENT_FILE} ; then
     echo "Success"
     break

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -36,7 +36,8 @@ const (
 	defaultHiveImage                = "registry.svc.ci.openshift.org/openshift/hive-v4.0:hive"
 	defaultHiveImagePullPolicy      = corev1.PullAlways
 
-	tryInstallOnceAnnotation = "hive.openshift.io/try-install-once"
+	tryInstallOnceAnnotation   = "hive.openshift.io/try-install-once"
+	tryUninstallOnceAnnotation = "hive.openshift.io/try-uninstall-once"
 )
 
 // GenerateInstallerJob creates a job to install an OpenShift cluster
@@ -297,6 +298,12 @@ func GenerateUninstallerJob(
 		return nil, fmt.Errorf("only AWS ClusterDeployments currently supported")
 	}
 
+	tryOnce := false
+	if cd.Annotations != nil {
+		value, exists := cd.Annotations[tryUninstallOnceAnnotation]
+		tryOnce = exists && value == "true"
+	}
+
 	env := []corev1.EnvVar{}
 	if cd.Spec.PlatformSecrets.AWS != nil && len(cd.Spec.PlatformSecrets.AWS.Credentials.Name) > 0 {
 		env = append(env, []corev1.EnvVar{
@@ -350,9 +357,14 @@ func GenerateUninstallerJob(
 		},
 	}
 
+	restartPolicy := corev1.RestartPolicyOnFailure
+	if tryOnce {
+		restartPolicy = corev1.RestartPolicyNever
+	}
+
 	podSpec := corev1.PodSpec{
 		DNSPolicy:     corev1.DNSClusterFirst,
-		RestartPolicy: corev1.RestartPolicyOnFailure,
+		RestartPolicy: restartPolicy,
 		Containers:    containers,
 	}
 


### PR DESCRIPTION
Adds annotation to clusterdeployment to allow running uninstall job only once.
Watches uninstall job in e2e script and displays the uninstall log.