### PR TITLE
Add controller reconcile time metrics for all controllers.

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -243,6 +243,7 @@ func (r *ReconcileClusterDeployment) Reconcile(request reconcile.Request) (recon
 	cdLog.Info("reconciling cluster deployment")
 	defer func() {
 		dur := time.Since(start)
+		hivemetrics.MetricControllerReconcileTime.WithLabelValues(controllerName).Observe(dur.Seconds())
 		cdLog.WithField("elapsed", dur).Info("reconcile complete")
 	}()
 

--- a/pkg/controller/clusterdeprovisionrequest/clusterdeprovisionrequest_controller.go
+++ b/pkg/controller/clusterdeprovisionrequest/clusterdeprovisionrequest_controller.go
@@ -102,6 +102,7 @@ func (r *ReconcileClusterDeprovisionRequest) Reconcile(request reconcile.Request
 	rLog.Info("reconciling cluster deprovision request")
 	defer func() {
 		dur := time.Since(start)
+		hivemetrics.MetricControllerReconcileTime.WithLabelValues(controllerName).Observe(dur.Seconds())
 		rLog.WithField("elapsed", dur).Info("reconcile complete")
 	}()
 	// Fetch the ClusterDeprovisionRequest instance

--- a/pkg/controller/dnszone/dnszone_controller.go
+++ b/pkg/controller/dnszone/dnszone_controller.go
@@ -105,6 +105,7 @@ func (r *ReconcileDNSZone) Reconcile(request reconcile.Request) (reconcile.Resul
 	dnsLog.Info("reconciling dns zone")
 	defer func() {
 		dur := time.Since(start)
+		hivemetrics.MetricControllerReconcileTime.WithLabelValues(controllerName).Observe(dur.Seconds())
 		dnsLog.WithField("elapsed", dur).Info("reconcile complete")
 	}()
 

--- a/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
+++ b/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
@@ -172,6 +172,7 @@ func (r *ReconcileSyncIdentityProviders) Reconcile(request reconcile.Request) (r
 	contextLogger.Info("reconciling syncidentityproviders and clusterdeployments")
 	defer func() {
 		dur := time.Since(start)
+		hivemetrics.MetricControllerReconcileTime.WithLabelValues(controllerName).Observe(dur.Seconds())
 		contextLogger.WithField("elapsed", dur).Info("reconcile complete")
 	}()
 

--- a/pkg/controller/unreachable/unreachable_controller.go
+++ b/pkg/controller/unreachable/unreachable_controller.go
@@ -112,6 +112,7 @@ func (r *ReconcileRemoteMachineSet) Reconcile(request reconcile.Request) (reconc
 	cdLog.Info("reconciling cluster deployment")
 	defer func() {
 		dur := time.Since(start)
+		hivemetrics.MetricControllerReconcileTime.WithLabelValues(controllerName).Observe(dur.Seconds())
 		cdLog.WithField("elapsed", dur).Info("reconcile complete")
 	}()
 


### PR DESCRIPTION
controller-runtime technically does this for us but due to a bug the
results currently include queue time, which completely skews the
results.

Add our own metric so we can monitor how long we're taking to get
through reconcile loops.