### PR TITLE
HiveAdmission Fixes

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -31,6 +31,7 @@ import (
 
 	oappsv1 "github.com/openshift/api/apps/v1"
 
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -83,6 +84,10 @@ func newRootCommand() *cobra.Command {
 			}
 
 			if err := apiregistrationv1.AddToScheme(mgr.GetScheme()); err != nil {
+				log.Fatal(err)
+			}
+
+			if err := apiextv1beta1.AddToScheme(mgr.GetScheme()); err != nil {
 				log.Fatal(err)
 			}
 

--- a/config/hiveadmission/clusterimageset-webhook.yaml
+++ b/config/hiveadmission/clusterimageset-webhook.yaml
@@ -2,9 +2,9 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: clusterdeployments.admission.hive.openshift.io
+  name: clusterimagesets.admission.hive.openshift.io
 webhooks:
-- name: clusterdeployments.admission.hive.openshift.io
+- name: clusterimagesets.admission.hive.openshift.io
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/config/operator/operator_role.yaml
+++ b/config/operator/operator_role.yaml
@@ -94,3 +94,12 @@ rules:
   - patch
   - list
   - watch
+# Allow get on CRDs so we can check for 4.x ClusterVersion to determine if running on 3.11 or not.
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -142,9 +142,9 @@ var _configHiveadmissionClusterimagesetWebhookYaml = []byte(`---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: clusterdeployments.admission.hive.openshift.io
+  name: clusterimagesets.admission.hive.openshift.io
 webhooks:
-- name: clusterdeployments.admission.hive.openshift.io
+- name: clusterimagesets.admission.hive.openshift.io
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -17,8 +17,6 @@ limitations under the License.
 package hive
 
 import (
-	"bytes"
-
 	log "github.com/sirupsen/logrus"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
@@ -60,14 +58,7 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helpe
 	// TODO: it would be nice to be able to log if there were changes or not
 	// for all artifacts we Apply.
 
-	// Encode our modified Deployment back to byte array for applying:
-	buf := bytes.NewBuffer([]byte{})
-	err := s.Encode(hiveDeployment, buf)
-	if err != nil {
-		hLog.WithError(err).Error("error encoding deployment")
-		return err
-	}
-	err = h.Apply(buf.Bytes())
+	err := h.ApplyRuntimeObject(hiveDeployment, s)
 	if err != nil {
 		hLog.WithError(err).Error("error applying deployment")
 		return err

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -17,7 +17,8 @@ limitations under the License.
 package hive
 
 import (
-	"bytes"
+	"context"
+	"fmt"
 
 	log "github.com/sirupsen/logrus"
 
@@ -30,8 +31,19 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 
+	admregv1 "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	clusterVersionCRDName = "clusterversions.config.openshift.io"
 )
 
 func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h *resource.Helper, instance *hivev1.HiveConfig, recorder events.Recorder) error {
@@ -56,33 +68,139 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h *resou
 	s := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme.Scheme,
 		scheme.Scheme)
 
-	buf := bytes.NewBuffer([]byte{})
-	err = s.Encode(hiveAdmDeployment, buf)
-	if err != nil {
-		hLog.WithError(err).Error("error encoding deployment")
-		return err
-	}
-	err = h.Apply(buf.Bytes())
+	err = h.ApplyRuntimeObject(hiveAdmDeployment, s)
 	if err != nil {
 		hLog.WithError(err).Error("error applying deployment")
 		return err
 	}
 	hLog.Info("deployment applied")
 
-	applyAssets := []string{
-		"config/hiveadmission/apiservice.yaml",
-		"config/hiveadmission/clusterdeployment-webhook.yaml",
-		"config/hiveadmission/clusterimageset-webhook.yaml",
-		"config/hiveadmission/dnszones-webhook.yaml",
+	hLog.Debug("reading apiservice")
+	asset = assets.MustAsset("config/hiveadmission/apiservice.yaml")
+	apiService := util.ReadAPIServiceV1Beta1OrDie(asset, scheme.Scheme)
+
+	asset = assets.MustAsset("config/hiveadmission/clusterdeployment-webhook.yaml")
+	cdWebhook := util.ReadValidatingWebhookConfigurationV1Beta1OrDie(asset, scheme.Scheme)
+
+	asset = assets.MustAsset("config/hiveadmission/clusterimageset-webhook.yaml")
+	cisWebhook := util.ReadValidatingWebhookConfigurationV1Beta1OrDie(asset, scheme.Scheme)
+
+	asset = assets.MustAsset("config/hiveadmission/dnszones-webhook.yaml")
+	dnsZonesWebhook := util.ReadValidatingWebhookConfigurationV1Beta1OrDie(asset, scheme.Scheme)
+
+	// If on 3.11 we need to set the service CA on the apiservice.
+	is311, err := r.is311(hLog)
+	if err != nil {
+		hLog.Error("error detecting 3.11 cluster")
+		return err
 	}
-	for _, a := range applyAssets {
-		err = util.ApplyAsset(h, a, hLog)
+	if is311 {
+		hLog.Debug("3.11 cluster detected, modifying objects for CA certs")
+		err = r.injectCerts(apiService, []*admregv1.ValidatingWebhookConfiguration{cdWebhook, cisWebhook, dnsZonesWebhook}, hLog)
 		if err != nil {
+			hLog.WithError(err).Error("error injecting certs")
 			return err
 		}
 	}
 
+	err = h.ApplyRuntimeObject(apiService, s)
+	if err != nil {
+		hLog.WithError(err).Error("error applying apiservice")
+		return err
+	}
+	hLog.Info("apiservice applied")
+
+	err = h.ApplyRuntimeObject(cdWebhook, s)
+	if err != nil {
+		hLog.WithError(err).Error("error applying cluster deployment webhook")
+		return err
+	}
+	hLog.Info("cluster deployment webhook applied")
+
+	err = h.ApplyRuntimeObject(cisWebhook, s)
+	if err != nil {
+		hLog.WithError(err).Error("error applying cluster image set webhook")
+		return err
+	}
+	hLog.Info("cluster image set webhook applied")
+
+	err = h.ApplyRuntimeObject(dnsZonesWebhook, s)
+	if err != nil {
+		hLog.WithError(err).Error("error applying dns zones webhook")
+		return err
+	}
+	hLog.Info("dns zones webhook applied")
+
 	hLog.Info("hiveadmission components reconciled successfully")
 
 	return nil
+}
+
+func (r *ReconcileHiveConfig) injectCerts(apiService *apiregistrationv1.APIService, webhooks []*admregv1.ValidatingWebhookConfiguration, hLog log.FieldLogger) error {
+
+	// Locate the kube CA by looking up secrets in kube-system namespace, finding one of
+	// type 'kubernetes.io/service-account-token', and reading the CA off it.
+	hLog.Debug("listing secrets in hive namespace")
+	secrets := &corev1.SecretList{}
+	err := r.globalClient.List(context.Background(), &client.ListOptions{Namespace: hiveNamespace}, secrets)
+	if err != nil {
+		hLog.WithError(err).Error("error listing secrets in hive namespace")
+		return err
+	}
+	var firstSATokenSecret *corev1.Secret
+	hLog.Debugf("found %d secrets", len(secrets.Items))
+	for _, s := range secrets.Items {
+		if s.Type == corev1.SecretTypeServiceAccountToken {
+			firstSATokenSecret = &s
+			break
+		}
+	}
+	if firstSATokenSecret == nil {
+		return fmt.Errorf("no %s secrets found", corev1.SecretTypeServiceAccountToken)
+	}
+	kubeCA, ok := firstSATokenSecret.Data["ca.crt"]
+	if !ok {
+		return fmt.Errorf("secret %s did not contain key ca.crt", firstSATokenSecret.Name)
+	}
+	hLog.Debugf("found kube CA: %s", string(kubeCA))
+
+	// Load the service CA:
+	svcCertSignerSecret := &corev1.Secret{}
+	err = r.globalClient.Get(context.Background(), types.NamespacedName{Namespace: "openshift-service-cert-signer", Name: "service-serving-cert-signer-signing-key"}, svcCertSignerSecret)
+	if err != nil {
+		hLog.WithError(err).Error("error loading secret service-serving-cert-signer-signing-key")
+		return err
+	}
+	serviceCA, ok := svcCertSignerSecret.Data["tls.crt"]
+	if !ok {
+		return fmt.Errorf("secret %s did not contain key tls.crt", svcCertSignerSecret.Name)
+	}
+	hLog.Debugf("found service CA: %s", string(serviceCA))
+
+	// Add the service CA to the aggregated API service:
+	apiService.Spec.CABundle = serviceCA
+
+	// Add the kube CA to each webhook:
+	for whi := range webhooks {
+		for whwhi := range webhooks[whi].Webhooks {
+			webhooks[whi].Webhooks[whwhi].ClientConfig.CABundle = kubeCA
+		}
+	}
+
+	return nil
+}
+
+// is311 returns true if this is a 3.11 OpenShift cluster. We check by looking for a ClusterVersion CRD,
+// which should only exist on OpenShift 4.x. We do not expect Hive to ever be deployed on pre-3.11.
+func (r *ReconcileHiveConfig) is311(hLog log.FieldLogger) (bool, error) {
+	cvCRD := &apiextv1beta1.CustomResourceDefinition{}
+	err := r.Client.Get(context.Background(), types.NamespacedName{Name: clusterVersionCRDName}, cvCRD)
+	if err != nil && errors.IsNotFound(err) {
+		// If this CRD does not exist, we must not be on a 4.x cluster.
+		return true, nil
+	} else if err != nil {
+		hLog.WithError(err).Error("error fetching clusterversion CRD")
+		return false, err
+	}
+	return false, nil
 }

--- a/pkg/operator/util/admissionregistration.go
+++ b/pkg/operator/util/admissionregistration.go
@@ -17,14 +17,9 @@ limitations under the License.
 package util
 
 import (
-	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	admregv1 "k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	admregv1client "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
 )
 
 // ReadValidatingWebhookConfigurationV1Beta1OrDie reads a ValidatingWebhookConfiguration,
@@ -37,27 +32,4 @@ func ReadValidatingWebhookConfigurationV1Beta1OrDie(objBytes []byte, scheme *run
 		panic(err)
 	}
 	return requiredObj.(*admregv1.ValidatingWebhookConfiguration)
-}
-
-// ApplyValidatingWebhookConfiguration merges objectmeta and requires apiservice coordinates.  It does not touch CA bundles, which should be managed via service CA controller.
-func ApplyValidatingWebhookConfiguration(client admregv1client.AdmissionregistrationV1beta1Interface, required *admregv1.ValidatingWebhookConfiguration) (*admregv1.ValidatingWebhookConfiguration, bool, error) {
-	existing, err := client.ValidatingWebhookConfigurations().Get(required.Name, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		actual, err := client.ValidatingWebhookConfigurations().Create(required)
-		return actual, true, err
-	}
-	if err != nil {
-		return nil, false, err
-	}
-
-	modified := resourcemerge.BoolPtr(false)
-	resourcemerge.EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
-	if equality.Semantic.DeepEqual(existing.Webhooks, required.Webhooks) {
-		return existing, false, nil
-	}
-
-	existing.Webhooks = required.Webhooks
-
-	actual, err := client.ValidatingWebhookConfigurations().Update(existing)
-	return actual, true, err
 }

--- a/pkg/resource/apply.go
+++ b/pkg/resource/apply.go
@@ -19,6 +19,8 @@ package resource
 import (
 	"bytes"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericclioptions/printers"
 	kcmd "k8s.io/kubernetes/pkg/kubectl/cmd"
@@ -52,6 +54,20 @@ func (r *Helper) Apply(obj []byte) error {
 		r.logger.WithError(err).
 			WithField("stdout", ioStreams.Out.(*bytes.Buffer).String()).
 			WithField("stderr", ioStreams.ErrOut.(*bytes.Buffer).String()).Error("running the apply command failed")
+		return err
+	}
+	return nil
+}
+
+// ApplyRuntimeObject serializes an object and applies it to the target cluster specified by the kubeconfig.
+func (r *Helper) ApplyRuntimeObject(obj runtime.Object, s *json.Serializer) error {
+	buf := bytes.NewBuffer([]byte{})
+	err := s.Encode(obj, buf)
+	if err != nil {
+		return err
+	}
+	err = r.Apply(buf.Bytes())
+	if err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Restores the setting of kube/service CA on APIService and webhooks, which was dropped in recent refactoring. This is now performed in the operator, but only if running on a 3.11 cluster.