### PR TITLE
Remove generation from container build process.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 as builder
 RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .
-RUN GOPATH=/go go get github.com/golang/mock/gomock; go install github.com/golang/mock/mockgen
-RUN PATH=$PATH:/go/bin make generate
 RUN go build -o bin/manager github.com/openshift/hive/cmd/manager
 RUN go build -o bin/hiveutil github.com/openshift/hive/contrib/cmd/hiveutil
 RUN go build -o bin/hiveadmission github.com/openshift/hive/cmd/hiveadmission

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 as builder
+FROM openshift/origin-release:golang-1.11 as builder
 RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ docker-push:
 
 # Build the image with buildah
 .PHONY: buildah-build
-buildah-build: generate
+buildah-build: 
 	$(SUDO_CMD) buildah bud --tag ${IMG} .
 
 # Push the buildah image

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openshift/origin-release:golang-1.10
+FROM openshift/origin-release:golang-1.11
 
 # Install the golint, use this to check our source for niceness
 RUN go get -u golang.org/x/lint/golint


### PR DESCRIPTION
This is now failing because master for gomock appears to require go
1.11.

However we don't need to generate code for a Docker build, assume we're
building a container with the latest committed code. A developer using
containers for their work will need to run make generate before building
their container.