### PR TITLE
Increase timeout for CI install job

### DIFF
--- a/contrib/cmd/waitforjob/main.go
+++ b/contrib/cmd/waitforjob/main.go
@@ -18,8 +18,8 @@ import (
 )
 
 var (
-	defaultJobExistenceTimeout = 3 * time.Minute
-	defaultJobExecutionTimeout = 45 * time.Minute
+	defaultJobExistenceTimeout = 5 * time.Minute
+	defaultJobExecutionTimeout = 90 * time.Minute
 )
 
 const (


### PR DESCRIPTION
At least a couple of e2e tests have failed with us timing out waiting for the job to complete, but nothing wrong going on in the install log. This increases the timeout so we don't prematurely fail the job.