### PR TITLE
Add some imageset resolution metrics

### DIFF
--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -49,7 +49,7 @@ const (
 	// UninstallJobLabel is the label used for counting the number of uninstall jobs in Hive
 	UninstallJobLabel = "hive.openshift.io/uninstall"
 
-	// ClusterDeploymentNameLabel is the label (along with ClusterDeploymentNamespaceLabel) that is used to identify the installer pod of a particular cluster deployment
+	// ClusterDeploymentNameLabel is the label that is used to identify the installer pod of a particular cluster deployment
 	ClusterDeploymentNameLabel = "hive.openshift.io/cluster-deployment-name"
 )
 


### PR DESCRIPTION
This covers total jobs running / failed, and the time between cluster creation and job to resolve creation.

We've discussed revamping this so we only resolve once per cluster image set instead of for every deployment, we just need to solve the pull secret problem.