### PR TITLE
Fix failed jobs showing as running in metrics.

### DIFF
--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -272,24 +272,14 @@ func processJobs(jobs []batchv1.Job) (runningTotal, succeededTotal, failedTotal 
 	succeeded := map[string]int{}
 	for _, job := range jobs {
 		clusterType := GetClusterDeploymentTypeForJob(job)
-		if _, ok := running[clusterType]; !ok {
-			running[clusterType] = 0
-		}
-		if _, ok := failed[clusterType]; !ok {
-			failed[clusterType] = 0
-		}
-		if _, ok := succeeded[clusterType]; !ok {
-			succeeded[clusterType] = 0
-		}
-		if job.Status.CompletionTime == nil {
-			running[clusterType]++
+
+		// Sort the jobs:
+		if job.Status.Failed > 0 {
+			failed[clusterType]++
+		} else if job.Status.Succeeded > 0 {
+			succeeded[clusterType]++
 		} else {
-			if job.Status.Failed > 0 {
-				failed[clusterType]++
-			}
-			if job.Status.Succeeded > 0 {
-				succeeded[clusterType]++
-			}
+			running[clusterType]++
 		}
 	}
 	return running, succeeded, failed


### PR DESCRIPTION
Failed jobs do not have a completion time, so they were appearing as
running.