### PR TITLE
Replace incorrect use of dockercfg pull secrets with dockerconfigjson.

### DIFF
--- a/config/clusterimagesets/openshift-4.0.0-0.8.yaml
+++ b/config/clusterimagesets/openshift-4.0.0-0.8.yaml
@@ -1,0 +1,11 @@
+apiVersion: hive.openshift.io/v1alpha1
+kind: ClusterImageSet
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openshift-v4.0.0-0.8
+spec:
+  releaseImage: "quay.io/openshift-release-dev/ocp-release:4.0.0-0.8"
+  # TODO: what hive image should we use here? it should be verified working
+  # with the release image. could switch to using appsre images we run in stage/prod.
+  hiveImage: "quay.io/twiest/hive-controller:20190327"

--- a/config/templates/cluster-deployment-customimageset.yaml
+++ b/config/templates/cluster-deployment-customimageset.yaml
@@ -57,9 +57,9 @@ objects:
   kind: Secret
   metadata:
     name: ${CLUSTER_NAME}-pull-secret
-  type: kubernetes.io/dockercfg
+  type: kubernetes.io/dockerconfigjson
   stringData:
-    ".dockercfg": "${PULL_SECRET}"
+    ".dockerconfigjson": "${PULL_SECRET}"
 
 - apiVersion: v1
   kind: Secret

--- a/config/templates/cluster-deployment.yaml
+++ b/config/templates/cluster-deployment.yaml
@@ -29,7 +29,7 @@ parameters:
 - name: HIVE_IMAGE
   displayName: Hive image URL
   description: Hive image URL
-  value: "registry.svc.ci.openshift.org/openshift/hive-v4.0:hive"
+  value: ""
 - name: HIVE_IMAGE_PULL_POLICY
   displayName: Hive image pull policy
   description: Hive image pull policy
@@ -73,9 +73,9 @@ objects:
   kind: Secret
   metadata:
     name: ${CLUSTER_NAME}-pull-secret
-  type: kubernetes.io/dockercfg
+  type: kubernetes.io/dockerconfigjson
   stringData:
-    ".dockercfg": "${PULL_SECRET}"
+    ".dockerconfigjson": "${PULL_SECRET}"
 
 - apiVersion: v1
   kind: Secret

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -63,7 +63,6 @@ const (
 	// deleteAfterAnnotation is the annotation that contains a duration after which the cluster should be cleaned up.
 	deleteAfterAnnotation       = "hive.openshift.io/delete-after"
 	adminCredsSecretPasswordKey = "password"
-	pullSecretKey               = ".dockerconfigjson"
 	adminSSHKeySecretKey        = "ssh-publickey"
 	adminKubeconfigKey          = "kubeconfig"
 	clusterVersionObjectName    = "version"
@@ -263,78 +262,83 @@ func (r *ReconcileClusterDeployment) Reconcile(request reconcile.Request) (recon
 		return reconcile.Result{}, err
 	}
 
-	cdLog.Debug("loading pull secret secret")
-	pullSecret, err := r.loadSecretData(cd.Spec.PullSecret.Name, cd.Namespace, pullSecretKey)
-	if err != nil {
-		cdLog.WithError(err).Error("unable to load pull secret from secret")
-		return reconcile.Result{}, err
-	}
-
 	if cd.Status.InstallerImage == nil {
 		return reconcile.Result{}, r.resolveInstallerImage(cd, hiveImage, cdLog)
 	}
 
-	job, cfgMap, err := install.GenerateInstallerJob(
-		cd,
-		hiveImage,
-		releaseImage,
-		serviceAccountName,
-		sshKey,
-		pullSecret)
-	if err != nil {
-		cdLog.WithError(err).Error("error generating install job")
-		return reconcile.Result{}, err
-	}
-
-	if err = controllerutil.SetControllerReference(cd, job, r.scheme); err != nil {
-		cdLog.WithError(err).Error("error setting controller reference on job")
-		return reconcile.Result{}, err
-	}
-	if err = controllerutil.SetControllerReference(cd, cfgMap, r.scheme); err != nil {
-		cdLog.WithError(err).Error("error setting controller reference on config map")
-		return reconcile.Result{}, err
-	}
-
-	cdLog = cdLog.WithField("job", job.Name)
-
-	// Check if the ConfigMap already exists for this ClusterDeployment:
-	cdLog.Debug("checking if install-config.yaml config map exists")
-	existingCfgMap := &kapi.ConfigMap{}
-	err = r.Get(context.TODO(), types.NamespacedName{Name: cfgMap.Name, Namespace: cfgMap.Namespace}, existingCfgMap)
-	if err != nil && errors.IsNotFound(err) {
-		cdLog.WithField("configMap", cfgMap.Name).Infof("creating config map")
-		err = r.Create(context.TODO(), cfgMap)
-		if err != nil {
-			cdLog.Errorf("error creating config map: %v", err)
-			return reconcile.Result{}, err
-		}
-	} else if err != nil {
-		cdLog.Errorf("error getting config map: %v", err)
-		return reconcile.Result{}, err
-	}
-
-	// Check if the Job already exists for this ClusterDeployment:
+	// Check if an install job already exists:
 	existingJob := &batchv1.Job{}
 	installJobName := install.GetInstallJobName(cd)
 	err = r.Get(context.TODO(), types.NamespacedName{Name: installJobName, Namespace: cd.Namespace}, existingJob)
 	if err != nil && errors.IsNotFound(err) {
-		// If the ClusterDeployment is already installed, we do not need to create a new job:
-		if cd.Status.Installed {
-			cdLog.Debug("cluster is already installed, no job needed")
-		} else {
+		cdLog.Debug("no install job exists")
+		existingJob = nil
+	} else if err != nil {
+		cdLog.WithError(err).Error("error looking for install job")
+		return reconcile.Result{}, err
+	}
+
+	if cd.Status.Installed {
+		cdLog.Debug("cluster is already installed, no processing of install job needed")
+	} else {
+		cdLog.Debug("loading pull secret secret")
+		pullSecret, err := r.loadSecretData(cd.Spec.PullSecret.Name, cd.Namespace, corev1.DockerConfigJsonKey)
+		if err != nil {
+			cdLog.WithError(err).Error("unable to load pull secret from secret")
+			return reconcile.Result{}, err
+		}
+
+		job, cfgMap, err := install.GenerateInstallerJob(
+			cd,
+			hiveImage,
+			releaseImage,
+			serviceAccountName,
+			sshKey,
+			pullSecret)
+		if err != nil {
+			cdLog.WithError(err).Error("error generating install job")
+			return reconcile.Result{}, err
+		}
+
+		if err = controllerutil.SetControllerReference(cd, job, r.scheme); err != nil {
+			cdLog.WithError(err).Error("error setting controller reference on job")
+			return reconcile.Result{}, err
+		}
+		if err = controllerutil.SetControllerReference(cd, cfgMap, r.scheme); err != nil {
+			cdLog.WithError(err).Error("error setting controller reference on config map")
+			return reconcile.Result{}, err
+		}
+
+		cdLog = cdLog.WithField("job", job.Name)
+
+		// Check if the ConfigMap already exists for this ClusterDeployment:
+		cdLog.Debug("checking if install-config.yaml config map exists")
+		existingCfgMap := &kapi.ConfigMap{}
+		err = r.Get(context.TODO(), types.NamespacedName{Name: cfgMap.Name, Namespace: cfgMap.Namespace}, existingCfgMap)
+		if err != nil && errors.IsNotFound(err) {
+			cdLog.WithField("configMap", cfgMap.Name).Infof("creating config map")
+			err = r.Create(context.TODO(), cfgMap)
+			if err != nil {
+				cdLog.Errorf("error creating config map: %v", err)
+				return reconcile.Result{}, err
+			}
+		} else if err != nil {
+			cdLog.Errorf("error getting config map: %v", err)
+			return reconcile.Result{}, err
+		}
+
+		if existingJob == nil {
 			cdLog.Infof("creating install job")
 			err = r.Create(context.TODO(), job)
 			if err != nil {
 				cdLog.Errorf("error creating job: %v", err)
 				return reconcile.Result{}, err
 			}
-		}
-	} else if err != nil {
-		cdLog.Errorf("error getting job: %v", err)
-		return reconcile.Result{}, err
-	} else {
-		cdLog.Infof("cluster job exists, cluster deployment status: %v", cd.Status.Installed)
-		if !cd.Status.Installed {
+		} else if err != nil {
+			cdLog.Errorf("error getting job: %v", err)
+			return reconcile.Result{}, err
+		} else {
+			cdLog.Infof("cluster job exists, cluster deployment status: %v", cd.Status.Installed)
 			if existingJob.Annotations != nil && cfgMap.Annotations != nil {
 				didGenerationChange, err := r.updateOutdatedConfigurations(cd.Generation, existingJob, cfgMap, cdLog)
 				if err != nil {

--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -63,7 +63,6 @@ const (
 
 	adminKubeConfigKey          = "kubeconfig"
 	adminCredsSecretPasswordKey = "password"
-	pullSecretKey               = ".dockerconfigjson"
 	adminSSHKeySecretKey        = "ssh-publickey"
 	hiveDefaultAMIAnnotation    = "hive.openshift.io/default-AMI"
 )
@@ -398,14 +397,9 @@ func (r *ReconcileRemoteMachineSet) generateInstallConfigFromClusterDeployment(c
 		return nil, err
 	}
 
-	cdLog.Debug("loading pull secret secret")
-	pullSecret, err := r.loadSecretData(cd.Spec.PullSecret.Name, cd.Namespace, pullSecretKey)
-	if err != nil {
-		cdLog.WithError(err).Error("unable to load pull secret from secret")
-		return nil, err
-	}
-
-	ic, err := install.GenerateInstallConfig(cd, sshKey, pullSecret, false)
+	// Using a fake pull secret here, we don't need the pull secret given our use of
+	// this install config, all we're after are the machine pools.
+	ic, err := install.GenerateInstallConfig(cd, sshKey, "{}", false)
 	if err != nil {
 		cdLog.WithError(err).Error("unable to generate install config")
 		return nil, err

--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -63,7 +63,7 @@ const (
 
 	adminKubeConfigKey          = "kubeconfig"
 	adminCredsSecretPasswordKey = "password"
-	pullSecretKey               = ".dockercfg"
+	pullSecretKey               = ".dockerconfigjson"
 	adminSSHKeySecretKey        = "ssh-publickey"
 	hiveDefaultAMIAnnotation    = "hive.openshift.io/default-AMI"
 )

--- a/pkg/controller/remotemachineset/remotemachineset_controller_test.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller_test.go
@@ -60,8 +60,6 @@ const (
 	adminPasswordSecretKey   = "password"
 	sshKeySecret             = "foo-ssh-key"
 	sshKeySecretKey          = "ssh-publickey"
-	pullSecretSecret         = "foo-pull-secret"
-	pullSecretSecretKey      = ".dockerconfigjson"
 	testUUID                 = "fakeUUID"
 	testAMI                  = "ami-totallyfake"
 )
@@ -111,7 +109,6 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 				testSecret(adminKubeconfigSecret, adminKubeconfigSecretKey, testName),
 				testSecret(adminPasswordSecret, adminPasswordSecretKey, testName),
 				testSecret(sshKeySecret, sshKeySecretKey, testName),
-				testSecret(pullSecretSecret, pullSecretSecretKey, testName),
 			},
 			remoteExisting: []runtime.Object{
 				testMachineSet("foo-12345-worker-us-east-1a", "worker", true, 1, 0),
@@ -137,7 +134,6 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 				testSecret(adminKubeconfigSecret, adminKubeconfigSecretKey, testName),
 				testSecret(adminPasswordSecret, adminPasswordSecretKey, testName),
 				testSecret(sshKeySecret, sshKeySecretKey, testName),
-				testSecret(pullSecretSecret, pullSecretSecretKey, testName),
 			},
 			remoteExisting: []runtime.Object{
 				testMachineSet("foo-12345-worker-us-east-1a", "worker", true, 1, 0),
@@ -163,7 +159,6 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 				testSecret(adminKubeconfigSecret, adminKubeconfigSecretKey, testName),
 				testSecret(adminPasswordSecret, adminPasswordSecretKey, testName),
 				testSecret(sshKeySecret, sshKeySecretKey, testName),
-				testSecret(pullSecretSecret, pullSecretSecretKey, testName),
 			},
 			remoteExisting: []runtime.Object{
 				testMachineSet("foo-12345-worker-us-east-1a", "worker", true, 1, 0),
@@ -188,7 +183,6 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 				testSecret(adminKubeconfigSecret, adminKubeconfigSecretKey, testName),
 				testSecret(adminPasswordSecret, adminPasswordSecretKey, testName),
 				testSecret(sshKeySecret, sshKeySecretKey, testName),
-				testSecret(pullSecretSecret, pullSecretSecretKey, testName),
 			},
 			remoteExisting: []runtime.Object{
 				testMachineSet("foo-12345-worker-us-east-1a", "worker", true, 1, 0),
@@ -216,7 +210,6 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 				testSecret(adminKubeconfigSecret, adminKubeconfigSecretKey, testName),
 				testSecret(adminPasswordSecret, adminPasswordSecretKey, testName),
 				testSecret(sshKeySecret, sshKeySecretKey, testName),
-				testSecret(pullSecretSecret, pullSecretSecretKey, testName),
 			},
 			remoteExisting: []runtime.Object{
 				testMachineSet("foo-12345-alpha-us-east-1a", "alpha", true, 3, 0),
@@ -241,7 +234,6 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 				testSecret(adminKubeconfigSecret, adminKubeconfigSecretKey, testName),
 				testSecret(adminPasswordSecret, adminPasswordSecretKey, testName),
 				testSecret(sshKeySecret, sshKeySecretKey, testName),
-				testSecret(pullSecretSecret, pullSecretSecretKey, testName),
 			},
 			remoteExisting: []runtime.Object{
 				testMachineSet("foo-12345-alpha-us-east-1a", "alpha", true, 4, 0),
@@ -266,7 +258,6 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 				testSecret(adminKubeconfigSecret, adminKubeconfigSecretKey, testName),
 				testSecret(adminPasswordSecret, adminPasswordSecretKey, testName),
 				testSecret(sshKeySecret, sshKeySecretKey, testName),
-				testSecret(pullSecretSecret, pullSecretSecretKey, testName),
 			},
 			remoteExisting: []runtime.Object{
 				testMachineSet("foo-12345-alpha-us-east-1a", "alpha", true, 1, 0),
@@ -295,7 +286,6 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 				testSecret(adminKubeconfigSecret, adminKubeconfigSecretKey, testName),
 				testSecret(adminPasswordSecret, adminPasswordSecretKey, testName),
 				testSecret(sshKeySecret, sshKeySecretKey, testName),
-				testSecret(pullSecretSecret, pullSecretSecretKey, testName),
 			},
 			remoteExisting: []runtime.Object{
 				testMachineSet("foo-12345-alpha-us-east-1a", "alpha", true, 1, 0),
@@ -493,9 +483,6 @@ func testClusterDeployment(computePools []hivev1.MachinePool) *hivev1.ClusterDep
 			ClusterName:  testName,
 			ControlPlane: hivev1.MachinePool{},
 			Compute:      computePools,
-			PullSecret: corev1.LocalObjectReference{
-				Name: pullSecretSecret,
-			},
 			Platform: hivev1.Platform{
 				AWS: &hivev1.AWSPlatform{
 					Region: "us-east-1",

--- a/pkg/controller/remotemachineset/remotemachineset_controller_test.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller_test.go
@@ -61,7 +61,7 @@ const (
 	sshKeySecret             = "foo-ssh-key"
 	sshKeySecretKey          = "ssh-publickey"
 	pullSecretSecret         = "foo-pull-secret"
-	pullSecretSecretKey      = ".dockercfg"
+	pullSecretSecretKey      = ".dockerconfigjson"
 	testUUID                 = "fakeUUID"
 	testAMI                  = "ami-totallyfake"
 )

--- a/pkg/imageset/generate.go
+++ b/pkg/imageset/generate.go
@@ -40,7 +40,7 @@ const (
 	extractImageScript = `#/bin/bash
 echo "About to run oc adm release info"
 if oc adm release info --image-for="installer" --registry-config "${PULL_SECRET}" "${RELEASE_IMAGE}" > /common/installer-image.txt 2> /common/error.log; then
-  echo "The command succeeded"  
+  echo "The command succeeded"
   echo "1" > /common/success
 else
   echo "The command failed"
@@ -66,7 +66,7 @@ func GenerateImageSetJob(cd *hivev1.ClusterDeployment, imageSet *hivev1.ClusterI
 		},
 		{
 			Name:  "PULL_SECRET",
-			Value: "/run/release-pull-secret/" + corev1.DockerConfigKey,
+			Value: "/run/release-pull-secret/" + corev1.DockerConfigJsonKey,
 		},
 	}
 

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -103,7 +103,7 @@ func GenerateInstallerJob(
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: cd.Spec.PullSecret,
-					Key:                  ".dockercfg",
+					Key:                  corev1.DockerConfigJsonKey,
 				},
 			},
 		},
@@ -254,6 +254,9 @@ func GenerateInstallerJob(
 		Containers:         containers,
 		Volumes:            volumes,
 		ServiceAccountName: serviceAccountName,
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			cd.Spec.PullSecret,
+		},
 	}
 
 	completions := int32(1)

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -12,6 +12,7 @@
 // config/manager/deployment.yaml
 // config/clusterimagesets/openshift-4.0-beta2.yaml
 // config/clusterimagesets/openshift-4.0-latest.yaml
+// config/clusterimagesets/openshift-4.0.0-0.8.yaml
 // DO NOT EDIT!
 
 package assets
@@ -590,6 +591,34 @@ func configClusterimagesetsOpenshift40LatestYaml() (*asset, error) {
 	return a, nil
 }
 
+var _configClusterimagesetsOpenshift40008Yaml = []byte(`apiVersion: hive.openshift.io/v1alpha1
+kind: ClusterImageSet
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openshift-v4.0.0-0.8
+spec:
+  releaseImage: "quay.io/openshift-release-dev/ocp-release:4.0.0-0.8"
+  # TODO: what hive image should we use here? it should be verified working
+  # with the release image. could switch to using appsre images we run in stage/prod.
+  hiveImage: "quay.io/twiest/hive-controller:20190327"
+`)
+
+func configClusterimagesetsOpenshift40008YamlBytes() ([]byte, error) {
+	return _configClusterimagesetsOpenshift40008Yaml, nil
+}
+
+func configClusterimagesetsOpenshift40008Yaml() (*asset, error) {
+	bytes, err := configClusterimagesetsOpenshift40008YamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "config/clusterimagesets/openshift-4.0.0-0.8.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -654,6 +683,7 @@ var _bindata = map[string]func() (*asset, error){
 	"config/manager/deployment.yaml":                            configManagerDeploymentYaml,
 	"config/clusterimagesets/openshift-4.0-beta2.yaml":          configClusterimagesetsOpenshift40Beta2Yaml,
 	"config/clusterimagesets/openshift-4.0-latest.yaml":         configClusterimagesetsOpenshift40LatestYaml,
+	"config/clusterimagesets/openshift-4.0.0-0.8.yaml":          configClusterimagesetsOpenshift40008Yaml,
 }
 
 // AssetDir returns the file names below a certain
@@ -701,6 +731,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"clusterimagesets": {nil, map[string]*bintree{
 			"openshift-4.0-beta2.yaml":  {configClusterimagesetsOpenshift40Beta2Yaml, map[string]*bintree{}},
 			"openshift-4.0-latest.yaml": {configClusterimagesetsOpenshift40LatestYaml, map[string]*bintree{}},
+			"openshift-4.0.0-0.8.yaml":  {configClusterimagesetsOpenshift40008Yaml, map[string]*bintree{}},
 		}},
 		"hiveadmission": {nil, map[string]*bintree{
 			"apiservice.yaml":                      {configHiveadmissionApiserviceYaml, map[string]*bintree{}},

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -68,8 +68,9 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helpe
 	// Deploy the desired ClusterImageSets representing installable releases of OpenShift.
 	// TODO: in future this should be pipelined somehow.
 	applyAssets := []string{
-		"config/clusterimagesets/openshift-4.0-beta2.yaml",
 		"config/clusterimagesets/openshift-4.0-latest.yaml",
+		"config/clusterimagesets/openshift-4.0-beta2.yaml",
+		"config/clusterimagesets/openshift-4.0.0-0.8.yaml", // pre-beta3
 	}
 	for _, a := range applyAssets {
 		err = util.ApplyAsset(h, a, hLog)

--- a/test/integration/clusterdeployment/clusterdeployment_controller_test.go
+++ b/test/integration/clusterdeployment/clusterdeployment_controller_test.go
@@ -112,7 +112,7 @@ func TestReconcileNewClusterDeployment(t *testing.T) {
 	err = c.Create(context.TODO(), testSecret("ssh-key", "ssh-publickey", "1234"))
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = c.Create(context.TODO(), testSecret("pull-secret", ".dockercfg", "1234"))
+	err = c.Create(context.TODO(), testSecret("pull-secret", ".dockerconfigjson", "1234"))
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	recFn, requests := SetupTestReconcile(clusterdeployment.NewReconciler(mgr))


### PR DESCRIPTION
Pull secrets are returned from try.openshift.com in a format that is invalid if used with a dockercfg secret. The correct secret type is dockercfgjson. 

This change converts our templates and all code to use the new secret type, and key within that secret.

We are not migrating pre-existing pull secrets, rather I have made sure to remove any code that uses those secrets after the cluster is installed, so outdated pull secrets should not be an issue in stage, which is the only environment where they could exist right now. Cluster deployment controller was unnecessarily loading pull secrets and reconstructing the install job even after installation, and the remote machine set controller was loading it just as an input to obtain a installer config, which it definitely does not need the pull secret set in.