### PR TITLE
Place `genclient:nonNamespaced` before `genclient`

### DIFF
--- a/pkg/apis/hive/v1alpha1/clusterimageset_types.go
+++ b/pkg/apis/hive/v1alpha1/clusterimageset_types.go
@@ -43,13 +43,13 @@ type ClusterImageSetSpec struct {
 // ClusterImageSetStatus defines the observed state of ClusterImageSet
 type ClusterImageSetStatus struct{}
 
+// +genclient:nonNamespaced
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterImageSet is the Schema for the clusterimagesets API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
-// +genclient:nonNamespaced
 // +kubebuilder:printcolumn:name="Hive",type="string",JSONPath=".spec.hiveImage"
 // +kubebuilder:printcolumn:name="Installer",type="string",JSONPath=".status.installerImage"
 // +kubebuilder:printcolumn:name="Release",type="string",JSONPath=".spec.releaseImage"


### PR DESCRIPTION
Without this the code generated by the `informers-gen` tool produces
code that then fails to compile with this error:

```
pkg/hive/informers/externalversions/hive/v1alpha1/interface.go:57:54:
unknown field 'namespace' in struct literal of type clusterImageSetInformer
```