### PR TITLE
Skip reconciles for unreachable clusters.

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -923,7 +923,7 @@ func testSecret(secretType corev1.SecretType, name, key, value string) *corev1.S
 	return s
 }
 
-func testRemoteClusterAPIClientBuilder(cd *hivev1.ClusterDeployment, secretData string) (client.Client, error) {
+func testRemoteClusterAPIClientBuilder(secretData string) (client.Client, error) {
 	remoteClusterVersion := &openshiftapiv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: remoteClusterVersionObjectName,

--- a/pkg/controller/clusterversion/clusterversion_controller_test.go
+++ b/pkg/controller/clusterversion/clusterversion_controller_test.go
@@ -219,7 +219,7 @@ func testSecret(name, key, value string) *corev1.Secret {
 	return s
 }
 
-func testRemoteClusterAPIClientBuilder(cd *hivev1.ClusterDeployment, secretData string) (client.Client, error) {
+func testRemoteClusterAPIClientBuilder(secretData string) (client.Client, error) {
 	remoteClusterVersion := &configv1.ClusterVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: remoteClusterVersionObjectName,

--- a/pkg/controller/syncset/syncset_controller.go
+++ b/pkg/controller/syncset/syncset_controller.go
@@ -206,6 +206,11 @@ func (r *ReconcileSyncSet) Reconcile(request reconcile.Request) (reconcile.Resul
 		"clusterDeployment": cd.Name,
 		"namespace":         cd.Namespace,
 	})
+	// If the cluster is unreachable, do not reconcile.
+	if controllerutils.HasUnreachableCondition(cd) {
+		cdLog.Debug("skipping cluster with unreachable condition")
+		return reconcile.Result{}, nil
+	}
 
 	if !cd.Status.Installed {
 		// Cluster isn't installed yet, return

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -67,18 +67,13 @@ func BuildClusterAPIClientFromKubeconfig(kubeconfigData string) (client.Client, 
 	})
 }
 
-// GetClusterAPIClient returns kube API client for the cluster deployment only when the cluster condition is reachable
-func GetClusterAPIClient(cd *hivev1.ClusterDeployment, kubeconfigData string) (client.Client, error) {
-
+// HasUnreachableCondition returns true if the cluster deployment has the unreachable condition set to true.
+func HasUnreachableCondition(cd *hivev1.ClusterDeployment) bool {
 	condition := FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.UnreachableCondition)
 	if condition != nil {
-		//Check condition status is true or not
-		if condition.Status == corev1.ConditionTrue {
-			err := fmt.Errorf(fmt.Sprintf("cluster deployment condition '%s' : %s", hivev1.UnreachableCondition, condition.Status))
-			return nil, err
-		}
+		return condition.Status == corev1.ConditionTrue
 	}
-	return BuildClusterAPIClientFromKubeconfig(kubeconfigData)
+	return false
 }
 
 // BuildDynamicClientFromKubeconfig returns a dynamic client using the provided kubeconfig


### PR DESCRIPTION
This code mistakenly assumed that if you tried to hit a cluster that
already has unreachable condition set, we should return that as an
error. This however causes the controller-runtime framework to keep
retrying, with backoff, but still a lot of reconciling and errors
logged.

Instead we should check for the condition and skip reconcile, without
considering this an error.

In time, if the cluster comes back, the unreachable controller will
clear the condition at which point all these controllers will resume
normal operation.