### PR TITLE
add support for ingress objects referencing certificates

### DIFF
--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -130,6 +130,8 @@ rules:
   - clusterdeployments
   verbs:
   - get
+  - watch
+  - update
 - apiGroups:
   - hive.openshift.io
   resources:

--- a/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
@@ -229,6 +229,10 @@ const (
 	// is not available, preventing the target cluster's control plane from being configured with
 	// certificates.
 	ControlPlaneCertificateNotFoundCondition ClusterDeploymentConditionType = "ControlPlaneCertificateNotFound"
+
+	// IngressCertificateNotFoundCondition is a condition indicating that one of the CertificateBundle
+	// secrets required by an Ingress is not available.
+	IngressCertificateNotFoundCondition ClusterDeploymentConditionType = "IngressCertificateNotFound"
 )
 
 // +genclient

--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -28,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -39,15 +41,32 @@ import (
 
 	ingresscontroller "github.com/openshift/api/operator/v1"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	"github.com/openshift/hive/pkg/controller/utils"
+	"github.com/openshift/hive/pkg/resource"
 )
 
 const (
 	controllerName = "remoteingress"
 
-	remoteClusterIngressNamespace = "openshift-ingress-operator"
+	// namespace where the ingressController objects must be created
+	remoteIngressControllerNamespace = "openshift-ingress-operator"
 
-	remoteIngressKind = "IngressController"
+	// while the IngressController objects live in openshift-ingress-operator
+	// the secrets that the ingressControllers refer to must live in openshift-ingress
+	remoteIngressConrollerSecretsNamespace = "openshift-ingress"
+
+	ingressCertificateNotFoundReason = "IngressCertificateNotFound"
+	ingressCertificateFoundReason    = "IngressCertificateFound"
+
+	// requeueAfter2 is just a static 2 minute delay for when to requeue
+	// for the case when a necessary secret is missing
+	requeueAfter2 = time.Minute * 2
 )
+
+// kubeCLIApplier knows how to ApplyRuntimeObject.
+type kubeCLIApplier interface {
+	ApplyRuntimeObject(obj runtime.Object, scheme *runtime.Scheme) error
+}
 
 // Add creates a new RemoteMachineSet Controller and adds it to the Manager with default RBAC. The Manager will set fields on the
 // Controller and Start it when the Manager is Started.
@@ -57,10 +76,16 @@ func Add(mgr manager.Manager) error {
 
 // NewReconciler returns a new reconcile.Reconciler
 func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
+	logger := log.WithField("controller", controllerName)
+	helper, err := resource.NewHelperFromRESTConfig(mgr.GetConfig(), logger)
+	if err != nil {
+		logger.WithError(err).Fatalf("cannot create resource helper for reconciler")
+	}
 	return &ReconcileRemoteClusterIngress{
-		Client: mgr.GetClient(),
-		scheme: mgr.GetScheme(),
-		logger: log.WithField("controller", controllerName),
+		Client:  mgr.GetClient(),
+		scheme:  mgr.GetScheme(),
+		logger:  log.WithField("controller", controllerName),
+		kubeCLI: helper,
 	}
 }
 
@@ -81,12 +106,19 @@ func AddToManager(mgr manager.Manager, r reconcile.Reconciler) error {
 	return nil
 }
 
+type reconcileContext struct {
+	clusterDeployment *hivev1.ClusterDeployment
+	certBundleSecrets []*corev1.Secret
+	logger            log.FieldLogger
+}
+
 var _ reconcile.Reconciler = &ReconcileRemoteClusterIngress{}
 
 // ReconcileRemoteClusterIngress reconciles the ingress objects defined in a ClusterDeployment object
 type ReconcileRemoteClusterIngress struct {
 	client.Client
-	scheme *runtime.Scheme
+	scheme  *runtime.Scheme
+	kubeCLI kubeCLIApplier
 
 	logger log.FieldLogger
 }
@@ -94,9 +126,11 @@ type ReconcileRemoteClusterIngress struct {
 // Reconcile reads that state of the cluster for a ClusterDeployment object and sets up
 // any needed ClusterIngress objects up for syncing to the remote cluster.
 //
-// +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=get
+// +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=get;watch;update
 // +kubebuilder:rbac:groups=hive.openshift.io,resources=syncsets,verbs=get;create;update;delete;patch;list;watch
 func (r *ReconcileRemoteClusterIngress) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	rContext := &reconcileContext{}
+
 	// Fetch the ClusterDeployment instance
 	cd := &hivev1.ClusterDeployment{}
 	err := r.Get(context.TODO(), request.NamespacedName, cd)
@@ -109,21 +143,47 @@ func (r *ReconcileRemoteClusterIngress) Reconcile(request reconcile.Request) (re
 		log.WithError(err).Error("error looking up cluster deployment")
 		return reconcile.Result{}, err
 	}
+	rContext.clusterDeployment = cd
 
 	cdLog := r.logger.WithFields(log.Fields{
 		"clusterDeployment": cd.Name,
 		"namespace":         cd.Namespace,
 	})
+	rContext.logger = cdLog
 
 	if cd.Spec.Ingress == nil {
 		// the addmission controller will ensure that we get valid-looking
 		// Spec.Ingress (ie no missing 'default', no going from a defined
 		// ingress list to an empty list, etc)
-		cdLog.Debug("no ingress objects defined. using default intaller behavior.")
+		rContext.logger.Debug("no ingress objects defined. using default intaller behavior.")
 		return reconcile.Result{}, nil
 	}
 
-	if err := r.syncClusterIngress(cd); err != nil {
+	// can't proceed if the secret(s) referred to doesn't exist
+	certBundleSecrets, err := r.getIngressSecrets(rContext)
+	if err != nil {
+		rContext.logger.WithError(err).Error("will need to retry until able to find all certBundle secrets")
+		conditionErr := r.setIngressCertificateNotFoundCondition(rContext, true, err.Error())
+		if conditionErr != nil {
+			rContext.logger.WithError(conditionErr).Error("unable to set IngressCertNotFound condition")
+			return reconcile.Result{}, conditionErr
+		}
+
+		// no error return b/c we just need to wait for the certificate/secret to appear
+		// which is out of our control.
+		return reconcile.Result{
+			Requeue:      true,
+			RequeueAfter: requeueAfter2,
+		}, nil
+	}
+	if err := r.setIngressCertificateNotFoundCondition(rContext, false, ""); err != nil {
+		rContext.logger.WithError(err).Error("error setting clusterDeployment condition")
+		return reconcile.Result{}, err
+	}
+
+	rContext.certBundleSecrets = certBundleSecrets
+
+	if err := r.syncClusterIngress(rContext); err != nil {
 		cdLog.Errorf("error syncing clusterIngress syncset: %v", err)
 		return reconcile.Result{}, err
 	}
@@ -131,22 +191,31 @@ func (r *ReconcileRemoteClusterIngress) Reconcile(request reconcile.Request) (re
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileRemoteClusterIngress) syncClusterIngress(cd *hivev1.ClusterDeployment) error {
-	cdLog := r.logger.WithFields(log.Fields{
-		"clusterDeployment": cd.Name,
-		"namespace":         cd.Namespace,
-	})
-	cdLog.Info("reconciling ClusterIngress for cluster deployment")
+// syncClusterIngress will create the syncSet with all the needed secrets and
+// ingressController objects to sync to the remote cluster
+func (r *ReconcileRemoteClusterIngress) syncClusterIngress(rContext *reconcileContext) error {
+	rContext.logger.Info("reconciling ClusterIngress for cluster deployment")
 
-	rawList := rawExtensionsFromClusterDeployment(cd)
+	rawList := rawExtensionsFromClusterDeployment(rContext)
 
-	return r.syncSyncSet(cd, rawList)
+	return r.syncSyncSet(rContext, rawList)
 }
 
-func rawExtensionsFromClusterDeployment(cd *hivev1.ClusterDeployment) []runtime.RawExtension {
+// rawExtensionsFromClusterDeployment will return the slice of runtime.RawExtension objects
+// (really the syncSet.Spec.Resources) to satisfy the ingress config for the clusterDeployment
+func rawExtensionsFromClusterDeployment(rContext *reconcileContext) []runtime.RawExtension {
 	rawList := []runtime.RawExtension{}
-	for _, ingress := range cd.Spec.Ingress {
-		ingressObj := createIngressController(cd, ingress)
+
+	// first the certBundle secrets
+	for _, cbSecret := range rContext.certBundleSecrets {
+		secret := createSecret(rContext, cbSecret)
+		raw := runtime.RawExtension{Object: secret}
+		rawList = append(rawList, raw)
+	}
+
+	// then the ingressControllers
+	for _, ingress := range rContext.clusterDeployment.Spec.Ingress {
+		ingressObj := createIngressController(rContext.clusterDeployment, ingress)
 		raw := runtime.RawExtension{Object: ingressObj}
 		rawList = append(rawList, raw)
 	}
@@ -169,62 +238,65 @@ func newSyncSetSpec(cd *hivev1.ClusterDeployment, rawExtensions []runtime.RawExt
 	return ssSpec
 }
 
-func (r *ReconcileRemoteClusterIngress) syncSyncSet(cd *hivev1.ClusterDeployment, rawExtensions []runtime.RawExtension) error {
+// syncSyncSet builds up a syncSet object with the passed-in rawExtensions as the spec.Resources
+func (r *ReconcileRemoteClusterIngress) syncSyncSet(rContext *reconcileContext, rawExtensions []runtime.RawExtension) error {
+	ssName := fmt.Sprintf("%v-clusteringress", rContext.clusterDeployment.Name)
 
-	ssName := fmt.Sprintf("%v-clusteringress", cd.Name)
-	newSyncSetSpec := newSyncSetSpec(cd, rawExtensions)
+	newSyncSetSpec := newSyncSetSpec(rContext.clusterDeployment, rawExtensions)
+	syncSet := &hivev1.SyncSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ssName,
+			Namespace: rContext.clusterDeployment.Namespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SyncSet",
+			APIVersion: hivev1.SchemeGroupVersion.String(),
+		},
+		Spec: *newSyncSetSpec,
+	}
 
-	ss := &hivev1.SyncSet{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: ssName, Namespace: cd.Namespace}, ss)
-	if errors.IsNotFound(err) {
-		// create the syncset
-		ss = &hivev1.SyncSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      ssName,
-				Namespace: cd.Namespace,
-			},
-			Spec: *newSyncSetSpec,
-		}
-
-		// ensure the syncset gets cleaned up when the clusterdeployment is deleted
-		if err := controllerutil.SetControllerReference(cd, ss, r.scheme); err != nil {
-			r.logger.WithError(err).Error("error setting owner reference")
-			return err
-		}
-
-		if err := r.Create(context.TODO(), ss); err != nil {
-			r.logger.Errorf("error creating sync set: %v", err)
-			return err
-		}
-
-		return nil
-	} else if err != nil {
-		r.logger.Errorf("error checking for existing syncset: %v", err)
+	// ensure the syncset gets cleaned up when the clusterdeployment is deleted
+	if err := controllerutil.SetControllerReference(rContext.clusterDeployment, syncSet, r.scheme); err != nil {
+		r.logger.WithError(err).Error("error setting owner reference")
 		return err
 	}
 
-	// update the syncset if there have been changes
-	if !reflect.DeepEqual(ss.Spec, *newSyncSetSpec) {
-		ss.Spec = *newSyncSetSpec
-		if err := r.Update(context.TODO(), ss); err != nil {
-			errDetails := fmt.Errorf("error updating existing syncset: %v", err)
-			r.logger.Error(errDetails)
-			return errDetails
-		}
+	if err := r.kubeCLI.ApplyRuntimeObject(syncSet, r.scheme); err != nil {
+		rContext.logger.WithError(err).Error("failed to apply syncset")
+		return err
 	}
 
 	return nil
 }
 
+// createSecret returns the secret that needs to be synced to the remote cluster
+// to satisfy any ingressController object that depends on the secret.
+func createSecret(rContext *reconcileContext, cbSecret *corev1.Secret) *corev1.Secret {
+	newSecret := cbSecret.DeepCopy()
+
+	// don't want all the local object meta (eg creation/uuid/etc), so replace it
+	// with a clean one with just the data we want.
+	newSecret.ObjectMeta = metav1.ObjectMeta{
+		Name:        remoteSecretNameForCertificateBundleSecret(cbSecret.Name, rContext.clusterDeployment),
+		Namespace:   remoteIngressConrollerSecretsNamespace,
+		Labels:      cbSecret.Labels,
+		Annotations: cbSecret.Annotations,
+	}
+
+	return newSecret
+}
+
+// createIngressController will return an ingressController based on a clusterDeployment's
+// spec.Ingress object
 func createIngressController(cd *hivev1.ClusterDeployment, ingress hivev1.ClusterIngress) *ingresscontroller.IngressController {
 	newIngress := ingresscontroller.IngressController{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       remoteIngressKind,
+			Kind:       "IngressController",
 			APIVersion: ingresscontroller.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ingress.Name,
-			Namespace: remoteClusterIngressNamespace,
+			Namespace: remoteIngressControllerNamespace,
 		},
 		Spec: ingresscontroller.IngressControllerSpec{
 			Domain:            ingress.Domain,
@@ -233,5 +305,104 @@ func createIngressController(cd *hivev1.ClusterDeployment, ingress hivev1.Cluste
 		},
 	}
 
+	// if the ingress entry references a certBundle, make sure to put the appropriate looking
+	// entry in the ingressController object
+	if ingress.ServingCertificate != "" {
+		for _, cb := range cd.Spec.CertificateBundles {
+			// assume we're going to find the certBundle as we would've errored earlier
+			if cb.Name == ingress.ServingCertificate {
+				newIngress.Spec.DefaultCertificate = &corev1.LocalObjectReference{
+					Name: remoteSecretNameForCertificateBundleSecret(cb.SecretRef.Name, cd),
+				}
+				break
+			}
+		}
+	}
+
 	return &newIngress
+}
+
+func (r *ReconcileRemoteClusterIngress) getIngressSecrets(rContext *reconcileContext) ([]*corev1.Secret, error) {
+	certSet := sets.NewString()
+
+	for _, ingress := range rContext.clusterDeployment.Spec.Ingress {
+		if ingress.ServingCertificate != "" {
+			certSet.Insert(ingress.ServingCertificate)
+		}
+	}
+
+	cbSecrets := []*corev1.Secret{}
+
+	for _, cert := range certSet.List() {
+		foundCertBundle := false
+		for _, cb := range rContext.clusterDeployment.Spec.CertificateBundles {
+			if cb.Name == cert {
+				foundCertBundle = true
+				cbSecret := &corev1.Secret{}
+				searchKey := types.NamespacedName{
+					Name:      cb.SecretRef.Name,
+					Namespace: rContext.clusterDeployment.Namespace,
+				}
+
+				if err := r.Get(context.TODO(), searchKey, cbSecret); err != nil {
+					if errors.IsNotFound(err) {
+						msg := fmt.Sprintf("secret %v for certbundle %v was not found", cb.SecretRef.Name, cb.Name)
+						rContext.logger.Error(msg)
+						return cbSecrets, fmt.Errorf(msg)
+					}
+					rContext.logger.WithError(err).Error("error while gathering certBundle secret")
+					return cbSecrets, err
+				}
+
+				cbSecrets = append(cbSecrets, cbSecret)
+			}
+		}
+		if !foundCertBundle {
+			return cbSecrets, fmt.Errorf("didn't find expected certbundle %v", cert)
+		}
+	}
+
+	return cbSecrets, nil
+}
+
+// setIngressCertificateNotFoundCondition will set/unset the condition indicating whether all certificates required
+// by the clusterDeployment ingress objects were found. Returns any error encountered while setting the condition.
+func (r *ReconcileRemoteClusterIngress) setIngressCertificateNotFoundCondition(rContext *reconcileContext, notFound bool, missingSecretMessage string) error {
+	var (
+		msg, reason string
+		status      corev1.ConditionStatus
+		updateCheck utils.UpdateConditionCheck
+	)
+
+	origCD := rContext.clusterDeployment.DeepCopy()
+
+	if notFound {
+		msg = missingSecretMessage
+		status = corev1.ConditionTrue
+		reason = ingressCertificateNotFoundReason
+		updateCheck = utils.UpdateConditionIfReasonOrMessageChange
+	} else {
+		msg = fmt.Sprintf("all secrets for ingress found")
+		status = corev1.ConditionFalse
+		reason = ingressCertificateFoundReason
+		updateCheck = utils.UpdateConditionNever
+	}
+
+	rContext.clusterDeployment.Status.Conditions = utils.SetClusterDeploymentCondition(rContext.clusterDeployment.Status.Conditions,
+		hivev1.IngressCertificateNotFoundCondition, status, reason, msg, updateCheck)
+
+	if !reflect.DeepEqual(rContext.clusterDeployment.Status.Conditions, origCD.Status.Conditions) {
+		if err := r.Status().Update(context.TODO(), rContext.clusterDeployment); err != nil {
+			rContext.logger.WithError(err).Error("error updating clusterDeployment condition")
+			return err
+		}
+	}
+
+	return nil
+}
+
+// remoteSecretNameForCertificateBundleSecret just stitches together a secret name consisting of
+// the original certificateBundle's secret name pre-pended with the clusterDeployment.Name
+func remoteSecretNameForCertificateBundleSecret(secretName string, cd *hivev1.ClusterDeployment) string {
+	return fmt.Sprintf("%s-%s", cd.Name, secretName)
 }

--- a/pkg/controller/remoteingress/remoteingress_controller_test.go
+++ b/pkg/controller/remoteingress/remoteingress_controller_test.go
@@ -18,7 +18,6 @@ package remoteingress
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -29,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -39,42 +37,45 @@ import (
 	ingresscontroller "github.com/openshift/api/operator/v1"
 	"github.com/openshift/hive/pkg/apis"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	"github.com/openshift/hive/pkg/controller/utils"
 )
 
 const (
-	testClusterName  = "foo"
-	testNamespace    = "default"
-	testClusterID    = "foo-12345-uuid"
-	testInfraID      = "foo-12345"
-	sshKeySecret     = "foo-ssh-key"
-	pullSecretSecret = "foo-pull-secret"
+	testClusterName = "foo"
+	testNamespace   = "default"
 
-	testSyncSetName        = "foo-clusteringress"
-	testDefaultIngressName = "default"
-	testIngressDomain      = "testapps.example.com"
+	testSyncSetName                      = "foo-clusteringress"
+	testDefaultIngressName               = "default"
+	testIngressDomain                    = "testapps.example.com"
+	testDefaultIngressServingCertificate = "test-bundle"
+	testDefaultCertBundle                = "test-bundle"
+	testDefaultCertBundleSecret          = "test-bundle-secret"
 )
 
 func init() {
 	log.SetLevel(log.DebugLevel)
 }
 
-type SyncSetEntry struct {
-	name              string
-	domain            string
-	routeSelector     *metav1.LabelSelector
-	namespaceSelector *metav1.LabelSelector
+type SyncSetIngressEntry struct {
+	name               string
+	domain             string
+	routeSelector      *metav1.LabelSelector
+	namespaceSelector  *metav1.LabelSelector
+	defaultCertificate string
 }
 
 func TestRemoteClusterIngressReconcile(t *testing.T) {
 	apis.AddToScheme(scheme.Scheme)
+	ingresscontroller.AddToScheme(scheme.Scheme)
 
 	tests := []struct {
-		name                   string
-		localObjects           []runtime.Object
-		expectedSyncSetEntries []SyncSetEntry
+		name                          string
+		localObjects                  []runtime.Object
+		expectedSyncSetIngressEntries []SyncSetIngressEntry
+		expectedSecretEntries         []string
 	}{
 		{
-			name: "Test no ingress defined (no expected syncset)",
+			name: "Test no ingress defined",
 			localObjects: []runtime.Object{
 				testClusterDeploymentWithoutIngress(),
 			},
@@ -84,22 +85,20 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 			localObjects: []runtime.Object{
 				testClusterDeployment(),
 			},
-			expectedSyncSetEntries: []SyncSetEntry{
+			expectedSyncSetIngressEntries: []SyncSetIngressEntry{
 				{
 					name:   testDefaultIngressName,
 					domain: testIngressDomain,
 				},
 			},
 		},
+
 		{
 			name: "Test multiple ingress",
 			localObjects: []runtime.Object{
-				addIngressToClusterDeployment(testClusterDeployment(), SyncSetEntry{
-					name:   "secondingress",
-					domain: "moreingress.example.com",
-				}),
+				addIngressToClusterDeployment(testClusterDeployment(), "secondingress", "moreingress.example.com", nil, nil, ""),
 			},
-			expectedSyncSetEntries: []SyncSetEntry{
+			expectedSyncSetIngressEntries: []SyncSetIngressEntry{
 				{
 					name:   testDefaultIngressName,
 					domain: testIngressDomain,
@@ -113,13 +112,10 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 		{
 			name: "Test updating existing syncset",
 			localObjects: []runtime.Object{
-				addIngressToClusterDeployment(testClusterDeployment(), SyncSetEntry{
-					name:   "secondingress",
-					domain: "moreingress.example.com",
-				}),
+				addIngressToClusterDeployment(testClusterDeployment(), "secondingress", "moreingress.example.com", nil, nil, ""),
 				syncSetFromClusterDeployment(testClusterDeployment()),
 			},
-			expectedSyncSetEntries: []SyncSetEntry{
+			expectedSyncSetIngressEntries: []SyncSetIngressEntry{
 				{
 					name:   testDefaultIngressName,
 					domain: testIngressDomain,
@@ -151,7 +147,7 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 
 				return objects
 			}(),
-			expectedSyncSetEntries: []SyncSetEntry{
+			expectedSyncSetIngressEntries: []SyncSetIngressEntry{
 				{
 					name:   testDefaultIngressName,
 					domain: testIngressDomain,
@@ -161,13 +157,9 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 		{
 			name: "Test setting routeSelector",
 			localObjects: []runtime.Object{
-				addIngressToClusterDeployment(testClusterDeployment(), SyncSetEntry{
-					name:          "secondingress",
-					domain:        "moreingress.example.com",
-					routeSelector: testRouteSelector(),
-				}),
+				addIngressToClusterDeployment(testClusterDeployment(), "secondingress", "moreingress.example.com", testRouteSelector(), nil, ""),
 			},
-			expectedSyncSetEntries: []SyncSetEntry{
+			expectedSyncSetIngressEntries: []SyncSetIngressEntry{
 				{
 					name:   testDefaultIngressName,
 					domain: testIngressDomain,
@@ -182,13 +174,9 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 		{
 			name: "Test setting namespaceSelector",
 			localObjects: []runtime.Object{
-				addIngressToClusterDeployment(testClusterDeployment(), SyncSetEntry{
-					name:              "secondingress",
-					domain:            "moreingress.example.com",
-					namespaceSelector: testNamespaceSelector(),
-				}),
+				addIngressToClusterDeployment(testClusterDeployment(), "secondingress", "moreingress.example.com", nil, testNamespaceSelector(), ""),
 			},
-			expectedSyncSetEntries: []SyncSetEntry{
+			expectedSyncSetIngressEntries: []SyncSetIngressEntry{
 				{
 					name:   testDefaultIngressName,
 					domain: testIngressDomain,
@@ -200,16 +188,154 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Test bringing your own custom certificate",
+			localObjects: func() []runtime.Object {
+				objects := []runtime.Object{}
+				cd := testClusterDeploymentWithManualCertificate()
+				objects = append(objects, cd)
+
+				// put the expected secrets to satisfy the list of certificateBundles
+				secrets := testSecretsForClusterDeployment(cd)
+				for i := range secrets {
+					objects = append(objects, &secrets[i])
+				}
+
+				return objects
+			}(),
+			expectedSyncSetIngressEntries: []SyncSetIngressEntry{
+				{
+					name:               testDefaultIngressName,
+					domain:             testIngressDomain,
+					defaultCertificate: fmt.Sprintf("%s-%s", testClusterName, testDefaultCertBundleSecret),
+				},
+			},
+			expectedSecretEntries: []string{
+				fmt.Sprintf("%s-%s", testClusterName, testDefaultCertBundleSecret),
+			},
+		},
+		{
+			name: "Test adding an ingress with custom certificate",
+			localObjects: func() []runtime.Object {
+				objects := []runtime.Object{}
+				// syncset object with single ingress
+				cd := testClusterDeploymentWithManualCertificate()
+				ss := syncSetFromClusterDeployment(cd)
+				objects = append(objects, ss)
+
+				// now add the extra ingress entry (use same certBundle)
+				addIngressToClusterDeployment(cd, "secondingress", "moreingress.example.com", nil, nil, testDefaultIngressServingCertificate)
+				cd.Spec.CertificateBundles = addCertificateBundlesForIngressList(cd)
+				objects = append(objects, cd)
+
+				// secrets for the clusterDeployment
+				secrets := testSecretsForClusterDeployment(cd)
+				for i := range secrets {
+					objects = append(objects, &secrets[i])
+				}
+				return objects
+			}(),
+			expectedSyncSetIngressEntries: []SyncSetIngressEntry{
+				{
+					name:               testDefaultIngressName,
+					domain:             testIngressDomain,
+					defaultCertificate: fmt.Sprintf("%s-%s", testClusterName, testDefaultCertBundleSecret),
+				},
+				{
+					name:               "secondingress",
+					domain:             "moreingress.example.com",
+					defaultCertificate: fmt.Sprintf("%s-%s", testClusterName, testDefaultCertBundleSecret),
+				},
+			},
+			expectedSecretEntries: []string{
+				// still just one secret since they are the same certBundle
+				testClusterName + "-" + testDefaultCertBundleSecret,
+			},
+		},
+		{
+			name: "Test removing an ingress with custom certificate",
+			localObjects: func() []runtime.Object {
+				objects := []runtime.Object{}
+				// syncset object with extra ingress (pointing to same certBundle)
+				cdExtraIngress := testClusterDeploymentWithManualCertificate()
+				addIngressToClusterDeployment(cdExtraIngress, "secondingress", "moreingress.example.com", nil, nil, testDefaultIngressServingCertificate)
+				cdExtraIngress.Spec.CertificateBundles = addCertificateBundlesForIngressList(cdExtraIngress)
+				ss := syncSetFromClusterDeployment(cdExtraIngress)
+				objects = append(objects, ss)
+
+				// clusterDeployment with only one ingress
+				cd := testClusterDeploymentWithManualCertificate()
+				objects = append(objects, cd)
+
+				// secrets for the clusterDeployment
+				secrets := testSecretsForClusterDeployment(cd)
+				for i := range secrets {
+					objects = append(objects, &secrets[i])
+				}
+
+				return objects
+			}(),
+			expectedSyncSetIngressEntries: []SyncSetIngressEntry{
+				{
+					name:               testDefaultIngressName,
+					domain:             testIngressDomain,
+					defaultCertificate: fmt.Sprintf("%s-%s", testClusterName, testDefaultCertBundleSecret),
+				},
+			},
+			expectedSecretEntries: []string{
+				fmt.Sprintf("%s-%s", testClusterName, testDefaultCertBundleSecret),
+			},
+		},
+		{
+			name: "Test two certbundles",
+			localObjects: func() []runtime.Object {
+				objects := []runtime.Object{}
+				// cluster with two ingress to two different certbundles
+				cd := testClusterDeploymentWithManualCertificate()
+				addIngressToClusterDeployment(cd, "secondingress", "moreingress.example.com", nil, nil, "secondCertBundle")
+				cd.Spec.CertificateBundles = addCertificateBundlesForIngressList(cd)
+				objects = append(objects, cd)
+
+				// add the secrets for the certbundles
+				secrets := testSecretsForClusterDeployment(cd)
+				for i := range secrets {
+					objects = append(objects, &secrets[i])
+				}
+
+				return objects
+			}(),
+			expectedSyncSetIngressEntries: []SyncSetIngressEntry{
+				{
+					name:               testDefaultIngressName,
+					domain:             testIngressDomain,
+					defaultCertificate: fmt.Sprintf("%s-%s", testClusterName, testDefaultCertBundleSecret),
+				},
+				{
+					name:               "secondingress",
+					domain:             "moreingress.example.com",
+					defaultCertificate: fmt.Sprintf("%s-secondCertBundle-secret", testClusterName),
+				},
+			},
+			expectedSecretEntries: []string{
+				fmt.Sprintf("%s-%s", testClusterName, testDefaultCertBundleSecret),
+				fmt.Sprintf("%s-secondCertBundle-secret", testClusterName),
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := fake.NewFakeClient(test.localObjects...)
 
+			helper := &fakeKubeCLI{
+				t: t,
+			}
+
 			rcd := &ReconcileRemoteClusterIngress{
-				Client: fakeClient,
-				scheme: scheme.Scheme,
-				logger: log.WithField("controller", controllerName),
+				Client:  fakeClient,
+				scheme:  scheme.Scheme,
+				logger:  log.WithField("controller", controllerName),
+				kubeCLI: helper,
 			}
 			_, err := rcd.Reconcile(reconcile.Request{
 				NamespacedName: types.NamespacedName{
@@ -219,55 +345,120 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 			})
 
 			if err != nil {
-				t.Errorf("unexpexted error: %v", err)
+				t.Errorf("unexpected error: %v", err)
 			}
 
-			ss := &hivev1.SyncSet{}
-			ssNamespacedName := types.NamespacedName{Name: testSyncSetName, Namespace: testNamespace}
-			if len(test.expectedSyncSetEntries) == 0 {
-				// should get an IsNotFound
-				assert.Error(t, fakeClient.Get(context.TODO(), ssNamespacedName, ss))
-			} else {
-				// validate the syncset data looks correct
-				if err := fakeClient.Get(context.TODO(), ssNamespacedName, ss); err != nil {
-					t.Errorf("failed fetching SyncSet to check whether it was properly created/updated: %v", err)
-				}
-
-				// validate that we're setting type meta info
-				ic := ingresscontroller.IngressController{}
-				assert.NoError(t, json.Unmarshal(ss.Spec.Resources[0].Raw, &ic), "json marshaling to IngressController should not fail")
-				assert.Equal(t, "IngressController", ic.Kind, "unexpected Object Kind")
-				assert.Equal(t, "operator.openshift.io/v1", ic.APIVersion, "unexpected Object APIVersion")
-
-				ingressControllers := rawToIngressControllers(ss.Spec.Resources)
-
-				// We should have the expected number of ingress objects
-				assert.Equal(t, len(test.expectedSyncSetEntries), len(ingressControllers))
-
-				// And the configuration of each ingress object should match what we expect
-				for _, entry := range test.expectedSyncSetEntries {
-					foundIngress := false
-					for _, ingressController := range ingressControllers {
-						if entry.name == ingressController.Name {
-							foundIngress = true
-
-							// check domain looks right
-							assert.Equal(t, entry.domain, ingressController.Spec.Domain)
-
-							// check routeSelector
-							assert.Equal(t, entry.routeSelector, ingressController.Spec.RouteSelector)
-
-							// check namespaceSelector
-							assert.Equal(t, entry.namespaceSelector, ingressController.Spec.NamespaceSelector)
-						}
-					}
-					assert.Equal(t, true, foundIngress)
-				}
-			}
+			validateSyncSet(t, helper.createdSyncSet, test.expectedSecretEntries, test.expectedSyncSetIngressEntries)
 		})
 	}
 }
 
+func TestRemoteClusterIngressReconcileConditions(t *testing.T) {
+	apis.AddToScheme(scheme.Scheme)
+	ingresscontroller.AddToScheme(scheme.Scheme)
+
+	tests := []struct {
+		name                    string
+		localObjects            []runtime.Object
+		expectClusterCondition  bool
+		expectedConditionReason string
+		expectedConditionStatus corev1.ConditionStatus
+	}{
+		{
+			name: "Test no issue no condition",
+			localObjects: func() []runtime.Object {
+				objects := []runtime.Object{}
+				cd := testClusterDeploymentWithManualCertificate()
+				objects = append(objects, cd)
+
+				//create the secret for the certbundle
+				secret := testSecretForCertificateBundle(cd.Spec.CertificateBundles[0])
+				objects = append(objects, &secret)
+
+				return objects
+			}(),
+			expectClusterCondition: false,
+		},
+		{
+			name: "Test certbundle missing",
+			localObjects: func() []runtime.Object {
+				cd := testClusterDeploymentWithManualCertificate()
+				cd.Spec.CertificateBundles = []hivev1.CertificateBundleSpec{}
+
+				return []runtime.Object{cd}
+			}(),
+			expectClusterCondition:  true,
+			expectedConditionReason: ingressCertificateNotFoundReason,
+			expectedConditionStatus: corev1.ConditionTrue,
+		},
+		{
+			name: "Test secret missing",
+			localObjects: []runtime.Object{
+				testClusterDeploymentWithManualCertificate(),
+			},
+			expectedConditionReason: ingressCertificateNotFoundReason,
+			expectedConditionStatus: corev1.ConditionTrue,
+		},
+		{
+			name: "Test clear previous condition",
+			localObjects: func() []runtime.Object {
+				objects := []runtime.Object{}
+				cd := testClusterDeploymentWithManualCertificate()
+				conditions := utils.SetClusterDeploymentCondition(cd.Status.Conditions,
+					hivev1.IngressCertificateNotFoundCondition, corev1.ConditionTrue, ingressCertificateNotFoundReason, "TEST MISSING SECRET MESSAGE",
+					utils.UpdateConditionIfReasonOrMessageChange)
+				cd.Status.Conditions = conditions
+				objects = append(objects, cd)
+
+				secret := testSecretForCertificateBundle(cd.Spec.CertificateBundles[0])
+				objects = append(objects, &secret)
+
+				return objects
+			}(),
+			expectClusterCondition:  true,
+			expectedConditionReason: ingressCertificateFoundReason,
+			expectedConditionStatus: corev1.ConditionFalse,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fakeClient := fake.NewFakeClient(test.localObjects...)
+
+			helper := &fakeKubeCLI{
+				t: t,
+			}
+
+			rcd := &ReconcileRemoteClusterIngress{
+				Client:  fakeClient,
+				scheme:  scheme.Scheme,
+				logger:  log.WithField("controller", controllerName),
+				kubeCLI: helper,
+			}
+			_, err := rcd.Reconcile(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      testClusterName,
+					Namespace: testNamespace,
+				},
+			})
+
+			assert.NoError(t, err, "unexpected error returned from Reconcile()")
+
+			if test.expectClusterCondition {
+				cd := hivev1.ClusterDeployment{}
+				searchKey := types.NamespacedName{Name: testClusterName, Namespace: testNamespace}
+				assert.NoError(t, fakeClient.Get(context.TODO(), searchKey, &cd), "error fetching resulting clusterDeployment")
+
+				condition := utils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.IngressCertificateNotFoundCondition)
+				assert.NotNil(t, condition, "didn't find expected condition")
+
+				assert.Equal(t, test.expectedConditionReason, condition.Reason)
+				assert.Equal(t, test.expectedConditionStatus, condition.Status)
+			}
+		})
+	}
+
+}
 func testNamespaceSelector() *metav1.LabelSelector {
 	return testRouteSelector()
 }
@@ -281,19 +472,25 @@ func testRouteSelector() *metav1.LabelSelector {
 	return selector
 }
 
-func addIngressToClusterDeployment(cd *hivev1.ClusterDeployment, ingress SyncSetEntry) *hivev1.ClusterDeployment {
+func addIngressToClusterDeployment(cd *hivev1.ClusterDeployment, ingressName, ingressDomain string, routeSelector, namespaceSelector *metav1.LabelSelector, servingCertificate string) *hivev1.ClusterDeployment {
 	cd.Spec.Ingress = append(cd.Spec.Ingress, hivev1.ClusterIngress{
-		Name:              ingress.name,
-		Domain:            ingress.domain,
-		RouteSelector:     ingress.routeSelector,
-		NamespaceSelector: ingress.namespaceSelector,
+		Name:               ingressName,
+		Domain:             ingressDomain,
+		RouteSelector:      routeSelector,
+		NamespaceSelector:  namespaceSelector,
+		ServingCertificate: servingCertificate,
 	})
 
 	return cd
 }
 
 func syncSetFromClusterDeployment(cd *hivev1.ClusterDeployment) *hivev1.SyncSet {
-	rawExtensions := rawExtensionsFromClusterDeployment(cd)
+	rContext := reconcileContext{
+		clusterDeployment: cd,
+		certBundleSecrets: fakeSecretListForCertBundles(cd),
+	}
+	rawExtensions := rawExtensionsFromClusterDeployment(&rContext)
+
 	ssSpec := newSyncSetSpec(cd, rawExtensions)
 	return &hivev1.SyncSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -304,12 +501,31 @@ func syncSetFromClusterDeployment(cd *hivev1.ClusterDeployment) *hivev1.SyncSet 
 	}
 }
 
+func fakeSecretListForCertBundles(cd *hivev1.ClusterDeployment) []*corev1.Secret {
+	secrets := []*corev1.Secret{}
+
+	for _, cb := range cd.Spec.CertificateBundles {
+		secret := testSecretForCertificateBundle(cb)
+		secrets = append(secrets, &secret)
+	}
+
+	return secrets
+}
+
+func testClusterDeploymentWithManualCertificate() *hivev1.ClusterDeployment {
+	cd := testClusterDeploymentWithoutIngress()
+
+	cd = addIngressToClusterDeployment(cd, testDefaultIngressName, testIngressDomain, nil, nil, testDefaultIngressServingCertificate)
+
+	cd.Spec.CertificateBundles = addCertificateBundlesForIngressList(cd)
+
+	return cd
+}
+
 func testClusterDeployment() *hivev1.ClusterDeployment {
 	cd := testClusterDeploymentWithoutIngress()
-	cd = addIngressToClusterDeployment(cd, SyncSetEntry{
-		name:   testDefaultIngressName,
-		domain: testIngressDomain,
-	})
+
+	cd = addIngressToClusterDeployment(cd, testDefaultIngressName, testIngressDomain, nil, nil, "")
 
 	return cd
 }
@@ -317,28 +533,11 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 func testClusterDeploymentWithoutIngress() *hivev1.ClusterDeployment {
 	return &hivev1.ClusterDeployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:       testClusterName,
-			Namespace:  testNamespace,
-			Finalizers: []string{hivev1.FinalizerDeprovision},
-			UID:        types.UID("1234"),
+			Name:      testClusterName,
+			Namespace: testNamespace,
 		},
 		Spec: hivev1.ClusterDeploymentSpec{
-			SSHKey: &corev1.LocalObjectReference{
-				Name: sshKeySecret,
-			},
-			ClusterName:  testClusterName,
-			ControlPlane: hivev1.MachinePool{},
-			PullSecret: corev1.LocalObjectReference{
-				Name: pullSecretSecret,
-			},
-			Platform: hivev1.Platform{
-				AWS: &hivev1.AWSPlatform{
-					Region: "us-east-1",
-				},
-			},
-			Networking: hivev1.Networking{
-				Type: hivev1.NetworkTypeOpenshiftSDN,
-			},
+			ClusterName: testClusterName,
 			PlatformSecrets: hivev1.PlatformSecrets{
 				AWS: &hivev1.AWSPlatformSecrets{
 					Credentials: corev1.LocalObjectReference{
@@ -347,40 +546,147 @@ func testClusterDeploymentWithoutIngress() *hivev1.ClusterDeployment {
 				},
 			},
 		},
-		Status: hivev1.ClusterDeploymentStatus{
-			Installed:             true,
-			AdminKubeconfigSecret: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-admin-kubeconfig", testClusterName)},
-			ClusterID:             testClusterID,
-			InfraID:               testInfraID,
+	}
+}
+
+func testSecretsForClusterDeployment(cd *hivev1.ClusterDeployment) []corev1.Secret {
+	secrets := []corev1.Secret{}
+
+	for _, certBundle := range cd.Spec.CertificateBundles {
+		secret := testSecretForCertificateBundle(certBundle)
+		secrets = append(secrets, secret)
+	}
+
+	return secrets
+}
+
+func testSecretForCertificateBundle(cb hivev1.CertificateBundleSpec) corev1.Secret {
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cb.SecretRef.Name,
+			Namespace: testNamespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Secret",
+		},
+		Data: map[string][]byte{
+			"tls.crt": []byte("SOME_FAKE_CERTIFICATE_DATA"),
+			"tls.key": []byte("SOME_FAKE_CERTIFICATE_KEY_DATA"),
 		},
 	}
+	return secret
 }
 
-func rawToIngressControllers(rawList []runtime.RawExtension) []*ingresscontroller.IngressController {
-	decoder := newIngressControllerDecoder()
-	ingressControllers := []*ingresscontroller.IngressController{}
+func addCertificateBundlesForIngressList(cd *hivev1.ClusterDeployment) []hivev1.CertificateBundleSpec {
+	certBundles := []hivev1.CertificateBundleSpec{}
+	certBundleAlreadyProcessed := map[string]bool{}
 
-	for _, raw := range rawList {
-		obj, _, err := decoder.Decode(raw.Raw, nil, &ingresscontroller.IngressController{})
-		if err != nil {
-			panic("error decoding to ingresscontroller object")
+	for _, ingress := range cd.Spec.Ingress {
+		if certBundleAlreadyProcessed[ingress.ServingCertificate] {
+			continue
 		}
-		ic, ok := obj.(*ingresscontroller.IngressController)
-		if !ok {
-			panic("error casting to IngressController")
+		cb := hivev1.CertificateBundleSpec{
+			Name: ingress.ServingCertificate,
+			SecretRef: corev1.LocalObjectReference{
+				Name: fmt.Sprintf("%s-secret", ingress.ServingCertificate),
+			},
 		}
-		ingressControllers = append(ingressControllers, ic)
+
+		certBundles = append(certBundles, cb)
+		// no need to make multiple certbundle entries for the same certbundle
+		certBundleAlreadyProcessed[ingress.ServingCertificate] = true
 	}
-	return ingressControllers
+
+	return certBundles
 }
 
-func newIngressControllerDecoder() runtime.Decoder {
-	scheme, err := hivev1.SchemeBuilder.Build()
-	if err != nil {
-		panic("error building ingresscontroller scheme")
-	}
-	codecFactory := serializer.NewCodecFactory(scheme)
-	decoder := codecFactory.UniversalDecoder(hivev1.SchemeGroupVersion)
+type createdResourceInfo struct {
+	name               string
+	namespace          string
+	kind               string
+	domain             string
+	namespaceSelector  *metav1.LabelSelector
+	routeSelector      *metav1.LabelSelector
+	defaultCertificate string
+}
+type createdSyncSetInfo struct {
+	name      string
+	namespace string
+	resources []createdResourceInfo
+}
 
-	return decoder
+type fakeKubeCLI struct {
+	t              *testing.T
+	createdSyncSet createdSyncSetInfo
+}
+
+func (f *fakeKubeCLI) ApplyRuntimeObject(obj runtime.Object, scheme *runtime.Scheme) error {
+	ss := obj.(*hivev1.SyncSet)
+	created := createdSyncSetInfo{
+		name:      ss.Name,
+		namespace: ss.Namespace,
+	}
+
+	for _, raw := range ss.Spec.Resources {
+		sec, ok := raw.Object.(*corev1.Secret)
+		if ok {
+			cr := createdResourceInfo{
+				name:      sec.Name,
+				namespace: sec.Namespace,
+				kind:      sec.Kind,
+			}
+			created.resources = append(created.resources, cr)
+			continue
+		}
+
+		ic, ok := raw.Object.(*ingresscontroller.IngressController)
+		if ok {
+			cr := createdResourceInfo{
+				name:              ic.Name,
+				namespace:         ic.Namespace,
+				kind:              ic.Kind,
+				domain:            ic.Spec.Domain,
+				namespaceSelector: ic.Spec.NamespaceSelector,
+				routeSelector:     ic.Spec.RouteSelector,
+			}
+			if ic.Spec.DefaultCertificate != nil {
+				cr.defaultCertificate = ic.Spec.DefaultCertificate.Name
+			}
+			created.resources = append(created.resources, cr)
+			continue
+		}
+	}
+
+	f.createdSyncSet = created
+
+	return nil
+}
+
+func validateSyncSet(t *testing.T, existingSyncSet createdSyncSetInfo, expectedSecrets []string, expectedIngressControllers []SyncSetIngressEntry) {
+	for _, secret := range expectedSecrets {
+		found := false
+		for _, resObj := range existingSyncSet.resources {
+			if resObj.kind == "Secret" && resObj.name == secret {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "didn't find expected secret: %v", secret)
+	}
+
+	for _, ic := range expectedIngressControllers {
+		found := false
+		for _, resObj := range existingSyncSet.resources {
+			if resObj.kind == "IngressController" && resObj.name == ic.name {
+				found = true
+
+				assert.Equal(t, ic.domain, resObj.domain, "unexpected domain for ingressController %v", ic.name)
+				assert.Equal(t, ic.namespaceSelector, resObj.namespaceSelector, "unexpected namespaceSelector on ingressController: %v", ic.name)
+				assert.Equal(t, ic.routeSelector, resObj.routeSelector, "unexpected routeSelector on ingressController: %v", ic.name)
+				assert.Equal(t, ic.defaultCertificate, resObj.defaultCertificate, "unexpected DefaultCertificate on ingressController: %v", ic.name)
+			}
+		}
+		assert.True(t, found, "didn't find expected ingressController: %v", ic.name)
+	}
+	return
 }

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1077,6 +1077,8 @@ rules:
   - clusterdeployments
   verbs:
   - get
+  - watch
+  - update
 - apiGroups:
   - hive.openshift.io
   resources:


### PR DESCRIPTION
plumb through code to pull the certBundle's secrets that ingress objects refer to so that the syncset created also makes sure a secret is mirrored over to the remote cluster so that the ingressController objects on the remote cluster can come up with custom certificates.