### PR TITLE
remove recent command line params for passing private ssh info

### DIFF
--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -212,6 +212,13 @@ func GenerateInstallerJob(
 			Name:      "sshkeys",
 			MountPath: SSHPrivateKeyDir,
 		})
+
+		// ok when the private key isn't in the secret, as the installmanager
+		// will just gracefully handle the file not being present
+		env = append(env, corev1.EnvVar{
+			Name:  "SSH_PRIV_KEY_PATH",
+			Value: SSHPrivateKeyFilePath,
+		})
 	}
 
 	if cd.Status.InstallerImage == nil {


### PR DESCRIPTION
we can't easily add new cli parameters to the install-manager subcommand b/c it would break
compatibility with older install images.

retire the recently added --ssh-priv-key-path param, and use SSH_PRIV_KEY_PATH env var instead.

update tests, and job generator as appropriate.