### PR TITLE
Monitor install logs for errors.

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: install-log-regexes
+  namespace: hive
+data:
+  DNSAlreadyExists: |
+    searchRegexStrings:
+    - "aws_route53_record.*Error building changeset:.*Tried to create resource record set.*but it already exists"
+    installFailingReason: DNSAlreadyExists
+    installFailingMessage: DNS record already exists
+  PendingVerification: |
+    searchRegexStrings:
+    - "PendingVerification: Your request for accessing resources in this region is being validated"
+    installFailingReason: PendingVerification
+    installFailingMessage: Account pending verification for region

--- a/config/rbac/manager_role.yaml
+++ b/config/rbac/manager_role.yaml
@@ -123,6 +123,20 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - secrets
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - hive.openshift.io
   resources:
   - clusterdeployments

--- a/contrib/pkg/installmanager/installmanager_test.go
+++ b/contrib/pkg/installmanager/installmanager_test.go
@@ -182,7 +182,7 @@ func TestInstallManager(t *testing.T) {
 			}
 
 			if test.failedUploadInstallerLog {
-				im.uploadInstallerLog = func(*hivev1.ClusterDeployment, *InstallManager) error {
+				im.uploadInstallerLog = func(*hivev1.ClusterDeployment, *InstallManager, error) error {
 					return fmt.Errorf("faiiled to save install log")
 				}
 			}

--- a/hack/update-bindata.sh
+++ b/hack/update-bindata.sh
@@ -18,5 +18,5 @@ go build -o ./bin/go-bindata ./vendor/github.com/jteeuwen/go-bindata/go-bindata
         -o "${OUTPUT_FILE}" \
         -ignore "OWNERS" \
         -ignore ".*\.sw.?" \
-        ./config/hiveadmission/... ./config/manager/... ./config/clusterimagesets/... ./config/external-dns/... ./config/rbac/... ./config/crds/... && \
+        ./config/hiveadmission/... ./config/manager/... ./config/clusterimagesets/... ./config/external-dns/... ./config/rbac/... ./config/crds/... ./config/configmaps/... && \
 gofmt -s -w "${OUTPUT_FILE}"

--- a/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
@@ -42,6 +42,13 @@ const (
 	// DefaultClusterType will be used when the above HiveClusterTypeLabel is unset. This
 	// value will not be added as a label, only used for metrics vectors.
 	DefaultClusterType = "unspecified"
+
+	// HiveClusterDeploymentNameLabel is used on various objects created by Hive to link to their associated
+	// ClusterDeployment
+	HiveClusterDeploymentNameLabel = "hive.openshift.io/cluster-deployment-name"
+
+	// HiveInstallLogLabel is used on ConfigMaps uploaded by the install manager which contain an install log.
+	HiveInstallLogLabel = "hive.openshift.io/install-log"
 )
 
 // ClusterDeploymentSpec defines the desired state of ClusterDeployment
@@ -253,6 +260,10 @@ const (
 
 	// UnreachableCondition indicates that are unable to establish an API connection to the remote cluster.
 	UnreachableCondition ClusterDeploymentConditionType = "Unreachable"
+
+	// InstallFailingCondition indicates that a failure has been detected and we will attempt to offer some
+	// information as to why in the reason.
+	InstallFailingCondition ClusterDeploymentConditionType = "InstallFailing"
 )
 
 // AllClusterDeploymentConditions is a slice containing all condition types. This can be used for dealing with
@@ -263,6 +274,7 @@ var AllClusterDeploymentConditions = []ClusterDeploymentConditionType{
 	ControlPlaneCertificateNotFoundCondition,
 	IngressCertificateNotFoundCondition,
 	UnreachableCondition,
+	InstallFailingCondition,
 }
 
 // +genclient

--- a/pkg/controller/add_installlogmonitor.go
+++ b/pkg/controller/add_installlogmonitor.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2018 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package controller
 
 import (

--- a/pkg/controller/add_installlogmonitor.go
+++ b/pkg/controller/add_installlogmonitor.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/openshift/hive/pkg/controller/installlogmonitor"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, installlogmonitor.Add)
+}

--- a/pkg/controller/installlogmonitor/installlogmonitor_controller.go
+++ b/pkg/controller/installlogmonitor/installlogmonitor_controller.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2019 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package installlogmonitor
 
 import (

--- a/pkg/controller/installlogmonitor/installlogmonitor_controller.go
+++ b/pkg/controller/installlogmonitor/installlogmonitor_controller.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installlogmonitor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	log "github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+)
+
+const (
+	controllerName      = "installlogmonitor"
+	processedAnnotation = "hive.openshift.io/install-log-processed"
+	regexConfigMapName  = "install-log-regexes"
+	hiveNamespace       = "hive"
+	unknownReason       = "UnknownError"
+	unknownMessage      = "Cluster install failed but no known errors found in logs"
+	successReason       = "ClusterInstalled"
+	successMessage      = "Cluster install completed successfully"
+)
+
+var (
+	metricInstallErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "hive_install_errors",
+		Help: "Counter incremented every time we observe certain errors strings in install logs.",
+	},
+		[]string{"cluster_type", "reason"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(metricInstallErrors)
+}
+
+// Add creates a new InstallLogMonitro Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileInstallLog{Client: mgr.GetClient(), scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("installlogmonitor-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to ConfigMap
+	err = c.Watch(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileInstallLog{}
+
+// ReconcileInstallLog reconciles an install log ConfigMap object uploaded by the hive installmanager pod.
+type ReconcileInstallLog struct {
+	client.Client
+	scheme *runtime.Scheme
+}
+
+func (r *ReconcileInstallLog) isHiveInstallLog(cm *corev1.ConfigMap) (isInstallLog bool, needsMigration bool) {
+	if _, ok := cm.Labels[hivev1.HiveInstallLogLabel]; ok {
+		return true, false
+	}
+
+	// If it looks like one of our install logs that predates install manager images, return true
+	// and indicate it needs migration.
+	if _, ok := cm.Data["log"]; ok && strings.HasSuffix(cm.Name, "-install-log") {
+		return true, true
+	}
+
+	return false, false
+}
+
+// migrateInstallLog is a temporary function that will apply the new labels to pre-existing install log configmaps.
+func (r *ReconcileInstallLog) migrateInstallLog(cm *corev1.ConfigMap) error {
+	if cm.Labels == nil {
+		cm.Labels = map[string]string{}
+	}
+
+	cm.Labels[hivev1.HiveInstallLogLabel] = "true"
+
+	// We must guess at the cluster deployment name:
+	clusterDeploymentName := cm.Name[:len(cm.Name)-len("-install-log")]
+	cm.Labels[hivev1.HiveClusterDeploymentNameLabel] = clusterDeploymentName
+
+	return r.Client.Update(context.Background(), cm)
+}
+
+// Reconcile parses install log to monitor for known issues.
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts;secrets;configmaps,verbs=get;list;watch;create;update;patch;delete
+func (r *ReconcileInstallLog) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	iLog := log.WithFields(log.Fields{
+		"configMap":  request.NamespacedName.String(),
+		"controller": controllerName,
+	})
+
+	// Load the regex configmap, if we don't have one, there's not much point proceeding here.
+	regexCM := &corev1.ConfigMap{}
+	err := r.Get(context.TODO(), types.NamespacedName{Name: regexConfigMapName, Namespace: hiveNamespace}, regexCM)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			iLog.Debugf("%s configmap does not exist, nothing to scan for", regexConfigMapName)
+			return reconcile.Result{}, nil
+		}
+		iLog.WithError(err).Errorf("error loading %s configmap", regexConfigMapName)
+		return reconcile.Result{}, err
+	}
+	ilRegexes, err := loadInstallLogRegexes(regexCM, iLog)
+	if err != nil {
+		iLog.WithError(err).Error("error loading regex configmap")
+		return reconcile.Result{}, err
+	}
+
+	cm := &corev1.ConfigMap{}
+	err = r.Get(context.TODO(), request.NamespacedName, cm)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Object not found, return.  Created objects are automatically garbage collected.
+			// For additional cleanup logic use finalizers.
+			iLog.Debug("ConfigMap not found, skipping")
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		iLog.WithError(err).Error("cannot get clusterdeprovisionrequest")
+		return reconcile.Result{}, err
+	}
+
+	if !cm.DeletionTimestamp.IsZero() {
+		iLog.Debug("configmap being deleted, skipping")
+		return reconcile.Result{}, nil
+	}
+
+	// Temporary migration of install logs created by hiveutil images prior to the labels being added.
+	// TODO: Remove this and watch for ConfigMaps with our labels once the main ClusterImageSets in use are
+	// new enough to populate the Hive labels on install log ConfigMaps.
+	isInstallLog, needsMigration := r.isHiveInstallLog(cm)
+	if !isInstallLog {
+		return reconcile.Result{}, nil
+	}
+
+	if needsMigration {
+		return reconcile.Result{}, r.migrateInstallLog(cm)
+	}
+
+	cd := &hivev1.ClusterDeployment{}
+	cdName, ok := cm.Labels[hivev1.HiveClusterDeploymentNameLabel]
+	if !ok {
+		iLog.Error("cannot reconcile install log configmap without cluster-deployment-name label")
+		return reconcile.Result{}, fmt.Errorf("install log configmap %s has no %s label",
+			request.NamespacedName.String(),
+			hivev1.HiveClusterDeploymentNameLabel)
+	}
+	cdNSName := types.NamespacedName{Namespace: cm.Namespace, Name: cdName}
+	err = r.Get(context.TODO(), cdNSName, cd)
+	if err != nil {
+		iLog.WithError(err).Error("unable to lookup cluster deployment for configmap")
+		return reconcile.Result{}, err
+	}
+
+	// Check if we've processed this configmap before and skip if so. The install manager currently
+	// replaces the log on a retry (full delete + recreate).
+	if _, ok := cm.Annotations[processedAnnotation]; ok {
+		iLog.Debugf("skipping install log that has already been processed (%s annotation present)", processedAnnotation)
+		return reconcile.Result{}, nil
+	}
+
+	iLog.Info("processing new install log")
+
+	// Apply the processed annotation and save before we report anything. If we succeed here and fail later
+	// we accept that we will lose processing of that install log. This is for tracking/metrics and not
+	// anything critical.
+	if cm.ObjectMeta.Annotations == nil {
+		cm.ObjectMeta.Annotations = map[string]string{}
+	}
+	cm.ObjectMeta.Annotations[processedAnnotation] = "true"
+	if err := r.Client.Update(context.Background(), cm); err != nil {
+		iLog.WithError(err).Error("error saving processed annotation")
+		return reconcile.Result{}, err
+	}
+
+	success, successKeyReported := cm.Data["success"]
+
+	foundError := false
+	if !successKeyReported || success == "false" {
+		log := cm.Data["log"]
+		// Log each line separately, this brings all our install logs from many namespaces into
+		// the main hive log where we can aggregate search results.
+		installLogLines := strings.Split(log, "\n")
+		for _, l := range installLogLines {
+			iLog.WithField("line", l).Info("install log line")
+		}
+
+		// Scan log contents for known errors if the install was not reported as a success:
+		for _, ilr := range ilRegexes {
+			for _, re := range ilr.SearchRegexes {
+				if re.Match([]byte(log)) {
+					iLog.WithField("reason", ilr.InstallFailingReason).Info("found known install failure string")
+					cd.Status.Conditions = controllerutils.SetClusterDeploymentCondition(cd.Status.Conditions, hivev1.InstallFailingCondition,
+						corev1.ConditionTrue, ilr.InstallFailingReason, ilr.InstallFailingMessage, controllerutils.UpdateConditionAlways)
+					// Increment a counter metric for this cluster type and error reason:
+					metricInstallErrors.WithLabelValues(hivemetrics.GetClusterDeploymentType(cd), ilr.InstallFailingReason).Inc()
+					foundError = true
+					break
+				}
+			}
+			if foundError {
+				break
+			}
+		}
+	}
+
+	// If we reach this point, we have found no errors. If the install log configmap specifies that the install failed,
+	// we will still report InstallFailed condition with reason unknown. Note that older install manager pods will not
+	// set success, so for these we will just assume success and no condition will be set.
+	if !foundError && successKeyReported && success == "false" {
+		iLog.Info("install failed but no errors strings found, reporting unknown error")
+		cd.Status.Conditions = controllerutils.SetClusterDeploymentCondition(cd.Status.Conditions, hivev1.InstallFailingCondition,
+			corev1.ConditionTrue, unknownReason, unknownMessage, controllerutils.UpdateConditionAlways)
+		metricInstallErrors.WithLabelValues(hivemetrics.GetClusterDeploymentType(cd), unknownReason).Inc()
+	} else if !foundError {
+		// Assume success and clear the condition if it is present.
+		iLog.Info("install successful, clearing InstallFailing condition if set")
+		cd.Status.Conditions = controllerutils.SetClusterDeploymentCondition(cd.Status.Conditions, hivev1.InstallFailingCondition,
+			corev1.ConditionFalse, successReason, successMessage, controllerutils.UpdateConditionIfReasonOrMessageChange)
+	}
+
+	// Save and return on first error, we don't store more than one.
+	err = r.Client.Status().Update(context.Background(), cd)
+	if err != nil {
+		iLog.WithError(err).Error("error saving condition onto cluster deployment, install log processing will be lost")
+	}
+	iLog.Info("reconcile complete")
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/installlogmonitor/installlogmonitor_controller_test.go
+++ b/pkg/controller/installlogmonitor/installlogmonitor_controller_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2019 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package installlogmonitor
 
 import (

--- a/pkg/controller/installlogmonitor/installlogmonitor_controller_test.go
+++ b/pkg/controller/installlogmonitor/installlogmonitor_controller_test.go
@@ -1,0 +1,298 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installlogmonitor
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openshift/hive/pkg/apis"
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+)
+
+const (
+	testName      = "mycluster-install-log"
+	testCDName    = "mycluster"
+	testNamespace = "default"
+)
+
+func init() {
+	log.SetLevel(log.DebugLevel)
+}
+
+func TestIsHiveInstallLogAndMigration(t *testing.T) {
+	apis.AddToScheme(scheme.Scheme)
+	tests := []struct {
+		name                          string
+		configMap                     *corev1.ConfigMap
+		isHiveInstallLog              bool
+		needsMigration                bool
+		expectedClusterDeploymentName string
+	}{
+		{
+			name:                          "install log missing labels migration",
+			configMap:                     buildInstallLogConfigMapwithoutLabels("mycluster-install-log", "log", "fakelogdata"),
+			isHiveInstallLog:              true,
+			needsMigration:                true,
+			expectedClusterDeploymentName: "mycluster",
+		},
+		{
+			name:             "install log missing labels name mismatch",
+			configMap:        buildInstallLogConfigMapwithoutLabels("unrelated-configmap", "log", "fakelogdata"),
+			isHiveInstallLog: false,
+			needsMigration:   false,
+		},
+		{
+			name:             "install log missing labels key mismatch",
+			configMap:        buildInstallLogConfigMapwithoutLabels("mycluster-install-log", "unexpectedkey", "fakelogdata"),
+			isHiveInstallLog: false,
+			needsMigration:   false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fakeClient := fake.NewFakeClient()
+			r := &ReconcileInstallLog{
+				Client: fakeClient,
+				scheme: scheme.Scheme,
+			}
+			isHiveInstallLog, needsMigration := r.isHiveInstallLog(test.configMap)
+			assert.Equal(t, test.isHiveInstallLog, isHiveInstallLog)
+			assert.Equal(t, test.needsMigration, needsMigration)
+			if needsMigration {
+				cm := test.configMap.DeepCopy()
+				r.migrateInstallLog(cm)
+				assert.Equal(t, test.expectedClusterDeploymentName, cm.Labels[hivev1.HiveClusterDeploymentNameLabel])
+				assert.Equal(t, "true", cm.Labels[hivev1.HiveInstallLogLabel])
+			}
+		})
+	}
+
+}
+
+const (
+	dnsAlreadyExistsLog    = "blahblah\naws_route53_record.api_external: [ERR]: Error building changeset: InvalidChangeBatch: [Tried to create resource record set [name='api.jh-stg-2405-2.n6b3.s1.devshift.org.'type='A'] but it already exists]\n\nblahblah"
+	pendingVerificationLog = "blahblah\naws_instance.master.2: Error launching source instance: PendingVerification: Your request for accessing resources in this region is being validated, and you will not be able to launch additional resources in this region until the validation is complete. We will notify you by email once your request has been validated. While normally resolved within minutes, please allow up to 4 hours for this process to complete. If the issue still persists, please let us know by writing to awsa\n\nblahblah"
+)
+
+func TestInstallLogProcessing(t *testing.T) {
+	apis.AddToScheme(scheme.Scheme)
+	tests := []struct {
+		name                    string
+		existing                []runtime.Object // NOTE: configmap will implicitly be added
+		expectedConditionStatus corev1.ConditionStatus
+		expectedConditionReason string
+	}{
+		{
+			name: "process new install log error DNS already exists",
+			existing: []runtime.Object{
+				buildRegexConfigMap(),
+				buildInstallLogConfigMap(testName, "log", dnsAlreadyExistsLog, "false"),
+				testClusterDeployment(),
+			},
+			expectedConditionStatus: corev1.ConditionTrue,
+			expectedConditionReason: "DNSAlreadyExists",
+		},
+		{
+			name: "process new install log error PendingVerification",
+			existing: []runtime.Object{
+				buildRegexConfigMap(),
+				buildInstallLogConfigMap(testName, "log", pendingVerificationLog, "false"),
+				testClusterDeployment(),
+			},
+			expectedConditionStatus: corev1.ConditionTrue,
+			expectedConditionReason: "PendingVerification",
+		},
+		{
+			name: "process new install log success",
+			existing: []runtime.Object{
+				buildRegexConfigMap(),
+				// Leaving an error in the log so we can test that we do not check for errors if success reported.
+				buildInstallLogConfigMap(testName, "log", dnsAlreadyExistsLog, "true"),
+				testClusterDeployment(),
+			},
+		},
+		{
+			name: "process retry install log success",
+			existing: []runtime.Object{
+				buildRegexConfigMap(),
+				// Leaving an error in the log so we can test that we do not check for errors if success reported.
+				buildInstallLogConfigMap(testName, "log", dnsAlreadyExistsLog, "true"),
+				testClusterDeploymentWithInstallFailingCondition(corev1.ConditionTrue, "blah", "blah"),
+			},
+			expectedConditionStatus: corev1.ConditionFalse,
+			expectedConditionReason: successReason,
+		},
+	}
+
+	for _, test := range tests {
+		getCD := func(c client.Client) *hivev1.ClusterDeployment {
+			cd := &hivev1.ClusterDeployment{}
+			err := c.Get(context.TODO(), client.ObjectKey{Name: testCDName, Namespace: testNamespace}, cd)
+			if err == nil {
+				return cd
+			}
+			return nil
+		}
+		getInstallLog := func(c client.Client) *corev1.ConfigMap {
+			cm := &corev1.ConfigMap{}
+			err := c.Get(context.TODO(), client.ObjectKey{Name: testName, Namespace: testNamespace}, cm)
+			if err == nil {
+				return cm
+			}
+			return nil
+		}
+		t.Run(test.name, func(t *testing.T) {
+			fakeClient := fake.NewFakeClient(test.existing...)
+			r := &ReconcileInstallLog{
+				Client: fakeClient,
+				scheme: scheme.Scheme,
+			}
+			_, err := r.Reconcile(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      testName,
+					Namespace: testNamespace,
+				},
+			})
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			cd := getCD(fakeClient)
+			assert.NotNil(t, cd)
+
+			installLog := getInstallLog(fakeClient)
+			processed, ok := installLog.Annotations[processedAnnotation]
+			if assert.True(t, ok) {
+				assert.Equal(t, "true", processed)
+			}
+
+			cond := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.InstallFailingCondition)
+			if test.expectedConditionReason != "" {
+				if assert.NotNil(t, cond, "cluster missing InstallFailing condition") {
+					assert.Equal(t, test.expectedConditionReason, cond.Reason)
+				}
+			} else {
+				assert.Nil(t, cond, "cluster has InstallFailing condition")
+			}
+
+		})
+	}
+
+}
+
+// buildInstallLogConfigMap builds an install log configmap.
+func buildInstallLogConfigMap(name, key, contents, successStr string) *corev1.ConfigMap {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				hivev1.HiveInstallLogLabel:            "true",
+				hivev1.HiveClusterDeploymentNameLabel: testCDName,
+			},
+		},
+		Data: map[string]string{
+			key: contents,
+		},
+	}
+	if successStr != "" {
+		cm.Data["success"] = successStr
+	}
+
+	return cm
+}
+
+func buildRegexConfigMap() *corev1.ConfigMap {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      regexConfigMapName,
+			Namespace: hiveNamespace,
+		},
+		Data: map[string]string{
+			"DNSAlreadyExists": `
+searchRegexStrings:
+- "aws_route53_record.*Error building changeset:.*Tried to create resource record set.*but it already exists"
+installFailingReason: DNSAlreadyExists
+installFailingMessage: DNS record already exists
+`,
+			"PendingVerification": `
+searchRegexStrings:
+- "PendingVerification: Your request for accessing resources in this region is being validated"
+installFailingReason: PendingVerification
+installFailingMessage: Account pending verification for region
+`,
+		},
+	}
+	return cm
+}
+
+func buildInstallLogConfigMapwithoutLabels(name, key, contents string) *corev1.ConfigMap {
+	cm := buildInstallLogConfigMap(name, key, contents, "")
+	cm.ObjectMeta.Labels = map[string]string{}
+	return cm
+}
+
+func testClusterDeployment() *hivev1.ClusterDeployment {
+	cd := &hivev1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testCDName,
+			Namespace:  testNamespace,
+			Finalizers: []string{hivev1.FinalizerDeprovision},
+			UID:        types.UID("1234"),
+		},
+		Spec: hivev1.ClusterDeploymentSpec{
+			ClusterName:  testCDName,
+			ControlPlane: hivev1.MachinePool{},
+			Compute:      []hivev1.MachinePool{},
+		},
+		Status: hivev1.ClusterDeploymentStatus{
+			ClusterID: "fakeid",
+			InfraID:   "fakeid",
+			AdminKubeconfigSecret: corev1.LocalObjectReference{
+				Name: "kubeconfig-secret",
+			},
+			Conditions: []hivev1.ClusterDeploymentCondition{},
+		},
+	}
+	controllerutils.FixupEmptyClusterVersionFields(&cd.Status.ClusterVersionStatus)
+	return cd
+}
+
+func testClusterDeploymentWithInstallFailingCondition(status corev1.ConditionStatus, reason, message string) *hivev1.ClusterDeployment {
+	cd := testClusterDeployment()
+	cd.Status.Conditions = controllerutils.SetClusterDeploymentCondition(cd.Status.Conditions, hivev1.InstallFailingCondition, corev1.ConditionTrue,
+		reason, message, controllerutils.UpdateConditionAlways)
+	return cd
+}

--- a/pkg/controller/installlogmonitor/installlogregex.go
+++ b/pkg/controller/installlogmonitor/installlogregex.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package installlogmonitor
+
+import (
+	"regexp"
+
+	"github.com/ghodss/yaml"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// InstallLogRegex is a struct that represents all the data we use to scan for certain
+// search strings in install logs. These structs are serialized as yaml and stored/read from
+// the install-log-regexes ConfigMap.
+type InstallLogRegex struct {
+	// SearchRegexStrings are the regex strings we will search for.
+	SearchRegexStrings []string `json:"searchRegexStrings"`
+
+	// SearchRegexes are the compile regexes created from the SearchRegexStrings. This field is
+	// set by the load code below, not parsed from json.
+	SearchRegexes []*regexp.Regexp
+
+	// InstallFailingReason is the single word CamelCase reason we report for this failure in conditions, metrics and logs.
+	InstallFailingReason string `json:"installFailingReason"`
+
+	// InstallFailingMessage is the user friendly sentence we report for this failure and conditions, metrics and logs.
+	InstallFailingMessage string `json:"installFailingMessage"`
+}
+
+func loadInstallLogRegexes(regexesCM *corev1.ConfigMap, logger log.FieldLogger) ([]InstallLogRegex, error) {
+	regexes := []InstallLogRegex{}
+	for k, v := range regexesCM.Data {
+		keyLog := logger.WithField("configMapKey", k)
+
+		var r InstallLogRegex
+		err := yaml.Unmarshal([]byte(v), &r)
+		if err != nil {
+			keyLog.WithError(err).WithField("data", v).Error("unable to deserialize yaml for InstallLogRegex")
+			return regexes, err
+		}
+		// Compile all the search regex strings:
+		r.SearchRegexes = []*regexp.Regexp{}
+		for _, ss := range r.SearchRegexStrings {
+			re, err := regexp.Compile(ss)
+			if err != nil {
+				logger.WithError(err).WithField("searchString", ss).Error("unable to compile regex")
+				return regexes, err
+			}
+			r.SearchRegexes = append(r.SearchRegexes, re)
+
+		}
+		regexes = append(regexes, r)
+
+	}
+	return regexes, nil
+}

--- a/pkg/controller/installlogmonitor/installlogregex.go
+++ b/pkg/controller/installlogmonitor/installlogregex.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2019 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package installlogmonitor
 
 import (

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -36,6 +36,7 @@
 // config/crds/hive_v1alpha1_selectorsyncset.yaml
 // config/crds/hive_v1alpha1_syncidentityprovider.yaml
 // config/crds/hive_v1alpha1_syncset.yaml
+// config/configmaps/install-log-regexes-configmap.yaml
 // DO NOT EDIT!
 
 package assets
@@ -1271,6 +1272,20 @@ rules:
   - dnszones/status
   - dnszones/finalizers
   - dnsendpoints
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - secrets
+  - configmaps
   verbs:
   - get
   - list
@@ -4420,6 +4435,39 @@ func configCrdsHive_v1alpha1_syncsetYaml() (*asset, error) {
 	return a, nil
 }
 
+var _configConfigmapsInstallLogRegexesConfigmapYaml = []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: install-log-regexes
+  namespace: hive
+data:
+  DNSAlreadyExists: |
+    searchRegexStrings:
+    - "aws_route53_record.*Error building changeset:.*Tried to create resource record set.*but it already exists"
+    installFailingReason: DNSAlreadyExists
+    installFailingMessage: DNS record already exists
+  PendingVerification: |
+    searchRegexStrings:
+    - "PendingVerification: Your request for accessing resources in this region is being validated"
+    installFailingReason: PendingVerification
+    installFailingMessage: Account pending verification for region
+`)
+
+func configConfigmapsInstallLogRegexesConfigmapYamlBytes() ([]byte, error) {
+	return _configConfigmapsInstallLogRegexesConfigmapYaml, nil
+}
+
+func configConfigmapsInstallLogRegexesConfigmapYaml() (*asset, error) {
+	bytes, err := configConfigmapsInstallLogRegexesConfigmapYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "config/configmaps/install-log-regexes-configmap.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -4508,6 +4556,7 @@ var _bindata = map[string]func() (*asset, error){
 	"config/crds/hive_v1alpha1_selectorsyncset.yaml":              configCrdsHive_v1alpha1_selectorsyncsetYaml,
 	"config/crds/hive_v1alpha1_syncidentityprovider.yaml":         configCrdsHive_v1alpha1_syncidentityproviderYaml,
 	"config/crds/hive_v1alpha1_syncset.yaml":                      configCrdsHive_v1alpha1_syncsetYaml,
+	"config/configmaps/install-log-regexes-configmap.yaml":        configConfigmapsInstallLogRegexesConfigmapYaml,
 }
 
 // AssetDir returns the file names below a certain
@@ -4554,6 +4603,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"config": {nil, map[string]*bintree{
 		"clusterimagesets": {nil, map[string]*bintree{
 			"openshift-4.0-latest.yaml": {configClusterimagesetsOpenshift40LatestYaml, map[string]*bintree{}},
+		}},
+		"configmaps": {nil, map[string]*bintree{
+			"install-log-regexes-configmap.yaml": {configConfigmapsInstallLogRegexesConfigmapYaml, map[string]*bintree{}},
 		}},
 		"crds": {nil, map[string]*bintree{
 			"hive_v1alpha1_clusterdeployment.yaml":            {configCrdsHive_v1alpha1_clusterdeploymentYaml, map[string]*bintree{}},

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -111,6 +111,8 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helpe
 		"config/crds/hive_v1alpha1_selectorsyncset.yaml",
 		"config/crds/hive_v1alpha1_syncidentityprovider.yaml",
 		"config/crds/hive_v1alpha1_syncset.yaml",
+
+		"config/configmaps/install-log-regexes-configmap.yaml",
 	}
 	for _, a := range applyAssets {
 		err = util.ApplyAsset(h, a, hLog)


### PR DESCRIPTION
Adds a new controller to monitor the install logs we upload as
configmaps. Logs will be logged to the main hive-controllers log so we
can find them in one place.

Logs will be scanned for a list of regexes (defined in a configmap and
delivered by our operator) which map to keys. If encountered those keys
are reported as the reason on the InstallFailing condition, and a metric
is incremented.

Only two errors right now, we've lost our access to ConfigMaps but the logging in this PR will let us see them again and we can add more search strings once we know what to expect. 