### PR TITLE
Add initial support for publishing prometheus metrics

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -70,7 +70,9 @@ func newRootCommand() *cobra.Command {
 			}
 
 			// Create a new Cmd to provide shared dependencies and start components
-			mgr, err := manager.New(cfg, manager.Options{})
+			mgr, err := manager.New(cfg, manager.Options{
+				MetricsBindAddress: ":2112",
+			})
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/controller/add_metrics.go
+++ b/pkg/controller/add_metrics.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/openshift/hive/pkg/controller/metrics"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, metrics.Add)
+}

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var (
+	metricClusterDeploymentsTotal = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "hive_cluster_deployments_total",
+		Help: "Total number of cluster deployments that exist in Hive.",
+	})
+	metricClusterDeploymentsInstalledTotal = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "hive_cluster_deployments_installed_total",
+		Help: "Total number of cluster deployments that are successfully installed.",
+	})
+)
+
+func init() {
+	metrics.Registry.MustRegister(metricClusterDeploymentsTotal)
+	metrics.Registry.MustRegister(metricClusterDeploymentsInstalledTotal)
+}
+
+// Add creates a new metrics Calculator and adds it to the Manager.
+func Add(mgr manager.Manager) error {
+	mc := &Calculator{
+		Client:   mgr.GetClient(),
+		Interval: 2 * time.Minute,
+	}
+	err := mgr.Add(mc)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Calculator runs in a goroutine and periodically calculates and publishes
+// Prometheus metrics which will be exposed at our /metrics endpoint. Note that this is not
+// a standard controller watching Kube resources, it runs periodically and then goes to sleep.
+//
+// This should be used for metrics which do not fit well into controller reconcile loops,
+// things that are calculated globally rather than metrics related to specific reconciliations.
+type Calculator struct {
+	Client client.Client
+
+	// Interval is the length of time we sleep between metrics calculations.
+	Interval time.Duration
+}
+
+// Start begins the metrics calculation loop.
+func (mc *Calculator) Start(stopCh <-chan struct{}) error {
+	log.Info("started metrics calculator goroutine")
+
+	// Run forever, sleep at the end:
+	wait.Until(func() {
+		mcLog := log.WithField("controller", "metrics")
+		// Load all ClusterDeployments so we can accumulate facts about them.
+		clusterDeployments := &hivev1.ClusterDeploymentList{}
+		err := mc.Client.List(context.Background(), &client.ListOptions{}, clusterDeployments)
+		if err != nil {
+			log.WithError(err).Error("error listing cluster deployments")
+		}
+		mcLog.WithField("totalClusterDeployments", len(clusterDeployments.Items)).Debug("loaded cluster deployments")
+		total := 0
+		installedTotal := 0
+		for _, cd := range clusterDeployments.Items {
+			total = total + 1
+			if cd.Status.Installed {
+				installedTotal = installedTotal + 1
+			}
+		}
+		metricClusterDeploymentsTotal.Set(float64(total))
+		metricClusterDeploymentsInstalledTotal.Set(float64(installedTotal))
+	}, mc.Interval, stopCh)
+
+	return nil
+}

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -91,4 +92,21 @@ func DeleteFinalizer(object metav1.Object, finalizer string) {
 	finalizers := sets.NewString(object.GetFinalizers()...)
 	finalizers.Delete(finalizer)
 	object.SetFinalizers(finalizers.List())
+}
+
+// GetKubeClient creates a new Kubernetes dynamic client.
+func GetKubeClient(scheme *runtime.Scheme) (client.Client, error) {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &clientcmd.ConfigOverrides{})
+	cfg, err := kubeconfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	dynamicClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, err
+	}
+
+	return dynamicClient, nil
 }


### PR DESCRIPTION
This is just a starter PR, @ShivamChamoli will be taking over writing most of these. Vendors prometheus, exposes a couple cluster deployment controller metrics, and establishes a metrics calc loop outside of controllers for more global totals calculated every 2 minutes.

This can be tested with "make run" and "curl http://localhost:2112/metrics". 