### PR TITLE
 Use short patch strings in syncset patch definition.

### DIFF
--- a/config/crds/hive_v1alpha1_selectorsyncset.yaml
+++ b/config/crds/hive_v1alpha1_selectorsyncset.yaml
@@ -61,8 +61,8 @@ spec:
                     description: Patch is the patch to apply.
                     type: string
                   patchType:
-                    description: PatchType indicates the PatchType as "json" (default),
-                      "merge" or "strategic".
+                    description: PatchType indicates the PatchType as "strategic"
+                      (default), "json", or "merge".
                     type: string
                 required:
                 - apiVersion

--- a/config/crds/hive_v1alpha1_syncset.yaml
+++ b/config/crds/hive_v1alpha1_syncset.yaml
@@ -64,8 +64,8 @@ spec:
                     description: Patch is the patch to apply.
                     type: string
                   patchType:
-                    description: PatchType indicates the PatchType as "json" (default),
-                      "merge" or "strategic".
+                    description: PatchType indicates the PatchType as "strategic"
+                      (default), "json", or "merge".
                     type: string
                 required:
                 - apiVersion

--- a/contrib/pkg/testresource/command.go
+++ b/contrib/pkg/testresource/command.go
@@ -117,7 +117,7 @@ func newPatchCommand() *cobra.Command {
 				cmd.Usage()
 				return
 			}
-			patchType, ok := patchTypes[patchTypeStr]
+			_, ok := patchTypes[patchTypeStr]
 			if !ok {
 				fmt.Printf("Invalid patch type %s\n", patchTypeStr)
 				cmd.Usage()
@@ -141,7 +141,7 @@ func newPatchCommand() *cobra.Command {
 			content := mustRead(args[0])
 			kubeconfig := mustRead(kubeconfigPath)
 			helper := resource.NewHelper(kubeconfig, log.WithField("cmd", "patch"))
-			err := helper.Patch(types.NamespacedName{Name: name, Namespace: namespace}, kind, apiVersion, content, patchType)
+			err := helper.Patch(types.NamespacedName{Name: name, Namespace: namespace}, kind, apiVersion, content, patchTypeStr)
 			if err != nil {
 				fmt.Printf("Error: %v\n", err)
 				return

--- a/pkg/apis/hive/v1alpha1/syncset_types.go
+++ b/pkg/apis/hive/v1alpha1/syncset_types.go
@@ -20,7 +20,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 // SyncSetResourceApplyMode is a string representing the mode with which to
@@ -77,10 +76,9 @@ type SyncObjectPatch struct {
 	// Patch is the patch to apply.
 	Patch string `json:"patch"`
 
-	// PatchType indicates the PatchType as "json" (default), "merge"
-	// or "strategic".
+	// PatchType indicates the PatchType as "strategic" (default), "json", or "merge".
 	// +optional
-	PatchType types.PatchType `json:"patchType,omitempty"`
+	PatchType string `json:"patchType,omitempty"`
 }
 
 // SyncConditionType is a valid value for SyncCondition.Type

--- a/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
+++ b/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
@@ -237,7 +237,7 @@ func (r *ReconcileSyncIdentityProviders) createSyncSetSpec(cd *hivev1.ClusterDep
 					APIVersion: oauthAPIVersion,
 					Kind:       oauthKind,
 					Name:       oauthObjectName,
-					PatchType:  types.MergePatchType,
+					PatchType:  "merge",
 					Patch:      string(patch),
 				},
 			},

--- a/pkg/controller/syncidentityprovider/syncidentityprovider_controller_test.go
+++ b/pkg/controller/syncidentityprovider/syncidentityprovider_controller_test.go
@@ -63,7 +63,7 @@ var (
 							APIVersion: "config.openshift.io/v1",
 							Kind:       "OAuth",
 							Name:       "cluster",
-							PatchType:  types.MergePatchType,
+							PatchType:  "merge",
 							Patch:      generatePatch([]openshiftapiv1.IdentityProvider{}),
 						},
 					},

--- a/pkg/controller/syncset/syncset_controller.go
+++ b/pkg/controller/syncset/syncset_controller.go
@@ -63,7 +63,7 @@ const (
 type Applier interface {
 	Apply(obj []byte) (hiveresource.ApplyResult, error)
 	Info(obj []byte) (*hiveresource.Info, error)
-	Patch(name types.NamespacedName, kind, apiVersion string, patch []byte, patchType types.PatchType) error
+	Patch(name types.NamespacedName, kind, apiVersion string, patch []byte, patchType string) error
 }
 
 // Add creates a new SyncSet Controller and adds it to the Manager with default RBAC. The Manager will set fields on the

--- a/pkg/controller/syncset/syncset_controller_test.go
+++ b/pkg/controller/syncset/syncset_controller_test.go
@@ -625,6 +625,7 @@ func testSyncObjectPatch(name, namespace, kind, apiVersion string, applyMode hiv
 		APIVersion: apiVersion,
 		ApplyMode:  applyMode,
 		Patch:      patch,
+		PatchType:  "merge",
 	}
 }
 
@@ -874,7 +875,7 @@ func (f *fakeHelper) Info(data []byte) (*resource.Info, error) {
 	}, nil
 }
 
-func (f *fakeHelper) Patch(name types.NamespacedName, kind, apiVersion string, patch []byte, patchType types.PatchType) error {
+func (f *fakeHelper) Patch(name types.NamespacedName, kind, apiVersion string, patch []byte, patchType string) error {
 	p := string(patch)
 	if strings.Contains(p, "patch-error") {
 		return fmt.Errorf("cannot apply patch")

--- a/pkg/resource/patch.go
+++ b/pkg/resource/patch.go
@@ -27,16 +27,8 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
-var (
-	patchTypeString = map[types.PatchType]string{
-		types.JSONPatchType:           "json",
-		types.MergePatchType:          "merge",
-		types.StrategicMergePatchType: "strategic",
-	}
-)
-
 // Patch invokes the kubectl patch command with the given resource, patch and patch type
-func (r *Helper) Patch(name types.NamespacedName, kind, apiVersion string, patch []byte, patchType types.PatchType) error {
+func (r *Helper) Patch(name types.NamespacedName, kind, apiVersion string, patch []byte, patchType string) error {
 
 	ioStreams := genericclioptions.IOStreams{
 		In:     &bytes.Buffer{},
@@ -62,7 +54,7 @@ func (r *Helper) Patch(name types.NamespacedName, kind, apiVersion string, patch
 	return nil
 }
 
-func (r *Helper) setupPatchCommand(name, kind, apiVersion string, patchType types.PatchType, f cmdutil.Factory, patch string, ioStreams genericclioptions.IOStreams) (*kcmd.PatchOptions, error) {
+func (r *Helper) setupPatchCommand(name, kind, apiVersion, patchType string, f cmdutil.Factory, patch string, ioStreams genericclioptions.IOStreams) (*kcmd.PatchOptions, error) {
 	r.logger.Debug("setting up patch command")
 
 	cmd := kcmd.NewCmdPatch(f, ioStreams)
@@ -79,7 +71,7 @@ func (r *Helper) setupPatchCommand(name, kind, apiVersion string, patchType type
 
 	o := kcmd.NewPatchOptions(ioStreams)
 	o.Complete(f, cmd, args)
-	o.PatchType = patchTypeString[patchType]
+	o.PatchType = patchType
 	o.Patch = patch
 
 	return o, nil

--- a/pkg/resource/patch.go
+++ b/pkg/resource/patch.go
@@ -27,6 +27,14 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
+var (
+	patchTypes = map[string]types.PatchType{
+		"json":      types.JSONPatchType,
+		"merge":     types.MergePatchType,
+		"strategic": types.StrategicMergePatchType,
+	}
+)
+
 // Patch invokes the kubectl patch command with the given resource, patch and patch type
 func (r *Helper) Patch(name types.NamespacedName, kind, apiVersion string, patch []byte, patchType string) error {
 
@@ -71,6 +79,13 @@ func (r *Helper) setupPatchCommand(name, kind, apiVersion, patchType string, f c
 
 	o := kcmd.NewPatchOptions(ioStreams)
 	o.Complete(f, cmd, args)
+	if patchType == "" {
+		patchType = "strategic"
+	}
+	_, ok := patchTypes[patchType]
+	if !ok {
+		return nil, fmt.Errorf("Invalid patch type: %s. Valid patch types are 'strategic', 'merge' or 'json'", patchType)
+	}
 	o.PatchType = patchType
 	o.Patch = patch
 

--- a/test/integration/resource/patch_test.go
+++ b/test/integration/resource/patch_test.go
@@ -16,14 +16,14 @@ func TestPatch(t *testing.T) {
 	tests := []struct {
 		name      string
 		patch     string
-		patchType types.PatchType
+		patchType string
 		validate  func(t *testing.T, cm *corev1.ConfigMap)
 	}{
 		// All tests begin with a single configmap with one key { "foo": "bar" }
 		{
 			name:      "json patch",
 			patch:     `[ { "op": "replace", "path": "/data/foo", "value": "baz" } ]`,
-			patchType: types.JSONPatchType,
+			patchType: "json",
 			validate: func(t *testing.T, cm *corev1.ConfigMap) {
 				if cm.Data["foo"] != "baz" {
 					t.Errorf("unexpected value in data: %v", cm.Data)
@@ -33,7 +33,7 @@ func TestPatch(t *testing.T) {
 		{
 			name:      "merge patch",
 			patch:     `{ "data": { "foo": null, "baz": "bar" } }`,
-			patchType: types.MergePatchType,
+			patchType: "merge",
 			validate: func(t *testing.T, cm *corev1.ConfigMap) {
 				if len(cm.Data) != 1 {
 					t.Errorf("unexpected length of data: %v", cm.Data)
@@ -46,7 +46,7 @@ func TestPatch(t *testing.T) {
 		{
 			name:      "strategic patch",
 			patch:     `{ "data": { "test": "baz" } }`,
-			patchType: types.StrategicMergePatchType,
+			patchType: "strategic",
 			validate: func(t *testing.T, cm *corev1.ConfigMap) {
 				if len(cm.Data) != 2 {
 					t.Errorf("unexpected length of data: %v", cm.Data)


### PR DESCRIPTION
I added a second commit that will test the patch type provided so that we get a useful error message for incorrect patch types.

```
ERRO[0019] failed to setup patch command controller=syncset error="Invalid patch type: potato. Valid patch types are 'strategic', 'merge' or 'json'"
ERRO[0019] unable to apply sync set patches clusterDeployment=abutcher controller=syncset error="Invalid patch type: potato. Valid patch types are 'strategic', 'merge' or 'json'" namespace=default syncSet=example2
```