### PR TITLE
ResourceHelper improvements

### DIFF
--- a/contrib/pkg/testresource/command.go
+++ b/contrib/pkg/testresource/command.go
@@ -80,12 +80,12 @@ func newApplyCommand() *cobra.Command {
 			}
 			name := types.NamespacedName{Namespace: info.Namespace, Name: info.Name}
 			fmt.Printf("The resource is %s (Kind: %s, APIVersion: %s)", name.String(), info.Kind, info.APIVersion)
-			err = helper.Apply(content)
+			applyResult, err := helper.Apply(content)
 			if err != nil {
 				fmt.Printf("Error applying: %v\n", err)
 				return
 			}
-			fmt.Printf("The resource was applied successfully\n")
+			fmt.Printf("The resource was applied successfully: %s\n", applyResult)
 		},
 	}
 	cmd.Flags().StringVarP(&kubeconfigPath, "kubeconfig", "k", os.Getenv("KUBECONFIG"), "Kubeconfig file to connect to target server")

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openshift/hive/pkg/apis"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+	"github.com/openshift/hive/pkg/resource"
 )
 
 const (
@@ -240,9 +241,9 @@ type fakeApplier struct {
 	appliedObjects []runtime.Object
 }
 
-func (a *fakeApplier) ApplyRuntimeObject(obj runtime.Object, scheme *runtime.Scheme) error {
+func (a *fakeApplier) ApplyRuntimeObject(obj runtime.Object, scheme *runtime.Scheme) (resource.ApplyResult, error) {
 	a.appliedObjects = append(a.appliedObjects, obj)
-	return nil
+	return "", nil
 }
 
 type fakeClusterDeploymentWrapper struct {

--- a/pkg/controller/remoteingress/remoteingress_controller_test.go
+++ b/pkg/controller/remoteingress/remoteingress_controller_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/openshift/hive/pkg/apis"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
 	"github.com/openshift/hive/pkg/controller/utils"
+	"github.com/openshift/hive/pkg/resource"
 )
 
 const (
@@ -620,7 +621,7 @@ type fakeKubeCLI struct {
 	createdSyncSet createdSyncSetInfo
 }
 
-func (f *fakeKubeCLI) ApplyRuntimeObject(obj runtime.Object, scheme *runtime.Scheme) error {
+func (f *fakeKubeCLI) ApplyRuntimeObject(obj runtime.Object, scheme *runtime.Scheme) (resource.ApplyResult, error) {
 	ss := obj.(*hivev1.SyncSet)
 	created := createdSyncSetInfo{
 		name:      ss.Name,
@@ -659,7 +660,7 @@ func (f *fakeKubeCLI) ApplyRuntimeObject(obj runtime.Object, scheme *runtime.Sch
 
 	f.createdSyncSet = created
 
-	return nil
+	return "", nil
 }
 
 func validateSyncSet(t *testing.T, existingSyncSet createdSyncSetInfo, expectedSecrets []string, expectedIngressControllers []SyncSetIngressEntry) {

--- a/pkg/controller/syncset/syncset_controller.go
+++ b/pkg/controller/syncset/syncset_controller.go
@@ -61,7 +61,7 @@ const (
 
 // Applier knows how to Apply, Patch and return Info for []byte arrays describing objects and patches.
 type Applier interface {
-	Apply(obj []byte) error
+	Apply(obj []byte) (resource.ApplyResult, error)
 	Info(obj []byte) (*resource.Info, error)
 	Patch(name types.NamespacedName, kind, apiVersion string, patch []byte, patchType types.PatchType) error
 }
@@ -364,10 +364,12 @@ func (r *ReconcileSyncSet) applySyncSetResources(applyMode hivev1.SyncSetResourc
 
 		if !found || different || shouldReApply {
 			ssLog.Debugf("applying resource: %s/%s (%s)", infos[i].Namespace, infos[i].Name, infos[i].Kind)
-			err = h.Apply(resource.Raw)
+			result, err := h.Apply(resource.Raw)
 			resourceSyncStatus.Conditions = r.setApplySyncConditions(resourceSyncConditions, err)
 			if err != nil {
 				ssLog.WithError(err).Errorf("error applying resource %s/%s (%s)", infos[i].Namespace, infos[i].Name, infos[i].Kind)
+			} else {
+				ssLog.Debug("resource %s/%s (%s): %s", infos[i].Namespace, infos[i].Name, infos[i].Kind, result)
 			}
 		} else {
 			ssLog.Debugf("resource %s/%s (%s) has not changed, will not apply", infos[i].Namespace, infos[i].Name, infos[i].Kind)

--- a/pkg/controller/syncset/syncset_controller_test.go
+++ b/pkg/controller/syncset/syncset_controller_test.go
@@ -842,12 +842,12 @@ func (f *fakeHelper) newHelper(kubeconfig []byte, logger log.FieldLogger) Applie
 	return f
 }
 
-func (f *fakeHelper) Apply(data []byte) error {
+func (f *fakeHelper) Apply(data []byte) (resource.ApplyResult, error) {
 	info, _ := f.Info(data)
 	if info.Name == "apply-error" {
-		return fmt.Errorf("cannot apply resource")
+		return "", fmt.Errorf("cannot apply resource")
 	}
-	return nil
+	return resource.UnknownApplyResult, nil
 }
 
 func (f *fakeHelper) Info(data []byte) (*resource.Info, error) {

--- a/pkg/operator/hive/externaldns.go
+++ b/pkg/operator/hive/externaldns.go
@@ -94,12 +94,12 @@ func (r *ReconcileHiveConfig) deployExternalDNS(hLog log.FieldLogger, h *resourc
 	}
 
 	// Apply deployment
-	err = h.ApplyRuntimeObject(deployment, scheme.Scheme)
+	result, err := h.ApplyRuntimeObject(deployment, scheme.Scheme)
 	if err != nil {
 		hLog.WithError(err).Error("error applying external-dns deployment")
 		return err
 	}
-	hLog.Info("external-dns deployment applied")
+	hLog.Infof("external-dns deployment applied (%s)", result)
 
 	return nil
 }

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -54,15 +54,12 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helpe
 		hiveDeployment.Spec.Template.Spec.Containers[0].Env = append(hiveDeployment.Spec.Template.Spec.Containers[0].Env, hiveImageEnvVar)
 	}
 
-	// TODO: it would be nice to be able to log if there were changes or not
-	// for all artifacts we Apply.
-
-	err := h.ApplyRuntimeObject(hiveDeployment, scheme.Scheme)
+	result, err := h.ApplyRuntimeObject(hiveDeployment, scheme.Scheme)
 	if err != nil {
 		hLog.WithError(err).Error("error applying deployment")
 		return err
 	}
-	hLog.Info("deployment applied")
+	hLog.Info("deployment applied (%s)", result)
 
 	// Deploy the desired ClusterImageSets representing installable releases of OpenShift.
 	// TODO: in future this should be pipelined somehow.

--- a/pkg/operator/hive/hive_controller.go
+++ b/pkg/operator/hive/hive_controller.go
@@ -301,12 +301,7 @@ func (r *ReconcileHiveConfig) Reconcile(request reconcile.Request) (reconcile.Re
 		hLog.WithError(err).Error("error serializing kubeconfig")
 		return reconcile.Result{}, err
 	}
-	h, err := resource.NewHelperFromRESTConfig(r.restConfig, hLog)
-	if err != nil {
-		hLog.WithError(err).Error("error creating resource helper")
-		return reconcile.Result{}, err
-	}
-
+	h := resource.NewHelperFromRESTConfig(r.restConfig, hLog)
 	err = r.deployHive(hLog, h, instance, recorder)
 	if err != nil {
 		hLog.WithError(err).Error("error deploying Hive")

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -81,7 +81,7 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h *resou
 
 	if len(instance.Spec.ManagedDomains) > 0 {
 		configMap := managedDomainsConfigMap(hiveAdmDeployment.Namespace, instance.Spec.ManagedDomains)
-		err = h.ApplyRuntimeObject(configMap, scheme.Scheme)
+		_, err = h.ApplyRuntimeObject(configMap, scheme.Scheme)
 		if err != nil {
 			hLog.WithError(err).Error("error applying managed domains configmap")
 		}
@@ -105,12 +105,12 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h *resou
 		hiveAdmDeployment.Spec.Template.Spec.Containers[0].Env = append(hiveAdmDeployment.Spec.Template.Spec.Containers[0].Env, envVar)
 	}
 
-	err = h.ApplyRuntimeObject(hiveAdmDeployment, scheme.Scheme)
+	result, err := h.ApplyRuntimeObject(hiveAdmDeployment, scheme.Scheme)
 	if err != nil {
 		hLog.WithError(err).Error("error applying deployment")
 		return err
 	}
-	hLog.Info("deployment applied")
+	hLog.Infof("deployment applied (%s)", result)
 
 	hLog.Debug("reading apiservice")
 	asset = assets.MustAsset("config/hiveadmission/apiservice.yaml")
@@ -140,33 +140,33 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h *resou
 		}
 	}
 
-	err = h.ApplyRuntimeObject(apiService, scheme.Scheme)
+	result, err = h.ApplyRuntimeObject(apiService, scheme.Scheme)
 	if err != nil {
 		hLog.WithError(err).Error("error applying apiservice")
 		return err
 	}
-	hLog.Info("apiservice applied")
+	hLog.Infof("apiservice applied (%s)", result)
 
-	err = h.ApplyRuntimeObject(cdWebhook, scheme.Scheme)
+	result, err = h.ApplyRuntimeObject(cdWebhook, scheme.Scheme)
 	if err != nil {
 		hLog.WithError(err).Error("error applying cluster deployment webhook")
 		return err
 	}
-	hLog.Info("cluster deployment webhook applied")
+	hLog.Infof("cluster deployment webhook applied (%s)", result)
 
-	err = h.ApplyRuntimeObject(cisWebhook, scheme.Scheme)
+	result, err = h.ApplyRuntimeObject(cisWebhook, scheme.Scheme)
 	if err != nil {
 		hLog.WithError(err).Error("error applying cluster image set webhook")
 		return err
 	}
-	hLog.Info("cluster image set webhook applied")
+	hLog.Infof("cluster image set webhook applied (%s)", result)
 
-	err = h.ApplyRuntimeObject(dnsZonesWebhook, scheme.Scheme)
+	result, err = h.ApplyRuntimeObject(dnsZonesWebhook, scheme.Scheme)
 	if err != nil {
 		hLog.WithError(err).Error("error applying dns zones webhook")
 		return err
 	}
-	hLog.Info("dns zones webhook applied")
+	hLog.Infof("dns zones webhook applied (%s)", result)
 
 	hLog.Info("hiveadmission components reconciled successfully")
 

--- a/pkg/operator/util/apply.go
+++ b/pkg/operator/util/apply.go
@@ -33,11 +33,11 @@ func ApplyAsset(h *resource.Helper, assetPath string, hLog log.FieldLogger) erro
 	assetLog.Debug("reading asset")
 	asset := assets.MustAsset(assetPath)
 	assetLog.Debug("applying asset")
-	err := h.Apply(asset)
+	result, err := h.Apply(asset)
 	if err != nil {
 		assetLog.WithError(err).Error("error applying asset")
 		return err
 	}
-	assetLog.Info("asset applied successfully")
+	assetLog.Info("asset applied successfully: %v", result)
 	return nil
 }

--- a/pkg/resource/apply.go
+++ b/pkg/resource/apply.go
@@ -18,70 +18,83 @@ package resource
 
 import (
 	"bytes"
+	"io"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/genericclioptions/printers"
 	kcmd "k8s.io/kubernetes/pkg/kubectl/cmd"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
-// Apply applies the given resource bytes to the target cluster specified by kubeconfig
-func (r *Helper) Apply(obj []byte) error {
+// ApplyResult indicates what type of change was performed
+// by calling the Apply function
+type ApplyResult string
 
+var (
+	// ConfiguredApplyResult is returned when a patch was submitted
+	ConfiguredApplyResult ApplyResult = "configured"
+
+	// UnchangedApplyResult is returned when no change occurred
+	UnchangedApplyResult ApplyResult = "unchanged"
+
+	// CreatedApplyResult is returned when no a resource was created
+	CreatedApplyResult ApplyResult = "created"
+
+	// UnknownApplyResult is returned when the resulting action could not be determined
+	UnknownApplyResult ApplyResult = "unknown"
+)
+
+// Apply applies the given resource bytes to the target cluster specified by kubeconfig
+func (r *Helper) Apply(obj []byte) (ApplyResult, error) {
 	fileName, err := r.createTempFile("apply-", obj)
 	if err != nil {
-		return err
+		r.logger.WithError(err).Error("failed to create temp file for apply")
+		return "", err
 	}
 	defer r.deleteTempFile(fileName)
-	factory, err := r.getFactory(r.kubeconfig, "")
+	factory, err := r.getFactory("")
 	if err != nil {
-		return err
+		r.logger.WithError(err).Error("failed to obtain factory for apply")
+		return "", err
 	}
 	ioStreams := genericclioptions.IOStreams{
 		In:     &bytes.Buffer{},
 		Out:    &bytes.Buffer{},
 		ErrOut: &bytes.Buffer{},
 	}
-	applyOptions, err := r.setupApplyCommand(factory, fileName, ioStreams)
+	applyOptions, changeTracker, err := r.setupApplyCommand(factory, fileName, ioStreams)
 	if err != nil {
 		r.logger.WithError(err).Error("failed to setup apply command")
-		return err
+		return "", err
 	}
 	err = applyOptions.Run()
 	if err != nil {
 		r.logger.WithError(err).
 			WithField("stdout", ioStreams.Out.(*bytes.Buffer).String()).
 			WithField("stderr", ioStreams.ErrOut.(*bytes.Buffer).String()).Error("running the apply command failed")
-		return err
+		return "", err
 	}
-	return nil
+	return changeTracker.GetResult(), nil
 }
 
 // ApplyRuntimeObject serializes an object and applies it to the target cluster specified by the kubeconfig.
-func (r *Helper) ApplyRuntimeObject(obj runtime.Object, scheme *runtime.Scheme) error {
-	s := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme, scheme)
-	buf := bytes.NewBuffer([]byte{})
-	err := s.Encode(obj, buf)
+func (r *Helper) ApplyRuntimeObject(obj runtime.Object, scheme *runtime.Scheme) (ApplyResult, error) {
+	data, err := r.Serialize(obj, scheme)
 	if err != nil {
-		return err
+		r.logger.WithError(err).Error("cannot serialize runtime object")
+		return "", err
 	}
-	err = r.Apply(buf.Bytes())
-	if err != nil {
-		return err
-	}
-	return nil
+	return r.Apply(data)
 }
 
-func (r *Helper) setupApplyCommand(f cmdutil.Factory, fileName string, ioStreams genericclioptions.IOStreams) (*kcmd.ApplyOptions, error) {
+func (r *Helper) setupApplyCommand(f cmdutil.Factory, fileName string, ioStreams genericclioptions.IOStreams) (*kcmd.ApplyOptions, *changeTracker, error) {
 	r.logger.Debug("setting up apply command")
 	o := kcmd.NewApplyOptions(ioStreams)
-	o.ToPrinter = func(string) (printers.ResourcePrinter, error) { return o.PrintFlags.ToPrinter() }
 	dynamicClient, err := f.DynamicClient()
 	if err != nil {
 		r.logger.WithError(err).Error("cannot obtain dynamic client from factory")
-		return nil, err
+		return nil, nil, err
 	}
 	o.DeleteOptions = o.DeleteFlags.ToOptions(dynamicClient, o.IOStreams)
 	o.OpenAPISchema, _ = f.OpenAPISchema()
@@ -90,16 +103,63 @@ func (r *Helper) setupApplyCommand(f cmdutil.Factory, fileName string, ioStreams
 	o.Mapper, err = f.ToRESTMapper()
 	if err != nil {
 		r.logger.WithError(err).Error("cannot obtain RESTMapper from factory")
-		return nil, err
+		return nil, nil, err
 	}
 
 	o.DynamicClient = dynamicClient
 	o.Namespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		r.logger.WithError(err).Error("cannot obtain namespace from factory")
+		return nil, nil, err
+	}
+	tracker := &changeTracker{
+		internalToPrinter: func(string) (printers.ResourcePrinter, error) { return o.PrintFlags.ToPrinter() },
+	}
+	o.ToPrinter = tracker.ToPrinter
+	o.DeleteOptions.FilenameOptions.Filenames = []string{fileName}
+	return o, tracker, nil
+}
+
+type trackerPrinter struct {
+	setResult       func()
+	internalPrinter printers.ResourcePrinter
+}
+
+func (p *trackerPrinter) PrintObj(o runtime.Object, w io.Writer) error {
+	if p.setResult != nil {
+		p.setResult()
+	}
+	return p.internalPrinter.PrintObj(o, w)
+}
+
+type changeTracker struct {
+	result            []ApplyResult
+	internalToPrinter func(string) (printers.ResourcePrinter, error)
+}
+
+func (t *changeTracker) GetResult() ApplyResult {
+	if len(t.result) == 1 {
+		return t.result[0]
+	}
+	return UnknownApplyResult
+}
+
+func (t *changeTracker) ToPrinter(name string) (printers.ResourcePrinter, error) {
+	var f func()
+	switch name {
+	case "created":
+		f = func() { t.result = append(t.result, CreatedApplyResult) }
+	case "configured":
+		f = func() { t.result = append(t.result, ConfiguredApplyResult) }
+	case "unchanged":
+		f = func() { t.result = append(t.result, UnchangedApplyResult) }
+	}
+	p, err := t.internalToPrinter(name)
+	if err != nil {
 		return nil, err
 	}
-
-	o.DeleteOptions.FilenameOptions.Filenames = []string{fileName}
-	return o, nil
+	return &trackerPrinter{
+		internalPrinter: p,
+		setResult:       f,
+	}, nil
 }

--- a/pkg/resource/factory_discovery.go
+++ b/pkg/resource/factory_discovery.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+func getDiscoveryClient(config *rest.Config, cacheDir string) (discovery.CachedDiscoveryInterface, error) {
+	config.Burst = 100
+	httpCacheDir := filepath.Join(cacheDir, ".kube", "http-cache")
+	discoveryCacheDir := computeDiscoverCacheDir(filepath.Join(cacheDir, ".kube", "cache", "discovery"), config.Host)
+	return discovery.NewCachedDiscoveryClientForConfig(config, discoveryCacheDir, httpCacheDir, time.Duration(10*time.Minute))
+}
+
+// overlyCautiousIllegalFileCharacters matches characters that *might* not be supported.  Windows is really restrictive, so this is really restrictive
+var overlyCautiousIllegalFileCharacters = regexp.MustCompile(`[^(\w/\.)]`)
+
+// computeDiscoverCacheDir takes the parentDir and the host and comes up with a "usually non-colliding" name.
+func computeDiscoverCacheDir(parentDir, host string) string {
+	// strip the optional scheme from host if its there:
+	schemelessHost := strings.Replace(strings.Replace(host, "https://", "", 1), "http://", "", 1)
+	// now do a simple collapse of non-AZ09 characters.  Collisions are possible but unlikely.  Even if we do collide the problem is short lived
+	safeHost := overlyCautiousIllegalFileCharacters.ReplaceAllString(schemelessHost, "_")
+	return filepath.Join(parentDir, safeHost)
+}

--- a/pkg/resource/info.go
+++ b/pkg/resource/info.go
@@ -34,7 +34,7 @@ type Info struct {
 
 // Info determines the name/namespace and type of the passed in resource bytes
 func (r *Helper) Info(obj []byte) (*Info, error) {
-	factory, err := r.getFactory(r.kubeconfig, "")
+	factory, err := r.getFactory("")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/patch.go
+++ b/pkg/resource/patch.go
@@ -43,7 +43,7 @@ func (r *Helper) Patch(name types.NamespacedName, kind, apiVersion string, patch
 		Out:    &bytes.Buffer{},
 		ErrOut: &bytes.Buffer{},
 	}
-	factory, err := r.getFactory(r.kubeconfig, name.Namespace)
+	factory, err := r.getFactory(name.Namespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/resource/restconfig_factory.go
+++ b/pkg/resource/restconfig_factory.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+)
+
+func (r *Helper) getRESTConfigFactory(namespace string) (cmdutil.Factory, error) {
+	r.logger.WithField("cache-dir", r.cacheDir).Debug("creating cmdutil.Factory from REST client config and cache directory")
+	f := cmdutil.NewFactory(&restConfigClientGetter{restConfig: r.restConfig, cacheDir: r.cacheDir, namespace: namespace})
+	return f, nil
+}
+
+type restConfigClientGetter struct {
+	restConfig *rest.Config
+	cacheDir   string
+	namespace  string
+}
+
+// ToRESTConfig returns restconfig
+func (r *restConfigClientGetter) ToRESTConfig() (*rest.Config, error) {
+	return r.restConfig, nil
+}
+
+// ToDiscoveryClient returns discovery client
+func (r *restConfigClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	config := rest.CopyConfig(r.restConfig)
+	return getDiscoveryClient(config, r.cacheDir)
+}
+
+// ToRESTMapper returns a restmapper
+func (r *restConfigClientGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	discoveryClient, err := r.ToDiscoveryClient()
+	if err != nil {
+		return nil, err
+	}
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
+	expander := restmapper.NewShortcutExpander(mapper, discoveryClient)
+	return expander, nil
+}
+
+// ToRawKubeConfigLoader return kubeconfig loader as-is
+func (r *restConfigClientGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	cfg := GenerateClientConfigFromRESTConfig("default", r.restConfig)
+	overrides := &clientcmd.ConfigOverrides{}
+	if len(r.namespace) > 0 {
+		overrides.Context.Namespace = r.namespace
+	}
+	return clientcmd.NewNonInteractiveClientConfig(*cfg, "", overrides, nil)
+}

--- a/pkg/resource/serializer.go
+++ b/pkg/resource/serializer.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"unsafe"
+
+	json "github.com/json-iterator/go"
+	"github.com/modern-go/reflect2"
+	log "github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions/printers"
+)
+
+var (
+	jsonAPI json.API
+)
+
+func init() {
+	jsonAPI = json.Config{EscapeHTML: true}.Froze()
+	jsonAPI.RegisterExtension(&metaTimeExtension{})
+}
+
+type metaTimeExtension struct {
+	json.DummyExtension
+}
+
+func (e *metaTimeExtension) CreateEncoder(typ reflect2.Type) json.ValEncoder {
+	if typ.Type1() == reflect.TypeOf(metav1.Time{}) {
+		return e
+	}
+	return nil
+}
+
+func (e *metaTimeExtension) IsEmpty(ptr unsafe.Pointer) bool {
+	metaTime := reflect2.TypeOf(metav1.Time{}).UnsafeIndirect(ptr).(metav1.Time)
+	return metaTime.IsZero()
+}
+
+func (e *metaTimeExtension) Encode(ptr unsafe.Pointer, stream *json.Stream) {
+	metaTime := reflect2.TypeOf(metav1.Time{}).UnsafeIndirect(ptr).(metav1.Time)
+	data, err := metaTime.MarshalJSON()
+	if err != nil {
+		log.Error("cannot marshal %#v as meta time: %v", ptr, err)
+		return
+	}
+	_, err = stream.Write(data)
+	if err != nil {
+		log.Error("cannot write serialized time (%s): %v", string(data), err)
+	}
+}
+
+type jsonPrinter struct{}
+
+func (p *jsonPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
+	data, err := jsonAPI.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = w.Write(data)
+	return err
+}
+
+// Serialize uses a custom JSON extension to properly determine whether metav1.Time should
+// be serialized or not. In cases where a metav1.Time is labeled as 'omitempty', the default
+// json marshaler still outputs a "null" value because it is considered a struct.
+// The json-iterator/go marshaler will first check whether a value is empty and if its tag
+// says 'omitempty' it will not output it.
+// This is needed for us to prevent patching from happening unnecessarily when applying resources
+// that don't have a timeCreated timestamp. With the default serializer, they output a
+// `timeCreated: null` which always causes a mismatch with whatever's already in the server.
+func (r *Helper) Serialize(obj runtime.Object, scheme *runtime.Scheme) ([]byte, error) {
+	printer := printers.NewTypeSetter(scheme).ToPrinter(&jsonPrinter{})
+	buf := &bytes.Buffer{}
+	if err := printer.PrintObj(obj, buf); err != nil {
+		r.logger.WithError(err).Error("cannot serialize runtime object of type %T", obj)
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}


### PR DESCRIPTION
- Apply now reports whether the call resulted in a create, modification, or no change
- Makes creating a helper from an existing rest.Config more robust by using the rest.Config directly instead of first serializing to a kubeconfig
- Fixes a bug with serialization that resulted in every apply always calling patch (because of `creationTimestamp: null` being present)