### PR TITLE
resources: add separate Info function

### DIFF
--- a/contrib/pkg/testresource/command.go
+++ b/contrib/pkg/testresource/command.go
@@ -73,13 +73,19 @@ func newApplyCommand() *cobra.Command {
 			content := mustRead(args[0])
 			kubeconfig := mustRead(kubeconfigPath)
 			helper := resource.NewHelper(kubeconfig, log.WithField("cmd", "apply"))
-			info, err := helper.Apply(content)
+			info, err := helper.Info(content)
 			if err != nil {
-				fmt.Printf("Error: %v\n", err)
+				fmt.Printf("Error obtaining info: %v\n", err)
 				return
 			}
 			name := types.NamespacedName{Namespace: info.Namespace, Name: info.Name}
-			fmt.Printf("The resource %s (Kind: %s, APIVersion: %s) was applied successfully", name.String(), info.Kind, info.APIVersion)
+			fmt.Printf("The resource is %s (Kind: %s, APIVersion: %s)", name.String(), info.Kind, info.APIVersion)
+			err = helper.Apply(content)
+			if err != nil {
+				fmt.Printf("Error applying: %v\n", err)
+				return
+			}
+			fmt.Printf("The resource was applied successfully\n")
 		},
 	}
 	cmd.Flags().StringVarP(&kubeconfigPath, "kubeconfig", "k", os.Getenv("KUBECONFIG"), "Kubeconfig file to connect to target server")

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -340,6 +340,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 
 `)
 

--- a/pkg/resource/apply.go
+++ b/pkg/resource/apply.go
@@ -18,7 +18,6 @@ package resource
 
 import (
 	"bytes"
-	"fmt"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericclioptions/printers"
@@ -26,29 +25,17 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
-// Info contains information obtained from a resource submitted to the Apply function
-type Info struct {
-	Name       string
-	Namespace  string
-	APIVersion string
-	Kind       string
-}
-
 // Apply applies the given resource bytes to the target cluster specified by kubeconfig
-func (r *Helper) Apply(obj []byte) (*Info, error) {
+func (r *Helper) Apply(obj []byte) error {
 
 	fileName, err := r.createTempFile("apply-", obj)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer r.deleteTempFile(fileName)
 	factory, err := r.getFactory(r.kubeconfig, "")
 	if err != nil {
-		return nil, err
-	}
-	resourceInfo, err := r.getResourceInfo(factory, obj)
-	if err != nil {
-		return nil, err
+		return err
 	}
 	ioStreams := genericclioptions.IOStreams{
 		In:     &bytes.Buffer{},
@@ -58,37 +45,16 @@ func (r *Helper) Apply(obj []byte) (*Info, error) {
 	applyOptions, err := r.setupApplyCommand(factory, fileName, ioStreams)
 	if err != nil {
 		r.logger.WithError(err).Error("failed to setup apply command")
-		return nil, err
+		return err
 	}
 	err = applyOptions.Run()
 	if err != nil {
 		r.logger.WithError(err).
 			WithField("stdout", ioStreams.Out.(*bytes.Buffer).String()).
 			WithField("stderr", ioStreams.ErrOut.(*bytes.Buffer).String()).Error("running the apply command failed")
-		return nil, err
+		return err
 	}
-	return resourceInfo, nil
-}
-
-func (r *Helper) getResourceInfo(f cmdutil.Factory, obj []byte) (*Info, error) {
-	builder := f.NewBuilder()
-	r.logger.Debug("Obtaining resource info for object")
-	infos, err := builder.Unstructured().Stream(bytes.NewBuffer(obj), "object").Flatten().Do().Infos()
-	if err != nil {
-		r.logger.WithError(err).Error("Failed to obtain resource info")
-		return nil, fmt.Errorf("could not get info from passed resource: %v", err)
-	}
-	if len(infos) != 1 {
-		r.logger.WithError(err).WithField("infos", infos).Errorf("Expected to get 1 resource info, got %d", len(infos))
-		return nil, fmt.Errorf("unexpected number of resources found: %d", len(infos))
-	}
-	r.logger.WithField("info", infos[0]).Debug("obtained resource information")
-	return &Info{
-		Name:       infos[0].Name,
-		Namespace:  infos[0].Namespace,
-		Kind:       infos[0].ResourceMapping().GroupVersionKind.Kind,
-		APIVersion: infos[0].ResourceMapping().GroupVersionKind.GroupVersion().String(),
-	}, nil
+	return nil
 }
 
 func (r *Helper) setupApplyCommand(f cmdutil.Factory, fileName string, ioStreams genericclioptions.IOStreams) (*kcmd.ApplyOptions, error) {

--- a/pkg/resource/info.go
+++ b/pkg/resource/info.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"bytes"
+	"fmt"
+
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+)
+
+// Info contains information obtained from a resource submitted to the Apply function
+type Info struct {
+	Name       string
+	Namespace  string
+	APIVersion string
+	Kind       string
+}
+
+// Info determines the name/namespace and type of the passed in resource bytes
+func (r *Helper) Info(obj []byte) (*Info, error) {
+	factory, err := r.getFactory(r.kubeconfig, "")
+	if err != nil {
+		return nil, err
+	}
+	resourceInfo, err := r.getResourceInfo(factory, obj)
+	if err != nil {
+		return nil, err
+	}
+	return resourceInfo, err
+}
+
+func (r *Helper) getResourceInfo(f cmdutil.Factory, obj []byte) (*Info, error) {
+	builder := f.NewBuilder()
+	r.logger.Debug("Obtaining resource info for object")
+	infos, err := builder.Unstructured().Stream(bytes.NewBuffer(obj), "object").Flatten().Do().Infos()
+	if err != nil {
+		r.logger.WithError(err).Error("Failed to obtain resource info")
+		return nil, fmt.Errorf("could not get info from passed resource: %v", err)
+	}
+	if len(infos) != 1 {
+		r.logger.WithError(err).WithField("infos", infos).Errorf("Expected to get 1 resource info, got %d", len(infos))
+		return nil, fmt.Errorf("unexpected number of resources found: %d", len(infos))
+	}
+	r.logger.WithField("info", infos[0]).Debug("obtained resource information")
+	return &Info{
+		Name:       infos[0].Name,
+		Namespace:  infos[0].Namespace,
+		Kind:       infos[0].ResourceMapping().GroupVersionKind.Kind,
+		APIVersion: infos[0].ResourceMapping().GroupVersionKind.GroupVersion().String(),
+	}, nil
+}

--- a/test/integration/resource/apply_test.go
+++ b/test/integration/resource/apply_test.go
@@ -115,7 +115,12 @@ func TestApply(t *testing.T) {
 			}
 			t.Logf("The serialized resource:\n%s\n", buf.String())
 			h := resource.NewHelper(kubeconfig, logger)
-			info, err := h.Apply(buf.Bytes())
+			info, err := h.Info(buf.Bytes())
+			if err != nil {
+				t.Errorf("unexpected error calling info: %v", err)
+				return
+			}
+			err = h.Apply(buf.Bytes())
 			if err != nil {
 				t.Errorf("unexpected error calling apply: %v", err)
 				return


### PR DESCRIPTION
Separates out the Info function so that we can call it first for all resources before applying anything to the cluster.