### PR TITLE
remoteingress controller

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2134,6 +2134,7 @@
     "github.com/onsi/gomega",
     "github.com/openshift/api/apps/v1",
     "github.com/openshift/api/config/v1",
+    "github.com/openshift/api/operator/v1",
     "github.com/openshift/api/route/v1",
     "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1",
     "github.com/openshift/cluster-network-operator/pkg/apis/networkoperator/v1",

--- a/config/crds/hive_v1alpha1_clusterdeployment.yaml
+++ b/config/crds/hive_v1alpha1_clusterdeployment.yaml
@@ -338,6 +338,32 @@ spec:
                     install.
                   type: string
               type: object
+            ingress:
+              description: Ingress allows defining desired clusteringress/shards to
+                be configured on the cluster.
+              items:
+                properties:
+                  domain:
+                    description: Domain (sometimes refered to as shard) is the full
+                      DNS suffix that the resulting IngressController object will
+                      service (eg abcd.mycluster.mydomain.com).
+                    type: string
+                  name:
+                    description: Name of the ClusterIngress object to create.
+                    type: string
+                  namespaceSelector:
+                    description: NamespaceSelector allows filtering the list of namespaces
+                      serviced by the ingress controller.
+                    type: object
+                  routeSelector:
+                    description: RouteSelector allows filtering the set of Routes
+                      serviced by the ingress controller
+                    type: object
+                required:
+                - name
+                - domain
+                type: object
+              type: array
             networking:
               description: Networking defines the pod network provider in the cluster.
               properties:

--- a/config/operator/operator_role.yaml
+++ b/config/operator/operator_role.yaml
@@ -101,3 +101,21 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  verbs:
+  - get
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - syncsets
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+  - patch
+  - list
+  - watch

--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -121,3 +121,21 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  verbs:
+  - get
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - syncsets
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+  - patch
+  - list
+  - watch

--- a/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
@@ -80,6 +80,10 @@ type ClusterDeploymentSpec struct {
 
 	// PreserveOnDelete allows the user to disconnect a cluster from Hive without deprovisioning it
 	PreserveOnDelete bool `json:"preserveOnDelete,omitempty"`
+
+	// Ingress allows defining desired clusteringress/shards to be configured on the cluster.
+	// +optional
+	Ingress []ClusterIngress `json:"ingress,omitempty"`
 }
 
 // ProvisionImages allows overriding the default images used to provision a cluster.
@@ -309,6 +313,26 @@ type LibvirtNetwork struct {
 	IfName string `json:"if"`
 	// IPRange is the range of IPs to use.
 	IPRange string `json:"ipRange"`
+}
+
+// ClusterIngress contains the configurable pieces for any ClusterIngress objects
+// that should exist on the cluster.
+type ClusterIngress struct {
+	// Name of the ClusterIngress object to create.
+	Name string `json:"name"`
+
+	// Domain (sometimes refered to as shard) is the full DNS suffix that the resulting
+	// IngressController object will service (eg abcd.mycluster.mydomain.com).
+	Domain string `json:"domain"`
+
+	// NamespaceSelector allows filtering the list of namespaces serviced by the
+	// ingress controller.
+	// +optional
+	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty"`
+
+	// RouteSelector allows filtering the set of Routes serviced by the ingress controller
+	// +optional
+	RouteSelector *metav1.LabelSelector `json:"routeSelector,omitempty"`
 }
 
 func init() {

--- a/pkg/controller/add_remoteingress.go
+++ b/pkg/controller/add_remoteingress.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/openshift/hive/pkg/controller/remoteingress"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, remoteingress.Add)
+}

--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remoteingress
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	log "github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	ingresscontroller "github.com/openshift/api/operator/v1"
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+)
+
+const (
+	controllerName = "remoteingress"
+
+	remoteClusterIngressNamespace = "openshift-ingress-operator"
+)
+
+// Add creates a new RemoteMachineSet Controller and adds it to the Manager with default RBAC. The Manager will set fields on the
+// Controller and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return AddToManager(mgr, NewReconciler(mgr))
+}
+
+// NewReconciler returns a new reconcile.Reconciler
+func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileRemoteClusterIngress{
+		Client: mgr.GetClient(),
+		scheme: mgr.GetScheme(),
+		logger: log.WithField("controller", controllerName),
+	}
+}
+
+// AddToManager adds a new Controller to mgr with r as the reconcile.Reconciler
+func AddToManager(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("remoteingress-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to ClusterDeployment
+	err = c.Watch(&source.Kind{Type: &hivev1.ClusterDeployment{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileRemoteClusterIngress{}
+
+// ReconcileRemoteClusterIngress reconciles the ingress objects defined in a ClusterDeployment object
+type ReconcileRemoteClusterIngress struct {
+	client.Client
+	scheme *runtime.Scheme
+
+	logger log.FieldLogger
+}
+
+// Reconcile reads that state of the cluster for a ClusterDeployment object and sets up
+// any needed ClusterIngress objects up for syncing to the remote cluster.
+//
+// +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=get
+// +kubebuilder:rbac:groups=hive.openshift.io,resources=syncsets,verbs=get;create;update;delete;patch;list;watch
+func (r *ReconcileRemoteClusterIngress) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	// Fetch the ClusterDeployment instance
+	cd := &hivev1.ClusterDeployment{}
+	err := r.Get(context.TODO(), request.NamespacedName, cd)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Object not found (must have been deleted), return
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request
+		log.WithError(err).Error("error looking up cluster deployment")
+		return reconcile.Result{}, err
+	}
+
+	cdLog := r.logger.WithFields(log.Fields{
+		"clusterDeployment": cd.Name,
+		"namespace":         cd.Namespace,
+	})
+
+	if cd.Spec.Ingress == nil {
+		// the addmission controller will ensure that we get valid-looking
+		// Spec.Ingress (ie no missing 'default', no going from a defined
+		// ingress list to an empty list, etc)
+		cdLog.Debug("no ingress objects defined. using default intaller behavior.")
+		return reconcile.Result{}, nil
+	}
+
+	if err := r.syncClusterIngress(cd); err != nil {
+		cdLog.Errorf("error syncing clusterIngress syncset: %v", err)
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileRemoteClusterIngress) syncClusterIngress(cd *hivev1.ClusterDeployment) error {
+	cdLog := r.logger.WithFields(log.Fields{
+		"clusterDeployment": cd.Name,
+		"namespace":         cd.Namespace,
+	})
+	cdLog.Info("reconciling ClusterIngress for cluster deployment")
+
+	rawList := rawExtensionsFromClusterDeployment(cd)
+
+	if err := r.syncSyncSet(cd, rawList); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func rawExtensionsFromClusterDeployment(cd *hivev1.ClusterDeployment) []runtime.RawExtension {
+	rawList := []runtime.RawExtension{}
+	for _, ingress := range cd.Spec.Ingress {
+		ingressObj := createIngressController(cd, ingress)
+		raw := runtime.RawExtension{Object: ingressObj}
+		rawList = append(rawList, raw)
+	}
+
+	return rawList
+}
+
+func newSyncSetSpec(cd *hivev1.ClusterDeployment, rawExtensions []runtime.RawExtension) *hivev1.SyncSetSpec {
+	ssSpec := &hivev1.SyncSetSpec{
+		SyncSetCommonSpec: hivev1.SyncSetCommonSpec{
+			Resources:         rawExtensions,
+			ResourceApplyMode: "sync",
+		},
+		ClusterDeploymentRefs: []corev1.LocalObjectReference{
+			{
+				Name: cd.Name,
+			},
+		},
+	}
+	return ssSpec
+}
+
+func (r *ReconcileRemoteClusterIngress) syncSyncSet(cd *hivev1.ClusterDeployment, rawExtensions []runtime.RawExtension) error {
+
+	ssName := fmt.Sprintf("%v-clusteringress", cd.Name)
+	newSyncSetSpec := newSyncSetSpec(cd, rawExtensions)
+
+	ss := &hivev1.SyncSet{}
+	err := r.Get(context.TODO(), types.NamespacedName{Name: ssName, Namespace: cd.Namespace}, ss)
+	if errors.IsNotFound(err) {
+		// create the syncset
+		ss = &hivev1.SyncSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ssName,
+				Namespace: cd.Namespace,
+			},
+			Spec: *newSyncSetSpec,
+		}
+
+		// ensure the syncset gets cleaned up when the clusterdeployment is deleted
+		if err := controllerutil.SetControllerReference(cd, ss, r.scheme); err != nil {
+			r.logger.WithError(err).Error("error setting owner reference")
+			return err
+		}
+
+		if err := r.Create(context.TODO(), ss); err != nil {
+			r.logger.Errorf("error creating sync set: %v", err)
+			return err
+		}
+
+		return nil
+	} else if err != nil {
+		r.logger.Errorf("error checking for existing syncset: %v", err)
+		return err
+	}
+
+	// update the syncset if there have been changes
+	if !reflect.DeepEqual(ss.Spec, *newSyncSetSpec) {
+		ss.Spec = *newSyncSetSpec
+		if err := r.Update(context.TODO(), ss); err != nil {
+			errDetails := fmt.Errorf("error updating existing syncset: %v", err)
+			r.logger.Error(errDetails)
+			return errDetails
+		}
+	}
+
+	return nil
+}
+
+func createIngressController(cd *hivev1.ClusterDeployment, ingress hivev1.ClusterIngress) *ingresscontroller.IngressController {
+	newIngress := ingresscontroller.IngressController{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ingress.Name,
+			Namespace: remoteClusterIngressNamespace,
+		},
+		Spec: ingresscontroller.IngressControllerSpec{
+			Domain:            ingress.Domain,
+			RouteSelector:     ingress.RouteSelector,
+			NamespaceSelector: ingress.NamespaceSelector,
+		},
+	}
+
+	return &newIngress
+}

--- a/pkg/controller/remoteingress/remoteingress_controller_test.go
+++ b/pkg/controller/remoteingress/remoteingress_controller_test.go
@@ -1,0 +1,378 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remoteingress
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ingresscontroller "github.com/openshift/api/operator/v1"
+	"github.com/openshift/hive/pkg/apis"
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+)
+
+const (
+	testClusterName  = "foo"
+	testNamespace    = "default"
+	testClusterID    = "foo-12345-uuid"
+	testInfraID      = "foo-12345"
+	sshKeySecret     = "foo-ssh-key"
+	pullSecretSecret = "foo-pull-secret"
+
+	testSyncSetName        = "foo-clusteringress"
+	testDefaultIngressName = "default"
+	testIngressDomain      = "testapps.example.com"
+)
+
+func init() {
+	log.SetLevel(log.DebugLevel)
+}
+
+type SyncSetEntry struct {
+	name              string
+	domain            string
+	routeSelector     *metav1.LabelSelector
+	namespaceSelector *metav1.LabelSelector
+}
+
+func TestRemoteClusterIngressReconcile(t *testing.T) {
+	apis.AddToScheme(scheme.Scheme)
+
+	tests := []struct {
+		name                   string
+		localObjects           []runtime.Object
+		expectedSyncSetEntries []SyncSetEntry
+	}{
+		{
+			name: "Test no ingress defined (no expected syncset)",
+			localObjects: []runtime.Object{
+				testClusterDeploymentWithoutIngress(),
+			},
+		},
+		{
+			name: "Test single ingress (only default)",
+			localObjects: []runtime.Object{
+				testClusterDeployment(),
+			},
+			expectedSyncSetEntries: []SyncSetEntry{
+				{
+					name:   testDefaultIngressName,
+					domain: testIngressDomain,
+				},
+			},
+		},
+		{
+			name: "Test multiple ingress",
+			localObjects: []runtime.Object{
+				addIngressToClusterDeployment(testClusterDeployment(), SyncSetEntry{
+					name:   "secondingress",
+					domain: "moreingress.example.com",
+				}),
+			},
+			expectedSyncSetEntries: []SyncSetEntry{
+				{
+					name:   testDefaultIngressName,
+					domain: testIngressDomain,
+				},
+				{
+					name:   "secondingress",
+					domain: "moreingress.example.com",
+				},
+			},
+		},
+		{
+			name: "Test updating existing syncset",
+			localObjects: []runtime.Object{
+				addIngressToClusterDeployment(testClusterDeployment(), SyncSetEntry{
+					name:   "secondingress",
+					domain: "moreingress.example.com",
+				}),
+				syncSetFromClusterDeployment(testClusterDeployment()),
+			},
+			expectedSyncSetEntries: []SyncSetEntry{
+				{
+					name:   testDefaultIngressName,
+					domain: testIngressDomain,
+				},
+				{
+					name:   "secondingress",
+					domain: "moreingress.example.com",
+				},
+			},
+		},
+		{
+			name: "Test removing an ingress from existing syncset",
+			localObjects: func() []runtime.Object {
+				objects := []runtime.Object{}
+				// create a temp cluster deployment with extra ingress
+				cd := testClusterDeployment()
+				cd.Spec.Ingress = append(cd.Spec.Ingress, hivev1.ClusterIngress{
+					Name:   "secondingress",
+					Domain: "moreingress.example.com",
+				})
+
+				// create a syncset that has the extra ingress
+				ss := syncSetFromClusterDeployment(cd)
+				objects = append(objects, ss)
+
+				// create the current cluster deployment with only a single ingress
+				cd = testClusterDeployment()
+				objects = append(objects, cd)
+
+				return objects
+			}(),
+			expectedSyncSetEntries: []SyncSetEntry{
+				{
+					name:   testDefaultIngressName,
+					domain: testIngressDomain,
+				},
+			},
+		},
+		{
+			name: "Test setting routeSelector",
+			localObjects: []runtime.Object{
+				addIngressToClusterDeployment(testClusterDeployment(), SyncSetEntry{
+					name:          "secondingress",
+					domain:        "moreingress.example.com",
+					routeSelector: testRouteSelector(),
+				}),
+			},
+			expectedSyncSetEntries: []SyncSetEntry{
+				{
+					name:   testDefaultIngressName,
+					domain: testIngressDomain,
+				},
+				{
+					name:          "secondingress",
+					domain:        "moreingress.example.com",
+					routeSelector: testRouteSelector(),
+				},
+			},
+		},
+		{
+			name: "Test setting namespaceSelector",
+			localObjects: []runtime.Object{
+				addIngressToClusterDeployment(testClusterDeployment(), SyncSetEntry{
+					name:              "secondingress",
+					domain:            "moreingress.example.com",
+					namespaceSelector: testNamespaceSelector(),
+				}),
+			},
+			expectedSyncSetEntries: []SyncSetEntry{
+				{
+					name:   testDefaultIngressName,
+					domain: testIngressDomain,
+				},
+				{
+					name:              "secondingress",
+					domain:            "moreingress.example.com",
+					namespaceSelector: testNamespaceSelector(),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fakeClient := fake.NewFakeClient(test.localObjects...)
+
+			rcd := &ReconcileRemoteClusterIngress{
+				Client: fakeClient,
+				scheme: scheme.Scheme,
+				logger: log.WithField("controller", controllerName),
+			}
+			_, err := rcd.Reconcile(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      testClusterName,
+					Namespace: testNamespace,
+				},
+			})
+
+			if err != nil {
+				t.Errorf("unexpexted error: %v", err)
+			}
+
+			ss := &hivev1.SyncSet{}
+			ssNamespacedName := types.NamespacedName{Name: testSyncSetName, Namespace: testNamespace}
+			if len(test.expectedSyncSetEntries) == 0 {
+				// should get an IsNotFound
+				assert.Error(t, fakeClient.Get(context.TODO(), ssNamespacedName, ss))
+			} else {
+				// validate the syncset data looks correct
+				if err := fakeClient.Get(context.TODO(), ssNamespacedName, ss); err != nil {
+					t.Errorf("failed fetching SyncSet to check whether it was properly created/updated: %v", err)
+				}
+				ingressControllers := rawToIngressControllers(ss.Spec.Resources)
+
+				// We should have the expected number of ingress objects
+				assert.Equal(t, len(test.expectedSyncSetEntries), len(ingressControllers))
+
+				// And the configuration of each ingress object should match what we expect
+				for _, entry := range test.expectedSyncSetEntries {
+					foundIngress := false
+					for _, ingressController := range ingressControllers {
+						if entry.name == ingressController.Name {
+							foundIngress = true
+
+							// check domain looks right
+							assert.Equal(t, entry.domain, ingressController.Spec.Domain)
+
+							// check routeSelector
+							assert.Equal(t, entry.routeSelector, ingressController.Spec.RouteSelector)
+
+							// check namespaceSelector
+							assert.Equal(t, entry.namespaceSelector, ingressController.Spec.NamespaceSelector)
+						}
+					}
+					assert.Equal(t, true, foundIngress)
+				}
+			}
+		})
+	}
+}
+
+func testNamespaceSelector() *metav1.LabelSelector {
+	return testRouteSelector()
+}
+
+func testRouteSelector() *metav1.LabelSelector {
+	selector := &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"shard": "secretshard",
+		},
+	}
+	return selector
+}
+
+func addIngressToClusterDeployment(cd *hivev1.ClusterDeployment, ingress SyncSetEntry) *hivev1.ClusterDeployment {
+	cd.Spec.Ingress = append(cd.Spec.Ingress, hivev1.ClusterIngress{
+		Name:              ingress.name,
+		Domain:            ingress.domain,
+		RouteSelector:     ingress.routeSelector,
+		NamespaceSelector: ingress.namespaceSelector,
+	})
+
+	return cd
+}
+
+func syncSetFromClusterDeployment(cd *hivev1.ClusterDeployment) *hivev1.SyncSet {
+	rawExtensions := rawExtensionsFromClusterDeployment(cd)
+	ssSpec := newSyncSetSpec(cd, rawExtensions)
+	return &hivev1.SyncSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cd.Name + "clusteringress",
+			Namespace: cd.Namespace,
+		},
+		Spec: *ssSpec,
+	}
+}
+
+func testClusterDeployment() *hivev1.ClusterDeployment {
+	cd := testClusterDeploymentWithoutIngress()
+	cd = addIngressToClusterDeployment(cd, SyncSetEntry{
+		name:   testDefaultIngressName,
+		domain: testIngressDomain,
+	})
+
+	return cd
+}
+
+func testClusterDeploymentWithoutIngress() *hivev1.ClusterDeployment {
+	return &hivev1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testClusterName,
+			Namespace:  testNamespace,
+			Finalizers: []string{hivev1.FinalizerDeprovision},
+			UID:        types.UID("1234"),
+		},
+		Spec: hivev1.ClusterDeploymentSpec{
+			SSHKey: &corev1.LocalObjectReference{
+				Name: sshKeySecret,
+			},
+			ClusterName:  testClusterName,
+			ControlPlane: hivev1.MachinePool{},
+			PullSecret: corev1.LocalObjectReference{
+				Name: pullSecretSecret,
+			},
+			Platform: hivev1.Platform{
+				AWS: &hivev1.AWSPlatform{
+					Region: "us-east-1",
+				},
+			},
+			Networking: hivev1.Networking{
+				Type: hivev1.NetworkTypeOpenshiftSDN,
+			},
+			PlatformSecrets: hivev1.PlatformSecrets{
+				AWS: &hivev1.AWSPlatformSecrets{
+					Credentials: corev1.LocalObjectReference{
+						Name: "aws-credentials",
+					},
+				},
+			},
+		},
+		Status: hivev1.ClusterDeploymentStatus{
+			Installed:             true,
+			AdminKubeconfigSecret: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-admin-kubeconfig", testClusterName)},
+			ClusterID:             testClusterID,
+			InfraID:               testInfraID,
+		},
+	}
+}
+
+func rawToIngressControllers(rawList []runtime.RawExtension) []*ingresscontroller.IngressController {
+	decoder := newIngressControllerDecoder()
+	ingressControllers := []*ingresscontroller.IngressController{}
+
+	for _, raw := range rawList {
+		obj, _, err := decoder.Decode(raw.Raw, nil, &ingresscontroller.IngressController{})
+		if err != nil {
+			panic("error decoding to ingresscontroller object")
+		}
+		ic, ok := obj.(*ingresscontroller.IngressController)
+		if !ok {
+			panic("error casting to IngressController")
+		}
+		ingressControllers = append(ingressControllers, ic)
+	}
+	return ingressControllers
+}
+
+func newIngressControllerDecoder() runtime.Decoder {
+	scheme, err := hivev1.SchemeBuilder.Build()
+	if err != nil {
+		panic("error building ingresscontroller scheme")
+	}
+	codecFactory := serializer.NewCodecFactory(scheme)
+	decoder := codecFactory.UniversalDecoder(hivev1.SchemeGroupVersion)
+
+	return decoder
+}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -822,6 +822,32 @@ spec:
                     install.
                   type: string
               type: object
+            ingress:
+              description: Ingress allows defining desired clusteringress/shards to
+                be configured on the cluster.
+              items:
+                properties:
+                  domain:
+                    description: Domain (sometimes refered to as shard) is the full
+                      DNS suffix that the resulting IngressController object will
+                      service (eg abcd.mycluster.mydomain.com).
+                    type: string
+                  name:
+                    description: Name of the ClusterIngress object to create.
+                    type: string
+                  namespaceSelector:
+                    description: NamespaceSelector allows filtering the list of namespaces
+                      serviced by the ingress controller.
+                    type: object
+                  routeSelector:
+                    description: RouteSelector allows filtering the set of Routes
+                      serviced by the ingress controller
+                    type: object
+                required:
+                - name
+                - domain
+                type: object
+              type: array
             networking:
               description: Networking defines the pod network provider in the cluster.
               properties:


### PR DESCRIPTION
extend ClusterDeployment to allow defining a list of ingress objects that should be configured on the cluster as IngressController objects for the openshift-ingress-operator to set up.
    
spec.ingress can be empty which will result in default cluster behavior (ie self-signed certs, *.apps.<base domain> default route, etc). otherwise, spec.ingress can provide for additional ingress objects (although you must provide settings for the 'default' ingress object in this case). and once you define ingress objects, you cannot go back to default behavior. all this is enforced by the admission webhooks.
    
when spec.ingress is defined, it will create a syncset object with all the desired ingress definitions so that the appropriate IngressController objects are set up in the cluster.
    
this version of the controller doesn't address having non-self-signed certificates created as part of the setup/sync process. this will come at a later date when the interaction between hive and the certificate request CRDs is finalized.