### PR TITLE
Adds IMAGE_TAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You should now see hive-operator, hive-controllers, and hiveadmission pods runni
 
 We do not currently publish an official OLM operator package, but you can run or work off the test script below to generate a ClusterServiceVersion, OLM bundle+package, registry image, catalog source, and subscription.
 
-`$ REGISTRY_IMG="quay.io/dgoodwin/hive-registry:latest" DEPLOY_IMG="quay.io/dgoodwin/hive:latest" hack/olm-registry-deploy.sh`
+`$ REGISTRY_IMG="quay.io/dgoodwin/hive-registry" DEPLOY_IMG="quay.io/dgoodwin/hive:latest" hack/olm-registry-deploy.sh`
 
 
 ### Run Hive Operator From Source

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -45,7 +45,7 @@ PREV_VERSION=$(ls $BUNDLE_DIR | sort -t . -k 3 -g | tail -n 1)
     $PREV_VERSION \
     $GIT_COMMIT_COUNT \
     $GIT_HASH \
-    $QUAY_IMAGE
+    $QUAY_IMAGE:$GIT_HASH
 
 # create package yaml
 NEW_VERSION=$(ls $BUNDLE_DIR | sort -t . -k 3 -g | tail -n 1)

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -72,7 +72,7 @@ git push origin "$BRANCH_CHANNEL"
 popd
 
 # build the registry image
-REGISTRY_IMG="quay.io/app-sre/hive-registry:${BRANCH_CHANNEL}"
+REGISTRY_IMG="quay.io/app-sre/hive-registry"
 DOCKERFILE_REGISTRY="Dockerfile.olm-registry"
 
 cat <<EOF > $DOCKERFILE_REGISTRY
@@ -84,13 +84,13 @@ RUN initializer
 CMD ["registry-server", "-t", "/tmp/terminate.log"]
 EOF
 
-docker build -f $DOCKERFILE_REGISTRY --tag "$REGISTRY_IMG" .
+docker build -f $DOCKERFILE_REGISTRY --tag "${REGISTRY_IMG}:${BRANCH_CHANNEL}-latest" .
 
 # push image
 skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-    "docker-daemon:${REGISTRY_IMG}" \
-    "docker://${REGISTRY_IMG}"
+    "docker-daemon:${REGISTRY_IMG}:${BRANCH_CHANNEL}-latest" \
+    "docker://${REGISTRY_IMG}:${BRANCH_CHANNEL}-latest"
 
 skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-    "docker-daemon:${REGISTRY_IMG}" \
-    "docker://${REGISTRY_IMG}-$GIT_HASH"
+    "docker-daemon::${REGISTRY_IMG}:${BRANCH_CHANNEL}-latest" \
+    "docker://:${REGISTRY_IMG}:${BRANCH_CHANNEL}-${GIT_HASH}"

--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -7,7 +7,9 @@ parameters:
 - name: REGISTRY_IMG
   required: true
 - name: CHANNEL
-  default: alpha
+  default: staging
+- name: IMAGE_TAG
+  default: latest
 
 objects:
 - apiVersion: operators.coreos.com/v1alpha1
@@ -16,7 +18,7 @@ objects:
     name: hive-catalog
   spec:
     sourceType: grpc
-    image: ${REGISTRY_IMG}
+    image: ${REGISTRY_IMG}:${CHANNEL}-${IMAGE_TAG}
     displayName: Hive Test Registry
     publisher: Hive Developer
 


### PR DESCRIPTION
IMAGE_TAG is a convention of saasherder, the CI/CD tool used by the
AppSRE team:
https://github.com/openshiftio/saasherder/

This tool revolves around the idea of deploying OpenShift templates,
always passing `IMAGE_TAG` as a parameter generated by obtaining the
short git commit hash.

In this particular case we need IMAGE_TAG to appear in the OpenShift
template we are applying:
`/hack/olm-registry/olm-artifacts-template.yaml`.

Since we need to have more than one catalog stream, namely `production`
and `staging` we opted for the idea of generating:

- `staging-<hash>` and `production-<hash>` as the non-moving targets
- `staging-latest` and `production-latest` as the moving targets

When it comes to iterating the CatalogSource, we would need to oc apply
the non-moving target, so it kicks OLM and the new image catalog is
deployed.

It might seem a bit convoluted to have the image catalog `image`
parameter built this way:

```yaml
image: ${REGISTRY_IMG}:${CHANNEL}-${IMAGE_TAG}
```

but as far as I can tell, it's the only way we can combine `IMAGE_TAG`
and multiple streams (`staging` and `production`).

For more context, saasherder will apply this:
https://github.com/app-sre/saas-hive/blob/master/hive-services/hive.yaml

`REGISTRY_IMG` and `CHANNEL` are hardcoded, but `IMAGE_TAG` is generated
dynamically, based on the git commit.