### PR TITLE
remove generate as a dependency of docker-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ generate:
 
 # Build the docker image
 .PHONY: docker-build
-docker-build: generate
+docker-build:
 	$(BUILD_CMD) -t ${IMG} .
 
 # Push the docker image


### PR DESCRIPTION
Since https://github.com/openshift/hive/commit/d22c82bcb was introduced,
there is no need to to run generate before the build as well, since it's
already happening inside the Dockerfile.