### PR TITLE
Workarounds for problems with managed DNSZone cleanup.

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -553,6 +553,23 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "Ensure managed DNSZone is deleted with cluster deployment",
+			existing: []runtime.Object{
+				func() *hivev1.ClusterDeployment {
+					cd := testDeletedClusterDeployment()
+					cd.Spec.ManageDNS = true
+					return cd
+				}(),
+				testSecret(corev1.SecretTypeDockerConfigJson, pullSecretSecret, corev1.DockerConfigJsonKey, "{}"),
+				testSecret(corev1.SecretTypeOpaque, sshKeySecret, adminSSHKeySecretKey, "fakesshkey"),
+				testDNSZone(),
+			},
+			validate: func(c client.Client, t *testing.T) {
+				dnsZone := getDNSZone(c)
+				assert.Nil(t, dnsZone, "dnsZone should not exist")
+			},
+		},
+		{
 			name: "Delete cluster deployment with image from clusterimageset",
 			existing: []runtime.Object{
 				func() *hivev1.ClusterDeployment {


### PR DESCRIPTION
Workaround an issue we've seen at least on 3.11 where is it possible for
a dnszone to be terminating when it's parent cluster deployment is gone,
despite blockOwnerDeletion on it's owner ref.

Instead we now refuse to remove the cluster deployment finalizer until
managed dnszones are deleted.

Additionally we have seen rare clusters where deleting the parent
cluster deployment did not automatically delete the managed DNSZone.
Also watch for this situation and issue our own delete if encountered.