### PR TITLE
WIP: force requeue after fixing status fields

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -76,6 +76,8 @@ const (
 	clusterImageSetFoundReason            = "ClusterImageSetFound"
 
 	dnsZoneCheckInterval = 30 * time.Second
+
+	defaultRequeueTime = time.Second
 )
 
 var (
@@ -210,8 +212,12 @@ func (r *ReconcileClusterDeployment) Reconcile(request reconcile.Request) (recon
 		err := r.Status().Update(context.TODO(), cd)
 		if err != nil {
 			cdLog.WithError(err).Error("error updating cluster deployment")
+			return reconcile.Result{}, err
 		}
-		return reconcile.Result{}, err
+		return reconcile.Result{
+			Requeue:      true,
+			RequeueAfter: defaultRequeueTime,
+		}, nil
 	}
 
 	_, err = r.setupClusterInstallServiceAccount(cd.Namespace, cdLog)


### PR DESCRIPTION
if we return empty reconcile.Result, nil, then we won't get requeued for the regular object requeue period (15 minutes?)

after fixing the empty fields, we should go ahead and requeue immediately to avoid any delay in processing the clusterdeployment