### PR TITLE
Fix plural rbac for operator for hive CRDs.

### DIFF
--- a/config/operator/operator_role.yaml
+++ b/config/operator/operator_role.yaml
@@ -80,10 +80,10 @@ rules:
   - clusterdeployments
   - dnszones
   - dnsendpoints
-  - selectorsyncidentityprovider
-  - selectorsyncset
-  - syncidentityprovider
-  - syncset
+  - selectorsyncidentityproviders
+  - selectorsyncsets
+  - syncidentityproviders
+  - syncsets
   - clusterimagesets
   verbs:
   - get


### PR DESCRIPTION
This is blocking rollout of the plural fix for hive-admin role as kube
thinks the operator is trying to grant more permissions than it has.