### PR TITLE
ClusterRole hive-admin can edit selectorsyncidentityproviders CRs

### DIFF
--- a/config/rbac/hive_admin_role.yaml
+++ b/config/rbac/hive_admin_role.yaml
@@ -43,6 +43,7 @@ rules:
   - clusterimagesets
   - hiveconfigs
   - selectorsyncsets
+  - selectorsyncidentityproviders
   verbs:
   - get
   - list

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -856,6 +856,7 @@ rules:
   - clusterimagesets
   - hiveconfigs
   - selectorsyncsets
+  - selectorsyncidentityproviders
   verbs:
   - get
   - list


### PR DESCRIPTION
Admins need to setup identity providers for support purposes that land on groups of clusters.