### PR TITLE
Use `+genclient` for the configuration object

### DIFF
--- a/pkg/apis/hive/v1alpha1/hiveconfig_types.go
+++ b/pkg/apis/hive/v1alpha1/hiveconfig_types.go
@@ -71,6 +71,7 @@ type ExternalDNSAWSConfig struct {
 }
 
 // +genclient:nonNamespaced
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // HiveConfig is the Schema for the hives API


### PR DESCRIPTION
The description of the `HiveConfig` type has the
`+genclient:nonNamespaced` comment, but not `+genclient`. Both need to
be present, otherwise the code generation tools don't generate a client
for the type.