### PR TITLE
Generate install-config in hiveutil install wrapper.

### DIFF
--- a/pkg/controller/dnszone/zonereconciler.go
+++ b/pkg/controller/dnszone/zonereconciler.go
@@ -390,7 +390,7 @@ func (zr *ZoneReconciler) findZoneByCallerReference(domain, callerRef string) (*
 	logger := zr.logger.WithField("domain", domain).WithField("callerRef", callerRef)
 	logger.Debug("Searching for zone by domain and callerRef")
 	var nextZoneID *string
-	var nextName *string = aws.String(domain)
+	var nextName = aws.String(domain)
 	for {
 		logger.Debug("listing hosted zones by name")
 		resp, err := zr.awsClient.ListHostedZonesByName(&route53.ListHostedZonesByNameInput{

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -17,8 +17,13 @@ limitations under the License.
 package utils
 
 import (
+	"context"
+	"fmt"
+
+	kapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
@@ -130,4 +135,18 @@ func GetKubeClient(scheme *runtime.Scheme) (client.Client, error) {
 	}
 
 	return dynamicClient, nil
+}
+
+// LoadSecretData loads a given secret key and returns it's data as a string.
+func LoadSecretData(c client.Client, secretName, namespace, dataKey string) (string, error) {
+	s := &kapi.Secret{}
+	err := c.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: namespace}, s)
+	if err != nil {
+		return "", err
+	}
+	retStr, ok := s.Data[dataKey]
+	if !ok {
+		return "", fmt.Errorf("secret %s did not contain key %s", secretName, dataKey)
+	}
+	return string(retStr), nil
 }

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -76,6 +76,8 @@ func GenerateInstallerJob(
 		tryOnce = exists && value == "true"
 	}
 
+	// TODO: drop all generation of install config here ASAP. We generate this on the fly now
+	// in the install manager. This is only being kept for beta2 and beta3 ClusterImageSet compatability.
 	d, err := yaml.Marshal(ic)
 	if err != nil {
 		return nil, nil, err
@@ -96,15 +98,7 @@ func GenerateInstallerJob(
 
 	env := []corev1.EnvVar{
 		{
-			Name:  "OPENSHIFT_INSTALL_BASE_DOMAIN",
-			Value: cd.Spec.BaseDomain,
-		},
-		{
-			Name:  "OPENSHIFT_INSTALL_CLUSTER_NAME",
-			Value: cd.Name,
-		},
-		{
-			Name: "OPENSHIFT_INSTALL_PULL_SECRET",
+			Name: "PULL_SECRET",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: cd.Spec.PullSecret,
@@ -112,18 +106,6 @@ func GenerateInstallerJob(
 				},
 			},
 		},
-	}
-	if cd.Spec.AWS != nil {
-		env = append(env, []corev1.EnvVar{
-			{
-				Name:  "OPENSHIFT_INSTALL_AWS_REGION",
-				Value: cd.Spec.AWS.Region,
-			},
-			{
-				Name:  "OPENSHIFT_INSTALL_PLATFORM",
-				Value: "aws",
-			},
-		}...)
 	}
 	if cd.Spec.PlatformSecrets.AWS != nil && len(cd.Spec.PlatformSecrets.AWS.Credentials.Name) > 0 {
 		env = append(env, []corev1.EnvVar{
@@ -158,7 +140,7 @@ func GenerateInstallerJob(
 
 	if cd.Spec.SSHKey != nil {
 		env = append(env, corev1.EnvVar{
-			Name: "OPENSHIFT_INSTALL_SSH_PUB_KEY",
+			Name: "SSH_PUB_KEY",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: *cd.Spec.SSHKey,


### PR DESCRIPTION
To help alleviate problems where one version of hive can only generate
one version of the install config, but we need to install many possible
releases which may not support that install config version.

This change now assumes that the hiveutil install wrapper looks up the
cluster deployment, and then generates the install config on the fly. By
pinning one version of hiveutil to one version of the installer (via a
ClusterImageSet), we should remain more compatible over time.

The previous method of generating an install config in the controller
and mounting via config map is still left behind for backward
compatability. Once we can drop beta2 and beta3 ClusterImageSets this
can be removed.