### PR TITLE
Add an installlog entry for the standard API timeout.

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -19,3 +19,8 @@ data:
     - "data.aws_route53_zone.public: no matching Route53Zone found"
     installFailingReason: NoMatchingRoute53Zone
     installFailingMessage: No matching Route53Zone found
+  KubeAPIWaitTimeout: |
+    searchRegexStrings:
+    - "waiting for Kubernetes API: context deadline exceeded"
+    installFailingReason: KubeAPIWaitTimeout
+    installFailingMessage: Timeout waiting for the Kubernetes API to begin responding

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -4785,6 +4785,11 @@ data:
     - "data.aws_route53_zone.public: no matching Route53Zone found"
     installFailingReason: NoMatchingRoute53Zone
     installFailingMessage: No matching Route53Zone found
+  KubeAPIWaitTimeout: |
+    searchRegexStrings:
+    - "waiting for Kubernetes API: context deadline exceeded"
+    installFailingReason: KubeAPIWaitTimeout
+    installFailingMessage: Timeout waiting for the Kubernetes API to begin responding
 `)
 
 func configConfigmapsInstallLogRegexesConfigmapYamlBytes() ([]byte, error) {


### PR DESCRIPTION
This is surfacing again in stage and historically one of the most common
failures.