### PR TITLE
Attempted fix for long (5-20m) delays creating install jobs.

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -29,11 +29,8 @@ spec:
         imagePullPolicy: Always
         name: manager
         resources:
-          limits:
-            cpu: 100m
-            memory: 1Gi
           requests:
-            cpu: 100m
+            cpu: 500m
             memory: 512Mi
         command:
           - /opt/services/manager

--- a/config/operator/operator_deployment.yaml
+++ b/config/operator/operator_deployment.yaml
@@ -36,12 +36,9 @@ spec:
         imagePullPolicy: Always
         name: hive-operator
         resources:
-          limits:
-            cpu: 100m
-            memory: 256Mi
           requests:
             cpu: 100m
-            memory: 75Mi
+            memory: 256Mi
         command:
           - /opt/services/hive-operator
           - --log-level

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -656,12 +656,13 @@ func (r *ReconcileClusterDeployment) updateClusterDeploymentStatus(cd *hivev1.Cl
 
 // setAdminKubeconfigStatus sets all cluster status fields that depend on the admin kubeconfig.
 func (r *ReconcileClusterDeployment) setAdminKubeconfigStatus(cd *hivev1.ClusterDeployment, adminKubeconfigSecret *corev1.Secret, cdLog log.FieldLogger) error {
-	remoteClusterAPIClient, err := r.remoteClusterAPIClientBuilder(string(adminKubeconfigSecret.Data[adminKubeconfigKey]))
-	if err != nil {
-		cdLog.WithError(err).Error("error building remote cluster-api client connection")
-		return err
-	}
 	if cd.Status.WebConsoleURL == "" || cd.Status.APIURL == "" {
+		remoteClusterAPIClient, err := r.remoteClusterAPIClientBuilder(string(adminKubeconfigSecret.Data[adminKubeconfigKey]))
+		if err != nil {
+			cdLog.WithError(err).Error("error building remote cluster-api client connection")
+			return err
+		}
+
 		// Parse the admin kubeconfig for the server URL:
 		config, err := clientcmd.Load(adminKubeconfigSecret.Data["kubeconfig"])
 		if err != nil {

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -120,7 +120,7 @@ func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 // AddToManager adds a new Controller to mgr with r as the reconcile.Reconciler
 func AddToManager(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("clusterdeployment-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("clusterdeployment-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: 100})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/clusterversion/clusterversion_controller.go
+++ b/pkg/controller/clusterversion/clusterversion_controller.go
@@ -64,7 +64,7 @@ func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 // AddToManager adds a new Controller to mgr with r as the reconcile.Reconciler
 func AddToManager(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("clusterversion-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("clusterversion-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: 100})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller.go
@@ -83,7 +83,7 @@ func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 // AddToManager adds a new Controller to mgr with r as the reconcile.Reconciler
 func AddToManager(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("controlplanecerts-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("controlplanecerts-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: 100})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/dnszone/dnszone_controller.go
+++ b/pkg/controller/dnszone/dnszone_controller.go
@@ -61,7 +61,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
+	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: 100})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -89,7 +89,7 @@ func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 // AddToManager adds a new Controller to mgr with r as the reconcile.Reconciler
 func AddToManager(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("remoteingress-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("remoteingress-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: 100})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -89,7 +89,7 @@ func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 // AddToManager adds a new Controller to mgr with r as the reconcile.Reconciler
 func AddToManager(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("remotemachineset-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("remotemachineset-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: 100})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
+++ b/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
@@ -71,7 +71,7 @@ func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 // +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=get;list;watch
 func AddToManager(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New(controllerName+"-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New(controllerName+"-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: 100})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/syncset/syncset_controller.go
+++ b/pkg/controller/syncset/syncset_controller.go
@@ -94,7 +94,7 @@ func applierBuilderFunc(kubeConfig []byte, logger log.FieldLogger) Applier {
 // AddToManager adds a new Controller to mgr with r as the reconcile.Reconciler
 func AddToManager(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("syncset-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("syncset-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: 100})
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -514,11 +514,8 @@ spec:
         imagePullPolicy: Always
         name: manager
         resources:
-          limits:
-            cpu: 100m
-            memory: 1Gi
           requests:
-            cpu: 100m
+            cpu: 500m
             memory: 512Mi
         command:
           - /opt/services/manager


### PR DESCRIPTION
Switches from serially processing 1 reconcile at a time to 100 for most controllers, it might be possible to go to thousands here but this is just a first test. Want to see how this behaves in stage.

Moved creation of a remote client in cluster deployment controller into a guarded block where it's actually used. We were doing this even if we didn't need it for every cluster.

Remove CPU and memory limits per advice from @jeremyeder .