### PR TITLE
wildcard ingress migration and webhook validation

### DIFF
--- a/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook.go
@@ -443,7 +443,8 @@ func hasClearedOutPreviouslyDefinedIngressList(oldObject, newObject *hivev1.Clus
 
 func validateIngressDomainsShareClusterDomain(newObject *hivev1.ClusterDeploymentSpec) bool {
 	// ingress entries must share the same domain as the cluster
-	regexString := fmt.Sprintf("(?i).*%s.%s$", newObject.ClusterName, newObject.BaseDomain)
+	// so watch for an ingress domain ending in: .<clusterName>.<baseDomain>
+	regexString := fmt.Sprintf(`(?i).*\.%s.%s$`, newObject.ClusterName, newObject.BaseDomain)
 	sharedSubdomain := regexp.MustCompile(regexString)
 
 	for _, ingress := range newObject.Ingress {

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"regexp"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -207,15 +208,9 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateCreate(admissionSpec 
 
 	// TODO: Put Create Validation Here (or in openAPIV3Schema validation section of crd)
 
-	if !validateIngressList(&newObject.Spec) {
-		message := "If defining the Ingress list, it must include a default ingress entry"
-		return &admissionv1beta1.AdmissionResponse{
-			Allowed: false,
-			Result: &metav1.Status{
-				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
-				Message: message,
-			},
-		}
+	// validate the ingress
+	if ingressValidationResult := validateIngress(newObject, contextLogger); ingressValidationResult != nil {
+		return ingressValidationResult
 	}
 
 	if newObject.Spec.ManageDNS {
@@ -298,18 +293,9 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateUpdate(admissionSpec 
 		}
 	}
 
-	// First check whether the newlist is valid at all
-	if !validateIngressList(&newObject.Spec) {
-		message := fmt.Sprintf("Ingress list must include a default entry")
-		contextLogger.Infof("Failed validation: %v", message)
-
-		return &admissionv1beta1.AdmissionResponse{
-			Allowed: false,
-			Result: &metav1.Status{
-				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
-				Message: message,
-			},
-		}
+	// validate the newly incoming ingress
+	if ingressValidationResult := validateIngress(newObject, contextLogger); ingressValidationResult != nil {
+		return ingressValidationResult
 	}
 
 	// Now catch the case where there was a previously defined list and now it's being emptied
@@ -455,6 +441,31 @@ func hasClearedOutPreviouslyDefinedIngressList(oldObject, newObject *hivev1.Clus
 	return false
 }
 
+func validateIngressDomainsShareClusterDomain(newObject *hivev1.ClusterDeploymentSpec) bool {
+	// ingress entries must share the same domain as the cluster
+	regexString := fmt.Sprintf("(?i).*%s.%s$", newObject.ClusterName, newObject.BaseDomain)
+	sharedSubdomain := regexp.MustCompile(regexString)
+
+	for _, ingress := range newObject.Ingress {
+		if !sharedSubdomain.Match([]byte(ingress.Domain)) {
+			return false
+		}
+	}
+	return true
+}
+func validateIngressDomainsNotWildcard(newObject *hivev1.ClusterDeploymentSpec) bool {
+	// check for domains with leading '*'
+	// the * is unecessary as the ingress controller assumes a wildcard
+	for _, ingress := range newObject.Ingress {
+		if ingress.Domain[0] == '*' {
+			return false
+		}
+	}
+	return true
+}
+
+// empty ingress is allowed (for create), but if it's non-zero
+// it must include an entry for 'default'
 func validateIngressList(newObject *hivev1.ClusterDeploymentSpec) bool {
 	if len(newObject.Ingress) == 0 {
 		return true
@@ -502,4 +513,46 @@ func validateDomain(domain string, validDomains []string) bool {
 		}
 	}
 	return false
+}
+
+func validateIngress(newObject *hivev1.ClusterDeployment, contextLogger *log.Entry) *admissionv1beta1.AdmissionResponse {
+	if !validateIngressList(&newObject.Spec) {
+		message := fmt.Sprintf("Ingress list must include a default entry")
+		contextLogger.Infof("Failed validation: %v", message)
+
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: message,
+			},
+		}
+	}
+
+	if !validateIngressDomainsNotWildcard(&newObject.Spec) {
+		message := "Ingress domains must not lead with *"
+		contextLogger.Infof("Failed validation: %v", message)
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: message,
+			},
+		}
+	}
+
+	if !validateIngressDomainsShareClusterDomain(&newObject.Spec) {
+		message := "Ingress domains must share the same domain as the cluster"
+		contextLogger.Infof("Failed validation: %v", message)
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: message,
+			},
+		}
+	}
+
+	// everything passed
+	return nil
 }

--- a/pkg/awsclient/mock/client_generated.go
+++ b/pkg/awsclient/mock/client_generated.go
@@ -41,7 +41,6 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 
 // DescribeAvailabilityZones mocks base method
 func (m *MockClient) DescribeAvailabilityZones(arg0 *ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeAvailabilityZones", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeAvailabilityZonesOutput)
 	ret1, _ := ret[1].(error)
@@ -50,13 +49,11 @@ func (m *MockClient) DescribeAvailabilityZones(arg0 *ec2.DescribeAvailabilityZon
 
 // DescribeAvailabilityZones indicates an expected call of DescribeAvailabilityZones
 func (mr *MockClientMockRecorder) DescribeAvailabilityZones(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAvailabilityZones", reflect.TypeOf((*MockClient)(nil).DescribeAvailabilityZones), arg0)
 }
 
 // DescribeImages mocks base method
 func (m *MockClient) DescribeImages(arg0 *ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeImages", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeImagesOutput)
 	ret1, _ := ret[1].(error)
@@ -65,13 +62,11 @@ func (m *MockClient) DescribeImages(arg0 *ec2.DescribeImagesInput) (*ec2.Describ
 
 // DescribeImages indicates an expected call of DescribeImages
 func (mr *MockClientMockRecorder) DescribeImages(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeImages", reflect.TypeOf((*MockClient)(nil).DescribeImages), arg0)
 }
 
 // DescribeVpcs mocks base method
 func (m *MockClient) DescribeVpcs(arg0 *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeVpcs", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeVpcsOutput)
 	ret1, _ := ret[1].(error)
@@ -80,13 +75,11 @@ func (m *MockClient) DescribeVpcs(arg0 *ec2.DescribeVpcsInput) (*ec2.DescribeVpc
 
 // DescribeVpcs indicates an expected call of DescribeVpcs
 func (mr *MockClientMockRecorder) DescribeVpcs(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcs", reflect.TypeOf((*MockClient)(nil).DescribeVpcs), arg0)
 }
 
 // DescribeSubnets mocks base method
 func (m *MockClient) DescribeSubnets(arg0 *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSubnets", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeSubnetsOutput)
 	ret1, _ := ret[1].(error)
@@ -95,13 +88,11 @@ func (m *MockClient) DescribeSubnets(arg0 *ec2.DescribeSubnetsInput) (*ec2.Descr
 
 // DescribeSubnets indicates an expected call of DescribeSubnets
 func (mr *MockClientMockRecorder) DescribeSubnets(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubnets", reflect.TypeOf((*MockClient)(nil).DescribeSubnets), arg0)
 }
 
 // DescribeSecurityGroups mocks base method
 func (m *MockClient) DescribeSecurityGroups(arg0 *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeSecurityGroups", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeSecurityGroupsOutput)
 	ret1, _ := ret[1].(error)
@@ -110,13 +101,11 @@ func (m *MockClient) DescribeSecurityGroups(arg0 *ec2.DescribeSecurityGroupsInpu
 
 // DescribeSecurityGroups indicates an expected call of DescribeSecurityGroups
 func (mr *MockClientMockRecorder) DescribeSecurityGroups(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecurityGroups", reflect.TypeOf((*MockClient)(nil).DescribeSecurityGroups), arg0)
 }
 
 // RunInstances mocks base method
 func (m *MockClient) RunInstances(arg0 *ec2.RunInstancesInput) (*ec2.Reservation, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunInstances", arg0)
 	ret0, _ := ret[0].(*ec2.Reservation)
 	ret1, _ := ret[1].(error)
@@ -125,13 +114,11 @@ func (m *MockClient) RunInstances(arg0 *ec2.RunInstancesInput) (*ec2.Reservation
 
 // RunInstances indicates an expected call of RunInstances
 func (mr *MockClientMockRecorder) RunInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunInstances", reflect.TypeOf((*MockClient)(nil).RunInstances), arg0)
 }
 
 // DescribeInstances mocks base method
 func (m *MockClient) DescribeInstances(arg0 *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DescribeInstances", arg0)
 	ret0, _ := ret[0].(*ec2.DescribeInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -140,13 +127,11 @@ func (m *MockClient) DescribeInstances(arg0 *ec2.DescribeInstancesInput) (*ec2.D
 
 // DescribeInstances indicates an expected call of DescribeInstances
 func (mr *MockClientMockRecorder) DescribeInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeInstances", reflect.TypeOf((*MockClient)(nil).DescribeInstances), arg0)
 }
 
 // TerminateInstances mocks base method
 func (m *MockClient) TerminateInstances(arg0 *ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TerminateInstances", arg0)
 	ret0, _ := ret[0].(*ec2.TerminateInstancesOutput)
 	ret1, _ := ret[1].(error)
@@ -155,13 +140,11 @@ func (m *MockClient) TerminateInstances(arg0 *ec2.TerminateInstancesInput) (*ec2
 
 // TerminateInstances indicates an expected call of TerminateInstances
 func (mr *MockClientMockRecorder) TerminateInstances(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateInstances", reflect.TypeOf((*MockClient)(nil).TerminateInstances), arg0)
 }
 
 // RegisterInstancesWithLoadBalancer mocks base method
 func (m *MockClient) RegisterInstancesWithLoadBalancer(arg0 *elb.RegisterInstancesWithLoadBalancerInput) (*elb.RegisterInstancesWithLoadBalancerOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RegisterInstancesWithLoadBalancer", arg0)
 	ret0, _ := ret[0].(*elb.RegisterInstancesWithLoadBalancerOutput)
 	ret1, _ := ret[1].(error)
@@ -170,13 +153,11 @@ func (m *MockClient) RegisterInstancesWithLoadBalancer(arg0 *elb.RegisterInstanc
 
 // RegisterInstancesWithLoadBalancer indicates an expected call of RegisterInstancesWithLoadBalancer
 func (mr *MockClientMockRecorder) RegisterInstancesWithLoadBalancer(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterInstancesWithLoadBalancer", reflect.TypeOf((*MockClient)(nil).RegisterInstancesWithLoadBalancer), arg0)
 }
 
 // CreateAccessKey mocks base method
 func (m *MockClient) CreateAccessKey(arg0 *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAccessKey", arg0)
 	ret0, _ := ret[0].(*iam.CreateAccessKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -185,13 +166,11 @@ func (m *MockClient) CreateAccessKey(arg0 *iam.CreateAccessKeyInput) (*iam.Creat
 
 // CreateAccessKey indicates an expected call of CreateAccessKey
 func (mr *MockClientMockRecorder) CreateAccessKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccessKey", reflect.TypeOf((*MockClient)(nil).CreateAccessKey), arg0)
 }
 
 // CreateUser mocks base method
 func (m *MockClient) CreateUser(arg0 *iam.CreateUserInput) (*iam.CreateUserOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateUser", arg0)
 	ret0, _ := ret[0].(*iam.CreateUserOutput)
 	ret1, _ := ret[1].(error)
@@ -200,13 +179,11 @@ func (m *MockClient) CreateUser(arg0 *iam.CreateUserInput) (*iam.CreateUserOutpu
 
 // CreateUser indicates an expected call of CreateUser
 func (mr *MockClientMockRecorder) CreateUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockClient)(nil).CreateUser), arg0)
 }
 
 // DeleteAccessKey mocks base method
 func (m *MockClient) DeleteAccessKey(arg0 *iam.DeleteAccessKeyInput) (*iam.DeleteAccessKeyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAccessKey", arg0)
 	ret0, _ := ret[0].(*iam.DeleteAccessKeyOutput)
 	ret1, _ := ret[1].(error)
@@ -215,13 +192,11 @@ func (m *MockClient) DeleteAccessKey(arg0 *iam.DeleteAccessKeyInput) (*iam.Delet
 
 // DeleteAccessKey indicates an expected call of DeleteAccessKey
 func (mr *MockClientMockRecorder) DeleteAccessKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccessKey", reflect.TypeOf((*MockClient)(nil).DeleteAccessKey), arg0)
 }
 
 // DeleteUser mocks base method
 func (m *MockClient) DeleteUser(arg0 *iam.DeleteUserInput) (*iam.DeleteUserOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteUser", arg0)
 	ret0, _ := ret[0].(*iam.DeleteUserOutput)
 	ret1, _ := ret[1].(error)
@@ -230,13 +205,11 @@ func (m *MockClient) DeleteUser(arg0 *iam.DeleteUserInput) (*iam.DeleteUserOutpu
 
 // DeleteUser indicates an expected call of DeleteUser
 func (mr *MockClientMockRecorder) DeleteUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*MockClient)(nil).DeleteUser), arg0)
 }
 
 // DeleteUserPolicy mocks base method
 func (m *MockClient) DeleteUserPolicy(arg0 *iam.DeleteUserPolicyInput) (*iam.DeleteUserPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteUserPolicy", arg0)
 	ret0, _ := ret[0].(*iam.DeleteUserPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -245,13 +218,11 @@ func (m *MockClient) DeleteUserPolicy(arg0 *iam.DeleteUserPolicyInput) (*iam.Del
 
 // DeleteUserPolicy indicates an expected call of DeleteUserPolicy
 func (mr *MockClientMockRecorder) DeleteUserPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserPolicy", reflect.TypeOf((*MockClient)(nil).DeleteUserPolicy), arg0)
 }
 
 // GetUser mocks base method
 func (m *MockClient) GetUser(arg0 *iam.GetUserInput) (*iam.GetUserOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUser", arg0)
 	ret0, _ := ret[0].(*iam.GetUserOutput)
 	ret1, _ := ret[1].(error)
@@ -260,13 +231,11 @@ func (m *MockClient) GetUser(arg0 *iam.GetUserInput) (*iam.GetUserOutput, error)
 
 // GetUser indicates an expected call of GetUser
 func (mr *MockClientMockRecorder) GetUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockClient)(nil).GetUser), arg0)
 }
 
 // ListAccessKeys mocks base method
 func (m *MockClient) ListAccessKeys(arg0 *iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAccessKeys", arg0)
 	ret0, _ := ret[0].(*iam.ListAccessKeysOutput)
 	ret1, _ := ret[1].(error)
@@ -275,13 +244,11 @@ func (m *MockClient) ListAccessKeys(arg0 *iam.ListAccessKeysInput) (*iam.ListAcc
 
 // ListAccessKeys indicates an expected call of ListAccessKeys
 func (mr *MockClientMockRecorder) ListAccessKeys(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccessKeys", reflect.TypeOf((*MockClient)(nil).ListAccessKeys), arg0)
 }
 
 // ListUserPolicies mocks base method
 func (m *MockClient) ListUserPolicies(arg0 *iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListUserPolicies", arg0)
 	ret0, _ := ret[0].(*iam.ListUserPoliciesOutput)
 	ret1, _ := ret[1].(error)
@@ -290,13 +257,11 @@ func (m *MockClient) ListUserPolicies(arg0 *iam.ListUserPoliciesInput) (*iam.Lis
 
 // ListUserPolicies indicates an expected call of ListUserPolicies
 func (mr *MockClientMockRecorder) ListUserPolicies(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserPolicies", reflect.TypeOf((*MockClient)(nil).ListUserPolicies), arg0)
 }
 
 // PutUserPolicy mocks base method
 func (m *MockClient) PutUserPolicy(arg0 *iam.PutUserPolicyInput) (*iam.PutUserPolicyOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutUserPolicy", arg0)
 	ret0, _ := ret[0].(*iam.PutUserPolicyOutput)
 	ret1, _ := ret[1].(error)
@@ -305,13 +270,11 @@ func (m *MockClient) PutUserPolicy(arg0 *iam.PutUserPolicyInput) (*iam.PutUserPo
 
 // PutUserPolicy indicates an expected call of PutUserPolicy
 func (mr *MockClientMockRecorder) PutUserPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutUserPolicy", reflect.TypeOf((*MockClient)(nil).PutUserPolicy), arg0)
 }
 
 // CreateBucket mocks base method
 func (m *MockClient) CreateBucket(arg0 *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateBucket", arg0)
 	ret0, _ := ret[0].(*s3.CreateBucketOutput)
 	ret1, _ := ret[1].(error)
@@ -320,13 +283,11 @@ func (m *MockClient) CreateBucket(arg0 *s3.CreateBucketInput) (*s3.CreateBucketO
 
 // CreateBucket indicates an expected call of CreateBucket
 func (mr *MockClientMockRecorder) CreateBucket(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBucket", reflect.TypeOf((*MockClient)(nil).CreateBucket), arg0)
 }
 
 // DeleteBucket mocks base method
 func (m *MockClient) DeleteBucket(arg0 *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteBucket", arg0)
 	ret0, _ := ret[0].(*s3.DeleteBucketOutput)
 	ret1, _ := ret[1].(error)
@@ -335,13 +296,11 @@ func (m *MockClient) DeleteBucket(arg0 *s3.DeleteBucketInput) (*s3.DeleteBucketO
 
 // DeleteBucket indicates an expected call of DeleteBucket
 func (mr *MockClientMockRecorder) DeleteBucket(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBucket", reflect.TypeOf((*MockClient)(nil).DeleteBucket), arg0)
 }
 
 // ListBuckets mocks base method
 func (m *MockClient) ListBuckets(arg0 *s3.ListBucketsInput) (*s3.ListBucketsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListBuckets", arg0)
 	ret0, _ := ret[0].(*s3.ListBucketsOutput)
 	ret1, _ := ret[1].(error)
@@ -350,13 +309,11 @@ func (m *MockClient) ListBuckets(arg0 *s3.ListBucketsInput) (*s3.ListBucketsOutp
 
 // ListBuckets indicates an expected call of ListBuckets
 func (mr *MockClientMockRecorder) ListBuckets(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBuckets", reflect.TypeOf((*MockClient)(nil).ListBuckets), arg0)
 }
 
 // GetS3API mocks base method
 func (m *MockClient) GetS3API() s3iface.S3API {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetS3API")
 	ret0, _ := ret[0].(s3iface.S3API)
 	return ret0
@@ -364,13 +321,11 @@ func (m *MockClient) GetS3API() s3iface.S3API {
 
 // GetS3API indicates an expected call of GetS3API
 func (mr *MockClientMockRecorder) GetS3API() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetS3API", reflect.TypeOf((*MockClient)(nil).GetS3API))
 }
 
 // CreateHostedZone mocks base method
 func (m *MockClient) CreateHostedZone(input *route53.CreateHostedZoneInput) (*route53.CreateHostedZoneOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateHostedZone", input)
 	ret0, _ := ret[0].(*route53.CreateHostedZoneOutput)
 	ret1, _ := ret[1].(error)
@@ -379,13 +334,11 @@ func (m *MockClient) CreateHostedZone(input *route53.CreateHostedZoneInput) (*ro
 
 // CreateHostedZone indicates an expected call of CreateHostedZone
 func (mr *MockClientMockRecorder) CreateHostedZone(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateHostedZone", reflect.TypeOf((*MockClient)(nil).CreateHostedZone), input)
 }
 
 // GetHostedZone mocks base method
 func (m *MockClient) GetHostedZone(arg0 *route53.GetHostedZoneInput) (*route53.GetHostedZoneOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHostedZone", arg0)
 	ret0, _ := ret[0].(*route53.GetHostedZoneOutput)
 	ret1, _ := ret[1].(error)
@@ -394,13 +347,11 @@ func (m *MockClient) GetHostedZone(arg0 *route53.GetHostedZoneInput) (*route53.G
 
 // GetHostedZone indicates an expected call of GetHostedZone
 func (mr *MockClientMockRecorder) GetHostedZone(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostedZone", reflect.TypeOf((*MockClient)(nil).GetHostedZone), arg0)
 }
 
 // ListTagsForResource mocks base method
 func (m *MockClient) ListTagsForResource(arg0 *route53.ListTagsForResourceInput) (*route53.ListTagsForResourceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListTagsForResource", arg0)
 	ret0, _ := ret[0].(*route53.ListTagsForResourceOutput)
 	ret1, _ := ret[1].(error)
@@ -409,13 +360,11 @@ func (m *MockClient) ListTagsForResource(arg0 *route53.ListTagsForResourceInput)
 
 // ListTagsForResource indicates an expected call of ListTagsForResource
 func (mr *MockClientMockRecorder) ListTagsForResource(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTagsForResource", reflect.TypeOf((*MockClient)(nil).ListTagsForResource), arg0)
 }
 
 // ChangeTagsForResource mocks base method
 func (m *MockClient) ChangeTagsForResource(input *route53.ChangeTagsForResourceInput) (*route53.ChangeTagsForResourceOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChangeTagsForResource", input)
 	ret0, _ := ret[0].(*route53.ChangeTagsForResourceOutput)
 	ret1, _ := ret[1].(error)
@@ -424,13 +373,11 @@ func (m *MockClient) ChangeTagsForResource(input *route53.ChangeTagsForResourceI
 
 // ChangeTagsForResource indicates an expected call of ChangeTagsForResource
 func (mr *MockClientMockRecorder) ChangeTagsForResource(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeTagsForResource", reflect.TypeOf((*MockClient)(nil).ChangeTagsForResource), input)
 }
 
 // DeleteHostedZone mocks base method
 func (m *MockClient) DeleteHostedZone(input *route53.DeleteHostedZoneInput) (*route53.DeleteHostedZoneOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteHostedZone", input)
 	ret0, _ := ret[0].(*route53.DeleteHostedZoneOutput)
 	ret1, _ := ret[1].(error)
@@ -439,13 +386,11 @@ func (m *MockClient) DeleteHostedZone(input *route53.DeleteHostedZoneInput) (*ro
 
 // DeleteHostedZone indicates an expected call of DeleteHostedZone
 func (mr *MockClientMockRecorder) DeleteHostedZone(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteHostedZone", reflect.TypeOf((*MockClient)(nil).DeleteHostedZone), input)
 }
 
 // ListHostedZones mocks base method
 func (m *MockClient) ListHostedZones(input *route53.ListHostedZonesInput) (*route53.ListHostedZonesOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListHostedZones", input)
 	ret0, _ := ret[0].(*route53.ListHostedZonesOutput)
 	ret1, _ := ret[1].(error)
@@ -454,13 +399,11 @@ func (m *MockClient) ListHostedZones(input *route53.ListHostedZonesInput) (*rout
 
 // ListHostedZones indicates an expected call of ListHostedZones
 func (mr *MockClientMockRecorder) ListHostedZones(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListHostedZones", reflect.TypeOf((*MockClient)(nil).ListHostedZones), input)
 }
 
 // ListResourceRecordSets mocks base method
 func (m *MockClient) ListResourceRecordSets(input *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResourceRecordSets", input)
 	ret0, _ := ret[0].(*route53.ListResourceRecordSetsOutput)
 	ret1, _ := ret[1].(error)
@@ -469,13 +412,11 @@ func (m *MockClient) ListResourceRecordSets(input *route53.ListResourceRecordSet
 
 // ListResourceRecordSets indicates an expected call of ListResourceRecordSets
 func (mr *MockClientMockRecorder) ListResourceRecordSets(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceRecordSets", reflect.TypeOf((*MockClient)(nil).ListResourceRecordSets), input)
 }
 
 // ListHostedZonesByName mocks base method
 func (m *MockClient) ListHostedZonesByName(input *route53.ListHostedZonesByNameInput) (*route53.ListHostedZonesByNameOutput, error) {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListHostedZonesByName", input)
 	ret0, _ := ret[0].(*route53.ListHostedZonesByNameOutput)
 	ret1, _ := ret[1].(error)
@@ -484,13 +425,11 @@ func (m *MockClient) ListHostedZonesByName(input *route53.ListHostedZonesByNameI
 
 // ListHostedZonesByName indicates an expected call of ListHostedZonesByName
 func (mr *MockClientMockRecorder) ListHostedZonesByName(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListHostedZonesByName", reflect.TypeOf((*MockClient)(nil).ListHostedZonesByName), input)
 }
 
 // GetResourcesPages mocks base method
 func (m *MockClient) GetResourcesPages(input *resourcegroupstaggingapi.GetResourcesInput, fn func(*resourcegroupstaggingapi.GetResourcesOutput, bool) bool) error {
-	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResourcesPages", input, fn)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -498,6 +437,5 @@ func (m *MockClient) GetResourcesPages(input *resourcegroupstaggingapi.GetResour
 
 // GetResourcesPages indicates an expected call of GetResourcesPages
 func (mr *MockClientMockRecorder) GetResourcesPages(input, fn interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResourcesPages", reflect.TypeOf((*MockClient)(nil).GetResourcesPages), input, fn)
 }


### PR DESCRIPTION
- [x] don't allow the domain field on an ingress entry to lead with `*`. this gets copied over to the remote cluster, and the ingress controller will reject the leading `*` (the cluster's ingress controller assumes the domain is a wildcard).
- [x] ingress controller doesn't allow ingress entries where the ingress domain specified is different than the domain the cluster is under (eg cluster.example.com can't have an ingress like extra.notexample.com, it must be under cluster.example.com).
- [x] migrate old clusterdeployments with wildcard ingress entries to new format.