### PR TITLE
Restart Hive Admission when certs expire

### DIFF
--- a/config/crds/hive_v1alpha1_hiveconfig.yaml
+++ b/config/crds/hive_v1alpha1_hiveconfig.yaml
@@ -11,6 +11,8 @@ spec:
     kind: HiveConfig
     plural: hiveconfigs
   scope: Cluster
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -29,6 +31,12 @@ spec:
         spec:
           type: object
         status:
+          properties:
+            aggregatorClientCAHash:
+              description: AggregatorClientCAHash keeps an md5 hash of the aggregator
+                client CA configmap data from the openshift-config-managed namespace.
+                When the configmap changes, admission is redeployed.
+              type: string
           type: object
   version: v1alpha1
 status:

--- a/config/operator/operator_role.yaml
+++ b/config/operator/operator_role.yaml
@@ -23,6 +23,15 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apiregistration.k8s.io
   resources:
   - apiservices
@@ -67,6 +76,7 @@ rules:
   resources:
   - hiveconfigs
   - hiveconfigs/finalizers
+  - hiveconfigs/status
   verbs:
   - get
   - list

--- a/pkg/apis/hive/v1alpha1/hiveconfig_types.go
+++ b/pkg/apis/hive/v1alpha1/hiveconfig_types.go
@@ -26,6 +26,10 @@ type HiveConfigSpec struct {
 
 // HiveConfigStatus defines the observed state of Hive
 type HiveConfigStatus struct {
+	// AggregatorClientCAHash keeps an md5 hash of the aggregator client CA
+	// configmap data from the openshift-config-managed namespace. When the configmap changes,
+	// admission is redeployed.
+	AggregatorClientCAHash string `json:"aggregatorClientCAHash,omitempty"`
 }
 
 // +genclient:nonNamespaced
@@ -33,6 +37,7 @@ type HiveConfigStatus struct {
 
 // HiveConfig is the Schema for the hives API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 type HiveConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -46,6 +46,10 @@ const (
 	clusterVersionCRDName = "clusterversions.config.openshift.io"
 )
 
+const (
+	aggregatorClientCAHashAnnotation = "hive.openshift.io/ca-hash"
+)
+
 func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h *resource.Helper, instance *hivev1.HiveConfig, recorder events.Recorder) error {
 	asset := assets.MustAsset("config/hiveadmission/deployment.yaml")
 	hLog.Debug("reading deployment")
@@ -64,6 +68,14 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h *resou
 	if r.hiveImage != "" {
 		hiveAdmDeployment.Spec.Template.Spec.Containers[0].Image = r.hiveImage
 	}
+	if hiveAdmDeployment.Annotations == nil {
+		hiveAdmDeployment.Annotations = map[string]string{}
+	}
+	if hiveAdmDeployment.Spec.Template.ObjectMeta.Annotations == nil {
+		hiveAdmDeployment.Spec.Template.ObjectMeta.Annotations = map[string]string{}
+	}
+	hiveAdmDeployment.Annotations[aggregatorClientCAHashAnnotation] = instance.Status.AggregatorClientCAHash
+	hiveAdmDeployment.Spec.Template.ObjectMeta.Annotations[aggregatorClientCAHashAnnotation] = instance.Status.AggregatorClientCAHash
 
 	s := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme.Scheme,
 		scheme.Scheme)


### PR DESCRIPTION
Adds a hash to the operator config to keep track of the openshift-config-managed/kube-apiserver-aggregator-client-ca configmap's contents. If it changes, admission is redeployed.