### PR TITLE
Fix IAM user leak on deprovision.

### DIFF
--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -351,6 +351,8 @@ func GenerateUninstallerJob(
 				"--region",
 				cd.Spec.AWS.Region,
 				fmt.Sprintf("kubernetes.io/cluster/%s=owned", cd.Status.InfraID),
+				// Also cleanup anything with the tag for the legacy cluster ID (credentials still using this for example)
+				fmt.Sprintf("openshiftClusterID=%s", cd.Status.ClusterID),
 			},
 		},
 	}


### PR DESCRIPTION
Credentials are not tagged in the new style because the infra ID is not
yet officially available in the cluster itself.

This change matches what the installer delete cluster command does by
also including the old openshiftClusterID tag.