### PR TITLE
WIP:installer pods restart metric

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -101,17 +101,9 @@ func Add(mgr manager.Manager) error {
 // NewReconciler returns a new reconcile.Reconciler
 func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileClusterDeployment{
-<<<<<<< HEAD
-		Client:                               mgr.GetClient(),
-		scheme:                               mgr.GetScheme(),
-		remoteClusterAPIClientBuilder: controllerutils.BuildClusterAPIClientFromKubeconfig,
-		clusterDeplymentInstallRetriesMetric: metricClusterDeploymentInstallRetriesTotal,
-=======
 		Client:                        mgr.GetClient(),
 		scheme:                        mgr.GetScheme(),
-		amiLookupFunc:                 lookupAMI,
 		remoteClusterAPIClientBuilder: controllerutils.BuildClusterAPIClientFromKubeconfig,
->>>>>>> final changes for metric
 	}
 }
 
@@ -872,7 +864,6 @@ func (r *ReconcileClusterDeployment) setupClusterInstallServiceAccount(namespace
 	return currentSA, nil
 }
 
-<<<<<<< HEAD
 func (r *ReconcileClusterDeployment) ensureManagedDNSZone(cd *hivev1.ClusterDeployment, cdLog log.FieldLogger) (bool, error) {
 	// for now we only support AWS
 	if cd.Spec.AWS == nil || cd.Spec.PlatformSecrets.AWS == nil {
@@ -934,10 +925,7 @@ func dnsZoneName(cdName string) string {
 	return fmt.Sprintf("%s-zone", cdName)
 }
 
-func (r *ReconcileClusterDeployment) selectorPodWatchHandler(a handler.MapObject) []reconcile.Request {
-=======
 func selectorPodWatchHandler(a handler.MapObject) []reconcile.Request {
->>>>>>> final changes for metric
 	retval := []reconcile.Request{}
 
 	pod := a.Object.(*corev1.Pod)
@@ -979,7 +967,7 @@ func (r *ReconcileClusterDeployment) updateInstallRetriesTotalMetric(clusterDepl
 				}
 			}
 			if podRestarts > 0 {
-				cdLog.WithField("Installer Pod Restarts:", podRestarts).Warn("installer pod restarts > 1")
+				cdLog.WithField("Installer Pod Restarts newest:", podRestarts).Warn("installer pod restarts > 1")
 			}
 			// Sets the value of the metricClusterDeploymentInstallRetries
 			metricClusterDeploymentInstallRetries.WithLabelValues(clusterDeploymentName, clusterDeploymentNamespace).Set(float64(podRestarts))

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/openshift/hive/pkg/install"
 	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -52,10 +51,6 @@ var (
 		Name: "hive_uninstall_jobs_running_total",
 		Help: "Total number of uninstall jobs running in Hive.",
 	})
-	metricInstallerPodsRestartsAverage = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "hive_installer_pods_restarts_average",
-		Help: "Average number of installer pods restarts in Hive.",
-	})
 )
 
 func init() {
@@ -63,7 +58,6 @@ func init() {
 	metrics.Registry.MustRegister(metricClusterDeploymentsInstalledTotal)
 	metrics.Registry.MustRegister(metricInstallJobsRunningTotal)
 	metrics.Registry.MustRegister(metricUninstallJobsRunningTotal)
-	metrics.Registry.MustRegister(metricInstallerPodsRestartsAverage)
 }
 
 // Add creates a new metrics Calculator and adds it to the Manager.
@@ -140,24 +134,6 @@ func (mc *Calculator) Start(stopCh <-chan struct{}) error {
 			uninstallJobsTotal := len(uninstallJobs.Items)
 			mcLog.WithField("totalRunningUninstallJobs", uninstallJobsTotal).Debug("loaded running uninstall jobs")
 			metricUninstallJobsRunningTotal.Set(float64(uninstallJobsTotal))
-		}
-		// pod metrics
-		mcLog.Debug("calculating installer pods metrics")
-		pods := &corev1.PodList{}
-		err = mc.Client.List(context.Background(), client.MatchingLabels(installJobLabelSelector), pods)
-		if err != nil {
-			log.WithError(err).Error("error listing pods")
-		} else {
-			podRestarts := 0
-			finalAverage := 0.0
-			for _, pod := range pods.Items {
-				for _, cs := range pod.Status.ContainerStatuses {
-					podRestarts = podRestarts + int(cs.RestartCount)
-				}
-			}
-			finalAverage = float64(podRestarts) / float64(len(pods.Items))
-			mcLog.WithField("averageNumberOfPodInstallerRestarts", finalAverage).Debug("installer pod restarts")
-			metricUninstallJobsRunningTotal.Set(float64(finalAverage))
 		}
 	}, mc.Interval, stopCh)
 

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -257,7 +257,7 @@ func GenerateInstallerJob(
 	}
 
 	labels := map[string]string{InstallJobLabel: "true"}
-	// installerPodLabels are the labels that are used by metricClusterDeploymentInstallRetriesTotal
+	// installerPodLabels are the labels that are used by metricClusterDeploymentInstallRetries
 	installerPodLabels := map[string]string{ClusterDeploymentNameLabel: cd.Name, InstallJobLabel: "true"}
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -266,6 +266,9 @@ func GenerateInstallerJob(
 			ActiveDeadlineSeconds: &deadline,
 			BackoffLimit:          &backoffLimit,
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
 				Spec: podSpec,
 			},
 		},

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -47,6 +47,12 @@ const (
 
 	// UninstallJobLabel is the label used for counting the number of uninstall jobs in Hive
 	UninstallJobLabel = "hive.openshift.io/uninstall"
+
+	// ClusterDeploymentNameLabel is the label (along with ClusterDeploymentNamespaceLabel) that is used to identify the installer pod of a particular cluster deployment
+	ClusterDeploymentNameLabel = "hive.openshift.io/cluster-deployment-name"
+
+	// ClusterDeploymentNamespaceLabel is the label (along with ClusterDeploymentNameLabel) that is used to identify the installer pod of a particular cluster deployment
+	ClusterDeploymentNamespaceLabel = "hive.openshift.io/cluster-deployment-namespace"
 )
 
 // GenerateInstallerJob creates a job to install an OpenShift cluster
@@ -254,6 +260,7 @@ func GenerateInstallerJob(
 	}
 
 	labels := map[string]string{InstallJobLabel: "true"}
+	installerPodLabels := map[string]string{ClusterDeploymentNameLabel: cd.Name, ClusterDeploymentNamespaceLabel: cd.Namespace, InstallJobLabel: "true"}
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        GetInstallJobName(cd),
@@ -267,7 +274,7 @@ func GenerateInstallerJob(
 			BackoffLimit:          &backoffLimit,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels: installerPodLabels,
 				},
 				Spec: podSpec,
 			},

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -50,9 +50,6 @@ const (
 
 	// ClusterDeploymentNameLabel is the label (along with ClusterDeploymentNamespaceLabel) that is used to identify the installer pod of a particular cluster deployment
 	ClusterDeploymentNameLabel = "hive.openshift.io/cluster-deployment-name"
-
-	// ClusterDeploymentNamespaceLabel is the label (along with ClusterDeploymentNameLabel) that is used to identify the installer pod of a particular cluster deployment
-	ClusterDeploymentNamespaceLabel = "hive.openshift.io/cluster-deployment-namespace"
 )
 
 // GenerateInstallerJob creates a job to install an OpenShift cluster
@@ -260,7 +257,8 @@ func GenerateInstallerJob(
 	}
 
 	labels := map[string]string{InstallJobLabel: "true"}
-	installerPodLabels := map[string]string{ClusterDeploymentNameLabel: cd.Name, ClusterDeploymentNamespaceLabel: cd.Namespace, InstallJobLabel: "true"}
+	// installerPodLabels are the labels that are used by metricClusterDeploymentInstallRetriesTotal
+	installerPodLabels := map[string]string{ClusterDeploymentNameLabel: cd.Name, InstallJobLabel: "true"}
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        GetInstallJobName(cd),


### PR DESCRIPTION
--> Basic implementation for computing metrics for installer pod restarts.
NOTE:
--> Initially the metric prints a NaN value as we are dividing by 0 (number of installer pods)
--> Metric name does not follow the naming guideline as 'metricInstallerPodsRestartsAverage'
seems better than 'metricInstallerPodsRestartsAverageTotal'