### PR TITLE
Add frontend role RBAC for HiveConfig to view top level DNS zones.

### DIFF
--- a/config/rbac/hive_frontend_role.yaml
+++ b/config/rbac/hive_frontend_role.yaml
@@ -59,6 +59,7 @@ rules:
   - hive.openshift.io
   resources:
   - clusterimagesets
+  - hiveconfigs
   verbs:
   - get
   - list


### PR DESCRIPTION
cc @jhernand 

The HiveConfig is always named "hive".