### PR TITLE
Generate kubeconfig secret with additional CAs

### DIFF
--- a/pkg/controller/clusterversion/clusterversion_controller.go
+++ b/pkg/controller/clusterversion/clusterversion_controller.go
@@ -43,7 +43,6 @@ import (
 const (
 	clusterVersionObjectName = "version"
 	clusterVersionUnknown    = "undef"
-	adminKubeconfigKey       = "kubeconfig"
 )
 
 // Add creates a new ClusterDeployment Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
@@ -126,7 +125,7 @@ func (r *ReconcileClusterVersion) Reconcile(request reconcile.Request) (reconcil
 		cdLog.WithError(err).WithField("secret", fmt.Sprintf("%s/%s", cd.Status.AdminKubeconfigSecret.Name, cd.Namespace)).Error("cannot read secret")
 		return reconcile.Result{}, err
 	}
-	kubeConfig, err := controllerutils.FixupKubeconfig(adminKubeconfigSecret.Data[adminKubeconfigKey])
+	kubeConfig, err := controllerutils.FixupKubeconfigSecretData(adminKubeconfigSecret.Data)
 	if err != nil {
 		cdLog.WithError(err).Error("cannot fixup kubeconfig for remote cluster")
 		return reconcile.Result{}, err

--- a/pkg/controller/utils/cacrt.go
+++ b/pkg/controller/utils/cacrt.go
@@ -26,7 +26,9 @@ import (
 )
 
 var (
-	additionalCAData []byte
+	additionalCAData      []byte
+	adminKubeconfigKey    = "kubeconfig"
+	rawAdminKubeconfigKey = "raw-kubeconfig"
 )
 
 // SetupAdditionalCA reads a file referenced by the ADDITIONAL_CA environment
@@ -64,4 +66,15 @@ func FixupKubeconfig(data []byte) ([]byte, error) {
 		}
 	}
 	return clientcmd.Write(*cfg)
+}
+
+// FixupKubeconfigSecretData adds additional certificate authorities to the kubeconfig
+// in the argument data map. It first looks for the raw secret key. If not found, it
+// uses the default kubeconfig key.
+func FixupKubeconfigSecretData(data map[string][]byte) ([]byte, error) {
+	rawData, hasRaw := data[rawAdminKubeconfigKey]
+	if !hasRaw {
+		rawData = data[adminKubeconfigKey]
+	}
+	return FixupKubeconfig(rawData)
 }


### PR DESCRIPTION
Adds field to ClusterDeployment status to hold the raw kubeconfig
Points the original status.AdminKubeconfigSecret to a new generated secret that contains additional CAs
Includes fix to hive operator to force a reload of the hive controllers pod when the AdditionalCertificateAuthorities value changes.