### PR TITLE
Add leader election for both operator and controllers.

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -27,7 +27,9 @@ import (
 )
 
 const (
-	defaultLogLevel = "info"
+	defaultLogLevel         = "info"
+	hiveNamespace           = "hive"
+	leaderElectionConfigMap = "hive-controllers-leader"
 )
 
 type controllerManagerOptions struct {
@@ -56,7 +58,10 @@ func newRootCommand() *cobra.Command {
 
 			// Create a new Cmd to provide shared dependencies and start components
 			mgr, err := manager.New(cfg, manager.Options{
-				MetricsBindAddress: ":2112",
+				MetricsBindAddress:      ":2112",
+				LeaderElection:          true,
+				LeaderElectionNamespace: hiveNamespace,
+				LeaderElectionID:        leaderElectionConfigMap,
 			})
 			if err != nil {
 				log.Fatal(err)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -27,7 +27,9 @@ import (
 )
 
 const (
-	defaultLogLevel = "info"
+	defaultLogLevel         = "info"
+	hiveNamespace           = "hive"
+	leaderElectionConfigMap = "hive-operator-leader"
 )
 
 type controllerManagerOptions struct {
@@ -55,7 +57,12 @@ func newRootCommand() *cobra.Command {
 			}
 
 			// Create a new Cmd to provide shared dependencies and start components
-			mgr, err := manager.New(cfg, manager.Options{Namespace: "hive"})
+			mgr, err := manager.New(cfg, manager.Options{
+				Namespace:               hiveNamespace,
+				LeaderElection:          true,
+				LeaderElectionNamespace: hiveNamespace,
+				LeaderElectionID:        leaderElectionConfigMap,
+			})
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/config/rbac/manager_role.yaml
+++ b/config/rbac/manager_role.yaml
@@ -22,6 +22,7 @@ rules:
   - serviceaccounts
   - secrets
   - configmaps
+  - events
   verbs:
   - get
   - list

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -224,7 +224,7 @@ type ReconcileClusterDeployment struct {
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
 //
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=core,resources=serviceaccounts;secrets;configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts;secrets;configmaps;events,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods;namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments;clusterdeployments/status;clusterdeployments/finalizers,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1213,6 +1213,7 @@ rules:
   - serviceaccounts
   - secrets
   - configmaps
+  - events
   verbs:
   - get
   - list


### PR DESCRIPTION
Primarily to prevent any problems during upgrades when both new and old
versions of the code may be running.