### PR TITLE
Use ClusterImageSets in clusterdeployment template and in e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ manifests: crd rbac
 	cp config/crds/hive_v1alpha1_hiveconfig.yaml config/manifests/01_hiveconfig_crd.yaml
 	cp config/crds/hive_v1alpha1_clusterdeployment.yaml config/manifests/01_clusterdeployment_crd.yaml
 	cp config/crds/hive_v1alpha1_dnszone.yaml config/manifests/01_dnszone_crd.yaml
+	cp config/crds/hive_v1alpha1_clusterimageset.yaml config/manifests/01_clusterimageset_crd.yaml
 	cp config/rbac/rbac_role.yaml config/manifests/01_rbac_role.yaml
 	cp config/rbac/rbac_role_binding.yaml config/manifests/01_rbac_role_binding.yaml
 	cp config/rbac/hiveadmission_rbac_role.yaml config/manifests/01_hiveadmission_rbac_role.yaml

--- a/config/hiveadmission/clusterimageset-webhook.yaml
+++ b/config/hiveadmission/clusterimageset-webhook.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: clusterdeployments.admission.hive.openshift.io
+webhooks:
+- name: clusterdeployments.admission.hive.openshift.io
+  clientConfig:
+    service:
+      # reach the webhook via the registered aggregated API
+      namespace: default
+      name: kubernetes
+      path: /apis/admission.hive.openshift.io/v1alpha1/clusterimagesets
+  rules:
+  - operations:
+    - CREATE
+    - UPDATE
+    apiGroups:
+    - hive.openshift.io
+    apiVersions:
+    - v1alpha1
+    resources:
+    - clusterimagesets
+  failurePolicy: Fail

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
 - ./manifests/00_namespace.yaml
 - ./manifests/01_hiveconfig_crd.yaml
 - ./manifests/01_clusterdeployment_crd.yaml
+- ./manifests/01_clusterimageset_crd.yaml
 - ./manifests/01_dnszone_crd.yaml
 - ./manifests/01_operator_role.yaml
 - ./manifests/01_operator_role_binding.yaml

--- a/config/manifests/01_clusterimageset_crd.yaml
+++ b/config/manifests/01_clusterimageset_crd.yaml
@@ -1,0 +1,69 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: clusterimagesets.hive.openshift.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.hiveImage
+    name: Hive
+    type: string
+  - JSONPath: .status.installerImage
+    name: Installer
+    type: string
+  - JSONPath: .spec.releaseImage
+    name: Release
+    type: string
+  group: hive.openshift.io
+  names:
+    kind: ClusterImageSet
+    plural: clusterimagesets
+    shortNames:
+    - imgset
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            hiveImage:
+              description: HiveImage is the Hive image to use when installing or destroying
+                a cluster. If not present, the default Hive image for the clusterdeployment
+                controller is used.
+              type: string
+            installerImage:
+              description: InstallerImage is the image used to install a cluster.
+                If not specified, the installer image reference is obtained from the
+                release image.
+              type: string
+            releaseImage:
+              description: ReleaseImage is the image that contains the payload to
+                use when installing a cluster. If the installer image is specified,
+                the release image is optional.
+              type: string
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/templates/cluster-deployment.yaml
+++ b/config/templates/cluster-deployment.yaml
@@ -35,16 +35,16 @@ parameters:
   description: Hive image pull policy
   value: Always
 - name: INSTALLER_IMAGE
-  displayName: OpenShift Installer image URL
-  description: OpenShift Installer image URL
-  value: "registry.svc.ci.openshift.org/openshift/origin-v4.0:installer"
+  displayName: OpenShift Installer image
+  description: OpenShift Installer image. Leave empty to use the default installer image from the release image.
+  value: ""
 - name: INSTALLER_IMAGE_PULL_POLICY
   displayName: OpenShift Installer image pull policy
   description: OpenShift Installer image pull policy
   value: Always
 - name: RELEASE_IMAGE
   displayName: OpenShift Release Image
-  description: The release image for the version of OpenShift you wish to install. Leave empty to allow installer to choose.
+  description: The release image for the version of OpenShift you wish to install. Leave empty to use latest release image.
   value: ""
 - name: TRY_INSTALL_ONCE
   displayName: Try Install Only Once
@@ -54,6 +54,14 @@ parameters:
   displayName: Try Uninstall Only Once
   description: If set, uninstall will only be tried once.
   value: "false"
+- name: CUSTOM_RELEASE_IMAGE
+  displayName: Custom release image in custom ClusterImageSet
+  description: Name of custom release image in custom ClusterImageSet. Defaults to latest in CI.
+  value: "registry.svc.ci.openshift.org/openshift/origin-release:v4.0"
+- name: CLUSTER_IMAGE_SET
+  displayName: ClusterImageSet to use for the cluster deployment
+  description: Specify an alternate ClusterImageSet to reference from the cluster deployment. Default is origin-latest.
+  value: origin-latest
 
 objects:
 - apiVersion: v1
@@ -82,6 +90,24 @@ objects:
     ssh-publickey: "${SSH_KEY}"
 
 - apiVersion: hive.openshift.io/v1alpha1
+  kind: ClusterImageSet
+  metadata:
+    labels:
+      controller-tools.k8s.io: "1.0"
+    name: origin-latest
+  spec:
+    releaseImage: "registry.svc.ci.openshift.org/openshift/origin-release:v4.0"
+
+- apiVersion: hive.openshift.io/v1alpha1
+  kind: ClusterImageSet
+  metadata:
+    labels:
+      controller-tools.k8s.io: "1.0"
+    name: custom
+  spec:
+    releaseImage: "${CUSTOM_RELEASE_IMAGE}"
+
+- apiVersion: hive.openshift.io/v1alpha1
   kind: ClusterDeployment
   metadata:
     labels:
@@ -102,6 +128,8 @@ objects:
       installerImage: "${INSTALLER_IMAGE}"
       installerImagePullPolicy: "${INSTALLER_IMAGE_PULL_POLICY}"
       releaseImage: "${RELEASE_IMAGE}"
+    imageSet:
+      name: "${CLUSTER_IMAGE_SET}"
     sshKey:
       name: "${CLUSTER_NAME}-ssh-key"
     clusterName: ${CLUSTER_NAME}

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -5,9 +5,8 @@ set -e
 max_tries=60
 sleep_between_tries=10
 component=hive
-TEST_IMAGE=$(eval "echo $IMAGE_FORMAT")
-component=installer
-INSTALLER_IMAGE=$(eval "echo $IMAGE_FORMAT")
+HIVE_IMAGE=$(eval "echo $IMAGE_FORMAT")
+RELEASE_IMAGE="registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/release:latest"
 
 ln -s $(which oc) $(pwd)/kubectl
 export PATH=$PATH:$(pwd)
@@ -45,7 +44,7 @@ fi
 
 
 # Install Hive
-make deploy DEPLOY_IMAGE="${TEST_IMAGE}"
+make deploy DEPLOY_IMAGE="${HIVE_IMAGE}"
 
 CLOUD_CREDS_DIR="/tmp/cluster"
 CLUSTER_DEPLOYMENT_FILE="/tmp/cluster-deployment.json"
@@ -106,9 +105,9 @@ while [ $i -le ${max_tries} ]; do
          AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}" \
          AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}" \
          BASE_DOMAIN="${BASE_DOMAIN}" \
-         HIVE_IMAGE="${TEST_IMAGE}" \
-         INSTALLER_IMAGE="${INSTALLER_IMAGE}" \
-         RELEASE_IMAGE="" \
+         HIVE_IMAGE="${HIVE_IMAGE}" \
+         CUSTOM_RELEASE_IMAGE="${RELEASE_IMAGE}" \
+         CLUSTER_IMAGE_SET="custom" \
          TRY_INSTALL_ONCE="true" \
          TRY_UNINSTALL_ONCE="true" \
       > ${CLUSTER_DEPLOYMENT_FILE} ; then

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -2,6 +2,7 @@
 // sources:
 // config/hiveadmission/apiservice.yaml
 // config/hiveadmission/clusterdeployment-webhook.yaml
+// config/hiveadmission/clusterimageset-webhook.yaml
 // config/hiveadmission/daemonset.yaml
 // config/hiveadmission/dnszones-webhook.yaml
 // config/hiveadmission/service-account.yaml
@@ -137,6 +138,47 @@ func configHiveadmissionClusterdeploymentWebhookYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "config/hiveadmission/clusterdeployment-webhook.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _configHiveadmissionClusterimagesetWebhookYaml = []byte(`---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: clusterdeployments.admission.hive.openshift.io
+webhooks:
+- name: clusterdeployments.admission.hive.openshift.io
+  clientConfig:
+    service:
+      # reach the webhook via the registered aggregated API
+      namespace: default
+      name: kubernetes
+      path: /apis/admission.hive.openshift.io/v1alpha1/clusterimagesets
+  rules:
+  - operations:
+    - CREATE
+    - UPDATE
+    apiGroups:
+    - hive.openshift.io
+    apiVersions:
+    - v1alpha1
+    resources:
+    - clusterimagesets
+  failurePolicy: Fail
+`)
+
+func configHiveadmissionClusterimagesetWebhookYamlBytes() ([]byte, error) {
+	return _configHiveadmissionClusterimagesetWebhookYaml, nil
+}
+
+func configHiveadmissionClusterimagesetWebhookYaml() (*asset, error) {
+	bytes, err := configHiveadmissionClusterimagesetWebhookYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "config/hiveadmission/clusterimageset-webhook.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3253,6 +3295,7 @@ func AssetNames() []string {
 var _bindata = map[string]func() (*asset, error){
 	"config/hiveadmission/apiservice.yaml":                        configHiveadmissionApiserviceYaml,
 	"config/hiveadmission/clusterdeployment-webhook.yaml":         configHiveadmissionClusterdeploymentWebhookYaml,
+	"config/hiveadmission/clusterimageset-webhook.yaml":           configHiveadmissionClusterimagesetWebhookYaml,
 	"config/hiveadmission/daemonset.yaml":                         configHiveadmissionDaemonsetYaml,
 	"config/hiveadmission/dnszones-webhook.yaml":                  configHiveadmissionDnszonesWebhookYaml,
 	"config/hiveadmission/service-account.yaml":                   configHiveadmissionServiceAccountYaml,
@@ -3323,6 +3366,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"hiveadmission": {nil, map[string]*bintree{
 			"apiservice.yaml":                {configHiveadmissionApiserviceYaml, map[string]*bintree{}},
 			"clusterdeployment-webhook.yaml": {configHiveadmissionClusterdeploymentWebhookYaml, map[string]*bintree{}},
+			"clusterimageset-webhook.yaml":   {configHiveadmissionClusterimagesetWebhookYaml, map[string]*bintree{}},
 			"daemonset.yaml":                 {configHiveadmissionDaemonsetYaml, map[string]*bintree{}},
 			"dnszones-webhook.yaml":          {configHiveadmissionDnszonesWebhookYaml, map[string]*bintree{}},
 			"service-account.yaml":           {configHiveadmissionServiceAccountYaml, map[string]*bintree{}},


### PR DESCRIPTION
Ensures that clusterimagesets and corresponding webhook are provisioned by the Hive operator. Makes the use of clusterimagesets the default in the clusterdeployment template and in the e2e test.