### PR TITLE
add Type info for the IngressController objects

### DIFF
--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -45,6 +45,8 @@ const (
 	controllerName = "remoteingress"
 
 	remoteClusterIngressNamespace = "openshift-ingress-operator"
+
+	remoteIngressKind = "IngressController"
 )
 
 // Add creates a new RemoteMachineSet Controller and adds it to the Manager with default RBAC. The Manager will set fields on the
@@ -216,6 +218,10 @@ func (r *ReconcileRemoteClusterIngress) syncSyncSet(cd *hivev1.ClusterDeployment
 
 func createIngressController(cd *hivev1.ClusterDeployment, ingress hivev1.ClusterIngress) *ingresscontroller.IngressController {
 	newIngress := ingresscontroller.IngressController{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       remoteIngressKind,
+			APIVersion: ingresscontroller.GroupVersion.String(),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ingress.Name,
 			Namespace: remoteClusterIngressNamespace,

--- a/pkg/controller/remoteingress/remoteingress_controller_test.go
+++ b/pkg/controller/remoteingress/remoteingress_controller_test.go
@@ -18,6 +18,7 @@ package remoteingress
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -231,6 +232,13 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 				if err := fakeClient.Get(context.TODO(), ssNamespacedName, ss); err != nil {
 					t.Errorf("failed fetching SyncSet to check whether it was properly created/updated: %v", err)
 				}
+
+				// validate that we're setting type meta info
+				ic := ingresscontroller.IngressController{}
+				assert.NoError(t, json.Unmarshal(ss.Spec.Resources[0].Raw, &ic), "json marshaling to IngressController should not fail")
+				assert.Equal(t, "IngressController", ic.Kind, "unexpected Object Kind")
+				assert.Equal(t, "operator.openshift.io/v1", ic.APIVersion, "unexpected Object APIVersion")
+
 				ingressControllers := rawToIngressControllers(ss.Spec.Resources)
 
 				// We should have the expected number of ingress objects


### PR DESCRIPTION
this is needed for the ability to generically apply all kinds of object types (from https://github.com/openshift/hive/pull/247 )