### PR TITLE
Remove legacy controller gen of install config.

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -240,7 +240,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testSecret(corev1.SecretTypeDockerConfigJson, pullSecretSecret, corev1.DockerConfigJsonKey, "{}"),
 				testSecret(corev1.SecretTypeOpaque, sshKeySecret, adminSSHKeySecretKey, "fakesshkey"),
 				func() *batchv1.Job {
-					job, _, _ := install.GenerateInstallerJob(
+					job, _ := install.GenerateInstallerJob(
 						testExpiredClusterDeployment(),
 						"example.com/fake:latest",
 						"",
@@ -297,7 +297,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testSecret(corev1.SecretTypeDockerConfigJson, pullSecretSecret, corev1.DockerConfigJsonKey, "{}"),
 				testSecret(corev1.SecretTypeOpaque, sshKeySecret, adminSSHKeySecretKey, "fakesshkey"),
 				func() *batchv1.Job {
-					job, _, _ := install.GenerateInstallerJob(
+					job, _ := install.GenerateInstallerJob(
 						testExpiredClusterDeployment(),
 						"example.com/fake:latest",
 						"",
@@ -324,7 +324,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testSecret(corev1.SecretTypeDockerConfigJson, pullSecretSecret, corev1.DockerConfigJsonKey, "{}"),
 				testSecret(corev1.SecretTypeOpaque, sshKeySecret, adminSSHKeySecretKey, "fakesshkey"),
 				func() *batchv1.Job {
-					job, _, _ := install.GenerateInstallerJob(
+					job, _ := install.GenerateInstallerJob(
 						testClusterDeployment(),
 						"fakeserviceaccount",
 						"",
@@ -913,7 +913,7 @@ func testExpiredClusterDeployment() *hivev1.ClusterDeployment {
 
 func testInstallJob() *batchv1.Job {
 	cd := testClusterDeployment()
-	job, _, err := install.GenerateInstallerJob(cd,
+	job, err := install.GenerateInstallerJob(cd,
 		images.DefaultHiveImage,
 		"",
 		serviceAccountName, "testSSHKey", "testPullSecret")

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -78,7 +78,6 @@ type InstallManager struct {
 	log                           log.FieldLogger
 	LogLevel                      string
 	WorkDir                       string
-	InstallConfig                 string
 	ClusterID                     string
 	ClusterName                   string
 	Region                        string
@@ -133,8 +132,6 @@ func NewInstallManagerCommand() *cobra.Command {
 	flags.StringVar(&im.LogLevel, "log-level", "info", "log level, one of: debug, info, warn, error, fatal, panic")
 	flags.StringVar(&im.WorkDir, "work-dir", "/output", "directory to use for all input and output")
 	flags.StringVar(&im.Region, "region", "us-east-1", "Region installing into")
-	// This is required due to how we have to share volume and mount in our install config. The installer also deletes the workdir copy.
-	flags.StringVar(&im.InstallConfig, "install-config", "/installconfig/install-config.yaml", "location of install-config.yaml to copy into work-dir")
 	return cmd
 }
 

--- a/pkg/installmanager/installmanager_test.go
+++ b/pkg/installmanager/installmanager_test.go
@@ -147,7 +147,6 @@ func TestInstallManager(t *testing.T) {
 			im := InstallManager{
 				LogLevel:              "debug",
 				WorkDir:               tempDir,
-				InstallConfig:         filepath.Join(tempDir, "tempinstallconfig.yml"),
 				ClusterDeploymentName: testClusterName,
 				Namespace:             testNamespace,
 				DynamicClient:         fakeClient,
@@ -156,11 +155,6 @@ func TestInstallManager(t *testing.T) {
 
 			if !assert.NoError(t, writeFakeBinary(filepath.Join(tempDir, installerBinary),
 				fmt.Sprintf(fakeInstallerBinary, tempDir))) {
-				t.Fail()
-			}
-
-			// Install config also doesn't get used, we just need a file we can copy:
-			if !assert.NoError(t, writeFakeInstallConfig(im.InstallConfig)) {
 				t.Fail()
 			}
 
@@ -318,12 +312,6 @@ func writeFakeBinary(fileName string, contents string) error {
 	data := []byte(contents)
 	err := ioutil.WriteFile(fileName, data, 0755)
 	return err
-}
-
-func writeFakeInstallConfig(fileName string) error {
-	// nothing needs to read this so for now just an empty file
-	data := []byte("fakefile")
-	return ioutil.WriteFile(fileName, data, 0755)
 }
 
 func testClusterDeployment() *hivev1.ClusterDeployment {


### PR DESCRIPTION
Some time back we moved this logic into the installmanager which runs
alongside the installer and is closely versioned with it. We carried
this code for the sake of some older ClusterImageSets which still needed
it, but these should be long gone now.