### PR TITLE
Update clusterdeployment controller to handle deleted resources

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -263,11 +263,6 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				}(),
 			},
 			validate: func(c client.Client, t *testing.T) {
-				deprovision := getDeprovisionRequest(c)
-				if deprovision == nil {
-					t.Errorf("did not find expected deprovision request")
-				}
-
 				instJob := getInstallJob(c)
 				if instJob != nil {
 					t.Errorf("got unexpected install job (expected delete)")
@@ -369,16 +364,6 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				}(),
 				testSecret(corev1.SecretTypeDockerConfigJson, pullSecretSecret, corev1.DockerConfigJsonKey, "{}"),
 				testSecret(corev1.SecretTypeOpaque, sshKeySecret, adminSSHKeySecretKey, "fakesshkey"),
-				func() *batchv1.Job {
-					job, _, _ := install.GenerateInstallerJob(
-						testDeletedClusterDeployment(),
-						"example.com/fake:latest",
-						"",
-						"fakeserviceaccount",
-						"sshkey",
-						"pullsecret")
-					return job
-				}(),
 			},
 			validate: func(c client.Client, t *testing.T) {
 				deprovision := getDeprovisionRequest(c)
@@ -766,16 +751,6 @@ func TestClusterDeploymentReconcileResults(t *testing.T) {
 		existing                 []runtime.Object
 		exptectedReconcileResult reconcile.Result
 	}{
-		{
-			name: "Requeue after empty clusterversion fields",
-			existing: []runtime.Object{
-				testEmptyClusterDeployment(),
-			},
-			exptectedReconcileResult: reconcile.Result{
-				Requeue:      true,
-				RequeueAfter: defaultRequeueTime,
-			},
-		},
 		{
 			name: "Requeue after adding finalizer",
 			existing: []runtime.Object{


### PR DESCRIPTION
Removes unnecessary code to fixup status fields in clusterdeployment controller (the fields are no longer required in latest crds)

Implements the following pattern when deleting a related resource:
- If deleting the resource, run the delete and return immediately (don't assume we can continue). No requeue is needed because the delete will cause a requeue.
- When retrieving the resource, if the resource is being deleted (DeletionTimestamp is non-nil), return and requeue for an interval of time. (Otherwise we are not guaranteed that the resource will be requeued)

Other than that, a few minor fixes in the code.