### PR TITLE
Post-Deploy e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ test-integration: generate
 test-e2e:
 	hack/e2e-test.sh
 
+.PHONY: test-e2e-postdeploy
+test-e2e-postdeploy:
+	go test ./test/e2e/postdeploy/...
+
 # Builds all of hive's binaries (including utils).
 .PHONY: build
 build: $(GOPATH)/bin/mockgen manager hiveutil hiveadmission operator

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -61,7 +61,12 @@ export AWS_SECRET_ACCESS_KEY="$(cat ${CLOUD_CREDS_DIR}/.awscred | awk '/aws_secr
 function teardown() {
 	oc logs -c hive job/${CLUSTER_NAME}-install &> "${ARTIFACT_DIR}/hive_install_job.log" || true
 	echo "************* INSTALL JOB LOG *************"
-	cat "${ARTIFACT_DIR}/hive_install_job.log"
+	if oc get cm/${CLUSTER_NAME}-install-log -o jsonpath='{ .data.log }' &> "${ARTIFACT_DIR}/hive_install_console.log"; then
+		cat "${ARTIFACT_DIR}/hive_install_console.log"
+	else
+		cat "${ARTIFACT_DIR}/hive_install_job.log"
+	fi
+
 	echo ""
 	echo ""
 	echo "Deleting ClusterDeployment ${CLUSTER_NAME}"
@@ -85,8 +90,7 @@ function teardown() {
 }
 trap 'teardown' EXIT
 
-# TODO: Determine how to wait for readiness of the validation webhook
-sleep 120
+make test-e2e-postdeploy
 
 i=1
 while [ $i -le ${max_tries} ]; do

--- a/test/e2e/common/apiservice.go
+++ b/test/e2e/common/apiservice.go
@@ -1,0 +1,69 @@
+package common
+
+import (
+	"fmt"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/tools/cache"
+	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	apiregv1client "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1"
+)
+
+func WaitForAPIServiceAvailable(c apiregv1client.ApiregistrationV1Interface, name string, timeOut time.Duration) error {
+	readyFunc := func(s *apiregv1.APIService) bool {
+		logger := log.WithField("apiservice", s.Name)
+		logger.Debug("determining if apiservice is ready")
+		for _, condition := range s.Status.Conditions {
+			if condition.Type == apiregv1.Available {
+				if condition.Status == apiregv1.ConditionTrue {
+					logger.Debug("apiservice is ready")
+					return true
+				}
+			}
+		}
+		logger.Debug("apiservice is not yet ready")
+		return false
+	}
+	return WaitForAPIService(c, name, readyFunc, timeOut)
+}
+
+func WaitForAPIService(c apiregv1client.ApiregistrationV1Interface, name string, testFunc func(*apiregv1.APIService) bool, timeOut time.Duration) error {
+	logger := log.WithField("APIService", name)
+	logger.Infof("Waiting for APIService")
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	onObject := func(obj interface{}) {
+		apiService, ok := obj.(*apiregv1.APIService)
+		if !ok {
+			logger.Warningf("object not APIService: %v", obj)
+			return
+		}
+		if testFunc(apiService) {
+			done <- struct{}{}
+		}
+	}
+	watchList := cache.NewListWatchFromClient(c.RESTClient(), "apiservices", "", fields.OneTermEqualSelector("metadata.name", name))
+	_, controller := cache.NewInformer(
+		watchList,
+		&apiregv1.APIService{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: onObject,
+			UpdateFunc: func(oldObject, newObject interface{}) {
+				onObject(newObject)
+			},
+		},
+	)
+	go controller.Run(stop)
+	defer func() { stop <- struct{}{} }()
+
+	select {
+	case <-time.After(timeOut):
+		return fmt.Errorf("timed out waiting for apiservice %s", name)
+	case <-done:
+	}
+	return nil
+}

--- a/test/e2e/common/client.go
+++ b/test/e2e/common/client.go
@@ -1,0 +1,64 @@
+package common
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/client-go/dynamic"
+	kclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	apiregv1client "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1"
+
+	hiveapis "github.com/openshift/hive/pkg/apis"
+)
+
+func init() {
+	apiextv1beta1.AddToScheme(scheme.Scheme)
+	hiveapis.AddToScheme(scheme.Scheme)
+	admissionv1beta1.AddToScheme(scheme.Scheme)
+}
+
+func MustGetClient() client.Client {
+	c, err := client.New(MustGetConfig(), client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		log.Fatalf("Error obtaining client: %v", err)
+	}
+	return c
+}
+
+func MustGetKubernetesClient() kclient.Interface {
+	c, err := kclient.NewForConfig(MustGetConfig())
+	if err != nil {
+		log.Fatalf("Error obtaining kubernetes client: %v", err)
+	}
+	return c
+}
+
+func MustGetAPIRegistrationClient() apiregv1client.ApiregistrationV1Interface {
+	c, err := apiregv1client.NewForConfig(MustGetConfig())
+	if err != nil {
+		log.Fatalf("Error obtaining API registration client: %v", err)
+	}
+	return c
+}
+
+func MustGetDynamicClient() dynamic.Interface {
+	c, err := dynamic.NewForConfig(MustGetConfig())
+	if err != nil {
+		log.Fatalf("Error obtaining dynamic client: %v", err)
+	}
+	return c
+}
+
+func MustGetConfig() *rest.Config {
+	config, err := config.GetConfig()
+	if err != nil {
+		log.Fatalf("Error obtaining client config: %v", err)
+	}
+	return config
+}

--- a/test/e2e/common/deployment.go
+++ b/test/e2e/common/deployment.go
@@ -1,0 +1,70 @@
+package common
+
+import (
+	"fmt"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	kclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+func WaitForDeploymentReady(c kclient.Interface, namespace, name string, timeOut time.Duration) error {
+	readyFunc := func(d *appsv1.Deployment) bool {
+		logger := log.WithField("deployment", fmt.Sprintf("%s/%s", d.Namespace, d.Name))
+		logger.Debug("determining if deployment is ready")
+		for _, condition := range d.Status.Conditions {
+			if condition.Type == appsv1.DeploymentAvailable {
+				if condition.Status == corev1.ConditionTrue {
+					logger.Debug("deployment is ready")
+					return true
+				}
+			}
+		}
+		logger.Debug("deployment is not yet ready")
+		return false
+	}
+	return WaitForDeployment(c, namespace, name, readyFunc, timeOut)
+}
+
+func WaitForDeployment(c kclient.Interface, namespace, name string, testFunc func(*appsv1.Deployment) bool, timeOut time.Duration) error {
+	logger := log.WithField("deployment", fmt.Sprintf("%s/%s", namespace, name))
+	logger.Infof("Waiting for deployment")
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	onObject := func(obj interface{}) {
+		deployment, ok := obj.(*appsv1.Deployment)
+		if !ok {
+			logger.Warningf("object not deployment: %v", obj)
+			return
+		}
+		if testFunc(deployment) {
+			done <- struct{}{}
+		}
+	}
+	watchList := cache.NewListWatchFromClient(c.AppsV1().RESTClient(), "deployments", namespace, fields.OneTermEqualSelector("metadata.name", name))
+	_, controller := cache.NewInformer(
+		watchList,
+		&appsv1.Deployment{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: onObject,
+			UpdateFunc: func(oldObject, newObject interface{}) {
+				onObject(newObject)
+			},
+		},
+	)
+	go controller.Run(stop)
+	defer func() { stop <- struct{}{} }()
+
+	select {
+	case <-time.After(timeOut):
+		return fmt.Errorf("timed out waiting for deployment %s/%s", namespace, name)
+	case <-done:
+	}
+	return nil
+}

--- a/test/e2e/common/diff.go
+++ b/test/e2e/common/diff.go
@@ -1,0 +1,18 @@
+package common
+
+import (
+	"encoding/json"
+	"github.com/evanphx/json-patch"
+)
+
+func JSONDiff(a, b interface{}) ([]byte, error) {
+	jsonA, err := json.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	jsonB, err := json.Marshal(b)
+	if err != nil {
+		return nil, err
+	}
+	return jsonpatch.CreateMergePatch(jsonA, jsonB)
+}

--- a/test/e2e/common/service.go
+++ b/test/e2e/common/service.go
@@ -1,0 +1,51 @@
+package common
+
+import (
+	"fmt"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	kclient "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+func WaitForService(c kclient.Interface, namespace, name string, testFunc func(*corev1.Service) bool, timeOut time.Duration) error {
+	logger := log.WithField("service", fmt.Sprintf("%s/%s", namespace, name))
+	logger.Infof("Waiting for service")
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	onObject := func(obj interface{}) {
+		service, ok := obj.(*corev1.Service)
+		if !ok {
+			logger.Warningf("object not service: %v", obj)
+			return
+		}
+		if testFunc(service) {
+			done <- struct{}{}
+		}
+	}
+	watchList := cache.NewListWatchFromClient(c.CoreV1().RESTClient(), "services", namespace, fields.OneTermEqualSelector("metadata.name", name))
+	_, controller := cache.NewInformer(
+		watchList,
+		&corev1.Service{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: onObject,
+			UpdateFunc: func(oldObject, newObject interface{}) {
+				onObject(newObject)
+			},
+		},
+	)
+	go controller.Run(stop)
+	defer func() { stop <- struct{}{} }()
+
+	select {
+	case <-time.After(timeOut):
+		return fmt.Errorf("timed out waiting for service %s/%s", namespace, name)
+	case <-done:
+	}
+	return nil
+}

--- a/test/e2e/postdeploy/admission/admission_test.go
+++ b/test/e2e/postdeploy/admission/admission_test.go
@@ -1,0 +1,102 @@
+package admission
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+	"time"
+
+	webhook "github.com/openshift/hive/pkg/apis/hive/v1alpha1/validating-webhooks"
+	"github.com/openshift/hive/test/e2e/common"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+const (
+	hiveNamespace           = "hive"
+	hiveAdmissionDeployment = "hiveadmission"
+	hiveAdmissionAPIService = "v1alpha1.admission.hive.openshift.io"
+)
+
+func waitForAdmissionDeployment(t *testing.T) bool {
+	client := common.MustGetKubernetesClient()
+	err := common.WaitForDeploymentReady(client, hiveNamespace, hiveAdmissionDeployment, 10*time.Minute)
+	if err != nil {
+		t.Errorf("Failed waiting for hive admission deployment: %v", err)
+		return false
+	}
+	return true
+}
+
+func waitForAdmissionAPIService(t *testing.T) bool {
+	client := common.MustGetAPIRegistrationClient()
+	err := common.WaitForAPIServiceAvailable(client, hiveAdmissionAPIService, 10*time.Minute)
+	if err != nil {
+		t.Errorf("Failed waiting for admission API service to be ready: %v", err)
+		return false
+	}
+	return true
+}
+
+func waitForAdmission(t *testing.T) bool {
+	return waitForAdmissionDeployment(t) && waitForAdmissionAPIService(t)
+}
+
+func TestAdmission(t *testing.T) {
+	c := common.MustGetDynamicClient()
+	gvr, _ := (&webhook.DNSZoneValidatingAdmissionHook{}).ValidatingResource()
+	if !waitForAdmission(t) {
+		return
+	}
+
+	tests := []struct {
+		name          string
+		file          string
+		expectAllowed bool
+	}{
+		{
+			name:          "review failure",
+			file:          "hiveadmission-review-failure.json",
+			expectAllowed: false,
+		},
+		{
+			name:          "review success",
+			file:          "hiveadmission-review-success.json",
+			expectAllowed: true,
+		},
+		{
+			name:          "review update failure",
+			file:          "hiveadmission-review-update-failure.json",
+			expectAllowed: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file := filepath.Join("../../../../config/samples", test.file)
+			b, err := ioutil.ReadFile(file)
+			if err != nil {
+				t.Fatalf("Unexpected file read error: %v", err)
+			}
+			obj := &unstructured.Unstructured{}
+			err = obj.UnmarshalJSON(b)
+			if err != nil {
+				t.Fatalf("Unexpected unmarshal error: %v", err)
+			}
+			result, err := c.Resource(gvr).Create(obj, metav1.CreateOptions{})
+			if err != nil {
+				t.Fatalf("Unexpected create error: %v", err)
+			}
+			reviewResult := &admissionv1beta1.AdmissionReview{}
+			err = scheme.Scheme.Convert(result, reviewResult, nil)
+			if err != nil {
+				t.Fatalf("Unexpected conversion error: %v", err)
+			}
+			if reviewResult.Response.Allowed != test.expectAllowed {
+				t.Errorf("Unexpected response: %v", reviewResult.Response.Allowed)
+			}
+		})
+	}
+}

--- a/test/e2e/postdeploy/hivecontroller/manager_test.go
+++ b/test/e2e/postdeploy/hivecontroller/manager_test.go
@@ -1,0 +1,88 @@
+package hivecontroller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	// "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/openshift/hive/test/e2e/common"
+)
+
+const (
+	hiveNamespace             = "hive"
+	hiveControllersDeployment = "hive-controllers"
+	hiveControllersService    = "hive-controllers"
+)
+
+func waitForManager(t *testing.T) bool {
+	kubeClient := common.MustGetKubernetesClient()
+	err := common.WaitForDeploymentReady(kubeClient, hiveNamespace, hiveControllersDeployment, 10*time.Minute)
+	if err != nil {
+		t.Errorf("Failed waiting for hive controllers deployment: %v", err)
+		return false
+	}
+	return true
+}
+
+func TestHiveControllersDeployment(t *testing.T) {
+	if !waitForManager(t) {
+		return
+	}
+	// Ensure that the deployment has 1 available replica
+	c := common.MustGetClient()
+	deployment := &appsv1.Deployment{}
+	err := c.Get(context.TODO(), types.NamespacedName{Name: hiveControllersDeployment, Namespace: hiveNamespace}, deployment)
+	if err != nil {
+		t.Errorf("Failed to get hive controllers deployment: %v", err)
+		return
+	}
+	if deployment.Status.AvailableReplicas != 1 {
+		t.Errorf("Unexpected controller manager available replicas: %d", deployment.Status.AvailableReplicas)
+	}
+}
+
+func TestHiveControllersMetrics(t *testing.T) {
+	if !waitForManager(t) {
+		return
+	}
+
+	c := common.MustGetClient()
+	service := &corev1.Service{}
+	err := c.Get(context.TODO(), types.NamespacedName{Name: hiveControllersService, Namespace: hiveNamespace}, service)
+	if err != nil {
+		t.Errorf("Failed to get hive controllers service: %v", err)
+		return
+	}
+
+	metricsPort := 0
+	for _, port := range service.Spec.Ports {
+		if port.Name == "metrics" {
+			metricsPort = int(port.Port)
+		}
+	}
+	if metricsPort == 0 {
+		t.Errorf("cannot find metrics port in hive controllers service")
+		return
+	}
+
+	kubeClient := common.MustGetKubernetesClient()
+
+	// Query the metrics port in the hive-controllers service using the apiserver proxy
+	body, err := kubeClient.CoreV1().RESTClient().Get().Namespace(hiveNamespace).Name(fmt.Sprintf("%s:%d", hiveControllersService, metricsPort)).Resource("services").SubResource("proxy").Suffix("metrics").DoRaw()
+	if err != nil {
+		t.Errorf("failed to reach metrics endpoint: %v", err)
+		return
+	}
+	if !strings.Contains(string(body), "hive_cluster_deployment_install_job_delay_seconds_bucket") {
+		t.Errorf("metrics response does not contain expected metric name")
+	}
+	t.Logf("metrics response:\n%s\n", string(body))
+}

--- a/test/e2e/postdeploy/operator/operator_test.go
+++ b/test/e2e/postdeploy/operator/operator_test.go
@@ -1,0 +1,197 @@
+package operator
+
+import (
+	"context"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ghodss/yaml"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/types"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	"github.com/openshift/hive/test/e2e/common"
+)
+
+const (
+	hiveNamespace          = "hive"
+	hiveOperatorDeployment = "hive-operator"
+	hiveConfigName         = "hive"
+	hiveManagerService     = "hive-controllers"
+	crdDirectory           = "../../../../config/crds"
+	lastAppliedAnnotation  = "kubectl.kubernetes.io/last-applied-configuration"
+)
+
+// TestOperatorDeployment ensures that the Hive operator deployment exists and that
+// it's available.
+func TestOperatorDeployment(t *testing.T) {
+	kubeClient := common.MustGetKubernetesClient()
+	err := common.WaitForDeploymentReady(kubeClient, hiveNamespace, hiveOperatorDeployment, 5*time.Minute)
+	if err != nil {
+		t.Errorf("Failed waiting for hive operator deployment: %v", err)
+		return
+	}
+
+	// Ensure that the deployment has 1 available replica
+	c := common.MustGetClient()
+	operatorDeployment := &appsv1.Deployment{}
+	err = c.Get(context.TODO(), types.NamespacedName{Name: hiveOperatorDeployment, Namespace: hiveNamespace}, operatorDeployment)
+	if err != nil {
+		t.Errorf("Failed to get hive operator deployment: %v", err)
+		return
+	}
+	if operatorDeployment.Status.AvailableReplicas != 1 {
+		t.Errorf("Unexpected operator available replicas: %d", operatorDeployment.Status.AvailableReplicas)
+	}
+}
+
+func readHiveCRDs(t *testing.T) []*apiextv1beta1.CustomResourceDefinition {
+	files, err := ioutil.ReadDir(crdDirectory)
+	if err != nil {
+		t.Fatalf("cannot read crd directory: %v", err)
+	}
+	result := []*apiextv1beta1.CustomResourceDefinition{}
+	for _, file := range files {
+		if !strings.HasSuffix(file.Name(), ".yaml") {
+			continue
+		}
+		b, err := ioutil.ReadFile(filepath.Join(crdDirectory, file.Name()))
+		if err != nil {
+			t.Fatalf("cannot read crd file %s: %v", file.Name(), err)
+		}
+		crd := &apiextv1beta1.CustomResourceDefinition{}
+		if err = yaml.Unmarshal(b, crd); err != nil {
+			t.Fatalf("failed to unmarshall crd from %s: %v", file.Name(), err)
+		}
+		result = append(result, crd)
+	}
+
+	return result
+}
+
+// TestHiveCRDs ensures that CRDs created by Hive exist in the cluster and that
+// they reflect the spec stored in the Hive source repository
+func TestHiveCRDs(t *testing.T) {
+	c := common.MustGetClient()
+	hiveCRDs := readHiveCRDs(t)
+	for _, crd := range hiveCRDs {
+		serverCRD := &apiextv1beta1.CustomResourceDefinition{}
+		err := c.Get(context.TODO(), types.NamespacedName{Name: crd.Name}, serverCRD)
+		if err != nil {
+			t.Errorf("cannot fetch expected crd (%s): %v", crd.Name, err)
+			continue
+		}
+
+		if serverCRD.Annotations == nil {
+			t.Logf("server crd %s has no annotations", serverCRD.Name)
+			continue
+		}
+
+		lastApplied, ok := serverCRD.Annotations[lastAppliedAnnotation]
+		if !ok {
+			t.Logf("server crd %s has no last applied annotation", serverCRD.Name)
+			continue
+		}
+
+		lastAppliedCRD := &apiextv1beta1.CustomResourceDefinition{}
+		if err = yaml.Unmarshal([]byte(lastApplied), lastAppliedCRD); err != nil {
+			t.Fatalf("Unable to unmarshal last applied CRD for %s", serverCRD.Name)
+		}
+
+		if !apiequality.Semantic.DeepEqual(crd.Spec, lastAppliedCRD.Spec) {
+			diff, err := common.JSONDiff(lastAppliedCRD.Spec, crd.Spec)
+			if err == nil {
+				t.Errorf("crd spec on server does not match expected crd spec (%s): %s", crd.Name, string(diff))
+				continue
+			}
+			t.Errorf("crd spec on server does not match expected crd spec (%s), could not calculate a diff", crd.Name)
+		}
+	}
+}
+
+// TestHiveConfig tests that the hive configuration exists and that it's a valid configuration
+func TestHiveConfig(t *testing.T) {
+	c := common.MustGetClient()
+	hiveConfig := &hivev1.HiveConfig{}
+	err := c.Get(context.TODO(), types.NamespacedName{Name: hiveConfigName}, hiveConfig)
+	if err != nil {
+		t.Errorf("could not fetch hive config: %v", err)
+		return
+	}
+	if len(hiveConfig.Spec.ManagedDomains) > 0 && hiveConfig.Spec.ExternalDNS == nil {
+		t.Errorf("external DNS is not configured, but managed domains are")
+	}
+	if hiveConfig.Spec.ExternalDNS != nil && len(hiveConfig.Spec.ManagedDomains) == 0 {
+		t.Errorf("external DNS is configured, but no managed domains are")
+	}
+	if hiveConfig.Spec.ExternalDNS != nil && hiveConfig.Spec.ExternalDNS.AWS != nil {
+		if len(hiveConfig.Spec.ExternalDNS.AWS.Credentials.Name) == 0 {
+			t.Errorf("AWS external DNS configured, but no credentials secret specified")
+			return
+		}
+		secret := &corev1.Secret{}
+		secretName := types.NamespacedName{
+			Namespace: hiveNamespace,
+			Name:      hiveConfig.Spec.ExternalDNS.AWS.Credentials.Name,
+		}
+		err := c.Get(context.TODO(), secretName, secret)
+		if err != nil {
+			t.Errorf("AWS external DNS credentials secret specified (%s), but secret cannot be fetched: %v", secretName.Name, err)
+		}
+	}
+}
+
+// TestOperatorApply ensures that changing a resource managed by the
+// Hive operator results in the operator overwriting the change.
+/*
+NOTE: Disabling this for now, since it won't pass. We need to fix
+the operator so that it does watch the resources that it creates and
+optionally we specify resources that we want unmanaged.
+
+func TestOperatorApply(t *testing.T) {
+	kubeClient := common.MustGetKubernetesClient()
+	// First ensure that the service exists
+	err := common.WaitForService(kubeClient, hiveNamespace, hiveManagerService, func(*corev1.Service) bool { return true }, 8*time.Minute)
+	if err != nil {
+		t.Errorf("Failed waiting for hive manager service: %v", err)
+		return
+	}
+
+	service := &corev1.Service{}
+	c := common.MustGetClient()
+	err = c.Get(context.TODO(), types.NamespacedName{Namespace: hiveNamespace, Name: hiveManagerService}, service)
+	if err != nil {
+		t.Errorf("Failed to fetch hive manager service: %v", err)
+		return
+	}
+
+	service.Annotations = map[string]string{"test-change": "my test change"}
+	err = c.Update(context.TODO(), service)
+	if err != nil {
+		t.Errorf("Failed to update hive manager service: %v", err)
+		return
+	}
+
+	serviceIsReverted := func(s *corev1.Service) bool {
+		annotations := s.Annotations
+		if annotations == nil {
+			return true
+		}
+		_, key_exists := annotations["test-change"]
+		return !key_exists
+	}
+
+	// Wait for change to service resource to be reverted
+	err = common.WaitForService(kubeClient, hiveNamespace, hiveManagerService, serviceIsReverted, 5*time.Minute)
+	if err != nil {
+		t.Errorf("Failed to get change reverted: %v", err)
+	}
+}
+*/


### PR DESCRIPTION
Adds post-deploy tests for hive, ensuring that main components (operator, controllers, and admission) are functional.

Switches to logging the install console log if available to reduce main log size. The full debug log should still be available in the artifacts directory.