### PR TITLE
vendor: Update the installer to get additional AWS deletion

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -717,8 +717,7 @@
   source = "github.com/csrwng/generic-admission-server"
 
 [[projects]]
-  branch = "master"
-  digest = "1:b06c1d2f9e9b6860706d1b8f5efb051740ba7890d531b843650f0371d9a5cca3"
+  digest = "1:b898453105c406ecec684335a93f19f0502d4b8cf53085215bfa8b426606d695"
   name = "github.com/openshift/installer"
   packages = [
     "pkg/asset/installconfig/aws",
@@ -735,7 +734,7 @@
     "pkg/version",
   ]
   pruneopts = "NUT"
-  revision = "2b65c9d4f31f0905a9845322c419b87973194fe0"
+  revision = "c91cdbc819851fb9f813ec0b3e3b76ed86ae43a3"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -67,7 +67,7 @@ version="v1.4.7"
 
 [[constraint]]
   name = "github.com/openshift/installer"
-  branch = "master"
+  revision = "c91cdbc819851fb9f813ec0b3e3b76ed86ae43a3"
 
 [[constraint]]
   name = "github.com/openshift/generic-admission-server"

--- a/vendor/github.com/openshift/installer/pkg/asset/installconfig/aws/permissions.go
+++ b/vendor/github.com/openshift/installer/pkg/asset/installconfig/aws/permissions.go
@@ -32,6 +32,7 @@ var installPermissions = []string{
 	"ec2:CreateVpc",
 	"ec2:CreateVpcEndpoint",
 	"ec2:CreateVolume",
+	"ec2:DeleteSnapshot",
 	"ec2:DeregisterImage",
 	"ec2:DescribeAccountAttributes",
 	"ec2:DescribeAddresses",
@@ -211,6 +212,9 @@ func ValidateCreds(ssn *session.Session) error {
 	if err != nil {
 		return errors.Wrap(err, "mint credentials check")
 	}
+	if canMint {
+		return nil
+	}
 
 	// Check whether we can use the current credentials in passthrough mode to satisfy
 	// cluster services needing to interact with the cloud
@@ -218,10 +222,9 @@ func ValidateCreds(ssn *session.Session) error {
 	if err != nil {
 		return errors.Wrap(err, "passthrough credentials check")
 	}
-
-	if !canMint && !canPassthrough {
-		return errors.New("AWS credentials cannot be used to either create new creds or use as-is")
+	if canPassthrough {
+		return nil
 	}
 
-	return nil
+	return errors.New("AWS credentials cannot be used to either create new creds or use as-is")
 }

--- a/vendor/github.com/openshift/installer/pkg/destroy/aws/aws.go
+++ b/vendor/github.com/openshift/installer/pkg/destroy/aws/aws.go
@@ -130,7 +130,7 @@ func (o *ClusterUninstaller) Run() error {
 							arn := *resource.ResourceARN
 							if _, ok := deleted[arn]; !ok {
 								matched = true
-								err := deleteARN(awsSession, arn, o.Logger)
+								err := deleteARN(awsSession, arn, filter, o.Logger)
 								if err != nil {
 									err = errors.Wrapf(err, "deleting %s", arn)
 									o.Logger.Debug(err)
@@ -144,7 +144,7 @@ func (o *ClusterUninstaller) Run() error {
 					},
 				)
 				if err != nil {
-					err = errors.Wrapf(err, "get tagged resources")
+					err = errors.Wrap(err, "get tagged resources")
 					o.Logger.Info(err)
 					matched = true
 					loopError = err
@@ -179,7 +179,7 @@ func (o *ClusterUninstaller) Run() error {
 		}
 		for _, arn := range arns {
 			if _, ok := deleted[arn]; !ok {
-				err = deleteARN(awsSession, arn, o.Logger)
+				err = deleteARN(awsSession, arn, nil, o.Logger)
 				if err != nil {
 					err = errors.Wrapf(err, "deleting %s", arn)
 					o.Logger.Debug(err)
@@ -221,6 +221,17 @@ func tagMatch(filters []Filter, tags map[string]string) bool {
 		}
 	}
 	return len(filters) == 0
+}
+
+func tagsForFilter(filter Filter) []*ec2.Tag {
+	tags := make([]*ec2.Tag, 0, len(filter))
+	for key, value := range filter {
+		tags = append(tags, &ec2.Tag{
+			Key:   aws.String(key),
+			Value: aws.String(value),
+		})
+	}
+	return tags
 }
 
 type iamRoleSearch struct {
@@ -417,7 +428,7 @@ func findPublicRoute53(client *route53.Route53, dnsName string, logger logrus.Fi
 	return "", nil
 }
 
-func deleteARN(session *session.Session, arnString string, logger logrus.FieldLogger) error {
+func deleteARN(session *session.Session, arnString string, filter Filter, logger logrus.FieldLogger) error {
 	logger = logger.WithField("arn", arnString)
 
 	parsed, err := arn.Parse(arnString)
@@ -427,7 +438,7 @@ func deleteARN(session *session.Session, arnString string, logger logrus.FieldLo
 
 	switch parsed.Service {
 	case "ec2":
-		return deleteEC2(session, parsed, logger)
+		return deleteEC2(session, parsed, filter, logger)
 	case "elasticloadbalancing":
 		return deleteElasticLoadBalancing(session, parsed, logger)
 	case "iam":
@@ -441,7 +452,7 @@ func deleteARN(session *session.Session, arnString string, logger logrus.FieldLo
 	}
 }
 
-func deleteEC2(session *session.Session, arn arn.ARN, logger logrus.FieldLogger) error {
+func deleteEC2(session *session.Session, arn arn.ARN, filter Filter, logger logrus.FieldLogger) error {
 	client := ec2.New(session)
 
 	resourceType, id, err := splitSlash("resource", arn.Resource)
@@ -456,7 +467,7 @@ func deleteEC2(session *session.Session, arn arn.ARN, logger logrus.FieldLogger)
 	case "elastic-ip":
 		return deleteEC2ElasticIP(client, id, logger)
 	case "image":
-		return deleteEC2Image(client, id, logger)
+		return deleteEC2Image(client, id, filter, logger)
 	case "instance":
 		return deleteEC2Instance(client, iam.New(session), id, logger)
 	case "internet-gateway":
@@ -467,6 +478,10 @@ func deleteEC2(session *session.Session, arn arn.ARN, logger logrus.FieldLogger)
 		return deleteEC2RouteTable(client, id, logger)
 	case "security-group":
 		return deleteEC2SecurityGroup(client, id, logger)
+	case "snapshot":
+		return deleteEC2Snapshot(client, id, logger)
+	case "network-interface":
+		return deleteEC2NetworkInterface(client, id, logger)
 	case "subnet":
 		return deleteEC2Subnet(client, id, logger)
 	case "volume":
@@ -493,8 +508,35 @@ func deleteEC2DHCPOptions(client *ec2.EC2, id string, logger logrus.FieldLogger)
 	return nil
 }
 
-func deleteEC2Image(client *ec2.EC2, id string, logger logrus.FieldLogger) error {
-	_, err := client.DeregisterImage(&ec2.DeregisterImageInput{
+func deleteEC2Image(client *ec2.EC2, id string, filter Filter, logger logrus.FieldLogger) error {
+	// tag the snapshots used by the AMI so that the snapshots are matched
+	// by the filter and deleted
+	response, err := client.DescribeImages(&ec2.DescribeImagesInput{
+		ImageIds: []*string{&id},
+	})
+	if err != nil {
+		if err.(awserr.Error).Code() == "InvalidAMIID.NotFound" {
+			return nil
+		}
+		return err
+	}
+	snapshots := []*string{}
+	for _, image := range response.Images {
+		for _, bdm := range image.BlockDeviceMappings {
+			if bdm.Ebs != nil && bdm.Ebs.SnapshotId != nil {
+				snapshots = append(snapshots, bdm.Ebs.SnapshotId)
+			}
+		}
+	}
+	_, err = client.CreateTags(&ec2.CreateTagsInput{
+		Resources: snapshots,
+		Tags:      tagsForFilter(filter),
+	})
+	if err != nil {
+		err = errors.Wrapf(err, "tagging snapshots for %s", id)
+	}
+
+	_, err = client.DeregisterImage(&ec2.DeregisterImageInput{
 		ImageId: &id,
 	})
 	if err != nil {
@@ -741,6 +783,36 @@ func deleteEC2SecurityGroup(client *ec2.EC2, id string, logger logrus.FieldLogge
 	})
 	if err != nil {
 		if err.(awserr.Error).Code() == "InvalidGroup.NotFound" {
+			return nil
+		}
+		return err
+	}
+
+	logger.Info("Deleted")
+	return nil
+}
+
+func deleteEC2Snapshot(client *ec2.EC2, id string, logger logrus.FieldLogger) error {
+	_, err := client.DeleteSnapshot(&ec2.DeleteSnapshotInput{
+		SnapshotId: &id,
+	})
+	if err != nil {
+		if err.(awserr.Error).Code() == "InvalidSnapshotID.NotFound" {
+			return nil
+		}
+		return err
+	}
+
+	logger.Info("Deleted")
+	return nil
+}
+
+func deleteEC2NetworkInterface(client *ec2.EC2, id string, logger logrus.FieldLogger) error {
+	_, err := client.DeleteNetworkInterface(&ec2.DeleteNetworkInterfaceInput{
+		NetworkInterfaceId: aws.String(id),
+	})
+	if err != nil {
+		if err.(awserr.Error).Code() == "InvalidNetworkInterfaceID.NotFound" {
 			return nil
 		}
 		return err

--- a/vendor/github.com/openshift/installer/pkg/rhcos/ami.go
+++ b/vendor/github.com/openshift/installer/pkg/rhcos/ami.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// AMI fetches the HVM AMI ID of the latest Red Hat CoreOS release.
+// AMI fetches the HVM AMI ID of the latest Red Hat Enterprise Linux CoreOS release.
 func AMI(ctx context.Context, channel, region string) (string, error) {
 	meta, err := fetchLatestMetadata(ctx, channel)
 	if err != nil {

--- a/vendor/github.com/openshift/installer/pkg/rhcos/qemu.go
+++ b/vendor/github.com/openshift/installer/pkg/rhcos/qemu.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// QEMU fetches the URL of the latest Red Hat CoreOS release.
+// QEMU fetches the URL of the latest Red Hat Enterprise Linux CoreOS release.
 func QEMU(ctx context.Context, channel string) (string, error) {
 	meta, err := fetchLatestMetadata(ctx, channel)
 	if err != nil {


### PR DESCRIPTION
Generated with:

```console
$ dep ensure -update
```

using:

```console
$ dep version
dep:
 version     : v0.5.0-31-g73b3afe
 build date  : 2019-02-08
 git hash    : 73b3afe
 go version  : go1.10.3
 go compiler : gc
 platform    : linux/amd64
 features    : ImportDuringSolve=false
```

Pulling in snapshot (openshift/installer#1346) and network-interface (openshift/installer#1361) deletion.