### PR TITLE
Replacing hiveadmission daemonset to deployment

### DIFF
--- a/config/hiveadmission/deployment.yaml
+++ b/config/hiveadmission/deployment.yaml
@@ -1,7 +1,7 @@
 ---
 # to create the namespace-reservation-server
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   namespace: hive
   name: hiveadmission
@@ -9,6 +9,7 @@ metadata:
     app: hiveadmission
     hiveadmission: "true"
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app: hiveadmission

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -3,7 +3,7 @@
 // config/hiveadmission/apiservice.yaml
 // config/hiveadmission/clusterdeployment-webhook.yaml
 // config/hiveadmission/clusterimageset-webhook.yaml
-// config/hiveadmission/daemonset.yaml
+// config/hiveadmission/deployment.yaml
 // config/hiveadmission/dnszones-webhook.yaml
 // config/hiveadmission/hiveadmission_rbac_role.yaml
 // config/hiveadmission/hiveadmission_rbac_role_binding.yaml
@@ -185,10 +185,10 @@ func configHiveadmissionClusterimagesetWebhookYaml() (*asset, error) {
 	return a, nil
 }
 
-var _configHiveadmissionDaemonsetYaml = []byte(`---
+var _configHiveadmissionDeploymentYaml = []byte(`---
 # to create the namespace-reservation-server
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   namespace: hive
   name: hiveadmission
@@ -196,6 +196,7 @@ metadata:
     app: hiveadmission
     hiveadmission: "true"
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app: hiveadmission
@@ -240,17 +241,17 @@ spec:
           secretName: hiveadmission-serving-cert
 `)
 
-func configHiveadmissionDaemonsetYamlBytes() ([]byte, error) {
-	return _configHiveadmissionDaemonsetYaml, nil
+func configHiveadmissionDeploymentYamlBytes() ([]byte, error) {
+	return _configHiveadmissionDeploymentYaml, nil
 }
 
-func configHiveadmissionDaemonsetYaml() (*asset, error) {
-	bytes, err := configHiveadmissionDaemonsetYamlBytes()
+func configHiveadmissionDeploymentYaml() (*asset, error) {
+	bytes, err := configHiveadmissionDeploymentYamlBytes()
 	if err != nil {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/hiveadmission/daemonset.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	info := bindataFileInfo{name: "config/hiveadmission/deployment.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3532,7 +3533,7 @@ var _bindata = map[string]func() (*asset, error){
 	"config/hiveadmission/apiservice.yaml":                        configHiveadmissionApiserviceYaml,
 	"config/hiveadmission/clusterdeployment-webhook.yaml":         configHiveadmissionClusterdeploymentWebhookYaml,
 	"config/hiveadmission/clusterimageset-webhook.yaml":           configHiveadmissionClusterimagesetWebhookYaml,
-	"config/hiveadmission/daemonset.yaml":                         configHiveadmissionDaemonsetYaml,
+	"config/hiveadmission/deployment.yaml":                        configHiveadmissionDeploymentYaml,
 	"config/hiveadmission/dnszones-webhook.yaml":                  configHiveadmissionDnszonesWebhookYaml,
 	"config/hiveadmission/hiveadmission_rbac_role.yaml":           configHiveadmissionHiveadmission_rbac_roleYaml,
 	"config/hiveadmission/hiveadmission_rbac_role_binding.yaml":   configHiveadmissionHiveadmission_rbac_role_bindingYaml,
@@ -3605,7 +3606,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"apiservice.yaml":                      {configHiveadmissionApiserviceYaml, map[string]*bintree{}},
 			"clusterdeployment-webhook.yaml":       {configHiveadmissionClusterdeploymentWebhookYaml, map[string]*bintree{}},
 			"clusterimageset-webhook.yaml":         {configHiveadmissionClusterimagesetWebhookYaml, map[string]*bintree{}},
-			"daemonset.yaml":                       {configHiveadmissionDaemonsetYaml, map[string]*bintree{}},
+			"deployment.yaml":                      {configHiveadmissionDeploymentYaml, map[string]*bintree{}},
 			"dnszones-webhook.yaml":                {configHiveadmissionDnszonesWebhookYaml, map[string]*bintree{}},
 			"hiveadmission_rbac_role.yaml":         {configHiveadmissionHiveadmission_rbac_roleYaml, map[string]*bintree{}},
 			"hiveadmission_rbac_role_binding.yaml": {configHiveadmissionHiveadmission_rbac_role_bindingYaml, map[string]*bintree{}},

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -35,9 +35,9 @@ import (
 )
 
 func (r *ReconcileHiveConfig) deployHiveAdmission(haLog log.FieldLogger, h *resource.Helper, instance *hivev1.HiveConfig, recorder events.Recorder) error {
-	asset := assets.MustAsset("config/hiveadmission/daemonset.yaml")
-	haLog.Debug("reading daemonset")
-	hiveAdmDaemonSet := resourceread.ReadDaemonSetV1OrDie(asset)
+	asset := assets.MustAsset("config/hiveadmission/deployment.yaml")
+	haLog.Debug("reading deployment")
+	hiveAdmDeployment := resourceread.ReadDeploymentV1OrDie(asset)
 
 	err := util.ApplyAsset(h, "config/hiveadmission/service.yaml", haLog)
 	if err != nil {
@@ -50,24 +50,24 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(haLog log.FieldLogger, h *reso
 	}
 
 	if r.hiveImage != "" {
-		hiveAdmDaemonSet.Spec.Template.Spec.Containers[0].Image = r.hiveImage
+		hiveAdmDeployment.Spec.Template.Spec.Containers[0].Image = r.hiveImage
 	}
 
 	s := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme.Scheme,
 		scheme.Scheme)
 
 	buf := bytes.NewBuffer([]byte{})
-	err = s.Encode(hiveAdmDaemonSet, buf)
+	err = s.Encode(hiveAdmDeployment, buf)
 	if err != nil {
-		haLog.WithError(err).Error("error encoding daemonset")
+		haLog.WithError(err).Error("error encoding deployment")
 		return err
 	}
 	err = h.Apply(buf.Bytes())
 	if err != nil {
-		haLog.WithError(err).Error("error applying daemonset")
+		haLog.WithError(err).Error("error applying deployment")
 		return err
 	}
-	haLog.Info("daemonset applied")
+	haLog.Info("deployment applied")
 
 	err = util.ApplyAsset(h, "config/hiveadmission/apiservice.yaml", haLog)
 	if err != nil {


### PR DESCRIPTION
--> Replaces the hiveadmission daemonset with a deployment (replication = 2)
--> Removes the daemonset from the clusters that might already have it. Needs to be removed once it is run in opshive 