### PR TITLE
Regenerate deprovision jobs when spec changes.

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -2,8 +2,6 @@ package clusterdeployment
 
 import (
 	"context"
-	"crypto/md5"
-	"encoding/hex"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -468,9 +466,9 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 			return reconcile.Result{}, err
 		}
 
-		jobHash, err := calculateJobSpecHash(job)
+		jobHash, err := controllerutils.CalculateJobSpecHash(job)
 		if err != nil {
-			cdLog.WithError(err).Error("failed to calulcate hash for generated install job")
+			cdLog.WithError(err).Error("failed to calculate hash for generated install job")
 			return reconcile.Result{}, err
 		}
 		if job.Annotations == nil {
@@ -1292,24 +1290,6 @@ func migrateWildcardIngress(cd *hivev1.ClusterDeployment) bool {
 		}
 	}
 	return migrated
-}
-
-func calculateJobSpecHash(job *batchv1.Job) (string, error) {
-
-	hasher := md5.New()
-	jobSpecBytes, err := job.Spec.Marshal()
-	if err != nil {
-		return "", err
-	}
-
-	_, err = hasher.Write(jobSpecBytes)
-	if err != nil {
-		return "", err
-	}
-
-	sum := hex.EncodeToString(hasher.Sum(nil))
-
-	return sum, nil
 }
 
 func dnsReadyTransitionTime(dnsZone *hivev1.DNSZone) *time.Time {

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -923,7 +923,7 @@ func testInstallJob() *batchv1.Job {
 
 	controllerutil.SetControllerReference(cd, job, scheme.Scheme)
 
-	hash, err := calculateJobSpecHash(job)
+	hash, err := controllerutils.CalculateJobSpecHash(job)
 	if err != nil {
 		panic("should never get error calculating job spec hash")
 	}

--- a/pkg/controller/utils/jobs.go
+++ b/pkg/controller/utils/jobs.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"crypto/md5"
+	"encoding/hex"
+
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -29,4 +32,23 @@ func IsFailed(job *batchv1.Job) bool {
 // IsFinished returns true if the job completed (succeeded or failed)
 func IsFinished(job *batchv1.Job) bool {
 	return IsSuccessful(job) || IsFailed(job)
+}
+
+// CalculateJobSpecHash returns a hash of the job.Spec.
+func CalculateJobSpecHash(job *batchv1.Job) (string, error) {
+
+	hasher := md5.New()
+	jobSpecBytes, err := job.Spec.Marshal()
+	if err != nil {
+		return "", err
+	}
+
+	_, err = hasher.Write(jobSpecBytes)
+	if err != nil {
+		return "", err
+	}
+
+	sum := hex.EncodeToString(hasher.Sum(nil))
+
+	return sum, nil
 }

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -476,6 +476,7 @@ func GenerateUninstallerJob(
 	job.Name = name
 	job.Namespace = namespace
 	job.ObjectMeta.Labels = labels
+	job.ObjectMeta.Annotations = map[string]string{}
 	job.Spec = batchv1.JobSpec{
 		Completions:  &completions,
 		BackoffLimit: &backoffLimit,


### PR DESCRIPTION
Similar to what we do for install jobs, track a hash of the spec we
generate and store in an annotation. If this is missing or changed on
the current job, delete it and allow another to be created.