### PR TITLE
add name to the port definition

### DIFF
--- a/config/manager/service.yaml
+++ b/config/manager/service.yaml
@@ -11,5 +11,5 @@ spec:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
   ports:
-  - port: 2112
-    name: metrics
+  - name: metrics
+    port: 2112

--- a/config/manager/service.yaml
+++ b/config/manager/service.yaml
@@ -12,3 +12,4 @@ spec:
     controller-tools.k8s.io: "1.0"
   ports:
   - port: 2112
+    name: metrics


### PR DESCRIPTION
Routes are not able to target unnamed ports.