### PR TITLE
Delay install retries with sleep.

### DIFF
--- a/contrib/pkg/installmanager/installmanager_test.go
+++ b/contrib/pkg/installmanager/installmanager_test.go
@@ -67,6 +67,14 @@ func init() {
 	log.SetLevel(log.DebugLevel)
 }
 
+func TestCalcSleepSeconds(t *testing.T) {
+	assert.Equal(t, 60, calcSleepSeconds(0))
+	assert.Equal(t, 120, calcSleepSeconds(1))
+	assert.Equal(t, 240, calcSleepSeconds(2))
+	assert.Equal(t, 480, calcSleepSeconds(3))
+	assert.Equal(t, 86400, calcSleepSeconds(5000493985937))
+}
+
 func TestInstallManager(t *testing.T) {
 	apis.AddToScheme(scheme.Scheme)
 	tests := []struct {

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -68,3 +68,14 @@ $ dep ensure -v
 * The Dep cache located under *_$GOPATH/pkg/dep_*.
 * If you see any Dep errors during `make vendor`, you can remove local cached directory and try again.
 
+## Developing Hiveutil Install Manager
+
+We use a hiveutil subcommand for the install-manager, in pods and thus in an image to wrap the openshift-install process and upload artifacts to Hive. Developing this is tricky because it requires a published image and ClusterImageSet. Instead, you can hack together an environment as follows:
+
+ 1. Create a ClusterDeployment, allow it to resolve the installer image, but before it can complete:
+   1. Scale down the hive-controllers so they are no longer running: `kubectl scale -n hive deployment.v1.apps/hive-controllers --replicas=0`
+   1. Delete the install job: `k delete job dgoodwin1-install`
+ 1. Make a temporary working directory in your hive checkout: `mkdir temp`
+ 1. Compile your hiveutil changes: `make hiveutil`
+ 1. Set your pull secret as an env var to match the pod: `export PULL_SECRET=$(cat ~/pull-secret)`
+ 1. ../bin/hiveutil install-manager --work-dir /home/dgoodwin/go/src/github.com/openshift/hive/temp --log-level=debug hive dgoodwin1

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -217,19 +217,16 @@ func GenerateInstallerJob(
 			Image:           hiveImage,
 			ImagePullPolicy: hiveImagePullPolicy,
 			Env:             env,
-			Command:         []string{"/usr/bin/hiveutil"},
-			Args: []string{
-				"install-manager",
-				"--work-dir",
-				"/output",
-				"--log-level",
-				"debug",
-				"--install-config",
-				"/installconfig/install-config.yaml",
-				"--region",
-				cd.Spec.Platform.AWS.Region,
-				cd.Namespace,
-				cd.Name,
+			Command:         []string{"/bin/sh"},
+			Args: []string{"-c",
+				// Inlining a script to be run, we cannot assume a script to be in older images, nor that older images will output
+				// a sleep-seconds.txt file. If one is written, we will sleep that number of seconds. This allows exponential backoff
+				// for failing installs.
+				fmt.Sprintf(
+					"/usr/bin/hiveutil install-manager --work-dir /output --log-level debug --install-config /installconfig/install-config.yaml --region %s %s %s; installer_result=$?; if [ -f /output/sleep-seconds.txt ]; then sleep_seconds=$(cat /output/sleep-seconds.txt); echo \"sleeping for $sleep_seconds seconds until next retry\"; sleep $sleep_seconds; fi; exit $installer_result",
+					cd.Spec.Platform.AWS.Region,
+					cd.Namespace,
+					cd.Name),
 			},
 			VolumeMounts: volumeMounts,
 		},


### PR DESCRIPTION
Modifies install manager to write a sleep-seconds.txt file that uses the
current number of retries for exponential backoff when an install fails,
up to a max of 24 hours. This will help prevent constant API calls on
clusters that need attention before they can possibly install
successfully.

Pod install command is now a shell script that optionally looks for this
file, and if found, sleeps the requested number of seconds. This should
allow the feature to be backward compatible with older hive images which
do not write the file.

This approach should limit the memory consumed as the hiveutil
install-manager has exited, and we're just left with a shell sleep.

Additionally this change adds a deprovison immediately after failed installs.

This will help reduce running resources in the event of a long delay to
the next attempt.

We will still attempt to cleanup at the start of a retry if the InfraID
is still set. It will not be if the deprovision after failure
succeessfully cleared it.