### PR TITLE
Write sleep seconds file when we fail to generate assets.

### DIFF
--- a/contrib/pkg/installmanager/installmanager.go
+++ b/contrib/pkg/installmanager/installmanager.go
@@ -246,6 +246,7 @@ func (m *InstallManager) Run() error {
 		if upErr := m.uploadInstallerLog(cd, m, err); upErr != nil {
 			m.log.WithError(err).Error("error saving asset generation log")
 		}
+		m.writeSleepSecondsFile()
 		return err
 	}
 

--- a/pkg/controller/installlogmonitor/installlogmonitor_controller.go
+++ b/pkg/controller/installlogmonitor/installlogmonitor_controller.go
@@ -131,6 +131,7 @@ func (r *ReconcileInstallLog) Reconcile(request reconcile.Request) (reconcile.Re
 		"configMap":  request.NamespacedName.String(),
 		"controller": controllerName,
 	})
+	iLog.Info("reconciling configmap")
 
 	// Load the regex configmap, if we don't have one, there's not much point proceeding here.
 	regexCM := &corev1.ConfigMap{}


### PR DESCRIPTION
Seeing clusters failing at this stage due to permissions, and their
retries are not getting limited via the sleep seconds.