### PR TITLE
Give up on deprovisioning in deleted namespaces.

### DIFF
--- a/config/rbac/manager_role.yaml
+++ b/config/rbac/manager_role.yaml
@@ -34,6 +34,7 @@ rules:
   - ""
   resources:
   - pods
+  - namespaces
   verbs:
   - get
   - list

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1259,6 +1259,7 @@ rules:
   - ""
   resources:
   - pods
+  - namespaces
   verbs:
   - get
   - list


### PR DESCRIPTION
A fix is coming to UHC next week to prevent namespaces from being deleted before the cluster deployment is gone.

However in meantime, and in case this happens again, we need to watch for the error and if encountered, give up on deprovision, as there's little we can do. This change removes the finalizer and lets the cluster go away.