### PR TITLE
Validate SyncSet PatchType

### DIFF
--- a/cmd/hiveadmission/main.go
+++ b/cmd/hiveadmission/main.go
@@ -33,5 +33,7 @@ func main() {
 		&hivevalidatingwebhooks.DNSZoneValidatingAdmissionHook{},
 		hivevalidatingwebhooks.NewClusterDeploymentValidatingAdmissionHook(),
 		&hivevalidatingwebhooks.ClusterImageSetValidatingAdmissionHook{},
+		&hivevalidatingwebhooks.SyncSetValidatingAdmissionHook{},
+		&hivevalidatingwebhooks.SelectorSyncSetValidatingAdmissionHook{},
 	)
 }

--- a/config/hiveadmission/selectorsyncset-webhook.yaml
+++ b/config/hiveadmission/selectorsyncset-webhook.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: selectorsyncsets.admission.hive.openshift.io
+webhooks:
+- name: selectorsyncsets.admission.hive.openshift.io
+  clientConfig:
+    service:
+      # reach the webhook via the registered aggregated API
+      namespace: default
+      name: kubernetes
+      path: /apis/admission.hive.openshift.io/v1alpha1/selectorsyncsets
+  rules:
+  - operations:
+    - CREATE
+    - UPDATE
+    apiGroups:
+    - hive.openshift.io
+    apiVersions:
+    - v1alpha1
+    resources:
+    - selectorsyncsets
+  failurePolicy: Fail

--- a/config/hiveadmission/syncset-webhook.yaml
+++ b/config/hiveadmission/syncset-webhook.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: syncsets.admission.hive.openshift.io
+webhooks:
+- name: syncsets.admission.hive.openshift.io
+  clientConfig:
+    service:
+      # reach the webhook via the registered aggregated API
+      namespace: default
+      name: kubernetes
+      path: /apis/admission.hive.openshift.io/v1alpha1/syncsets
+  rules:
+  - operations:
+    - CREATE
+    - UPDATE
+    apiGroups:
+    - hive.openshift.io
+    apiVersions:
+    - v1alpha1
+    resources:
+    - syncsets
+  failurePolicy: Fail

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/selector_syncset_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/selector_syncset_validating_admission_hook.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validatingwebhooks
+
+import (
+	"encoding/json"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+
+	"net/http"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	selectorSyncSetGroup    = "hive.openshift.io"
+	selectorSyncSetVersion  = "v1alpha1"
+	selectorSyncSetResource = "selectorsyncsets"
+)
+
+// SelectorSyncSetValidatingAdmissionHook is a struct that is used to reference what code should be run by the generic-admission-server.
+type SelectorSyncSetValidatingAdmissionHook struct{}
+
+// ValidatingResource is called by generic-admission-server on startup to register the returned REST resource through which the
+//                    webhook is accessed by the kube apiserver.
+// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.hive.openshift.io/v1alpha1/selectorsyncsets".
+//              When the kube apiserver calls this registered REST resource, the generic-admission-server calls the Validate() method below.
+func (a *SelectorSyncSetValidatingAdmissionHook) ValidatingResource() (plural schema.GroupVersionResource, singular string) {
+	log.WithFields(log.Fields{
+		"group":    "admission.hive.openshift.io",
+		"version":  "v1alpha1",
+		"resource": "selectorsyncsets",
+	}).Info("Registering validation REST resource")
+	// NOTE: This GVR is meant to be different than the SelectorSyncSet CRD GVR which has group "hive.openshift.io".
+	return schema.GroupVersionResource{
+			Group:    "admission.hive.openshift.io",
+			Version:  "v1alpha1",
+			Resource: "selectorsyncsets",
+		},
+		"selectorsyncset"
+}
+
+// Initialize is called by generic-admission-server on startup to setup any special initialization that your webhook needs.
+func (a *SelectorSyncSetValidatingAdmissionHook) Initialize(kubeClientConfig *rest.Config, stopCh <-chan struct{}) error {
+	log.WithFields(log.Fields{
+		"group":    "admission.hive.openshift.io",
+		"version":  "v1alpha1",
+		"resource": "selectorsyncsets",
+	}).Info("Initializing validation REST resource")
+	return nil // No initialization needed right now.
+}
+
+// Validate is called by generic-admission-server when the registered REST resource above is called with an admission request.
+// Usually it's the kube apiserver that is making the admission validation request.
+func (a *SelectorSyncSetValidatingAdmissionHook) Validate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+	contextLogger := log.WithFields(log.Fields{
+		"operation": admissionSpec.Operation,
+		"group":     admissionSpec.Resource.Group,
+		"version":   admissionSpec.Resource.Version,
+		"resource":  admissionSpec.Resource.Resource,
+		"method":    "Validate",
+	})
+
+	if !a.shouldValidate(admissionSpec) {
+		contextLogger.Info("Skipping validation for request")
+		// The request object isn't something that this validator should validate.
+		// Therefore, we say that it's allowed.
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: true,
+		}
+	}
+
+	contextLogger.Info("Validating request")
+
+	if admissionSpec.Operation == admissionv1beta1.Create {
+		return a.validateCreate(admissionSpec)
+	}
+
+	if admissionSpec.Operation == admissionv1beta1.Update {
+		return a.validateUpdate(admissionSpec)
+	}
+
+	// We're only validating creates and updates at this time, so all other operations are explicitly allowed.
+	contextLogger.Info("Successful validation")
+	return &admissionv1beta1.AdmissionResponse{
+		Allowed: true,
+	}
+}
+
+// shouldValidate explicitly checks if the request should validated. For example, this webhook may have accidentally been registered to check
+// the validity of some other type of object with a different GVR.
+func (a *SelectorSyncSetValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1beta1.AdmissionRequest) bool {
+	contextLogger := log.WithFields(log.Fields{
+		"operation": admissionSpec.Operation,
+		"group":     admissionSpec.Resource.Group,
+		"version":   admissionSpec.Resource.Version,
+		"resource":  admissionSpec.Resource.Resource,
+		"method":    "shouldValidate",
+	})
+
+	if admissionSpec.Resource.Group != selectorSyncSetGroup {
+		contextLogger.Debug("Returning False, not our group")
+		return false
+	}
+
+	if admissionSpec.Resource.Version != selectorSyncSetVersion {
+		contextLogger.Debug("Returning False, it's our group, but not the right version")
+		return false
+	}
+
+	if admissionSpec.Resource.Resource != selectorSyncSetResource {
+		contextLogger.Debug("Returning False, it's our group and version, but not the right resource")
+		return false
+	}
+
+	// If we get here, then we're supposed to validate the object.
+	contextLogger.Debug("Returning True, passed all prerequisites.")
+	return true
+}
+
+// validateCreate specifically validates create operations for SelectorSyncSet objects.
+func (a *SelectorSyncSetValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+	contextLogger := log.WithFields(log.Fields{
+		"operation": admissionSpec.Operation,
+		"group":     admissionSpec.Resource.Group,
+		"version":   admissionSpec.Resource.Version,
+		"resource":  admissionSpec.Resource.Resource,
+		"method":    "validateCreate",
+	})
+
+	newObject := &hivev1.SelectorSyncSet{}
+	err := json.Unmarshal(admissionSpec.Object.Raw, newObject)
+	if err != nil {
+		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: err.Error(),
+			},
+		}
+	}
+
+	if newObject != nil {
+		// Add the new data to the contextLogger
+		contextLogger.Data["object.Name"] = newObject.Name
+	}
+
+	if invalid, ok := checkValidPatchTypes(newObject.Spec.Patches); !ok {
+		message := fmt.Sprintf("Failed validation: Invalid patch type detected: %s. Valid patch types are: json, merge, and strategic", invalid)
+		contextLogger.Infof(message)
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: message,
+			},
+		}
+	}
+
+	// If we get here, then all checks passed, so the object is valid.
+	contextLogger.Info("Successful validation")
+	return &admissionv1beta1.AdmissionResponse{
+		Allowed: true,
+	}
+}
+
+// validateUpdate specifically validates update operations for SelectorSyncSet objects.
+func (a *SelectorSyncSetValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+	contextLogger := log.WithFields(log.Fields{
+		"operation": admissionSpec.Operation,
+		"group":     admissionSpec.Resource.Group,
+		"version":   admissionSpec.Resource.Version,
+		"resource":  admissionSpec.Resource.Resource,
+		"method":    "validateUpdate",
+	})
+
+	newObject := &hivev1.SelectorSyncSet{}
+	err := json.Unmarshal(admissionSpec.Object.Raw, newObject)
+	if err != nil {
+		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: err.Error(),
+			},
+		}
+	}
+
+	if newObject != nil {
+		// Add the new data to the contextLogger
+		contextLogger.Data["object.Name"] = newObject.Name
+	}
+
+	if invalid, ok := checkValidPatchTypes(newObject.Spec.Patches); !ok {
+		message := fmt.Sprintf("Failed validation: Invalid patch type detected: %s. Valid patch types are: json, merge, and strategic", invalid)
+		contextLogger.Infof(message)
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: message,
+			},
+		}
+	}
+
+	// If we get here, then all checks passed, so the object is valid.
+	contextLogger.Info("Successful validation")
+	return &admissionv1beta1.AdmissionResponse{
+		Allowed: true,
+	}
+}

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/selector_syncset_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/selector_syncset_validating_admission_hook_test.go
@@ -87,6 +87,18 @@ func TestSelectorSyncSetValidate(t *testing.T) {
 			selectorSyncSet: testInvalidPatchSelectorSyncSet(),
 			expectedAllowed: false,
 		},
+		{
+			name:            "Test create syncset with no patches",
+			operation:       admissionv1beta1.Create,
+			selectorSyncSet: testSelectorSyncSet(),
+			expectedAllowed: true,
+		},
+		{
+			name:            "Test update syncset with no patches",
+			operation:       admissionv1beta1.Update,
+			selectorSyncSet: testSelectorSyncSet(),
+			expectedAllowed: true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -128,24 +140,29 @@ func testInvalidPatchSelectorSyncSet() *hivev1.SelectorSyncSet {
 }
 
 func testPatchSelectorSyncSet(patchType string) *hivev1.SelectorSyncSet {
+	ss := testSelectorSyncSet()
+	ss.Spec = hivev1.SelectorSyncSetSpec{
+		SyncSetCommonSpec: hivev1.SyncSetCommonSpec{
+			Patches: []hivev1.SyncObjectPatch{
+				{
+					Patch:     "blah",
+					PatchType: "json",
+				},
+				{
+					Patch:     "foo",
+					PatchType: patchType,
+				},
+			},
+		},
+	}
+	return ss
+}
+
+func testSelectorSyncSet() *hivev1.SelectorSyncSet {
 	return &hivev1.SelectorSyncSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-selector-sync-set",
 			Namespace: "test-namespace",
-		},
-		Spec: hivev1.SelectorSyncSetSpec{
-			SyncSetCommonSpec: hivev1.SyncSetCommonSpec{
-				Patches: []hivev1.SyncObjectPatch{
-					{
-						Patch:     "blah",
-						PatchType: "json",
-					},
-					{
-						Patch:     "foo",
-						PatchType: patchType,
-					},
-				},
-			},
 		},
 	}
 }

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/selector_syncset_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/selector_syncset_validating_admission_hook_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validatingwebhooks
+
+import (
+	"encoding/json"
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"testing"
+)
+
+func TestSelectorSyncSetValidatingResource(t *testing.T) {
+	// Arrange
+	data := SelectorSyncSetValidatingAdmissionHook{}
+	expectedPlural := schema.GroupVersionResource{
+		Group:    "admission.hive.openshift.io",
+		Version:  "v1alpha1",
+		Resource: "selectorsyncsets",
+	}
+	expectedSingular := "selectorsyncset"
+
+	// Act
+	plural, singular := data.ValidatingResource()
+
+	// Assert
+	assert.Equal(t, expectedPlural, plural)
+	assert.Equal(t, expectedSingular, singular)
+}
+
+func TestSelectorSyncSetInitialize(t *testing.T) {
+	// Arrange
+	data := SelectorSyncSetValidatingAdmissionHook{}
+
+	// Act
+	err := data.Initialize(nil, nil)
+
+	// Assert
+	assert.Nil(t, err)
+}
+
+func TestSelectorSyncSetValidate(t *testing.T) {
+	cases := []struct {
+		name            string
+		operation       admissionv1beta1.Operation
+		expectedAllowed bool
+		selectorSyncSet *hivev1.SelectorSyncSet
+	}{
+		{
+			name:            "Test valid patch type create",
+			operation:       admissionv1beta1.Create,
+			selectorSyncSet: testValidPatchSelectorSyncSet(),
+			expectedAllowed: true,
+		},
+		{
+			name:            "Test invalid patch type create",
+			operation:       admissionv1beta1.Create,
+			selectorSyncSet: testInvalidPatchSelectorSyncSet(),
+			expectedAllowed: false,
+		},
+		{
+			name:            "Test valid patch type update",
+			operation:       admissionv1beta1.Update,
+			selectorSyncSet: testValidPatchSelectorSyncSet(),
+			expectedAllowed: true,
+		},
+		{
+			name:            "Test invalid patch type update",
+			operation:       admissionv1beta1.Update,
+			selectorSyncSet: testInvalidPatchSelectorSyncSet(),
+			expectedAllowed: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			data := SelectorSyncSetValidatingAdmissionHook{}
+
+			objectRaw, _ := json.Marshal(tc.selectorSyncSet)
+
+			gvr := metav1.GroupVersionResource{
+				Group:    "hive.openshift.io",
+				Version:  "v1alpha1",
+				Resource: "selectorsyncsets",
+			}
+
+			request := &admissionv1beta1.AdmissionRequest{
+				Operation: tc.operation,
+				Resource:  gvr,
+				Object: runtime.RawExtension{
+					Raw: objectRaw,
+				},
+				OldObject: runtime.RawExtension{
+					Raw: objectRaw,
+				},
+			}
+
+			response := data.Validate(request)
+			assert.Equal(t, tc.expectedAllowed, response.Allowed)
+		})
+	}
+}
+
+func testValidPatchSelectorSyncSet() *hivev1.SelectorSyncSet {
+	return testPatchSelectorSyncSet("merge")
+}
+
+func testInvalidPatchSelectorSyncSet() *hivev1.SelectorSyncSet {
+	return testPatchSelectorSyncSet("application/json-patch+json")
+}
+
+func testPatchSelectorSyncSet(patchType string) *hivev1.SelectorSyncSet {
+	return &hivev1.SelectorSyncSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-selector-sync-set",
+			Namespace: "test-namespace",
+		},
+		Spec: hivev1.SelectorSyncSetSpec{
+			SyncSetCommonSpec: hivev1.SyncSetCommonSpec{
+				Patches: []hivev1.SyncObjectPatch{
+					{
+						Patch:     "blah",
+						PatchType: "json",
+					},
+					{
+						Patch:     "foo",
+						PatchType: patchType,
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/syncset_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/syncset_validating_admission_hook.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validatingwebhooks
+
+import (
+	"encoding/json"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+
+	"net/http"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	syncSetGroup    = "hive.openshift.io"
+	syncSetVersion  = "v1alpha1"
+	syncSetResource = "syncsets"
+)
+
+// SyncSetValidatingAdmissionHook is a struct that is used to reference what code should be run by the generic-admission-server.
+type SyncSetValidatingAdmissionHook struct{}
+
+// ValidatingResource is called by generic-admission-server on startup to register the returned REST resource through which the
+//                    webhook is accessed by the kube apiserver.
+// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.hive.openshift.io/v1alpha1/syncsets".
+//              When the kube apiserver calls this registered REST resource, the generic-admission-server calls the Validate() method below.
+func (a *SyncSetValidatingAdmissionHook) ValidatingResource() (plural schema.GroupVersionResource, singular string) {
+	log.WithFields(log.Fields{
+		"group":    "admission.hive.openshift.io",
+		"version":  "v1alpha1",
+		"resource": "syncsets",
+	}).Info("Registering validation REST resource")
+	// NOTE: This GVR is meant to be different than the SyncSet CRD GVR which has group "hive.openshift.io".
+	return schema.GroupVersionResource{
+			Group:    "admission.hive.openshift.io",
+			Version:  "v1alpha1",
+			Resource: "syncsets",
+		},
+		"syncset"
+}
+
+// Initialize is called by generic-admission-server on startup to setup any special initialization that your webhook needs.
+func (a *SyncSetValidatingAdmissionHook) Initialize(kubeClientConfig *rest.Config, stopCh <-chan struct{}) error {
+	log.WithFields(log.Fields{
+		"group":    "admission.hive.openshift.io",
+		"version":  "v1alpha1",
+		"resource": "syncsets",
+	}).Info("Initializing validation REST resource")
+	return nil // No initialization needed right now.
+}
+
+// Validate is called by generic-admission-server when the registered REST resource above is called with an admission request.
+// Usually it's the kube apiserver that is making the admission validation request.
+func (a *SyncSetValidatingAdmissionHook) Validate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+	contextLogger := log.WithFields(log.Fields{
+		"operation": admissionSpec.Operation,
+		"group":     admissionSpec.Resource.Group,
+		"version":   admissionSpec.Resource.Version,
+		"resource":  admissionSpec.Resource.Resource,
+		"method":    "Validate",
+	})
+
+	if !a.shouldValidate(admissionSpec) {
+		contextLogger.Info("Skipping validation for request")
+		// The request object isn't something that this validator should validate.
+		// Therefore, we say that it's allowed.
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: true,
+		}
+	}
+
+	contextLogger.Info("Validating request")
+
+	if admissionSpec.Operation == admissionv1beta1.Create {
+		return a.validateCreate(admissionSpec)
+	}
+
+	if admissionSpec.Operation == admissionv1beta1.Update {
+		return a.validateUpdate(admissionSpec)
+	}
+
+	// We're only validating creates and updates at this time, so all other operations are explicitly allowed.
+	contextLogger.Info("Successful validation")
+	return &admissionv1beta1.AdmissionResponse{
+		Allowed: true,
+	}
+}
+
+// shouldValidate explicitly checks if the request should validated. For example, this webhook may have accidentally been registered to check
+// the validity of some other type of object with a different GVR.
+func (a *SyncSetValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1beta1.AdmissionRequest) bool {
+	contextLogger := log.WithFields(log.Fields{
+		"operation": admissionSpec.Operation,
+		"group":     admissionSpec.Resource.Group,
+		"version":   admissionSpec.Resource.Version,
+		"resource":  admissionSpec.Resource.Resource,
+		"method":    "shouldValidate",
+	})
+
+	if admissionSpec.Resource.Group != syncSetGroup {
+		contextLogger.Debug("Returning False, not our group")
+		return false
+	}
+
+	if admissionSpec.Resource.Version != syncSetVersion {
+		contextLogger.Debug("Returning False, it's our group, but not the right version")
+		return false
+	}
+
+	if admissionSpec.Resource.Resource != syncSetResource {
+		contextLogger.Debug("Returning False, it's our group and version, but not the right resource")
+		return false
+	}
+
+	// If we get here, then we're supposed to validate the object.
+	contextLogger.Debug("Returning True, passed all prerequisites.")
+	return true
+}
+
+// validateCreate specifically validates create operations for SyncSet objects.
+func (a *SyncSetValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+	contextLogger := log.WithFields(log.Fields{
+		"operation": admissionSpec.Operation,
+		"group":     admissionSpec.Resource.Group,
+		"version":   admissionSpec.Resource.Version,
+		"resource":  admissionSpec.Resource.Resource,
+		"method":    "validateCreate",
+	})
+
+	newObject := &hivev1.SyncSet{}
+	err := json.Unmarshal(admissionSpec.Object.Raw, newObject)
+	if err != nil {
+		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: err.Error(),
+			},
+		}
+	}
+
+	if newObject != nil {
+		// Add the new data to the contextLogger
+		contextLogger.Data["object.Name"] = newObject.Name
+	}
+
+	if invalid, ok := checkValidPatchTypes(newObject.Spec.Patches); !ok {
+		message := fmt.Sprintf("Failed validation: Invalid patch type detected: %s. Valid patch types are: json, merge, and strategic", invalid)
+		contextLogger.Infof(message)
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: message,
+			},
+		}
+	}
+
+	// If we get here, then all checks passed, so the object is valid.
+	contextLogger.Info("Successful validation")
+	return &admissionv1beta1.AdmissionResponse{
+		Allowed: true,
+	}
+}
+
+// validateUpdate specifically validates update operations for SyncSet objects.
+func (a *SyncSetValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+	contextLogger := log.WithFields(log.Fields{
+		"operation": admissionSpec.Operation,
+		"group":     admissionSpec.Resource.Group,
+		"version":   admissionSpec.Resource.Version,
+		"resource":  admissionSpec.Resource.Resource,
+		"method":    "validateUpdate",
+	})
+
+	newObject := &hivev1.SyncSet{}
+	err := json.Unmarshal(admissionSpec.Object.Raw, newObject)
+	if err != nil {
+		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: err.Error(),
+			},
+		}
+	}
+
+	if newObject != nil {
+		// Add the new data to the contextLogger
+		contextLogger.Data["object.Name"] = newObject.Name
+	}
+
+	if invalid, ok := checkValidPatchTypes(newObject.Spec.Patches); !ok {
+		message := fmt.Sprintf("Failed validation: Invalid patch type detected: %s. Valid patch types are: json, merge, and strategic", invalid)
+		contextLogger.Infof(message)
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: message,
+			},
+		}
+	}
+
+	// If we get here, then all checks passed, so the object is valid.
+	contextLogger.Info("Successful validation")
+	return &admissionv1beta1.AdmissionResponse{
+		Allowed: true,
+	}
+}
+
+func checkValidPatchTypes(patches []hivev1.SyncObjectPatch) (string, bool) {
+	validTypes := map[string]struct{}{"json": {}, "merge": {}, "strategic": {}}
+	for _, patch := range patches {
+		if _, ok := validTypes[patch.PatchType]; !ok {
+			return patch.PatchType, false
+		}
+	}
+	return "", true
+}

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/syncset_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/syncset_validating_admission_hook_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validatingwebhooks
+
+import (
+	"encoding/json"
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"testing"
+)
+
+func TestSyncSetValidatingResource(t *testing.T) {
+	// Arrange
+	data := SyncSetValidatingAdmissionHook{}
+	expectedPlural := schema.GroupVersionResource{
+		Group:    "admission.hive.openshift.io",
+		Version:  "v1alpha1",
+		Resource: "syncsets",
+	}
+	expectedSingular := "syncset"
+
+	// Act
+	plural, singular := data.ValidatingResource()
+
+	// Assert
+	assert.Equal(t, expectedPlural, plural)
+	assert.Equal(t, expectedSingular, singular)
+}
+
+func TestSyncSetInitialize(t *testing.T) {
+	// Arrange
+	data := SyncSetValidatingAdmissionHook{}
+
+	// Act
+	err := data.Initialize(nil, nil)
+
+	// Assert
+	assert.Nil(t, err)
+}
+
+func TestSyncSetValidate(t *testing.T) {
+	cases := []struct {
+		name            string
+		operation       admissionv1beta1.Operation
+		expectedAllowed bool
+		syncSet         *hivev1.SyncSet
+	}{
+		{
+			name:            "Test valid patch type create",
+			operation:       admissionv1beta1.Create,
+			syncSet:         testValidPatchSyncSet(),
+			expectedAllowed: true,
+		},
+		{
+			name:            "Test invalid patch type create",
+			operation:       admissionv1beta1.Create,
+			syncSet:         testInvalidPatchSyncSet(),
+			expectedAllowed: false,
+		},
+		{
+			name:            "Test valid patch type update",
+			operation:       admissionv1beta1.Update,
+			syncSet:         testValidPatchSyncSet(),
+			expectedAllowed: true,
+		},
+		{
+			name:            "Test invalid patch type update",
+			operation:       admissionv1beta1.Update,
+			syncSet:         testInvalidPatchSyncSet(),
+			expectedAllowed: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			data := SyncSetValidatingAdmissionHook{}
+
+			objectRaw, _ := json.Marshal(tc.syncSet)
+
+			gvr := metav1.GroupVersionResource{
+				Group:    "hive.openshift.io",
+				Version:  "v1alpha1",
+				Resource: "syncsets",
+			}
+
+			request := &admissionv1beta1.AdmissionRequest{
+				Operation: tc.operation,
+				Resource:  gvr,
+				Object: runtime.RawExtension{
+					Raw: objectRaw,
+				},
+				OldObject: runtime.RawExtension{
+					Raw: objectRaw,
+				},
+			}
+
+			response := data.Validate(request)
+			assert.Equal(t, tc.expectedAllowed, response.Allowed)
+		})
+	}
+}
+
+func testValidPatchSyncSet() *hivev1.SyncSet {
+	return testPatchSyncSet("merge")
+}
+
+func testInvalidPatchSyncSet() *hivev1.SyncSet {
+	return testPatchSyncSet("application/json-patch+json")
+}
+
+func testPatchSyncSet(patchType string) *hivev1.SyncSet {
+	return &hivev1.SyncSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-sync-set",
+			Namespace: "test-namespace",
+		},
+		Spec: hivev1.SyncSetSpec{
+			SyncSetCommonSpec: hivev1.SyncSetCommonSpec{
+				Patches: []hivev1.SyncObjectPatch{
+					{
+						Patch:     "blah",
+						PatchType: "json",
+					},
+					{
+						Patch:     "foo",
+						PatchType: patchType,
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/syncset_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/syncset_validating_admission_hook_test.go
@@ -87,6 +87,18 @@ func TestSyncSetValidate(t *testing.T) {
 			syncSet:         testInvalidPatchSyncSet(),
 			expectedAllowed: false,
 		},
+		{
+			name:            "Test create with no patches",
+			operation:       admissionv1beta1.Create,
+			syncSet:         testSyncSet(),
+			expectedAllowed: true,
+		},
+		{
+			name:            "Test update with no patches",
+			operation:       admissionv1beta1.Update,
+			syncSet:         testSyncSet(),
+			expectedAllowed: true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -128,24 +140,29 @@ func testInvalidPatchSyncSet() *hivev1.SyncSet {
 }
 
 func testPatchSyncSet(patchType string) *hivev1.SyncSet {
+	ss := testSyncSet()
+	ss.Spec = hivev1.SyncSetSpec{
+		SyncSetCommonSpec: hivev1.SyncSetCommonSpec{
+			Patches: []hivev1.SyncObjectPatch{
+				{
+					Patch:     "blah",
+					PatchType: "json",
+				},
+				{
+					Patch:     "foo",
+					PatchType: patchType,
+				},
+			},
+		},
+	}
+	return ss
+}
+
+func testSyncSet() *hivev1.SyncSet {
 	return &hivev1.SyncSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-sync-set",
 			Namespace: "test-namespace",
-		},
-		Spec: hivev1.SyncSetSpec{
-			SyncSetCommonSpec: hivev1.SyncSetCommonSpec{
-				Patches: []hivev1.SyncObjectPatch{
-					{
-						Patch:     "blah",
-						PatchType: "json",
-					},
-					{
-						Patch:     "foo",
-						PatchType: patchType,
-					},
-				},
-			},
 		},
 	}
 }

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -7,8 +7,10 @@
 // config/hiveadmission/dnszones-webhook.yaml
 // config/hiveadmission/hiveadmission_rbac_role.yaml
 // config/hiveadmission/hiveadmission_rbac_role_binding.yaml
+// config/hiveadmission/selectorsyncset-webhook.yaml
 // config/hiveadmission/service-account.yaml
 // config/hiveadmission/service.yaml
+// config/hiveadmission/syncset-webhook.yaml
 // config/manager/deployment.yaml
 // config/manager/service.yaml
 // config/clusterimagesets/openshift-4.0-beta3.yaml
@@ -430,6 +432,47 @@ func configHiveadmissionHiveadmission_rbac_role_bindingYaml() (*asset, error) {
 	return a, nil
 }
 
+var _configHiveadmissionSelectorsyncsetWebhookYaml = []byte(`---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: selectorsyncsets.admission.hive.openshift.io
+webhooks:
+- name: selectorsyncsets.admission.hive.openshift.io
+  clientConfig:
+    service:
+      # reach the webhook via the registered aggregated API
+      namespace: default
+      name: kubernetes
+      path: /apis/admission.hive.openshift.io/v1alpha1/selectorsyncsets
+  rules:
+  - operations:
+    - CREATE
+    - UPDATE
+    apiGroups:
+    - hive.openshift.io
+    apiVersions:
+    - v1alpha1
+    resources:
+    - selectorsyncsets
+  failurePolicy: Fail
+`)
+
+func configHiveadmissionSelectorsyncsetWebhookYamlBytes() ([]byte, error) {
+	return _configHiveadmissionSelectorsyncsetWebhookYaml, nil
+}
+
+func configHiveadmissionSelectorsyncsetWebhookYaml() (*asset, error) {
+	bytes, err := configHiveadmissionSelectorsyncsetWebhookYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "config/hiveadmission/selectorsyncset-webhook.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _configHiveadmissionServiceAccountYaml = []byte(`---
 # to be able to assign powers to the hiveadmission process
 apiVersion: v1
@@ -481,6 +524,47 @@ func configHiveadmissionServiceYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "config/hiveadmission/service.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _configHiveadmissionSyncsetWebhookYaml = []byte(`---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: syncsets.admission.hive.openshift.io
+webhooks:
+- name: syncsets.admission.hive.openshift.io
+  clientConfig:
+    service:
+      # reach the webhook via the registered aggregated API
+      namespace: default
+      name: kubernetes
+      path: /apis/admission.hive.openshift.io/v1alpha1/syncsets
+  rules:
+  - operations:
+    - CREATE
+    - UPDATE
+    apiGroups:
+    - hive.openshift.io
+    apiVersions:
+    - v1alpha1
+    resources:
+    - syncsets
+  failurePolicy: Fail
+`)
+
+func configHiveadmissionSyncsetWebhookYamlBytes() ([]byte, error) {
+	return _configHiveadmissionSyncsetWebhookYaml, nil
+}
+
+func configHiveadmissionSyncsetWebhookYaml() (*asset, error) {
+	bytes, err := configHiveadmissionSyncsetWebhookYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "config/hiveadmission/syncset-webhook.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1434,8 +1518,10 @@ var _bindata = map[string]func() (*asset, error){
 	"config/hiveadmission/dnszones-webhook.yaml":                configHiveadmissionDnszonesWebhookYaml,
 	"config/hiveadmission/hiveadmission_rbac_role.yaml":         configHiveadmissionHiveadmission_rbac_roleYaml,
 	"config/hiveadmission/hiveadmission_rbac_role_binding.yaml": configHiveadmissionHiveadmission_rbac_role_bindingYaml,
+	"config/hiveadmission/selectorsyncset-webhook.yaml":         configHiveadmissionSelectorsyncsetWebhookYaml,
 	"config/hiveadmission/service-account.yaml":                 configHiveadmissionServiceAccountYaml,
 	"config/hiveadmission/service.yaml":                         configHiveadmissionServiceYaml,
+	"config/hiveadmission/syncset-webhook.yaml":                 configHiveadmissionSyncsetWebhookYaml,
 	"config/manager/deployment.yaml":                            configManagerDeploymentYaml,
 	"config/manager/service.yaml":                               configManagerServiceYaml,
 	"config/clusterimagesets/openshift-4.0-beta3.yaml":          configClusterimagesetsOpenshift40Beta3Yaml,
@@ -1516,8 +1602,10 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"dnszones-webhook.yaml":                {configHiveadmissionDnszonesWebhookYaml, map[string]*bintree{}},
 			"hiveadmission_rbac_role.yaml":         {configHiveadmissionHiveadmission_rbac_roleYaml, map[string]*bintree{}},
 			"hiveadmission_rbac_role_binding.yaml": {configHiveadmissionHiveadmission_rbac_role_bindingYaml, map[string]*bintree{}},
+			"selectorsyncset-webhook.yaml":         {configHiveadmissionSelectorsyncsetWebhookYaml, map[string]*bintree{}},
 			"service-account.yaml":                 {configHiveadmissionServiceAccountYaml, map[string]*bintree{}},
 			"service.yaml":                         {configHiveadmissionServiceYaml, map[string]*bintree{}},
+			"syncset-webhook.yaml":                 {configHiveadmissionSyncsetWebhookYaml, map[string]*bintree{}},
 		}},
 		"manager": {nil, map[string]*bintree{
 			"deployment.yaml": {configManagerDeploymentYaml, map[string]*bintree{}},


### PR DESCRIPTION
Adds validating webhooks for syncsets and selectorsyncsets. Rejects patches with invalid patch types.