### PR TITLE
Client Metrics

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -159,7 +159,7 @@ func Add(mgr manager.Manager) error {
 // NewReconciler returns a new reconcile.Reconciler
 func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileClusterDeployment{
-		Client:                        mgr.GetClient(),
+		Client:                        hivemetrics.NewClientWithMetricsOrDie(mgr, controllerName),
 		scheme:                        mgr.GetScheme(),
 		remoteClusterAPIClientBuilder: controllerutils.GetClusterAPIClient,
 	}

--- a/pkg/controller/clusterdeprovisionrequest/clusterdeprovisionrequest_controller.go
+++ b/pkg/controller/clusterdeprovisionrequest/clusterdeprovisionrequest_controller.go
@@ -39,6 +39,7 @@ import (
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
 	"github.com/openshift/hive/pkg/controller/images"
+	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/install"
 )
@@ -69,7 +70,7 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileClusterDeprovisionRequest{Client: mgr.GetClient(), scheme: mgr.GetScheme()}
+	return &ReconcileClusterDeprovisionRequest{Client: hivemetrics.NewClientWithMetricsOrDie(mgr, controllerName), scheme: mgr.GetScheme()}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler

--- a/pkg/controller/clusterversion/clusterversion_controller.go
+++ b/pkg/controller/clusterversion/clusterversion_controller.go
@@ -37,12 +37,14 @@ import (
 
 	openshiftapiv1 "github.com/openshift/api/config/v1"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 )
 
 const (
 	clusterVersionObjectName = "version"
 	clusterVersionUnknown    = "undef"
+	controllerName           = "clusterversion"
 )
 
 // Add creates a new ClusterDeployment Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
@@ -54,7 +56,7 @@ func Add(mgr manager.Manager) error {
 // NewReconciler returns a new reconcile.Reconciler
 func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileClusterVersion{
-		Client:                        mgr.GetClient(),
+		Client:                        hivemetrics.NewClientWithMetricsOrDie(mgr, controllerName),
 		scheme:                        mgr.GetScheme(),
 		remoteClusterAPIClientBuilder: controllerutils.GetClusterAPIClient,
 	}
@@ -111,7 +113,7 @@ func (r *ReconcileClusterVersion) Reconcile(request reconcile.Request) (reconcil
 	cdLog := log.WithFields(log.Fields{
 		"clusterDeployment": cd.Name,
 		"namespace":         cd.Namespace,
-		"controller":        "clusterversion",
+		"controller":        controllerName,
 	})
 	cdLog.Info("reconciling cluster version")
 

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller.go
@@ -42,6 +42,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	apihelpers "github.com/openshift/hive/pkg/apis/helpers"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/resource"
 )
@@ -75,7 +76,7 @@ func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 	logger := log.WithField("controller", controllerName)
 	helper := resource.NewHelperFromRESTConfig(mgr.GetConfig(), logger)
 	return &ReconcileControlPlaneCerts{
-		Client:  mgr.GetClient(),
+		Client:  hivemetrics.NewClientWithMetricsOrDie(mgr, controllerName),
 		scheme:  mgr.GetScheme(),
 		applier: helper,
 	}

--- a/pkg/controller/dnszone/dnszone_controller.go
+++ b/pkg/controller/dnszone/dnszone_controller.go
@@ -24,6 +24,7 @@ import (
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
 	awsclient "github.com/openshift/hive/pkg/awsclient"
+	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	corev1 "k8s.io/api/core/v1"
 
@@ -52,7 +53,7 @@ func Add(mgr manager.Manager) error {
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileDNSZone{
-		Client:           mgr.GetClient(),
+		Client:           hivemetrics.NewClientWithMetricsOrDie(mgr, controllerName),
 		scheme:           mgr.GetScheme(),
 		logger:           log.WithField("controller", controllerName),
 		awsClientBuilder: awsclient.NewClient,

--- a/pkg/controller/installlogmonitor/installlogmonitor_controller.go
+++ b/pkg/controller/installlogmonitor/installlogmonitor_controller.go
@@ -61,7 +61,7 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileInstallLog{Client: mgr.GetClient(), scheme: mgr.GetScheme()}
+	return &ReconcileInstallLog{Client: hivemetrics.NewClientWithMetricsOrDie(mgr, controllerName), scheme: mgr.GetScheme()}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler

--- a/pkg/controller/metrics/clientwrapper.go
+++ b/pkg/controller/metrics/clientwrapper.go
@@ -1,0 +1,104 @@
+package metrics
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	metricKubeClientRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "hive_kube_client_requests_total",
+		Help: "Counter incremented for each kube client request.",
+	},
+		[]string{"controller", "method", "resource"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(metricKubeClientRequests)
+}
+
+// NewClientWithMetricsOrDie creates a new controller-runtime client with a wrapper which increments
+// metrics for requests by controller name, HTTP method, and URL path. The client will re-use the
+// managers cache. This should be used in all Hive controllers.
+func NewClientWithMetricsOrDie(mgr manager.Manager, ctrlrName string) client.Client {
+	// Copy the rest config as we want our round trippers to be controller specific.
+	cfg := rest.CopyConfig(mgr.GetConfig())
+	cfg.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
+		return &ControllerMetricsTripper{
+			RoundTripper: rt,
+			controller:   ctrlrName,
+		}
+	}
+
+	options := client.Options{
+		Scheme: mgr.GetScheme(),
+		Mapper: mgr.GetRESTMapper(),
+	}
+	c, err := client.New(cfg, options)
+	if err != nil {
+		log.WithError(err).Fatal("unable to initialize metrics wrapped client")
+	}
+
+	return &client.DelegatingClient{
+		Reader: &client.DelegatingReader{
+			CacheReader:  mgr.GetCache(),
+			ClientReader: c,
+		},
+		Writer:       c,
+		StatusClient: c,
+	}
+}
+
+// ControllerMetricsTripper is a RoundTripper implementation which tracks our metrics for client requests.
+type ControllerMetricsTripper struct {
+	http.RoundTripper
+	controller string
+}
+
+// RoundTrip implements the http RoundTripper interface.
+func (cmt *ControllerMetricsTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	metricKubeClientRequests.WithLabelValues(cmt.controller, req.Method, parsePath(req.URL.Path)).Inc()
+	// Call the nested RoundTripper.
+	resp, err := cmt.RoundTripper.RoundTrip(req)
+	return resp, err
+}
+
+// parsePath returns a group/version/resource string from the given path. Used to avoid per cluster metrics
+// for cardinality reasons.
+func parsePath(path string) string {
+	tokens := strings.Split(path[1:], "/")
+	fmt.Printf("tokens: %v\n", tokens)
+	if tokens[0] == "api" {
+		// Handle core resources:
+		if len(tokens) == 3 || len(tokens) == 4 {
+			return strings.Join([]string{"core", tokens[1], tokens[2]}, "/")
+		}
+		// Handle operators on direct namespaced resources:
+		if len(tokens) > 4 && tokens[2] == "namespaces" {
+			return strings.Join([]string{"core", tokens[1], tokens[4]}, "/")
+		}
+	} else if tokens[0] == "apis" {
+		// Handle resources with apigroups:
+		if len(tokens) == 4 || len(tokens) == 5 {
+			return strings.Join([]string{tokens[1], tokens[2], tokens[3]}, "/")
+		}
+		if len(tokens) > 5 && tokens[3] == "namespaces" {
+			return strings.Join([]string{tokens[1], tokens[2], tokens[5]}, "/")
+		}
+
+	}
+	log.Warnf("unable to parse path for client metrics: %s", path)
+
+	return "unknown-resource"
+}

--- a/pkg/controller/metrics/clientwrapper_test.go
+++ b/pkg/controller/metrics/clientwrapper_test.go
@@ -1,0 +1,78 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPathParse(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "core pods list",
+			path:     "/api/v1/pods",
+			expected: "core/v1/pods",
+		},
+		{
+			name:     "core global nodes update",
+			path:     "/api/v1/nodes/nodename",
+			expected: "core/v1/nodes",
+		},
+		{
+			name:     "core configmaps update",
+			path:     "/api/v1/namespaces/hive/configmaps/dgoodwin-del-install-log",
+			expected: "core/v1/configmaps",
+		},
+		{
+			name:     "batch job list",
+			path:     "/apis/batch/v1/jobs",
+			expected: "batch/v1/jobs",
+		},
+		{
+			name:     "batch job create",
+			path:     "/apis/batch/v1/namespaces/hive/jobs",
+			expected: "batch/v1/jobs",
+		},
+		{
+			name:     "batch job delete",
+			path:     "/apis/batch/v1/namespaces/hive/jobs/dgoodwin-del-install",
+			expected: "batch/v1/jobs",
+		},
+		{
+			name:     "hive global crd list",
+			path:     "/apis/hive.openshift.io/v1alpha1/selectorsyncidentityproviders",
+			expected: "hive.openshift.io/v1alpha1/selectorsyncidentityproviders",
+		},
+		{
+			name:     "hive global crd update",
+			path:     "/apis/hive.openshift.io/v1alpha1/selectorsyncidentityproviders/ssname",
+			expected: "hive.openshift.io/v1alpha1/selectorsyncidentityproviders",
+		},
+		{
+			name:     "hive namespaced crd create",
+			path:     "/apis/hive.openshift.io/v1alpha1/namespaces/hive/clusterdeprovisionrequests",
+			expected: "hive.openshift.io/v1alpha1/clusterdeprovisionrequests",
+		},
+		{
+			name:     "hive namespaced crd update",
+			path:     "/apis/hive.openshift.io/v1alpha1/namespaces/hive/clusterdeployments/dgoodwin-del",
+			expected: "hive.openshift.io/v1alpha1/clusterdeployments",
+		},
+		{
+			name:     "hive namespaced crd update status",
+			path:     "/apis/hive.openshift.io/v1alpha1/namespaces/hive/clusterdeployments/dgoodwin-del/status",
+			expected: "hive.openshift.io/v1alpha1/clusterdeployments",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := parsePath(test.path)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+
+}

--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -45,6 +45,7 @@ import (
 	ingresscontroller "github.com/openshift/api/operator/v1"
 	apihelpers "github.com/openshift/hive/pkg/apis/helpers"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	"github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/resource"
 )
@@ -85,7 +86,7 @@ func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 	logger := log.WithField("controller", controllerName)
 	helper := resource.NewHelperFromRESTConfig(mgr.GetConfig(), logger)
 	return &ReconcileRemoteClusterIngress{
-		Client:  mgr.GetClient(),
+		Client:  hivemetrics.NewClientWithMetricsOrDie(mgr, controllerName),
 		scheme:  mgr.GetScheme(),
 		logger:  log.WithField("controller", controllerName),
 		kubeCLI: helper,

--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -53,6 +53,7 @@ import (
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
 	"github.com/openshift/hive/pkg/awsclient"
+	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/install"
 )
@@ -77,7 +78,7 @@ func Add(mgr manager.Manager) error {
 // NewReconciler returns a new reconcile.Reconciler
 func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileRemoteMachineSet{
-		Client:                        mgr.GetClient(),
+		Client:                        hivemetrics.NewClientWithMetricsOrDie(mgr, controllerName),
 		scheme:                        mgr.GetScheme(),
 		logger:                        log.WithField("controller", controllerName),
 		remoteClusterAPIClientBuilder: controllerutils.GetClusterAPIClient,

--- a/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
+++ b/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
@@ -25,6 +25,7 @@ import (
 
 	openshiftapiv1 "github.com/openshift/api/config/v1"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -63,7 +64,7 @@ func Add(mgr manager.Manager) error {
 // NewReconciler returns a new reconcile.Reconciler
 func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileSyncIdentityProviders{
-		Client: mgr.GetClient(),
+		Client: hivemetrics.NewClientWithMetricsOrDie(mgr, controllerName),
 		scheme: mgr.GetScheme(),
 		logger: log.WithField("controller", controllerName),
 	}

--- a/pkg/controller/syncset/syncset_controller.go
+++ b/pkg/controller/syncset/syncset_controller.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	hiveresource "github.com/openshift/hive/pkg/resource"
 )
@@ -72,7 +73,7 @@ func Add(mgr manager.Manager) error {
 // NewReconciler returns a new reconcile.Reconciler
 func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 	r := &ReconcileSyncSet{
-		Client:               mgr.GetClient(),
+		Client:               hivemetrics.NewClientWithMetricsOrDie(mgr, controllerName),
 		scheme:               mgr.GetScheme(),
 		logger:               log.WithField("controller", controllerName),
 		applierBuilder:       applierBuilderFunc,

--- a/pkg/controller/unreachable/unreachable_controller.go
+++ b/pkg/controller/unreachable/unreachable_controller.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 )
 
@@ -60,7 +61,7 @@ func Add(mgr manager.Manager) error {
 // NewReconciler returns a new reconcile.Reconciler
 func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileRemoteMachineSet{
-		Client:                        mgr.GetClient(),
+		Client:                        hivemetrics.NewClientWithMetricsOrDie(mgr, controllerName),
 		scheme:                        mgr.GetScheme(),
 		logger:                        log.WithField("controller", controllerName),
 		remoteClusterAPIClientBuilder: controllerutils.BuildClusterAPIClientFromKubeconfig,


### PR DESCRIPTION
Adds a transport wrapper which parses a little info about the request to determine what resource we're dealing with, and then increments a prometheus counter with labels for method, resource, and what controller the client is from. This allows us to identify who is causing hotloops with excessive writes.

Only tricky part of this was the rest config copying, last week it did not function properly (no metrics), today it does, so we'll see how this goes in stage.