### PR TITLE
Fix leaking resources on install retries.

### DIFF
--- a/contrib/pkg/installmanager/installmanager.go
+++ b/contrib/pkg/installmanager/installmanager.go
@@ -376,6 +376,8 @@ func (m *InstallManager) cleanupFailedInstall(cd *hivev1.ClusterDeployment) erro
 		}
 
 		m.log.Info("clear out clusterID and infraID from clusterdeployment")
+		cd.Status.ClusterID = ""
+		cd.Status.InfraID = ""
 		err := updateClusterDeploymentStatusWithRetries(m, func(cd *hivev1.ClusterDeployment) {
 			cd.Status.ClusterID = ""
 			cd.Status.InfraID = ""
@@ -564,6 +566,8 @@ func uploadClusterMetadata(cd *hivev1.ClusterDeployment, m *InstallManager) erro
 
 	// Set the clusterID and infraID
 	m.log.Info("setting clusterID and infraID on clusterdeployment")
+	cd.Status.ClusterID = md.ClusterID
+	cd.Status.InfraID = md.InfraID
 	err = updateClusterDeploymentStatusWithRetries(m, func(cd *hivev1.ClusterDeployment) {
 		cd.Status.ClusterID = md.ClusterID
 		cd.Status.InfraID = md.InfraID


### PR DESCRIPTION
Recent change to cleanup immediately after failed installs had a bug
where we updated the cluster deployment with the new infra ID, but on a
different pointer to the object than we used later in the code to do the
cleanup, resulting in an attempt to cleanup an infra ID we already
cleaned up, and nothing is found, leaving cluster objects in place.

Issue surfaced as a DNS hosted zone already existing in this case.

Fix by setting the infra ID explicitly on the cd we use throughout the
install.