### PR TITLE
Ensure release image from ClusterImageSet is set for install job

### DIFF
--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -138,11 +138,7 @@ func (r *ReconcileRemoteClusterIngress) syncClusterIngress(cd *hivev1.ClusterDep
 
 	rawList := rawExtensionsFromClusterDeployment(cd)
 
-	if err := r.syncSyncSet(cd, rawList); err != nil {
-		return err
-	}
-
-	return nil
+	return r.syncSyncSet(cd, rawList)
 }
 
 func rawExtensionsFromClusterDeployment(cd *hivev1.ClusterDeployment) []runtime.RawExtension {

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -48,7 +48,7 @@ const (
 // given a ClusterDeployment and an installer image.
 func GenerateInstallerJob(
 	cd *hivev1.ClusterDeployment,
-	hiveImage string,
+	hiveImage, releaseImage string,
 	serviceAccountName string,
 	sshKey string,
 	pullSecret string) (*batchv1.Job, *corev1.ConfigMap, error) {
@@ -142,11 +142,11 @@ func GenerateInstallerJob(
 			},
 		}...)
 	}
-	if cd.Spec.Images.ReleaseImage != "" {
+	if releaseImage != "" {
 		env = append(env, []corev1.EnvVar{
 			{
 				Name:  "OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE",
-				Value: cd.Spec.Images.ReleaseImage,
+				Value: releaseImage,
 			},
 		}...)
 	}


### PR DESCRIPTION
When using a ClusterImageSet and its release image is set. Ensure that we are using that to set the OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE environment variable.