### PR TITLE
deprovision job duration metrics

### DIFF
--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -27,8 +27,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
 	"strconv"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
 )
 
 const (


### PR DESCRIPTION
1) Calculated deprovision job duration metrics by assigning a label to the uninstall job which has the unix timestamp when it is created, and found out the difference between the unix timestamp when the uninstall job finished.
2) Used unix timestamp so that there is no date compatibility issue.
3) Metrics were not calculated if the job failed at any step. 