### PR TITLE
Cleanup NS records created for managed domains

### DIFF
--- a/config/external-dns/deployment.yaml
+++ b/config/external-dns/deployment.yaml
@@ -23,5 +23,5 @@ spec:
         - --source=crd
         - --crd-source-apiversion=hive.openshift.io/v1alpha1
         - --crd-source-kind=DNSEndpoint
-        - --registry=noop
-        - --policy=upsert-only
+        - --registry=txt
+        - --policy=sync

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -723,8 +723,8 @@ spec:
         - --source=crd
         - --crd-source-apiversion=hive.openshift.io/v1alpha1
         - --crd-source-kind=DNSEndpoint
-        - --registry=noop
-        - --policy=upsert-only
+        - --registry=txt
+        - --policy=sync
 `)
 
 func configExternalDnsDeploymentYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Changes the external-dns deployment to use a TXT record registry and mode `sync` so that when a dnsendpoint is deleted, it cleans up the records associated with that dnsendpoint.

Fixes https://jira.coreos.com/browse/CO-403