### PR TITLE
Generate new OLM bundles and document testing.

### DIFF
--- a/build/olm-registry/Dockerfile
+++ b/build/olm-registry/Dockerfile
@@ -1,0 +1,6 @@
+FROM quay.io/openshift/origin-operator-registry:latest
+
+COPY bundle manifests/hive
+RUN initializer
+
+CMD ["registry-server", "-t", "/tmp/terminate.log"]

--- a/bundle/0.1.494-3f73a592/hive-operator.v0.1.494-3f73a592.clusterserviceversion.yaml
+++ b/bundle/0.1.494-3f73a592/hive-operator.v0.1.494-3f73a592.clusterserviceversion.yaml
@@ -1,0 +1,343 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    categories: A list of comma separated categories that your operator falls under.
+    certified: 'false'
+    containerImage: quay.io/dgoodwin/hive:latest
+    createdAt: '2019-03-08T15:51:08Z'
+    description: OpenShift cluster provisioning and management at scale.
+    support: Devan Goodwin
+  name: hive-operator.v0.1.494-3f73a592
+  namespace: placeholder
+spec:
+  customresourcedefinitions:
+    owned:
+    - description: Configuration for the Hive Operator
+      displayName: Hive Config
+      kind: HiveConfig
+      name: hiveconfigs.hive.openshift.io
+      version: v1alpha1
+    - description: Defines an OpenShift cluster to be created.
+      displayName: Cluster Deployment
+      kind: ClusterDeployment
+      name: clusterdeployments.hive.openshift.io
+      version: v1alpha1
+    - description: Defines a DNSZone to be managed in a cloud provider.
+      displayName: DNS Zone
+      kind: DNSZone
+      name: dnszones.hive.openshift.io
+      version: v1alpha1
+  description: OpenShift cluster provisioning and management at scale.
+  displayName: Hive
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ''
+          resources:
+          - serviceaccounts
+          - serviceaccounts/finalizers
+          - secrets
+          - secrets/finalizers
+          - services
+          - services/finalizers
+          - events
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - apiregistration.k8s.io
+          resources:
+          - apiservices
+          - apiservices/finalizers
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - deployments/finalizers
+          - daemonsets
+          - daemonsets/finalizers
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          - deploymentconfigs/finalizers
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - hive.openshift.io
+          resources:
+          - hiveconfigs
+          - hiveconfigs/finalizers
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        serviceAccountName: hive-operator
+      - rules:
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ''
+          resources:
+          - serviceaccounts
+          - secrets
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - hive.openshift.io
+          resources:
+          - clusterdeployments
+          - clusterdeployments/status
+          - clusterdeployments/finalizers
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - hive.openshift.io
+          resources:
+          - clusterimagesets
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - hive.openshift.io
+          resources:
+          - clusterimagesets/status
+          verbs:
+          - get
+          - update
+          - patch
+        - apiGroups:
+          - hive.openshift.io
+          resources:
+          - dnszones
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - clusterregistry.k8s.io
+          resources:
+          - clusters
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - core.federation.k8s.io
+          resources:
+          - federatedclusters
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        serviceAccountName: default
+      - rules:
+        - apiGroups:
+          - admission.hive.openshift.io
+          resources:
+          - dnszones
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          verbs:
+          - get
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: hiveadmission
+      deployments:
+      - name: hive-operator
+        spec:
+          replicas: 1
+          revisionHistoryLimit: 4
+          selector:
+            matchLabels:
+              control-plane: hive-operator
+              controller-tools.k8s.io: '1.0'
+          template:
+            metadata:
+              labels:
+                control-plane: hive-operator
+                controller-tools.k8s.io: '1.0'
+            spec:
+              containers:
+              - command:
+                - /opt/services/hive-operator
+                - --log-level
+                - debug
+                image: quay.io/dgoodwin/hive:latest
+                imagePullPolicy: Always
+                name: hive-operator
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 256Mi
+                  requests:
+                    cpu: 100m
+                    memory: 75Mi
+              serviceAccountName: hive-operator
+              terminationGracePeriodSeconds: 10
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - kubernetes
+  - openshift
+  - multi-cluster
+  - cluster
+  maturity: alpha
+  provider:
+    name: Red Hat, Inc
+  replaces: hive-operator.v0.1.5-4b53b492
+  version: 0.1.494-3f73a592

--- a/bundle/0.1.494-3f73a592/hive_v1alpha1_clusterdeployment.yaml
+++ b/bundle/0.1.494-3f73a592/hive_v1alpha1_clusterdeployment.yaml
@@ -1,0 +1,884 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: clusterdeployments.hive.openshift.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.baseDomain
+    name: BaseDomain
+    type: string
+  - JSONPath: .status.installed
+    name: Installed
+    type: boolean
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: hive.openshift.io
+  names:
+    kind: ClusterDeployment
+    plural: clusterdeployments
+    shortNames:
+    - cd
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            baseDomain:
+              description: BaseDomain is the base domain to which the cluster should
+                belong.
+              type: string
+            clusterName:
+              description: ClusterName is the friendly name of the cluster. It is
+                used for subdomains, some resource tagging, and other instances where
+                a friendly name for the cluster is useful.
+              type: string
+            compute:
+              description: Compute is the list of MachinePools containing compute
+                nodes that need to be installed.
+              items:
+                properties:
+                  labels:
+                    description: Map of label string keys and values that will be
+                      applied to the created MachineSet's MachineSpec. This list will
+                      overwrite any modifications made to Node labels on an ongoing
+                      basis.
+                    type: object
+                  name:
+                    description: Name is the name of the machine pool.
+                    type: string
+                  platform:
+                    description: Platform is configuration for machine pool specific
+                      to the platfrom.
+                    properties:
+                      aws:
+                        description: AWS is the configuration used when installing
+                          on AWS.
+                        properties:
+                          rootVolume:
+                            description: EC2RootVolume defines the storage for ec2
+                              instance.
+                            properties:
+                              iops:
+                                description: IOPS defines the iops for the instance.
+                                format: int64
+                                type: integer
+                              size:
+                                description: Size defines the size of the instance.
+                                format: int64
+                                type: integer
+                              type:
+                                description: Type defines the type of the instance.
+                                type: string
+                            required:
+                            - iops
+                            - size
+                            - type
+                            type: object
+                          type:
+                            description: InstanceType defines the ec2 instance type.
+                              eg. m4-large
+                            type: string
+                          zones:
+                            description: Zones is list of availability zones that
+                              can be used.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - type
+                        - rootVolume
+                        type: object
+                      libvirt:
+                        description: Libvirt is the configuration used when installing
+                          on libvirt.
+                        properties:
+                          image:
+                            description: Image is the URL to the OS image. E.g. "http://aos-ostree.rhev-ci-vms.eng.rdu2.redhat.com/rhcos/images/cloud/latest/rhcos-qemu.qcow2.gz"
+                            type: string
+                          imagePool:
+                            description: ImagePool is the name of the libvirt storage
+                              pool to which the storage volume containing the OS image
+                              belongs.
+                            type: string
+                          imageVolume:
+                            description: ImageVolume is the name of the libvirt storage
+                              volume containing the OS image.
+                            type: string
+                        required:
+                        - image
+                        type: object
+                      openstack:
+                        description: OpenStack is the configuration used when installing
+                          on OpenStack.
+                        properties:
+                          rootVolume:
+                            description: OpenStackRootVolume defines the storage for
+                              Nova instance.
+                            properties:
+                              iops:
+                                description: IOPS defines the iops for the instance.
+                                format: int64
+                                type: integer
+                              size:
+                                description: Size defines the size of the instance.
+                                format: int64
+                                type: integer
+                              type:
+                                description: Type defines the type of the instance.
+                                type: string
+                            required:
+                            - iops
+                            - size
+                            - type
+                            type: object
+                          type:
+                            description: FlavorName defines the OpenStack Nova flavor.
+                              eg. m1.large
+                            type: string
+                        required:
+                        - type
+                        - rootVolume
+                        type: object
+                    type: object
+                  replicas:
+                    description: Replicas is the count of machines for this machine
+                      pool. Default is 1.
+                    format: int64
+                    type: integer
+                  taints:
+                    description: List of taints that will be applied to the created
+                      MachineSet's MachineSpec. This list will overwrite any modifications
+                      made to Node taints on an ongoing basis.
+                    items:
+                      type: object
+                    type: array
+                required:
+                - name
+                - replicas
+                - platform
+                type: object
+              type: array
+            controlPlane:
+              description: ControlPlane is the MachinePool containing control plane
+                nodes that need to be installed.
+              properties:
+                labels:
+                  description: Map of label string keys and values that will be applied
+                    to the created MachineSet's MachineSpec. This list will overwrite
+                    any modifications made to Node labels on an ongoing basis.
+                  type: object
+                name:
+                  description: Name is the name of the machine pool.
+                  type: string
+                platform:
+                  description: Platform is configuration for machine pool specific
+                    to the platfrom.
+                  properties:
+                    aws:
+                      description: AWS is the configuration used when installing on
+                        AWS.
+                      properties:
+                        rootVolume:
+                          description: EC2RootVolume defines the storage for ec2 instance.
+                          properties:
+                            iops:
+                              description: IOPS defines the iops for the instance.
+                              format: int64
+                              type: integer
+                            size:
+                              description: Size defines the size of the instance.
+                              format: int64
+                              type: integer
+                            type:
+                              description: Type defines the type of the instance.
+                              type: string
+                          required:
+                          - iops
+                          - size
+                          - type
+                          type: object
+                        type:
+                          description: InstanceType defines the ec2 instance type.
+                            eg. m4-large
+                          type: string
+                        zones:
+                          description: Zones is list of availability zones that can
+                            be used.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - type
+                      - rootVolume
+                      type: object
+                    libvirt:
+                      description: Libvirt is the configuration used when installing
+                        on libvirt.
+                      properties:
+                        image:
+                          description: Image is the URL to the OS image. E.g. "http://aos-ostree.rhev-ci-vms.eng.rdu2.redhat.com/rhcos/images/cloud/latest/rhcos-qemu.qcow2.gz"
+                          type: string
+                        imagePool:
+                          description: ImagePool is the name of the libvirt storage
+                            pool to which the storage volume containing the OS image
+                            belongs.
+                          type: string
+                        imageVolume:
+                          description: ImageVolume is the name of the libvirt storage
+                            volume containing the OS image.
+                          type: string
+                      required:
+                      - image
+                      type: object
+                    openstack:
+                      description: OpenStack is the configuration used when installing
+                        on OpenStack.
+                      properties:
+                        rootVolume:
+                          description: OpenStackRootVolume defines the storage for
+                            Nova instance.
+                          properties:
+                            iops:
+                              description: IOPS defines the iops for the instance.
+                              format: int64
+                              type: integer
+                            size:
+                              description: Size defines the size of the instance.
+                              format: int64
+                              type: integer
+                            type:
+                              description: Type defines the type of the instance.
+                              type: string
+                          required:
+                          - iops
+                          - size
+                          - type
+                          type: object
+                        type:
+                          description: FlavorName defines the OpenStack Nova flavor.
+                            eg. m1.large
+                          type: string
+                      required:
+                      - type
+                      - rootVolume
+                      type: object
+                  type: object
+                replicas:
+                  description: Replicas is the count of machines for this machine
+                    pool. Default is 1.
+                  format: int64
+                  type: integer
+                taints:
+                  description: List of taints that will be applied to the created
+                    MachineSet's MachineSpec. This list will overwrite any modifications
+                    made to Node taints on an ongoing basis.
+                  items:
+                    type: object
+                  type: array
+              required:
+              - name
+              - replicas
+              - platform
+              type: object
+            imageSet:
+              description: ImageSet is a reference to a ClusterImageSet. If values
+                are specified for Images, those will take precedence over the ones
+                from the ClusterImageSet.
+              properties:
+                name:
+                  description: Name is the name of the ClusterImageSet that this refers
+                    to
+                  type: string
+              required:
+              - name
+              type: object
+            images:
+              description: Images allows overriding the default images used to provision
+                and manage the cluster.
+              properties:
+                hiveImage:
+                  description: HiveImage is the image used in the sidecar container
+                    to manage execution of openshift-install.
+                  type: string
+                hiveImagePullPolicy:
+                  description: HiveImagePullPolicy is the pull policy for the installer
+                    image.
+                  type: string
+                installerImage:
+                  description: InstallerImage is the image containing the openshift-install
+                    binary that will be used to install.
+                  type: string
+                installerImagePullPolicy:
+                  description: InstallerImagePullPolicy is the pull policy for the
+                    installer image.
+                  type: string
+                releaseImage:
+                  description: ReleaseImage is the image containing metadata for all
+                    components that run in the cluster, and is the primary and best
+                    way to specify what specific version of OpenShift you wish to
+                    install.
+                  type: string
+              type: object
+            networking:
+              description: Networking defines the pod network provider in the cluster.
+              properties:
+                clusterNetworks:
+                  description: ClusterNetworks is the IP address space from which
+                    to assign pod IPs.
+                  items:
+                    properties:
+                      cidr:
+                        type: string
+                      hostSubnetLength:
+                        format: int32
+                        type: integer
+                    required:
+                    - cidr
+                    - hostSubnetLength
+                    type: object
+                  type: array
+                machineCIDR:
+                  description: MachineCIDR is the IP address space from which to assign
+                    machine IPs.
+                  type: string
+                serviceCIDR:
+                  description: ServiceCIDR is the IP address space from which to assign
+                    service IPs.
+                  type: string
+                type:
+                  description: Type is the network type to install
+                  type: string
+              required:
+              - machineCIDR
+              - type
+              - serviceCIDR
+              type: object
+            platform:
+              description: Platform is the configuration for the specific platform
+                upon which to perform the installation.
+              properties:
+                aws:
+                  description: AWS is the configuration used when installing on AWS.
+                  properties:
+                    defaultMachinePlatform:
+                      description: DefaultMachinePlatform is the default configuration
+                        used when installing on AWS for machine pools which do not
+                        define their own platform configuration.
+                      properties:
+                        rootVolume:
+                          description: EC2RootVolume defines the storage for ec2 instance.
+                          properties:
+                            iops:
+                              description: IOPS defines the iops for the instance.
+                              format: int64
+                              type: integer
+                            size:
+                              description: Size defines the size of the instance.
+                              format: int64
+                              type: integer
+                            type:
+                              description: Type defines the type of the instance.
+                              type: string
+                          required:
+                          - iops
+                          - size
+                          - type
+                          type: object
+                        type:
+                          description: InstanceType defines the ec2 instance type.
+                            eg. m4-large
+                          type: string
+                        zones:
+                          description: Zones is list of availability zones that can
+                            be used.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - type
+                      - rootVolume
+                      type: object
+                    region:
+                      description: Region specifies the AWS region where the cluster
+                        will be created.
+                      type: string
+                    userTags:
+                      description: UserTags specifies additional tags for AWS resources
+                        created for the cluster.
+                      type: object
+                  required:
+                  - region
+                  type: object
+                libvirt:
+                  description: Libvirt is the configuration used when installing on
+                    libvirt.
+                  properties:
+                    URI:
+                      description: URI is the identifier for the libvirtd connection.  It
+                        must be reachable from both the host (where the installer
+                        is run) and the cluster (where the cluster-API controller
+                        pod will be running).
+                      type: string
+                    defaultMachinePlatform:
+                      description: DefaultMachinePlatform is the default configuration
+                        used when installing on AWS for machine pools which do not
+                        define their own platform configuration.
+                      properties:
+                        image:
+                          description: Image is the URL to the OS image. E.g. "http://aos-ostree.rhev-ci-vms.eng.rdu2.redhat.com/rhcos/images/cloud/latest/rhcos-qemu.qcow2.gz"
+                          type: string
+                        imagePool:
+                          description: ImagePool is the name of the libvirt storage
+                            pool to which the storage volume containing the OS image
+                            belongs.
+                          type: string
+                        imageVolume:
+                          description: ImageVolume is the name of the libvirt storage
+                            volume containing the OS image.
+                          type: string
+                      required:
+                      - image
+                      type: object
+                    masterIPs:
+                      description: MasterIPs
+                      items:
+                        format: byte
+                        type: string
+                      type: array
+                    network:
+                      description: Network
+                      properties:
+                        if:
+                          description: IfName is the name of the network interface.
+                          type: string
+                        ipRange:
+                          description: IPRange is the range of IPs to use.
+                          type: string
+                        name:
+                          description: Name is the name of the nework.
+                          type: string
+                      required:
+                      - name
+                      - if
+                      - ipRange
+                      type: object
+                  required:
+                  - URI
+                  - network
+                  - masterIPs
+                  type: object
+              type: object
+            platformSecrets:
+              description: PlatformSecrets contains credentials and secrets for the
+                cluster infrastructure.
+              properties:
+                aws:
+                  properties:
+                    credentials:
+                      description: Credentials refers to a secret that contains the
+                        AWS account access credentials.
+                      type: object
+                  required:
+                  - credentials
+                  type: object
+              type: object
+            preserveOnDelete:
+              description: PreserveOnDelete allows the user to disconnect a cluster
+                from Hive without deprovisioning it
+              type: boolean
+            pullSecret:
+              description: PullSecret is the reference to the secret to use when pulling
+                images.
+              type: object
+            sshKey:
+              description: SSHKey is the reference to the secret that contains a public
+                key to use for access to compute instances.
+              type: object
+          required:
+          - clusterName
+          - baseDomain
+          - networking
+          - controlPlane
+          - compute
+          - platform
+          - pullSecret
+          - platformSecrets
+          type: object
+        status:
+          properties:
+            adminKubeconfigSecret:
+              description: AdminKubeconfigSecret references the secret containing
+                the admin kubeconfig for this cluster.
+              type: object
+            adminPasswordSecret:
+              description: AdminPasswordSecret references the secret containing the
+                admin username/password which can be used to login to this cluster.
+              type: object
+            apiURL:
+              description: APIURL is the URL where the cluster's API can be accessed.
+              type: string
+            clusterID:
+              description: ClusterID is a globally unique identifier for this cluster
+                generated during installation. Used for reporting metrics among other
+                places.
+              type: string
+            clusterVersionStatus:
+              description: ClusterVersionStatus will hold a copy of the remote cluster's
+                ClusterVersion.Status
+              properties:
+                availableUpdates:
+                  description: availableUpdates contains the list of updates that
+                    are appropriate for this cluster. This list may be empty if no
+                    updates are recommended, if the update service is unavailable,
+                    or if an invalid channel has been specified.
+                  items:
+                    properties:
+                      payload:
+                        description: payload is a container image location that contains
+                          the update. When this field is part of spec, payload is
+                          optional if version is specified and the availableUpdates
+                          field contains a matching version.
+                        type: string
+                      version:
+                        description: version is a semantic versioning identifying
+                          the update version. When this field is part of spec, version
+                          is optional if payload is specified.
+                        type: string
+                    type: object
+                  type: array
+                conditions:
+                  description: conditions provides information about the cluster version.
+                    The condition "Available" is set to true if the desiredUpdate
+                    has been reached. The condition "Progressing" is set to true if
+                    an update is being applied. The condition "Failing" is set to
+                    true if an update is currently blocked by a temporary or permanent
+                    error. Conditions are only valid for the current desiredUpdate
+                    when metadata.generation is equal to status.generation.
+                  items:
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the time of the last update
+                          to the current status object.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message provides additional information about
+                          the current condition. This is only to be consumed by humans.
+                        type: string
+                      reason:
+                        description: reason is the reason for the condition's last
+                          transition.  Reasons are CamelCase
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False,
+                          Unknown.
+                        type: string
+                      type:
+                        description: type specifies the state of the operator's reconciliation
+                          functionality.
+                        type: string
+                    required:
+                    - type
+                    - status
+                    - lastTransitionTime
+                    type: object
+                  type: array
+                desired:
+                  description: desired is the version that the cluster is reconciling
+                    towards. If the cluster is not yet fully initialized desired will
+                    be set with the information available, which may be a payload
+                    or a tag.
+                  properties:
+                    payload:
+                      description: payload is a container image location that contains
+                        the update. When this field is part of spec, payload is optional
+                        if version is specified and the availableUpdates field contains
+                        a matching version.
+                      type: string
+                    version:
+                      description: version is a semantic versioning identifying the
+                        update version. When this field is part of spec, version is
+                        optional if payload is specified.
+                      type: string
+                  type: object
+                generation:
+                  description: generation reports which version of the spec is being
+                    processed. If this value is not equal to metadata.generation,
+                    then the current and conditions fields have not yet been updated
+                    to reflect the latest request.
+                  format: int64
+                  type: integer
+                history:
+                  description: history contains a list of the most recent versions
+                    applied to the cluster. This value may be empty during cluster
+                    startup, and then will be updated when a new update is being applied.
+                    The newest update is first in the list and it is ordered by recency.
+                    Updates in the history have state Completed if the rollout completed
+                    - if an update was failing or halfway applied the state will be
+                    Partial. Only a limited amount of update history is preserved.
+                  items:
+                    properties:
+                      completionTime:
+                        description: completionTime, if set, is when the update was
+                          fully applied. The update that is currently being applied
+                          will have a null completion time. Completion time will always
+                          be set for entries that are not the current update (usually
+                          to the started time of the next update).
+                        format: date-time
+                        type: string
+                      payload:
+                        description: payload is a container image location that contains
+                          the update. This value is always populated.
+                        type: string
+                      startedTime:
+                        description: startedTime is the time at which the update was
+                          started.
+                        format: date-time
+                        type: string
+                      state:
+                        description: state reflects whether the update was fully applied.
+                          The Partial state indicates the update is not fully applied,
+                          while the Completed state indicates the update was successfully
+                          rolled out at least once (all parts of the update successfully
+                          applied).
+                        type: string
+                      version:
+                        description: version is a semantic versioning identifying
+                          the update version. If the requested payload does not define
+                          a version, or if a failure occurs retrieving the payload,
+                          this value may be empty.
+                        type: string
+                    required:
+                    - state
+                    - startedTime
+                    - completionTime
+                    - payload
+                    type: object
+                  type: array
+                versionHash:
+                  description: versionHash is a fingerprint of the content that the
+                    cluster will be updated with. It is used by the operator to avoid
+                    unnecessary work and is for internal use only.
+                  type: string
+              required:
+              - desired
+              - history
+              - generation
+              - versionHash
+              - conditions
+              - availableUpdates
+              type: object
+            conditions:
+              description: Conditions includes more detailed status for the cluster
+                deployment
+              items:
+                properties:
+                  lastProbeTime:
+                    description: LastProbeTime is the last time we probed the condition.
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: LastTransitionTime is the last time the condition
+                      transitioned from one status to another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human-readable message indicating details
+                      about last transition.
+                    type: string
+                  reason:
+                    description: Reason is a unique, one-word, CamelCase reason for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status is the status of the condition.
+                    type: string
+                  type:
+                    description: Type is the type of the condition.
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            federated:
+              description: Federated is true if the cluster deployment has been federated
+                with the host cluster.
+              type: boolean
+            federatedClusterRef:
+              description: FederatedClusterRef is the reference to the federated cluster
+                resource associated with this ClusterDeployment.
+              type: object
+            infraID:
+              description: InfraID is an identifier for this cluster generated during
+                installation and used for tagging/naming resources in cloud providers.
+              type: string
+            installed:
+              description: Installed is true if the installer job has successfully
+                completed for this cluster.
+              type: boolean
+            installerImage:
+              description: InstallerImage is the name of the installer image to use
+                when installing the target cluster
+              type: string
+            syncPatches:
+              description: SyncPatches is the list of SyncStatus for patches that
+                have been applied.
+              items:
+                properties:
+                  conditions:
+                    description: Conditions is the list of conditions indicating success
+                      or failure of object create, update and delete as well as patch
+                      application.
+                    items:
+                      properties:
+                        lastProbeTime:
+                          description: LastProbeTime is the last time we probed the
+                            condition.
+                          format: date-time
+                          type: string
+                        lastTransitionTime:
+                          description: LastTransitionTime is the last time the condition
+                            transitioned from one status to another.
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message is a human-readable message indicating
+                            details about last transition.
+                          type: string
+                        reason:
+                          description: Reason is a unique, one-word, CamelCase reason
+                            for the condition's last transition.
+                          type: string
+                        status:
+                          description: Status is the status of the condition.
+                          type: string
+                        type:
+                          description: Type is the type of the condition.
+                          type: string
+                      required:
+                      - type
+                      - status
+                      type: object
+                    type: array
+                  groupVersionKind:
+                    description: GroupVersionKind is the Group, Version and Kind of
+                      the object that was synced or patched.
+                    type: object
+                  hash:
+                    description: Hash is the unique md5 hash of the resource or patch.
+                    format: byte
+                    type: string
+                  name:
+                    description: Name is the name of the object that was synced or
+                      patched.
+                    type: string
+                  namespace:
+                    description: Namespace is the Namespace of the object that was
+                      synced or patched.
+                    type: string
+                required:
+                - groupVersionKind
+                - name
+                - namespace
+                - hash
+                - conditions
+                type: object
+              type: array
+            syncResources:
+              description: SyncResources is the list of SyncStatus for objects that
+                have been synced.
+              items:
+                properties:
+                  conditions:
+                    description: Conditions is the list of conditions indicating success
+                      or failure of object create, update and delete as well as patch
+                      application.
+                    items:
+                      properties:
+                        lastProbeTime:
+                          description: LastProbeTime is the last time we probed the
+                            condition.
+                          format: date-time
+                          type: string
+                        lastTransitionTime:
+                          description: LastTransitionTime is the last time the condition
+                            transitioned from one status to another.
+                          format: date-time
+                          type: string
+                        message:
+                          description: Message is a human-readable message indicating
+                            details about last transition.
+                          type: string
+                        reason:
+                          description: Reason is a unique, one-word, CamelCase reason
+                            for the condition's last transition.
+                          type: string
+                        status:
+                          description: Status is the status of the condition.
+                          type: string
+                        type:
+                          description: Type is the type of the condition.
+                          type: string
+                      required:
+                      - type
+                      - status
+                      type: object
+                    type: array
+                  groupVersionKind:
+                    description: GroupVersionKind is the Group, Version and Kind of
+                      the object that was synced or patched.
+                    type: object
+                  hash:
+                    description: Hash is the unique md5 hash of the resource or patch.
+                    format: byte
+                    type: string
+                  name:
+                    description: Name is the name of the object that was synced or
+                      patched.
+                    type: string
+                  namespace:
+                    description: Namespace is the Namespace of the object that was
+                      synced or patched.
+                    type: string
+                required:
+                - groupVersionKind
+                - name
+                - namespace
+                - hash
+                - conditions
+                type: object
+              type: array
+            webConsoleURL:
+              description: WebConsoleURL is the URL for the cluster's web console
+                UI.
+              type: string
+          required:
+          - installed
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/0.1.494-3f73a592/hive_v1alpha1_clusterimageset.yaml
+++ b/bundle/0.1.494-3f73a592/hive_v1alpha1_clusterimageset.yaml
@@ -1,0 +1,69 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: clusterimagesets.hive.openshift.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.hiveImage
+    name: Hive
+    type: string
+  - JSONPath: .status.installerImage
+    name: Installer
+    type: string
+  - JSONPath: .spec.releaseImage
+    name: Release
+    type: string
+  group: hive.openshift.io
+  names:
+    kind: ClusterImageSet
+    plural: clusterimagesets
+    shortNames:
+    - imgset
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            hiveImage:
+              description: HiveImage is the Hive image to use when installing or destroying
+                a cluster. If not present, the default Hive image for the clusterdeployment
+                controller is used.
+              type: string
+            installerImage:
+              description: InstallerImage is the image used to install a cluster.
+                If not specified, the installer image reference is obtained from the
+                release image.
+              type: string
+            releaseImage:
+              description: ReleaseImage is the image that contains the payload to
+                use when installing a cluster. If the installer image is specified,
+                the release image is optional.
+              type: string
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/0.1.494-3f73a592/hive_v1alpha1_dnszone.yaml
+++ b/bundle/0.1.494-3f73a592/hive_v1alpha1_dnszone.yaml
@@ -1,0 +1,73 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: dnszones.hive.openshift.io
+spec:
+  group: hive.openshift.io
+  names:
+    kind: DNSZone
+    plural: dnszones
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            aws:
+              description: AWS specifies AWS-specific cloud configuration
+              properties:
+                accountSecret:
+                  description: AccountSecret contains a reference to a secret that
+                    contains AWS credentials for CRUD operations
+                  type: object
+                region:
+                  description: Region specifies the region-specific API endpoint to
+                    use
+                  type: string
+              required:
+              - accountSecret
+              - region
+              type: object
+            zone:
+              description: Zone is the DNS zoneto host
+              type: string
+          required:
+          - zone
+          type: object
+        status:
+          properties:
+            lastSyncGeneration:
+              description: LastSyncGeneration is the generation of the zone resource
+                that was last sync'd. This is used to know if the Object has changed
+                and we should sync immediately.
+              format: int64
+              type: integer
+            lastSyncTimestamp:
+              description: LastSyncTimestamp is the time that the zone was last sync'd.
+              format: date-time
+              type: string
+          required:
+          - lastSyncGeneration
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/0.1.494-3f73a592/hive_v1alpha1_hiveconfig.yaml
+++ b/bundle/0.1.494-3f73a592/hive_v1alpha1_hiveconfig.yaml
@@ -1,0 +1,39 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: hiveconfigs.hive.openshift.io
+spec:
+  group: hive.openshift.io
+  names:
+    kind: HiveConfig
+    plural: hiveconfigs
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/0.1.494-3f73a592/hive_v1alpha1_selectorsyncidentityprovider.yaml
+++ b/bundle/0.1.494-3f73a592/hive_v1alpha1_selectorsyncidentityprovider.yaml
@@ -1,0 +1,647 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: selectorsyncidentityproviders.hive.openshift.io
+spec:
+  group: hive.openshift.io
+  names:
+    kind: SelectorSyncIdentityProvider
+    plural: selectorsyncidentityproviders
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            clusterDeploymentSelector:
+              description: ClusterDeploymentSelector is a LabelSelector indicating
+                which clusters the SelectorIdentityProvider applies to in any namespace.
+              type: object
+            identityProviders:
+              description: IdentityProviders is an ordered list of ways for a user
+                to identify themselves
+              items:
+                properties:
+                  basicAuth:
+                    description: basicAuth contains configuration options for the
+                      BasicAuth IdP
+                    properties:
+                      ca:
+                        description: ca is an optional reference to a config map by
+                          name containing the PEM-encoded CA bundle. It is used as
+                          a trust anchor to validate the TLS certificate presented
+                          by the remote server. The key "ca.crt" is used to locate
+                          the data. If specified and the config map or expected key
+                          is not found, the identity provider is not honored. If the
+                          specified ca data is not valid, the identity provider is
+                          not honored. If empty, the default system roots are used.
+                          The namespace for this config map is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      tlsClientCert:
+                        description: tlsClientCert is an optional reference to a secret
+                          by name that contains the PEM-encoded TLS client certificate
+                          to present when connecting to the server. The key "tls.crt"
+                          is used to locate the data. If specified and the secret
+                          or expected key is not found, the identity provider is not
+                          honored. If the specified certificate data is not valid,
+                          the identity provider is not honored. The namespace for
+                          this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      tlsClientKey:
+                        description: tlsClientKey is an optional reference to a secret
+                          by name that contains the PEM-encoded TLS private key for
+                          the client certificate referenced in tlsClientCert. The
+                          key "tls.key" is used to locate the data. If specified and
+                          the secret or expected key is not found, the identity provider
+                          is not honored. If the specified certificate data is not
+                          valid, the identity provider is not honored. The namespace
+                          for this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      url:
+                        description: url is the remote URL to connect to
+                        type: string
+                    required:
+                    - url
+                    type: object
+                  challenge:
+                    description: challenge indicates whether to issue WWW-Authenticate
+                      challenges for this provider
+                    type: boolean
+                  github:
+                    description: github enables user authentication using GitHub credentials
+                    properties:
+                      ca:
+                        description: ca is an optional reference to a config map by
+                          name containing the PEM-encoded CA bundle. It is used as
+                          a trust anchor to validate the TLS certificate presented
+                          by the remote server. The key "ca.crt" is used to locate
+                          the data. If specified and the config map or expected key
+                          is not found, the identity provider is not honored. If the
+                          specified ca data is not valid, the identity provider is
+                          not honored. If empty, the default system roots are used.
+                          This can only be configured when hostname is set to a non-empty
+                          value. The namespace for this config map is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      clientID:
+                        description: clientID is the oauth client ID
+                        type: string
+                      clientSecret:
+                        description: clientSecret is a required reference to the secret
+                          by name containing the oauth client secret. The key "clientSecret"
+                          is used to locate the data. If the secret or expected key
+                          is not found, the identity provider is not honored. The
+                          namespace for this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      hostname:
+                        description: hostname is the optional domain (e.g. "mycompany.com")
+                          for use with a hosted instance of GitHub Enterprise. It
+                          must match the GitHub Enterprise settings value configured
+                          at /setup/settings#hostname.
+                        type: string
+                      organizations:
+                        description: organizations optionally restricts which organizations
+                          are allowed to log in
+                        items:
+                          type: string
+                        type: array
+                      teams:
+                        description: teams optionally restricts which teams are allowed
+                          to log in. Format is <org>/<team>.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - clientID
+                    - clientSecret
+                    type: object
+                  gitlab:
+                    description: gitlab enables user authentication using GitLab credentials
+                    properties:
+                      ca:
+                        description: ca is an optional reference to a config map by
+                          name containing the PEM-encoded CA bundle. It is used as
+                          a trust anchor to validate the TLS certificate presented
+                          by the remote server. The key "ca.crt" is used to locate
+                          the data. If specified and the config map or expected key
+                          is not found, the identity provider is not honored. If the
+                          specified ca data is not valid, the identity provider is
+                          not honored. If empty, the default system roots are used.
+                          The namespace for this config map is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      clientID:
+                        description: clientID is the oauth client ID
+                        type: string
+                      clientSecret:
+                        description: clientSecret is a required reference to the secret
+                          by name containing the oauth client secret. The key "clientSecret"
+                          is used to locate the data. If the secret or expected key
+                          is not found, the identity provider is not honored. The
+                          namespace for this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      url:
+                        description: url is the oauth server base URL
+                        type: string
+                    required:
+                    - clientID
+                    - clientSecret
+                    - url
+                    type: object
+                  google:
+                    description: google enables user authentication using Google credentials
+                    properties:
+                      clientID:
+                        description: clientID is the oauth client ID
+                        type: string
+                      clientSecret:
+                        description: clientSecret is a required reference to the secret
+                          by name containing the oauth client secret. The key "clientSecret"
+                          is used to locate the data. If the secret or expected key
+                          is not found, the identity provider is not honored. The
+                          namespace for this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      hostedDomain:
+                        description: hostedDomain is the optional Google App domain
+                          (e.g. "mycompany.com") to restrict logins to
+                        type: string
+                    required:
+                    - clientID
+                    - clientSecret
+                    type: object
+                  htpasswd:
+                    description: htpasswd enables user authentication using an HTPasswd
+                      file to validate credentials
+                    properties:
+                      fileData:
+                        description: fileData is a required reference to a secret
+                          by name containing the data to use as the htpasswd file.
+                          The key "htpasswd" is used to locate the data. If the secret
+                          or expected key is not found, the identity provider is not
+                          honored. If the specified htpasswd data is not valid, the
+                          identity provider is not honored. The namespace for this
+                          secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - fileData
+                    type: object
+                  keystone:
+                    description: keystone enables user authentication using keystone
+                      password credentials
+                    properties:
+                      ca:
+                        description: ca is an optional reference to a config map by
+                          name containing the PEM-encoded CA bundle. It is used as
+                          a trust anchor to validate the TLS certificate presented
+                          by the remote server. The key "ca.crt" is used to locate
+                          the data. If specified and the config map or expected key
+                          is not found, the identity provider is not honored. If the
+                          specified ca data is not valid, the identity provider is
+                          not honored. If empty, the default system roots are used.
+                          The namespace for this config map is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      domainName:
+                        description: domainName is required for keystone v3
+                        type: string
+                      tlsClientCert:
+                        description: tlsClientCert is an optional reference to a secret
+                          by name that contains the PEM-encoded TLS client certificate
+                          to present when connecting to the server. The key "tls.crt"
+                          is used to locate the data. If specified and the secret
+                          or expected key is not found, the identity provider is not
+                          honored. If the specified certificate data is not valid,
+                          the identity provider is not honored. The namespace for
+                          this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      tlsClientKey:
+                        description: tlsClientKey is an optional reference to a secret
+                          by name that contains the PEM-encoded TLS private key for
+                          the client certificate referenced in tlsClientCert. The
+                          key "tls.key" is used to locate the data. If specified and
+                          the secret or expected key is not found, the identity provider
+                          is not honored. If the specified certificate data is not
+                          valid, the identity provider is not honored. The namespace
+                          for this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      url:
+                        description: url is the remote URL to connect to
+                        type: string
+                      useUsernameIdentity:
+                        description: useUsernameIdentity indicates that users should
+                          be authenticated by username, not keystone ID DEPRECATED
+                          - only use this option for legacy systems to ensure backwards
+                          compatibility
+                        type: boolean
+                    required:
+                    - url
+                    - domainName
+                    type: object
+                  ldap:
+                    description: ldap enables user authentication using LDAP credentials
+                    properties:
+                      attributes:
+                        description: attributes maps LDAP attributes to identities
+                        properties:
+                          email:
+                            description: email is the list of attributes whose values
+                              should be used as the email address. Optional. If unspecified,
+                              no email is set for the identity
+                            items:
+                              type: string
+                            type: array
+                          id:
+                            description: id is the list of attributes whose values
+                              should be used as the user ID. Required. First non-empty
+                              attribute is used. At least one attribute is required.
+                              If none of the listed attribute have a value, authentication
+                              fails. LDAP standard identity attribute is "dn"
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: name is the list of attributes whose values
+                              should be used as the display name. Optional. If unspecified,
+                              no display name is set for the identity LDAP standard
+                              display name attribute is "cn"
+                            items:
+                              type: string
+                            type: array
+                          preferredUsername:
+                            description: preferredUsername is the list of attributes
+                              whose values should be used as the preferred username.
+                              LDAP standard login attribute is "uid"
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - id
+                        type: object
+                      bindDN:
+                        description: bindDN is an optional DN to bind with during
+                          the search phase.
+                        type: string
+                      bindPassword:
+                        description: bindPassword is an optional reference to a secret
+                          by name containing a password to bind with during the search
+                          phase. The key "bindPassword" is used to locate the data.
+                          If specified and the secret or expected key is not found,
+                          the identity provider is not honored. The namespace for
+                          this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      ca:
+                        description: ca is an optional reference to a config map by
+                          name containing the PEM-encoded CA bundle. It is used as
+                          a trust anchor to validate the TLS certificate presented
+                          by the remote server. The key "ca.crt" is used to locate
+                          the data. If specified and the config map or expected key
+                          is not found, the identity provider is not honored. If the
+                          specified ca data is not valid, the identity provider is
+                          not honored. If empty, the default system roots are used.
+                          The namespace for this config map is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      insecure:
+                        description: 'insecure, if true, indicates the connection
+                          should not use TLS WARNING: Should not be set to `true`
+                          with the URL scheme "ldaps://" as "ldaps://" URLs always          attempt
+                          to connect using TLS, even when `insecure` is set to `true`
+                          When `true`, "ldap://" URLS connect insecurely. When `false`,
+                          "ldap://" URLs are upgraded to a TLS connection using StartTLS
+                          as specified in https://tools.ietf.org/html/rfc2830.'
+                        type: boolean
+                      url:
+                        description: 'url is an RFC 2255 URL which specifies the LDAP
+                          search parameters to use. The syntax of the URL is: ldap://host:port/basedn?attribute?scope?filter'
+                        type: string
+                    required:
+                    - url
+                    - insecure
+                    - attributes
+                    type: object
+                  login:
+                    description: login indicates whether to use this identity provider
+                      for unauthenticated browsers to login against
+                    type: boolean
+                  mappingMethod:
+                    description: mappingMethod determines how identities from this
+                      provider are mapped to users Defaults to "claim"
+                    type: string
+                  name:
+                    description: 'name is used to qualify the identities returned
+                      by this provider. - It MUST be unique and not shared by any
+                      other identity provider used - It MUST be a valid path segment:
+                      name cannot equal "." or ".." or contain "/" or "%" or ":"   Ref:
+                      https://godoc.org/github.com/openshift/origin/pkg/user/apis/user/validation#ValidateIdentityProviderName'
+                    type: string
+                  openID:
+                    description: openID enables user authentication using OpenID credentials
+                    properties:
+                      ca:
+                        description: ca is an optional reference to a config map by
+                          name containing the PEM-encoded CA bundle. It is used as
+                          a trust anchor to validate the TLS certificate presented
+                          by the remote server. The key "ca.crt" is used to locate
+                          the data. If specified and the config map or expected key
+                          is not found, the identity provider is not honored. If the
+                          specified ca data is not valid, the identity provider is
+                          not honored. If empty, the default system roots are used.
+                          The namespace for this config map is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      claims:
+                        description: claims mappings
+                        properties:
+                          email:
+                            description: email is the list of claims whose values
+                              should be used as the email address. Optional. If unspecified,
+                              no email is set for the identity
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: name is the list of claims whose values should
+                              be used as the display name. Optional. If unspecified,
+                              no display name is set for the identity
+                            items:
+                              type: string
+                            type: array
+                          preferredUsername:
+                            description: preferredUsername is the list of claims whose
+                              values should be used as the preferred username. If
+                              unspecified, the preferred username is determined from
+                              the value of the sub claim
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      clientID:
+                        description: clientID is the oauth client ID
+                        type: string
+                      clientSecret:
+                        description: clientSecret is a required reference to the secret
+                          by name containing the oauth client secret. The key "clientSecret"
+                          is used to locate the data. If the secret or expected key
+                          is not found, the identity provider is not honored. The
+                          namespace for this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      extraAuthorizeParameters:
+                        description: extraAuthorizeParameters are any custom parameters
+                          to add to the authorize request.
+                        type: object
+                      extraScopes:
+                        description: extraScopes are any scopes to request in addition
+                          to the standard "openid" scope.
+                        items:
+                          type: string
+                        type: array
+                      urls:
+                        description: urls to use to authenticate
+                        properties:
+                          authorize:
+                            description: authorize is the oauth authorization URL
+                            type: string
+                          token:
+                            description: token is the oauth token granting URL
+                            type: string
+                          userInfo:
+                            description: userInfo is the optional userinfo URL. If
+                              present, a granted access_token is used to request claims
+                              If empty, a granted id_token is parsed for claims
+                            type: string
+                        required:
+                        - authorize
+                        - token
+                        type: object
+                    required:
+                    - clientID
+                    - clientSecret
+                    - urls
+                    - claims
+                    type: object
+                  requestHeader:
+                    description: requestHeader enables user authentication using request
+                      header credentials
+                    properties:
+                      ca:
+                        description: ca is a required reference to a config map by
+                          name containing the PEM-encoded CA bundle. It is used as
+                          a trust anchor to validate the TLS certificate presented
+                          by the remote server. Specifically, it allows verification
+                          of incoming requests to prevent header spoofing. The key
+                          "ca.crt" is used to locate the data. If the config map or
+                          expected key is not found, the identity provider is not
+                          honored. If the specified ca data is not valid, the identity
+                          provider is not honored. The namespace for this config map
+                          is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      challengeURL:
+                        description: challengeURL is a URL to redirect unauthenticated
+                          /authorize requests to Unauthenticated requests from OAuth
+                          clients which expect WWW-Authenticate challenges will be
+                          redirected here. ${url} is replaced with the current URL,
+                          escaped to be safe in a query parameter   https://www.example.com/sso-login?then=${url}
+                          ${query} is replaced with the current query string   https://www.example.com/auth-proxy/oauth/authorize?${query}
+                          Required when challenge is set to true.
+                        type: string
+                      clientCommonNames:
+                        description: clientCommonNames is an optional list of common
+                          names to require a match from. If empty, any client certificate
+                          validated against the clientCA bundle is considered authoritative.
+                        items:
+                          type: string
+                        type: array
+                      emailHeaders:
+                        description: emailHeaders is the set of headers to check for
+                          the email address
+                        items:
+                          type: string
+                        type: array
+                      headers:
+                        description: headers is the set of headers to check for identity
+                          information
+                        items:
+                          type: string
+                        type: array
+                      loginURL:
+                        description: loginURL is a URL to redirect unauthenticated
+                          /authorize requests to Unauthenticated requests from OAuth
+                          clients which expect interactive logins will be redirected
+                          here ${url} is replaced with the current URL, escaped to
+                          be safe in a query parameter   https://www.example.com/sso-login?then=${url}
+                          ${query} is replaced with the current query string   https://www.example.com/auth-proxy/oauth/authorize?${query}
+                          Required when login is set to true.
+                        type: string
+                      nameHeaders:
+                        description: nameHeaders is the set of headers to check for
+                          the display name
+                        items:
+                          type: string
+                        type: array
+                      preferredUsernameHeaders:
+                        description: preferredUsernameHeaders is the set of headers
+                          to check for the preferred username
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - loginURL
+                    - challengeURL
+                    - ca
+                    - headers
+                    - preferredUsernameHeaders
+                    - nameHeaders
+                    - emailHeaders
+                    type: object
+                  type:
+                    description: type identifies the identity provider type for this
+                      entry.
+                    type: string
+                required:
+                - name
+                - challenge
+                - login
+                - type
+                type: object
+              type: array
+          required:
+          - identityProviders
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/0.1.494-3f73a592/hive_v1alpha1_selectorsyncset.yaml
+++ b/bundle/0.1.494-3f73a592/hive_v1alpha1_selectorsyncset.yaml
@@ -1,0 +1,83 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: selectorsyncsets.hive.openshift.io
+spec:
+  group: hive.openshift.io
+  names:
+    kind: SelectorSyncSet
+    plural: selectorsyncsets
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            clusterDeploymentSelector:
+              description: ClusterDeploymentSelector is a LabelSelector indicating
+                which clusters the SelectorSyncSet applies to in any namespace.
+              type: object
+            patches:
+              description: Patches is the list of patches to apply.
+              items:
+                properties:
+                  groupVersionKind:
+                    description: GroupVersionKind is the Group, Version and Kind of
+                      the object to be patched.
+                    type: object
+                  name:
+                    description: Name is the name of the object to be patched.
+                    type: string
+                  namespace:
+                    description: Namespace is the Namespace in which the object to
+                      patch exists. Defaults to the SyncSet's Namespace.
+                    type: string
+                  patch:
+                    description: Patch is the patch to apply.
+                    format: byte
+                    type: string
+                  patchType:
+                    description: PatchType indicates the PatchType as "json" (default),
+                      "merge" or "strategic".
+                    type: string
+                required:
+                - groupVersionKind
+                - name
+                - patch
+                type: object
+              type: array
+            resourceApplyMode:
+              description: ResourceApplyMode indicates if the resource apply mode
+                is "upsert" (default) or "sync". ApplyMode "upsert" indicates create
+                and update. ApplyMode "sync" indicates create, update and delete.
+              type: string
+            resources:
+              description: Resources is the list of objects to sync.
+              items:
+                type: object
+              type: array
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/0.1.494-3f73a592/hive_v1alpha1_syncidentityprovider.yaml
+++ b/bundle/0.1.494-3f73a592/hive_v1alpha1_syncidentityprovider.yaml
@@ -1,0 +1,651 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: syncidentityproviders.hive.openshift.io
+spec:
+  group: hive.openshift.io
+  names:
+    kind: SyncIdentityProvider
+    plural: syncidentityproviders
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            clusterDeploymentRefs:
+              description: ClusterDeploymentRefs is the list of LocalObjectReference
+                indicating which clusters the SyncSet applies to in the SyncSet's
+                namespace.
+              items:
+                type: object
+              type: array
+            identityProviders:
+              description: IdentityProviders is an ordered list of ways for a user
+                to identify themselves
+              items:
+                properties:
+                  basicAuth:
+                    description: basicAuth contains configuration options for the
+                      BasicAuth IdP
+                    properties:
+                      ca:
+                        description: ca is an optional reference to a config map by
+                          name containing the PEM-encoded CA bundle. It is used as
+                          a trust anchor to validate the TLS certificate presented
+                          by the remote server. The key "ca.crt" is used to locate
+                          the data. If specified and the config map or expected key
+                          is not found, the identity provider is not honored. If the
+                          specified ca data is not valid, the identity provider is
+                          not honored. If empty, the default system roots are used.
+                          The namespace for this config map is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      tlsClientCert:
+                        description: tlsClientCert is an optional reference to a secret
+                          by name that contains the PEM-encoded TLS client certificate
+                          to present when connecting to the server. The key "tls.crt"
+                          is used to locate the data. If specified and the secret
+                          or expected key is not found, the identity provider is not
+                          honored. If the specified certificate data is not valid,
+                          the identity provider is not honored. The namespace for
+                          this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      tlsClientKey:
+                        description: tlsClientKey is an optional reference to a secret
+                          by name that contains the PEM-encoded TLS private key for
+                          the client certificate referenced in tlsClientCert. The
+                          key "tls.key" is used to locate the data. If specified and
+                          the secret or expected key is not found, the identity provider
+                          is not honored. If the specified certificate data is not
+                          valid, the identity provider is not honored. The namespace
+                          for this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      url:
+                        description: url is the remote URL to connect to
+                        type: string
+                    required:
+                    - url
+                    type: object
+                  challenge:
+                    description: challenge indicates whether to issue WWW-Authenticate
+                      challenges for this provider
+                    type: boolean
+                  github:
+                    description: github enables user authentication using GitHub credentials
+                    properties:
+                      ca:
+                        description: ca is an optional reference to a config map by
+                          name containing the PEM-encoded CA bundle. It is used as
+                          a trust anchor to validate the TLS certificate presented
+                          by the remote server. The key "ca.crt" is used to locate
+                          the data. If specified and the config map or expected key
+                          is not found, the identity provider is not honored. If the
+                          specified ca data is not valid, the identity provider is
+                          not honored. If empty, the default system roots are used.
+                          This can only be configured when hostname is set to a non-empty
+                          value. The namespace for this config map is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      clientID:
+                        description: clientID is the oauth client ID
+                        type: string
+                      clientSecret:
+                        description: clientSecret is a required reference to the secret
+                          by name containing the oauth client secret. The key "clientSecret"
+                          is used to locate the data. If the secret or expected key
+                          is not found, the identity provider is not honored. The
+                          namespace for this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      hostname:
+                        description: hostname is the optional domain (e.g. "mycompany.com")
+                          for use with a hosted instance of GitHub Enterprise. It
+                          must match the GitHub Enterprise settings value configured
+                          at /setup/settings#hostname.
+                        type: string
+                      organizations:
+                        description: organizations optionally restricts which organizations
+                          are allowed to log in
+                        items:
+                          type: string
+                        type: array
+                      teams:
+                        description: teams optionally restricts which teams are allowed
+                          to log in. Format is <org>/<team>.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - clientID
+                    - clientSecret
+                    type: object
+                  gitlab:
+                    description: gitlab enables user authentication using GitLab credentials
+                    properties:
+                      ca:
+                        description: ca is an optional reference to a config map by
+                          name containing the PEM-encoded CA bundle. It is used as
+                          a trust anchor to validate the TLS certificate presented
+                          by the remote server. The key "ca.crt" is used to locate
+                          the data. If specified and the config map or expected key
+                          is not found, the identity provider is not honored. If the
+                          specified ca data is not valid, the identity provider is
+                          not honored. If empty, the default system roots are used.
+                          The namespace for this config map is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      clientID:
+                        description: clientID is the oauth client ID
+                        type: string
+                      clientSecret:
+                        description: clientSecret is a required reference to the secret
+                          by name containing the oauth client secret. The key "clientSecret"
+                          is used to locate the data. If the secret or expected key
+                          is not found, the identity provider is not honored. The
+                          namespace for this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      url:
+                        description: url is the oauth server base URL
+                        type: string
+                    required:
+                    - clientID
+                    - clientSecret
+                    - url
+                    type: object
+                  google:
+                    description: google enables user authentication using Google credentials
+                    properties:
+                      clientID:
+                        description: clientID is the oauth client ID
+                        type: string
+                      clientSecret:
+                        description: clientSecret is a required reference to the secret
+                          by name containing the oauth client secret. The key "clientSecret"
+                          is used to locate the data. If the secret or expected key
+                          is not found, the identity provider is not honored. The
+                          namespace for this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      hostedDomain:
+                        description: hostedDomain is the optional Google App domain
+                          (e.g. "mycompany.com") to restrict logins to
+                        type: string
+                    required:
+                    - clientID
+                    - clientSecret
+                    type: object
+                  htpasswd:
+                    description: htpasswd enables user authentication using an HTPasswd
+                      file to validate credentials
+                    properties:
+                      fileData:
+                        description: fileData is a required reference to a secret
+                          by name containing the data to use as the htpasswd file.
+                          The key "htpasswd" is used to locate the data. If the secret
+                          or expected key is not found, the identity provider is not
+                          honored. If the specified htpasswd data is not valid, the
+                          identity provider is not honored. The namespace for this
+                          secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - fileData
+                    type: object
+                  keystone:
+                    description: keystone enables user authentication using keystone
+                      password credentials
+                    properties:
+                      ca:
+                        description: ca is an optional reference to a config map by
+                          name containing the PEM-encoded CA bundle. It is used as
+                          a trust anchor to validate the TLS certificate presented
+                          by the remote server. The key "ca.crt" is used to locate
+                          the data. If specified and the config map or expected key
+                          is not found, the identity provider is not honored. If the
+                          specified ca data is not valid, the identity provider is
+                          not honored. If empty, the default system roots are used.
+                          The namespace for this config map is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      domainName:
+                        description: domainName is required for keystone v3
+                        type: string
+                      tlsClientCert:
+                        description: tlsClientCert is an optional reference to a secret
+                          by name that contains the PEM-encoded TLS client certificate
+                          to present when connecting to the server. The key "tls.crt"
+                          is used to locate the data. If specified and the secret
+                          or expected key is not found, the identity provider is not
+                          honored. If the specified certificate data is not valid,
+                          the identity provider is not honored. The namespace for
+                          this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      tlsClientKey:
+                        description: tlsClientKey is an optional reference to a secret
+                          by name that contains the PEM-encoded TLS private key for
+                          the client certificate referenced in tlsClientCert. The
+                          key "tls.key" is used to locate the data. If specified and
+                          the secret or expected key is not found, the identity provider
+                          is not honored. If the specified certificate data is not
+                          valid, the identity provider is not honored. The namespace
+                          for this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      url:
+                        description: url is the remote URL to connect to
+                        type: string
+                      useUsernameIdentity:
+                        description: useUsernameIdentity indicates that users should
+                          be authenticated by username, not keystone ID DEPRECATED
+                          - only use this option for legacy systems to ensure backwards
+                          compatibility
+                        type: boolean
+                    required:
+                    - url
+                    - domainName
+                    type: object
+                  ldap:
+                    description: ldap enables user authentication using LDAP credentials
+                    properties:
+                      attributes:
+                        description: attributes maps LDAP attributes to identities
+                        properties:
+                          email:
+                            description: email is the list of attributes whose values
+                              should be used as the email address. Optional. If unspecified,
+                              no email is set for the identity
+                            items:
+                              type: string
+                            type: array
+                          id:
+                            description: id is the list of attributes whose values
+                              should be used as the user ID. Required. First non-empty
+                              attribute is used. At least one attribute is required.
+                              If none of the listed attribute have a value, authentication
+                              fails. LDAP standard identity attribute is "dn"
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: name is the list of attributes whose values
+                              should be used as the display name. Optional. If unspecified,
+                              no display name is set for the identity LDAP standard
+                              display name attribute is "cn"
+                            items:
+                              type: string
+                            type: array
+                          preferredUsername:
+                            description: preferredUsername is the list of attributes
+                              whose values should be used as the preferred username.
+                              LDAP standard login attribute is "uid"
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - id
+                        type: object
+                      bindDN:
+                        description: bindDN is an optional DN to bind with during
+                          the search phase.
+                        type: string
+                      bindPassword:
+                        description: bindPassword is an optional reference to a secret
+                          by name containing a password to bind with during the search
+                          phase. The key "bindPassword" is used to locate the data.
+                          If specified and the secret or expected key is not found,
+                          the identity provider is not honored. The namespace for
+                          this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      ca:
+                        description: ca is an optional reference to a config map by
+                          name containing the PEM-encoded CA bundle. It is used as
+                          a trust anchor to validate the TLS certificate presented
+                          by the remote server. The key "ca.crt" is used to locate
+                          the data. If specified and the config map or expected key
+                          is not found, the identity provider is not honored. If the
+                          specified ca data is not valid, the identity provider is
+                          not honored. If empty, the default system roots are used.
+                          The namespace for this config map is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      insecure:
+                        description: 'insecure, if true, indicates the connection
+                          should not use TLS WARNING: Should not be set to `true`
+                          with the URL scheme "ldaps://" as "ldaps://" URLs always          attempt
+                          to connect using TLS, even when `insecure` is set to `true`
+                          When `true`, "ldap://" URLS connect insecurely. When `false`,
+                          "ldap://" URLs are upgraded to a TLS connection using StartTLS
+                          as specified in https://tools.ietf.org/html/rfc2830.'
+                        type: boolean
+                      url:
+                        description: 'url is an RFC 2255 URL which specifies the LDAP
+                          search parameters to use. The syntax of the URL is: ldap://host:port/basedn?attribute?scope?filter'
+                        type: string
+                    required:
+                    - url
+                    - insecure
+                    - attributes
+                    type: object
+                  login:
+                    description: login indicates whether to use this identity provider
+                      for unauthenticated browsers to login against
+                    type: boolean
+                  mappingMethod:
+                    description: mappingMethod determines how identities from this
+                      provider are mapped to users Defaults to "claim"
+                    type: string
+                  name:
+                    description: 'name is used to qualify the identities returned
+                      by this provider. - It MUST be unique and not shared by any
+                      other identity provider used - It MUST be a valid path segment:
+                      name cannot equal "." or ".." or contain "/" or "%" or ":"   Ref:
+                      https://godoc.org/github.com/openshift/origin/pkg/user/apis/user/validation#ValidateIdentityProviderName'
+                    type: string
+                  openID:
+                    description: openID enables user authentication using OpenID credentials
+                    properties:
+                      ca:
+                        description: ca is an optional reference to a config map by
+                          name containing the PEM-encoded CA bundle. It is used as
+                          a trust anchor to validate the TLS certificate presented
+                          by the remote server. The key "ca.crt" is used to locate
+                          the data. If specified and the config map or expected key
+                          is not found, the identity provider is not honored. If the
+                          specified ca data is not valid, the identity provider is
+                          not honored. If empty, the default system roots are used.
+                          The namespace for this config map is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      claims:
+                        description: claims mappings
+                        properties:
+                          email:
+                            description: email is the list of claims whose values
+                              should be used as the email address. Optional. If unspecified,
+                              no email is set for the identity
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: name is the list of claims whose values should
+                              be used as the display name. Optional. If unspecified,
+                              no display name is set for the identity
+                            items:
+                              type: string
+                            type: array
+                          preferredUsername:
+                            description: preferredUsername is the list of claims whose
+                              values should be used as the preferred username. If
+                              unspecified, the preferred username is determined from
+                              the value of the sub claim
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      clientID:
+                        description: clientID is the oauth client ID
+                        type: string
+                      clientSecret:
+                        description: clientSecret is a required reference to the secret
+                          by name containing the oauth client secret. The key "clientSecret"
+                          is used to locate the data. If the secret or expected key
+                          is not found, the identity provider is not honored. The
+                          namespace for this secret is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      extraAuthorizeParameters:
+                        description: extraAuthorizeParameters are any custom parameters
+                          to add to the authorize request.
+                        type: object
+                      extraScopes:
+                        description: extraScopes are any scopes to request in addition
+                          to the standard "openid" scope.
+                        items:
+                          type: string
+                        type: array
+                      urls:
+                        description: urls to use to authenticate
+                        properties:
+                          authorize:
+                            description: authorize is the oauth authorization URL
+                            type: string
+                          token:
+                            description: token is the oauth token granting URL
+                            type: string
+                          userInfo:
+                            description: userInfo is the optional userinfo URL. If
+                              present, a granted access_token is used to request claims
+                              If empty, a granted id_token is parsed for claims
+                            type: string
+                        required:
+                        - authorize
+                        - token
+                        type: object
+                    required:
+                    - clientID
+                    - clientSecret
+                    - urls
+                    - claims
+                    type: object
+                  requestHeader:
+                    description: requestHeader enables user authentication using request
+                      header credentials
+                    properties:
+                      ca:
+                        description: ca is a required reference to a config map by
+                          name containing the PEM-encoded CA bundle. It is used as
+                          a trust anchor to validate the TLS certificate presented
+                          by the remote server. Specifically, it allows verification
+                          of incoming requests to prevent header spoofing. The key
+                          "ca.crt" is used to locate the data. If the config map or
+                          expected key is not found, the identity provider is not
+                          honored. If the specified ca data is not valid, the identity
+                          provider is not honored. The namespace for this config map
+                          is openshift-config.
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      challengeURL:
+                        description: challengeURL is a URL to redirect unauthenticated
+                          /authorize requests to Unauthenticated requests from OAuth
+                          clients which expect WWW-Authenticate challenges will be
+                          redirected here. ${url} is replaced with the current URL,
+                          escaped to be safe in a query parameter   https://www.example.com/sso-login?then=${url}
+                          ${query} is replaced with the current query string   https://www.example.com/auth-proxy/oauth/authorize?${query}
+                          Required when challenge is set to true.
+                        type: string
+                      clientCommonNames:
+                        description: clientCommonNames is an optional list of common
+                          names to require a match from. If empty, any client certificate
+                          validated against the clientCA bundle is considered authoritative.
+                        items:
+                          type: string
+                        type: array
+                      emailHeaders:
+                        description: emailHeaders is the set of headers to check for
+                          the email address
+                        items:
+                          type: string
+                        type: array
+                      headers:
+                        description: headers is the set of headers to check for identity
+                          information
+                        items:
+                          type: string
+                        type: array
+                      loginURL:
+                        description: loginURL is a URL to redirect unauthenticated
+                          /authorize requests to Unauthenticated requests from OAuth
+                          clients which expect interactive logins will be redirected
+                          here ${url} is replaced with the current URL, escaped to
+                          be safe in a query parameter   https://www.example.com/sso-login?then=${url}
+                          ${query} is replaced with the current query string   https://www.example.com/auth-proxy/oauth/authorize?${query}
+                          Required when login is set to true.
+                        type: string
+                      nameHeaders:
+                        description: nameHeaders is the set of headers to check for
+                          the display name
+                        items:
+                          type: string
+                        type: array
+                      preferredUsernameHeaders:
+                        description: preferredUsernameHeaders is the set of headers
+                          to check for the preferred username
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - loginURL
+                    - challengeURL
+                    - ca
+                    - headers
+                    - preferredUsernameHeaders
+                    - nameHeaders
+                    - emailHeaders
+                    type: object
+                  type:
+                    description: type identifies the identity provider type for this
+                      entry.
+                    type: string
+                required:
+                - name
+                - challenge
+                - login
+                - type
+                type: object
+              type: array
+          required:
+          - identityProviders
+          - clusterDeploymentRefs
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/0.1.494-3f73a592/hive_v1alpha1_syncset.yaml
+++ b/bundle/0.1.494-3f73a592/hive_v1alpha1_syncset.yaml
@@ -1,0 +1,88 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: syncsets.hive.openshift.io
+spec:
+  group: hive.openshift.io
+  names:
+    kind: SyncSet
+    plural: syncsets
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            clusterDeploymentRefs:
+              description: ClusterDeploymentRefs is the list of LocalObjectReference
+                indicating which clusters the SyncSet applies to in the SyncSet's
+                namespace.
+              items:
+                type: object
+              type: array
+            patches:
+              description: Patches is the list of patches to apply.
+              items:
+                properties:
+                  groupVersionKind:
+                    description: GroupVersionKind is the Group, Version and Kind of
+                      the object to be patched.
+                    type: object
+                  name:
+                    description: Name is the name of the object to be patched.
+                    type: string
+                  namespace:
+                    description: Namespace is the Namespace in which the object to
+                      patch exists. Defaults to the SyncSet's Namespace.
+                    type: string
+                  patch:
+                    description: Patch is the patch to apply.
+                    format: byte
+                    type: string
+                  patchType:
+                    description: PatchType indicates the PatchType as "json" (default),
+                      "merge" or "strategic".
+                    type: string
+                required:
+                - groupVersionKind
+                - name
+                - patch
+                type: object
+              type: array
+            resourceApplyMode:
+              description: ResourceApplyMode indicates if the resource apply mode
+                is "upsert" (default) or "sync". ApplyMode "upsert" indicates create
+                and update. ApplyMode "sync" indicates create, update and delete.
+              type: string
+            resources:
+              description: Resources is the list of objects to sync.
+              items:
+                type: object
+              type: array
+          required:
+          - clusterDeploymentRefs
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/0.1.5-4b53b492/hive-operator.v0.1.5-4b53b492.clusterserviceversion.yaml
+++ b/bundle/0.1.5-4b53b492/hive-operator.v0.1.5-4b53b492.clusterserviceversion.yaml
@@ -1,0 +1,7 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: hive-operator.v0.1.5-4b53b492
+  namespace: placeholder
+spec:
+version: 0.1.5-4b53b492

--- a/bundle/hive.package.yaml
+++ b/bundle/hive.package.yaml
@@ -1,0 +1,4 @@
+packageName: hive-operator
+channels:
+- name: alpha
+  currentCSV: hive-operator.v0.1.494-3f73a592

--- a/config/hiveadmission/hiveadmission_rbac_role.yaml
+++ b/config/hiveadmission/hiveadmission_rbac_role.yaml
@@ -35,4 +35,10 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 

--- a/docs/olm.md
+++ b/docs/olm.md
@@ -1,0 +1,35 @@
+# Deploying Hive via OLM
+
+Hive can be deployed as an OLM operator. We do not currently publish artifacts, so to do so you need to build your own artifacts as follows.
+
+Ensure the Hive namespace exists:
+
+```
+oc new-project hive
+```
+
+Identify the current version of the operator you wish to replace, if applicable. (TODO)
+
+```
+GIT_HASH=`git rev-parse --short HEAD`
+GIT_COMMIT_COUNT=`git rev-list 9c56c62c6d0180c27e1cc9cf195f4bbfd7a617dd..HEAD --count`
+./hack/generate-operator-bundle.py bundle/ 0.1.5-4b53b492 $GIT_COMMIT_COUNT $GIT_HASH quay.io/dgoodwin/hive:latest alpha
+```
+
+Build a registry image containing your bundle and publish to quay:
+
+```
+sudo buildah bud --file build/olm-registry/Dockerfile --tag "quay.io/dgoodwin/hive-registry:latest" .
+sudo podman push quay.io/dgoodwin/hive-registry:latest
+```
+
+Create a CatlogSource, OperatorGroup, and Subscription for hive:
+
+
+Create a CatalogSource in your cluster where OLM is running. This will spawn a registry pod using your image just published.
+
+```
+kubectl apply -f hack/olm-registry/
+```
+
+Wait a few minutes and you should see a ClusterServiceVersion in the 'hive' namespace, then an operator pod, and soon the rest of hive.

--- a/hack/generate-operator-bundle.py
+++ b/hack/generate-operator-bundle.py
@@ -4,7 +4,10 @@
 # into a directory, and composes the ClusterServiceVersion which needs bits and
 # pieces of our rbac and deployment files.
 #
-# Usage ./hack/generate-operator-bundle.py OUTPUT_DIR GIT_HASH
+# Usage ./hack/generate-operator-bundle.py OUTPUT_DIR PREVIOUS_VERSION GIT_NUM_COMMITS GIT_HASH HIVE_IMAGE OLM_CHANNEL
+#
+# Commit count can be obtained with: git rev-list 9c56c62c6d0180c27e1cc9cf195f4bbfd7a617dd..HEAD --count
+# This is the first hive commit, if we tag a release we can then switch to using that tag and bump the base version.
 
 import datetime
 import os
@@ -12,29 +15,54 @@ import sys
 import yaml
 import shutil
 
+# This script will append the current number of commits given as an arg
+# (presumably since some past base tag), and the git hash arg for a final
+# version like: 0.1.189-3f73a592
+VERSION_BASE = "0.1"
+
 PACKAGE = '''packageName: hive-operator
 channels:
-- name: alpha
+- name: %s
   currentCSV: %s
 '''
 
-if len(sys.argv) != 4:
-    print("USAGE: %s OUTPUT_DIR GIT_HASH HIVE_IMAGE" % sys.argv[0])
+
+FAKE_PREVIOUS_CSV = '''apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: %s
+  namespace: placeholder
+spec:
+version: %s
+'''
+
+if len(sys.argv) != 7:
+    print("USAGE: %s OUTPUT_DIR PREVIOUS_VERSION GIT_NUM_COMMITS GIT_HASH HIVE_IMAGE OLM_CHANNEL" % sys.argv[0])
     sys.exit(1)
 
 outdir = sys.argv[1]
-git_hash = sys.argv[2]
-hive_image = sys.argv[3]
+prev_version = sys.argv[2]
+git_num_commits = sys.argv[3]
+git_hash = sys.argv[4]
+hive_image = sys.argv[5]
+olm_channel = sys.argv[6]
+
+full_version = "%s.%s-%s" % (VERSION_BASE, git_num_commits, git_hash)
+print("Generating CSV for version: %s" % full_version)
 
 if not os.path.exists(outdir):
     os.mkdir(outdir)
+
+version_dir = os.path.join(outdir, full_version)
+if not os.path.exists(version_dir):
+    os.mkdir(version_dir)
 
 # Copy all CSV files over to the bundle output dir:
 crd_files = os.listdir('config/crds/')
 for file_name in crd_files:
     full_path = os.path.join('config/crds', file_name)
     if (os.path.isfile(os.path.join('config/crds', file_name))):
-        shutil.copy(full_path, os.path.join(outdir, file_name))
+        shutil.copy(full_path, os.path.join(version_dir, file_name))
 
 with open('config/templates/hive-csv-template.yaml', 'r') as stream:
     csv = yaml.load(stream)
@@ -81,20 +109,35 @@ with open('config/operator/operator_deployment.yaml', 'r') as stream:
 csv['spec']['install']['spec']['deployments'][0]['spec']['template']['spec']['containers'][0]['image'] = hive_image
 
 # Update the versions to include git hash:
-csv['metadata']['name'] = "hive-operator-%s" % git_hash
-csv['spec']['version'] = git_hash
+csv['metadata']['name'] = "hive-operator.v%s" % full_version
+csv['spec']['version'] = full_version
+csv['spec']['replaces'] = "hive-operator.v%s" % prev_version
 
 # Set the CSV createdAt annotation:
 now = datetime.datetime.now()
 csv['metadata']['annotations']['createdAt'] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-
 # Write the CSV to disk:
-csv_file = os.path.join(outdir, 'hive-csv.yaml')
+csv_filename = "hive-operator.v%s.clusterserviceversion.yaml" % full_version
+csv_file = os.path.join(version_dir, csv_filename)
 with open(csv_file, 'w') as outfile:
     yaml.dump(csv, outfile, default_flow_style=False)
+print("Wrote ClusterServiceVersion: %s" % csv_file)
 
 # Write the package file:
-package_file = os.path.join(outdir, 'hive-package.yaml')
+package_file = os.path.join(outdir, 'hive.package.yaml')
 with open(package_file, 'w') as outfile:
-    outfile.write(PACKAGE % csv['metadata']['name'])
+    outfile.write(PACKAGE % (olm_channel, csv['metadata']['name']))
+print("Wrote package file: %s" % package_file)
+
+
+
+# Write a fake previous CSV:
+# TODO: we're not 100% sure this should be required, but it seems to be.
+fake_prev_version_dir = os.path.join(outdir, prev_version)
+if not os.path.exists(fake_prev_version_dir):
+    os.mkdir(fake_prev_version_dir)
+fake_prev_csv_file = os.path.join(fake_prev_version_dir, "hive-operator.v%s.clusterserviceversion.yaml" % prev_version)
+with open(fake_prev_csv_file, 'w') as outfile:
+    outfile.write(FAKE_PREVIOUS_CSV % (csv['spec']['replaces'], prev_version))
+print("Wrote fake previous ClusterServiceVersion file: %s" % fake_prev_csv_file)

--- a/hack/olm-registry/catalog-source.yaml
+++ b/hack/olm-registry/catalog-source.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: hive-catalog
+  namespace: hive
+spec:
+  sourceType: grpc
+  image: quay.io/dgoodwin/hive-registry:latest
+  displayName: Hive Test Registry
+  publisher: Devan Goodwin

--- a/hack/olm-registry/hive-subscription.yaml
+++ b/hack/olm-registry/hive-subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: hive
+spec:
+  channel: alpha
+  # TODO: name here matches the dir in the registry, change to hive-operator
+  name: hive-operator
+  source: hive-catalog
+  sourceNamespace: hive

--- a/hack/olm-registry/operator-group.yaml
+++ b/hack/olm-registry/operator-group.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: hive-og
+  namespace: hive
+spec:
+  targetNamespaces:
+  - hive


### PR DESCRIPTION
Updates operator bundle generation script, document how to use it,
generate a bundle and CSV, build an OLM registry image, and then install
everything in a 4.0 cluster.