### PR TITLE
Override PreserveOnDelete if cd is not installed

### DIFF
--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -293,7 +293,9 @@ func GenerateUninstallerJob(
 	cd *hivev1.ClusterDeployment, hiveImage string) (*batchv1.Job, error) {
 
 	if cd.Spec.PreserveOnDelete {
-		return nil, fmt.Errorf("no creation of uninstaller job, because of PreserveOnDelete")
+		if cd.Status.Installed {
+			return nil, fmt.Errorf("no creation of uninstaller job, because of PreserveOnDelete")
+		}
 	}
 
 	if cd.Spec.AWS == nil {

--- a/pkg/install/generate_test.go
+++ b/pkg/install/generate_test.go
@@ -25,6 +25,7 @@ func init() {
 
 func TestGenerate(t *testing.T) {
 	cd := testClusterDeployment()
+	cd.Status.Installed = true
 	cd.Spec.PreserveOnDelete = true
 	job, err := GenerateUninstallerJob(cd, "example.com/fake:latest")
 	assert.Nil(t, job)


### PR DESCRIPTION
--> Skips the creation of uninstall job only if Spec.PreserveOnDelete and Status.Installed are true. If the cluster deployment is not installed, overrides the PreserveOnDelete to create an uninstall job.