### PR TITLE
hive-admin role can CRUD SelectorSyncSets

### DIFF
--- a/config/rbac/hive_admin_role.yaml
+++ b/config/rbac/hive_admin_role.yaml
@@ -29,7 +29,6 @@ rules:
   - dnszones
   - dnsendpoints
   - selectorsyncidentityproviders
-  - selectorsyncsets
   - syncidentityproviders
   - syncsets
   verbs:
@@ -41,6 +40,7 @@ rules:
   resources:
   - clusterimagesets
   - hiveconfigs
+  - selectorsyncsets
   verbs:
   - get
   - list

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -825,7 +825,6 @@ rules:
   - dnszones
   - dnsendpoints
   - selectorsyncidentityproviders
-  - selectorsyncsets
   - syncidentityproviders
   - syncsets
   verbs:
@@ -837,6 +836,7 @@ rules:
   resources:
   - clusterimagesets
   - hiveconfigs
+  - selectorsyncsets
   verbs:
   - get
   - list


### PR DESCRIPTION
This is needed because we need to set up a pipeline that manages the SelectorSyncSets on the Hive clusters