### PR TITLE
Add Velero Backup When ClusterDeployment Changes

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,6 +24,8 @@ import (
 	openshiftapiv1 "github.com/openshift/api/config/v1"
 	_ "github.com/openshift/generic-admission-server/pkg/cmd"
 	awsprovider "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1"
+
+	velerov1 "github.com/heptio/velero/pkg/apis/velero/v1"
 )
 
 const (
@@ -87,6 +89,10 @@ func newRootCommand() *cobra.Command {
 			}
 
 			if err := crv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
+				log.Fatal(err)
+			}
+
+			if err := velerov1.AddToScheme(mgr.GetScheme()); err != nil {
 				log.Fatal(err)
 			}
 

--- a/config/rbac/manager_role.yaml
+++ b/config/rbac/manager_role.yaml
@@ -226,3 +226,17 @@ rules:
   - patch
   - list
   - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - velero.io
+  resources:
+  - backups
+  verbs:
+  - create

--- a/pkg/controller/add_velerobackup.go
+++ b/pkg/controller/add_velerobackup.go
@@ -1,0 +1,7 @@
+package controller
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	// TODO: Uncomment this line once card CO-488 is completed (adding HiveConfig option for this).
+	//AddToManagerFuncs = append(AddToManagerFuncs, velerobackup.Add)
+}

--- a/pkg/controller/syncset/syncset_controller.go
+++ b/pkg/controller/syncset/syncset_controller.go
@@ -2,8 +2,6 @@ package syncset
 
 import (
 	"context"
-	"crypto/md5"
-	"encoding/json"
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
@@ -44,7 +42,7 @@ func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 		Client:      controllerutils.NewClientWithMetricsOrDie(mgr, controllerName),
 		scheme:      mgr.GetScheme(),
 		logger:      log.WithField("controller", controllerName),
-		computeHash: getHash,
+		computeHash: controllerutils.GetChecksumOfObject,
 	}
 	return r
 }
@@ -464,12 +462,4 @@ func syncSetInstanceNameForSyncSet(cd *hivev1.ClusterDeployment, syncSet *hivev1
 func syncSetInstanceNameForSelectorSyncSet(cd *hivev1.ClusterDeployment, selectorSyncSet *hivev1.SelectorSyncSet) string {
 	syncSetPart := helpers.GetName(selectorSyncSet.Name, "selector-syncset", validation.DNS1123SubdomainMaxLength-validation.DNS1123LabelMaxLength)
 	return fmt.Sprintf("%s-%s", cd.Name, syncSetPart)
-}
-
-func getHash(data interface{}) (string, error) {
-	b, err := json.Marshal(data)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%x", md5.Sum(b)), nil
 }

--- a/pkg/controller/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/controller/test/clusterdeployment/clusterdeployment.go
@@ -1,0 +1,94 @@
+package clusterdeployment
+
+import (
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+)
+
+// Option defines a function signature for any function that wants to be passed into BuildClusterDeployment
+type Option func(*hivev1.ClusterDeployment)
+
+// Checksum defines a function signature for checksumming objects.
+type Checksum func(*hivev1.ClusterDeployment) (string, error)
+
+// BuildClusterDeployment runs each of the functions passed in to generate a cluster deployment.
+func BuildClusterDeployment(opts ...Option) *hivev1.ClusterDeployment {
+	retval := &hivev1.ClusterDeployment{}
+	for _, o := range opts {
+		o(retval)
+	}
+
+	return retval
+}
+
+// WithName sets the ClusterDeployment.Name field when building a clusterdeployment with BuildClusterDeployment.
+func WithName(name string) Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Name = name
+	}
+}
+
+// WithNamePostfix appends the string passed in to the ClusterDeployment.Name field when building a clusterdeployment with BuildClusterDeployment.
+func WithNamePostfix(postfix string) Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Name = clusterDeployment.Name + "-" + postfix
+	}
+}
+
+// WithNamespace sets the ClusterDeployment.Namespace field when building a clusterdeployment with BuildClusterDeployment.
+func WithNamespace(namespace string) Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Namespace = namespace
+	}
+}
+
+// WithAnnotationsSet ensures that ClusterDeployment.Annotations is not nil.
+func WithAnnotationsSet() Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		// Only set if Nil (don't wipe out existing)
+		if clusterDeployment.Annotations == nil {
+			clusterDeployment.Annotations = map[string]string{}
+		}
+	}
+}
+
+// WithEmptyAnnotations ensures that annotations is set and that map is empty.
+func WithEmptyAnnotations() Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		// Wipe out existing so that it's actually empty.
+		clusterDeployment.Annotations = map[string]string{}
+	}
+}
+
+// WithEmptyBackupChecksum ensures that the checksum annotation is empty.
+func WithEmptyBackupChecksum() Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		// Case where annotations don't exist, so checksum doesn't exist.
+		if clusterDeployment.ObjectMeta.Annotations == nil {
+			return
+		}
+
+		// Case where Annotations exist, -and- checksum annotation exists.
+		delete(clusterDeployment.Annotations, controllerutils.LastBackupAnnotation)
+
+		// If that was the only entry, then we should nil out annotations (this makes comparisons with FakeClient work).
+		if len(clusterDeployment.Annotations) == 0 {
+			clusterDeployment.Annotations = nil
+		}
+	}
+}
+
+// WithBackupChecksum sets the object's checksum attribute to the correct value.
+func WithBackupChecksum(checksum Checksum) Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		// In order for the checksum to be correct, the checksum needs to be calculated AFTER all other changes have been made
+		checksum, err := checksum(clusterDeployment)
+		if err != nil {
+			// On error, panic as this should never happen.
+			panic(err)
+		}
+
+		WithAnnotationsSet()(clusterDeployment)
+		clusterDeployment.Annotations[controllerutils.LastBackupAnnotation] = checksum
+	}
+}

--- a/pkg/controller/utils/constants.go
+++ b/pkg/controller/utils/constants.go
@@ -1,0 +1,6 @@
+package utils
+
+const (
+	// LastBackupAnnotation is the Kubernetes Annotation key that holds the object checksum from the last backup.
+	LastBackupAnnotation = "hive.openshift.io/last-backup-checksum"
+)

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -1,7 +1,9 @@
 package utils
 
 import (
+	"crypto/md5"
 	"encoding/json"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -182,4 +184,28 @@ func MergeJsons(globalPullSecret string, localPullSecret string, cdLog log.Field
 		return "", err
 	}
 	return string(jMerged), nil
+}
+
+// ChecksumOfObjectFunc is a function signature for returning a checksum of a single object.
+type ChecksumOfObjectFunc func(objects ...interface{}) (string, error)
+
+// GetChecksumOfObject returns the md5sum hash of the object passed in.
+func GetChecksumOfObject(object interface{}) (string, error) {
+	b, err := json.Marshal(object)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", md5.Sum(b)), nil
+}
+
+// ChecksumOfObjectsFunc is a function signature for returning a checksum of multiple objects.
+type ChecksumOfObjectsFunc func(objects ...interface{}) (string, error)
+
+// GetChecksumOfObjects returns the md5sum hash of the objects passed in.
+func GetChecksumOfObjects(objects ...interface{}) (string, error) {
+	b, err := json.Marshal(objects)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", md5.Sum(b)), nil
 }

--- a/pkg/controller/velerobackup/clusterdeployment.go
+++ b/pkg/controller/velerobackup/clusterdeployment.go
@@ -1,0 +1,141 @@
+package velerobackup
+
+import (
+	"context"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+func (r *ReconcileBackup) registerClusterDeploymentWatch(c controller.Controller) error {
+	// Watch for changes to ClusterDeployment
+	return c.Watch(&source.Kind{Type: &hivev1.ClusterDeployment{}}, &handler.EnqueueRequestsFromMapFunc{
+		ToRequests: handler.ToRequestsFunc(r.clusterDeploymentWatchHandler),
+	})
+}
+
+func (r *ReconcileBackup) clusterDeploymentWatchHandler(a handler.MapObject) []reconcile.Request {
+	cd, ok := a.Object.(*hivev1.ClusterDeployment)
+	if !ok {
+		// Wasn't a ClusterDeployment, bail out. This should not happen.
+		r.logger.Errorf("Error converting MapObject.Object to ClusterDeployment. Value: %+v", a.Object)
+		return []reconcile.Request{}
+	}
+
+	// Queue up the NS for this ClusterDeployment
+	retval := []reconcile.Request{
+		{NamespacedName: types.NamespacedName{
+			Namespace: cd.Namespace,
+		}}}
+	return retval
+}
+
+func (r *ReconcileBackup) getModifiedClusterDeploymentsInNamespace(namespace string) ([]*hivev1.ClusterDeployment, error) {
+	nsLogger := addNamespaceLoggerFields(r.logger, namespace)
+
+	allClusterDeployments := &hivev1.ClusterDeploymentList{}
+	err := r.List(context.TODO(), allClusterDeployments, client.InNamespace(namespace))
+	if err != nil {
+		nsLogger.WithError(err).Error("Couldn't get list of ClusterDeployments")
+		return nil, err
+	}
+
+	changedClusterDeployments := []*hivev1.ClusterDeployment{}
+	for i, clusterDeployment := range allClusterDeployments.Items {
+		hasChanged, err := r.hasClusterDeploymentChanged(&clusterDeployment)
+		if err != nil {
+			return nil, err
+		}
+
+		if hasChanged {
+			// This one is different!
+			changedClusterDeployments = append(changedClusterDeployments, &allClusterDeployments.Items[i])
+		}
+	}
+
+	return changedClusterDeployments, nil
+}
+
+func (r *ReconcileBackup) hasClusterDeploymentChanged(clusterDeployment *hivev1.ClusterDeployment) (bool, error) {
+	cdLogger := addClusterDeploymentLoggerFields(r.logger, clusterDeployment)
+
+	newChecksum, err := r.clusterDeploymentChecksum(clusterDeployment)
+	if err != nil {
+		cdLogger.WithError(err).Info("error calculating checksum of cluster deployment")
+		return false, err
+	}
+
+	// Make sure newChecksum is different than the old checksum.
+	oldChecksum := clusterDeployment.Annotations[controllerutils.LastBackupAnnotation]
+	return newChecksum != oldChecksum, nil
+}
+
+func (r *ReconcileBackup) clusterDeploymentChecksum(clusterDeployment *hivev1.ClusterDeployment) (string, error) {
+	// We need to take the checksum WITHOUT the previous checksum
+	// to avoid an infinite loop of always changing the checksum.
+	metaCopy := clusterDeployment.ObjectMeta.DeepCopy()
+	delete(metaCopy.Annotations, controllerutils.LastBackupAnnotation)
+
+	// We also need to take the checksum WITHOUT the previous ResourceVersion
+	// as when we update the checksum annotation, ResourceVersion changes.
+	metaCopy.ResourceVersion = ""
+
+	return r.checksumFunc(metaCopy, clusterDeployment.Spec)
+}
+
+func (r *ReconcileBackup) updateClusterDeploymentLastBackupChecksum(clusterDeployments []*hivev1.ClusterDeployment) error {
+	errors := []error{}
+
+	for _, clusterDeployment := range clusterDeployments {
+		checksumStr, err := r.clusterDeploymentChecksum(clusterDeployment)
+
+		if err != nil {
+			aggregate, ok := err.(utilerrors.Aggregate)
+			if ok {
+				// Unpack the aggregate error so that we don't return an aggregate of an aggregate.
+				errors = append(errors, aggregate.Errors()...)
+			} else {
+				errors = append(errors, err)
+			}
+
+			continue // It errored, so jump to next loop.
+		}
+
+		// Make sure Annotations is a map.
+		if clusterDeployment.Annotations == nil {
+			clusterDeployment.Annotations = map[string]string{}
+		}
+
+		// Actually set the checksum
+		clusterDeployment.Annotations[controllerutils.LastBackupAnnotation] = checksumStr
+
+		err = r.Update(context.TODO(), clusterDeployment)
+		if err != nil {
+			errors = append(errors, err)
+			continue // It errored, so jump to next loop.
+		}
+	}
+
+	return utilerrors.NewAggregate(errors)
+}
+
+func addClusterDeploymentLoggerFields(logger log.FieldLogger, cd *hivev1.ClusterDeployment) *log.Entry {
+	return logger.WithFields(log.Fields{
+		"clusterDeployment": cd.Name,
+		"namespace":         cd.Namespace,
+	})
+}
+
+func addNamespaceLoggerFields(logger log.FieldLogger, namespace string) *log.Entry {
+	return logger.WithFields(log.Fields{
+		"namespace": namespace,
+	})
+}

--- a/pkg/controller/velerobackup/clusterdeployment_test.go
+++ b/pkg/controller/velerobackup/clusterdeployment_test.go
@@ -1,0 +1,370 @@
+package velerobackup
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/hive/pkg/apis"
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	testclusterdeployment "github.com/openshift/hive/pkg/controller/test/clusterdeployment"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	namespace = "notarealns"
+)
+
+func unchangedClusterDeploymentBase() testclusterdeployment.Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		testclusterdeployment.WithName("someclusterdeployment-unchanged")(clusterDeployment)
+		testclusterdeployment.WithNamespace(namespace)(clusterDeployment)
+		testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)(clusterDeployment)
+	}
+}
+
+func changedClusterDeploymentBase() testclusterdeployment.Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		testclusterdeployment.WithName("someclusterdeployment-changed")(clusterDeployment)
+		testclusterdeployment.WithNamespace(namespace)(clusterDeployment)
+	}
+}
+
+func emptyReconcileBackup() *ReconcileBackup {
+	return &ReconcileBackup{
+		logger:       log.WithField("controller", controllerName),
+		checksumFunc: controllerutils.GetChecksumOfObjects,
+	}
+}
+
+func getHashOfObjectsFuncReturnsError(objects ...interface{}) (string, error) {
+	return "", errDefault
+}
+
+func fakeClientReconcileBackup(existingObjects []runtime.Object) *ReconcileBackup {
+	return &ReconcileBackup{
+		Client:       fake.NewFakeClient(existingObjects...),
+		scheme:       scheme.Scheme,
+		logger:       log.WithField("controller", controllerName),
+		checksumFunc: controllerutils.GetChecksumOfObjects,
+	}
+}
+
+func newReconcileBackupUsingFunc(getHashOfObjectsFunc controllerutils.ChecksumOfObjectsFunc) *ReconcileBackup {
+	retval := emptyReconcileBackup()
+
+	if getHashOfObjectsFunc != nil {
+		retval.checksumFunc = getHashOfObjectsFunc
+	}
+	return retval
+}
+
+func newReconcileBackupUsingFakeClient(existingObjects []runtime.Object, getHashOfObjectsFunc controllerutils.ChecksumOfObjectsFunc) *ReconcileBackup {
+	tmp := newReconcileBackupUsingFunc(getHashOfObjectsFunc)
+
+	retval := &ReconcileBackup{
+		Client:       fake.NewFakeClient(existingObjects...),
+		scheme:       scheme.Scheme,
+		logger:       log.WithField("controller", controllerName),
+		checksumFunc: tmp.checksumFunc,
+	}
+	return retval
+}
+
+func changedClusterDeploymentReconcileRequests() []reconcile.Request {
+	return []reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Namespace: namespace,
+			},
+		},
+	}
+}
+
+var (
+	errDefault = fmt.Errorf("Not a real error")
+	errStatus  = errors.StatusError{
+		ErrStatus: metav1.Status{
+			Message: "clusterdeployments.hive.openshift.io \"someclusterdeployment-changed-1\" not found",
+		},
+	}
+
+	defaultClusterDeploymentChecksumFunc = emptyReconcileBackup().clusterDeploymentChecksum
+)
+
+func TestClusterDeploymentWatchHandler(t *testing.T) {
+	tests := []struct {
+		name             string
+		mapObject        handler.MapObject
+		expectedRequests []reconcile.Request
+	}{
+		{
+			name: "Not ClusterDeployment passed in case",
+			mapObject: handler.MapObject{
+				Object: &hivev1.SyncSet{},
+			},
+			expectedRequests: []reconcile.Request{},
+		},
+		{
+			name: "ClusterDeployment unchanged since last backup case",
+			mapObject: handler.MapObject{
+				Object: testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase()),
+			},
+			expectedRequests: changedClusterDeploymentReconcileRequests(),
+		},
+		{
+			name: "ClusterDeployment changed since last backup case",
+			mapObject: handler.MapObject{
+				Object: testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase()),
+			},
+			expectedRequests: changedClusterDeploymentReconcileRequests(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Arrange
+			r := newReconcileBackupUsingFunc(nil)
+
+			// Act
+			requests := r.clusterDeploymentWatchHandler(test.mapObject)
+
+			// Assert
+			assert.Equal(t, test.expectedRequests, requests)
+		})
+	}
+}
+
+func TestGetChangedInNamespace(t *testing.T) {
+	apis.AddToScheme(scheme.Scheme)
+
+	tests := []struct {
+		name                       string
+		getHashOfObjectsFunc       controllerutils.ChecksumOfObjectsFunc
+		existingObjects            []runtime.Object
+		expectedClusterDeployments []*hivev1.ClusterDeployment
+		expectedError              error
+	}{
+		{
+			name:                       "No ClusterDeployments case",
+			existingObjects:            []runtime.Object{},
+			expectedClusterDeployments: []*hivev1.ClusterDeployment{},
+			expectedError:              nil,
+		},
+		{
+			name: "No Chnaged ClusterDeployments case",
+			existingObjects: []runtime.Object{
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase()),
+			},
+			expectedClusterDeployments: []*hivev1.ClusterDeployment{},
+			expectedError:              nil,
+		},
+		{
+			name: "1 Changed ClusterDeployments case",
+			existingObjects: []runtime.Object{
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase()),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase()),
+			},
+			expectedClusterDeployments: []*hivev1.ClusterDeployment{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase()),
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Multiple Changed ClusterDeployments case",
+			existingObjects: []runtime.Object{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("1")),
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("1"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("2")),
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("2"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+			},
+			expectedClusterDeployments: []*hivev1.ClusterDeployment{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("1")),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("2")),
+			},
+			expectedError: nil,
+		},
+		{
+			name:                 "Error  case",
+			getHashOfObjectsFunc: getHashOfObjectsFuncReturnsError,
+			existingObjects: []runtime.Object{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("1")),
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("1"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("2")),
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("2"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+			},
+			expectedError:              errDefault,
+			expectedClusterDeployments: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Arrange
+			r := newReconcileBackupUsingFakeClient(test.existingObjects, test.getHashOfObjectsFunc)
+
+			// Act
+			actualClusterDeployments, actualError := r.getModifiedClusterDeploymentsInNamespace(namespace)
+
+			// Assert
+			assert.Equal(t, len(test.expectedClusterDeployments), len(actualClusterDeployments))
+			//assert.True(t, reflect.DeepEqual(actualClusterDeployments, test.expectedClusterDeployments))
+			assert.Equal(t, test.expectedClusterDeployments, actualClusterDeployments)
+			assert.Equal(t, test.expectedError, actualError)
+		})
+	}
+}
+
+func TestUpdateLastBackupChecksum(t *testing.T) {
+	apis.AddToScheme(scheme.Scheme)
+
+	tests := []struct {
+		name                       string
+		getHashOfObjectsFunc       controllerutils.ChecksumOfObjectsFunc
+		clusterDeployments         []*hivev1.ClusterDeployment
+		existingObjects            []runtime.Object
+		expectedClusterDeployments []*hivev1.ClusterDeployment
+		expectedError              error
+	}{
+		{
+			name:                       "No ClusterDeployments case",
+			clusterDeployments:         []*hivev1.ClusterDeployment{},
+			existingObjects:            []runtime.Object{},
+			expectedClusterDeployments: []*hivev1.ClusterDeployment{},
+			expectedError:              nil,
+		},
+		{
+			name: "1 changed ClusterDeployment case",
+			clusterDeployments: []*hivev1.ClusterDeployment{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase()),
+			},
+			existingObjects: []runtime.Object{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase()),
+			},
+			expectedClusterDeployments: []*hivev1.ClusterDeployment{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Multiple changed ClusterDeployment case",
+			clusterDeployments: []*hivev1.ClusterDeployment{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("1")),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("2")),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("3")),
+			},
+			existingObjects: []runtime.Object{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("1")),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("2")),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("3")),
+			},
+			expectedClusterDeployments: []*hivev1.ClusterDeployment{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("1"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("2"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("3"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+			},
+			expectedError: nil,
+		},
+		{
+			name:                 "Checksum error case",
+			getHashOfObjectsFunc: getHashOfObjectsFuncReturnsError,
+			clusterDeployments: []*hivev1.ClusterDeployment{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase()),
+			},
+			existingObjects:            []runtime.Object{},
+			expectedError:              utilerrors.NewAggregate([]error{errDefault}),
+			expectedClusterDeployments: []*hivev1.ClusterDeployment{},
+		},
+		{
+			name: "List error case",
+			clusterDeployments: []*hivev1.ClusterDeployment{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase()),
+			},
+			existingObjects:            []runtime.Object{},
+			expectedError:              utilerrors.NewAggregate([]error{&errStatus}),
+			expectedClusterDeployments: []*hivev1.ClusterDeployment{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Arrange
+			r := newReconcileBackupUsingFakeClient(test.existingObjects, test.getHashOfObjectsFunc)
+
+			// Act
+			actualError := r.updateClusterDeploymentLastBackupChecksum(test.clusterDeployments)
+			actualClusterDeploymentList := &hivev1.ClusterDeploymentList{}
+			r.List(context.TODO(), actualClusterDeploymentList, client.InNamespace(namespace))
+			actualClusterDeployments := toPtrSlice(actualClusterDeploymentList)
+
+			// Assert
+			assert.Equal(t, test.expectedClusterDeployments, actualClusterDeployments)
+			assert.True(t, areErrorsEqualType(test.expectedError, actualError))
+		})
+	}
+}
+
+func toPtrSlice(clusterDeployments *hivev1.ClusterDeploymentList) []*hivev1.ClusterDeployment {
+	retval := make([]*hivev1.ClusterDeployment, 0)
+
+	clusterDeploymentItems := clusterDeployments.Items
+
+	for i := range clusterDeploymentItems {
+		val := clusterDeploymentItems[i]
+		retval = append(retval, &val)
+	}
+
+	return retval
+}
+
+func areErrorsEqualType(lhs, rhs error) bool {
+	if lhs == nil && rhs == nil {
+		return true
+	}
+
+	lhsType := reflect.TypeOf(lhs)
+	rhsType := reflect.TypeOf(rhs)
+
+	if lhsType != rhsType {
+		return false
+	}
+
+	// Test for aggregate errors (and make sure they contain equal errors)
+	aggregateErrorType := reflect.TypeOf(utilerrors.NewAggregate([]error{errDefault}))
+	if lhsType == aggregateErrorType {
+		return areAggregateErrorsEqualType(lhs.(utilerrors.Aggregate), rhs.(utilerrors.Aggregate))
+	}
+
+	return false
+}
+
+func areAggregateErrorsEqualType(lhs, rhs utilerrors.Aggregate) bool {
+	lhsErrors := lhs.Errors()
+	rhsErrors := rhs.Errors()
+
+	if len(lhsErrors) != len(rhsErrors) {
+		return false
+	}
+
+	for i := range lhsErrors {
+		if reflect.TypeOf(lhsErrors[i]) != reflect.TypeOf(rhsErrors[i]) {
+			return false
+		}
+	}
+
+	// If we make it here, then all comparisions succeeded.
+	return true
+}

--- a/pkg/controller/velerobackup/velerobackup_controller.go
+++ b/pkg/controller/velerobackup/velerobackup_controller.go
@@ -1,0 +1,155 @@
+package velerobackup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	velerov1 "github.com/heptio/velero/pkg/apis/velero/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	controllerName = "velerobackup"
+)
+
+var (
+	// DefaultExcludedBackupResources is the deault list of excludes when backing up resources.
+	DefaultExcludedBackupResources = []string{
+		// NOTE: even though pods is in the "core" group, specifying "pods.core" here will cause
+		// pods to BE BACKED UP (not excluded)!!!
+		"pods",
+		"jobs.batch",
+	}
+)
+
+// Add creates a new Backup Controller and adds it to the Manager with default RBAC. The Manager will set fields on the
+// Controller and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return AddToManager(mgr, NewReconciler(mgr))
+}
+
+// NewReconciler returns a new reconcile.Reconciler
+func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileBackup{
+		Client:       controllerutils.NewClientWithMetricsOrDie(mgr, controllerName),
+		scheme:       mgr.GetScheme(),
+		logger:       log.WithField("controller", controllerName),
+		checksumFunc: controllerutils.GetChecksumOfObjects,
+	}
+}
+
+// AddToManager adds a new Controller to mgr with r as the reconcile.Reconciler
+func AddToManager(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New(controllerName+"-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: controllerutils.GetConcurrentReconciles()})
+	if err != nil {
+		return err
+	}
+
+	reconciler := r.(*ReconcileBackup)
+	err = reconciler.registerClusterDeploymentWatch(c)
+	if err != nil {
+		return err
+	}
+
+	return nil // If we got here, then no errors occurred.
+}
+
+// This ensures that ReconcileBackup struct implements all functions that the reconcile.Reconciler interface requires.
+var _ reconcile.Reconciler = &ReconcileBackup{}
+
+// ReconcileBackup ensures that Velero backup objects are created when changes are made to Hive objects.
+type ReconcileBackup struct {
+	client.Client
+	scheme *runtime.Scheme
+
+	logger       log.FieldLogger
+	checksumFunc controllerutils.ChecksumOfObjectsFunc
+}
+
+// Reconcile ensures that all Hive object changes have corresponding Velero backup objects.
+// ClusterDeployment.Spec.Config.Machines
+// +kubebuilder:rbac:groups=hive.openshift.io,resources=clusterdeployments,verbs=get;list;watch
+// +kubebuilder:rbac:groups=velero.io,resources=backups,verbs=create
+func (r *ReconcileBackup) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	start := time.Now()
+	rrLogger := addReconcileRequestLoggerFields(r.logger, request)
+
+	// For logging, we need to see when the reconciliation loop starts and ends.
+	rrLogger.Info("reconciling backups and Hive object changes")
+	defer func() {
+		dur := time.Since(start)
+		hivemetrics.MetricControllerReconcileTime.WithLabelValues(controllerName).Observe(dur.Seconds())
+		rrLogger.WithField("elapsed", dur).Info("reconcile complete")
+	}()
+
+	// Get all ClusterDeployments that have a different hash than the last backup hash.
+	changedCDs, err := r.getModifiedClusterDeploymentsInNamespace(request.Namespace)
+	if err != nil {
+		rrLogger.WithError(err).Error("error finding changed cluster deployments in namespace")
+		return reconcile.Result{}, err
+	}
+
+	if len(changedCDs) == 0 {
+		rrLogger.Debug("Nothing changed, so nothing to back up. Don't create a Velero backup object.")
+		return reconcile.Result{}, nil
+	}
+
+	// There are changes that need to be backed up.
+	err = createVeleroBackupObject(r.Client, request.Namespace)
+	if err != nil {
+		rrLogger.WithError(err).Error("error creating velero backup object")
+		return reconcile.Result{}, err
+	}
+
+	// If the above is successful, save this objects new checksum to the "lastBackupChecksum" annotation.
+	err = r.updateClusterDeploymentLastBackupChecksum(changedCDs)
+	if err != nil {
+		rrLogger.WithError(err).Errorf("error updating %v annotation", controllerutils.LastBackupAnnotation)
+		// Not returning with an error because a backup object was created,
+		// we just failed to update the objects with the backup checksum (not a fatal error).
+		// This will cause these objects to be backed during the next change in this ns or the next reconcile.
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func addReconcileRequestLoggerFields(logger log.FieldLogger, request reconcile.Request) *log.Entry {
+	return logger.WithFields(log.Fields{
+		"NamespacedName": request.NamespacedName,
+	})
+}
+
+// createVeleroBackupObjectForNamespace creates a Velero Backup object for the namespace specified.
+// The Backup options are set specifically for Hive object backups.
+// DO NOT use this function call for any other type objects as it may not back them up correctly.
+func createVeleroBackupObject(client client.Client, namespace string) error {
+	formatStr := "2006-01-02t15-04-05z"
+	timestamp := time.Now().UTC().Format(formatStr)
+
+	backupName := fmt.Sprintf("backup-%v-%v", namespace, timestamp)
+	backup := &velerov1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      backupName,
+			Namespace: velerov1.DefaultNamespace,
+		},
+		Spec: velerov1.BackupSpec{
+			IncludedNamespaces: []string{
+				namespace,
+			},
+			ExcludedResources: DefaultExcludedBackupResources,
+		},
+	}
+
+	return client.Create(context.TODO(), backup)
+}

--- a/pkg/controller/velerobackup/velerobackup_controller_test.go
+++ b/pkg/controller/velerobackup/velerobackup_controller_test.go
@@ -1,0 +1,152 @@
+package velerobackup
+
+import (
+	"context"
+	"testing"
+
+	velerov1 "github.com/heptio/velero/pkg/apis/velero/v1"
+	"github.com/openshift/hive/pkg/apis"
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+	testclusterdeployment "github.com/openshift/hive/pkg/controller/test/clusterdeployment"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconcile(t *testing.T) {
+	apis.AddToScheme(scheme.Scheme)
+	velerov1.AddToScheme(scheme.Scheme)
+
+	tests := []struct {
+		name                       string
+		request                    reconcile.Request
+		existingObjects            []runtime.Object
+		expectedResult             reconcile.Result
+		expectedError              error
+		expectedClusterDeployments []*hivev1.ClusterDeployment
+	}{
+		{
+			name: "Empty Namespace case",
+			request: reconcile.Request{
+				NamespacedName: types.NamespacedName{},
+			},
+			existingObjects:            []runtime.Object{},
+			expectedResult:             reconcile.Result{},
+			expectedClusterDeployments: []*hivev1.ClusterDeployment{},
+		},
+		{
+			name: "1 unchanged ClusterDeployment case",
+			request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: namespace,
+				},
+			},
+			existingObjects: []runtime.Object{
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase()),
+			},
+			expectedResult: reconcile.Result{},
+			expectedClusterDeployments: []*hivev1.ClusterDeployment{
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase()),
+			},
+		},
+		{
+			name: "1 changed ClusterDeployment case",
+			request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: namespace,
+				},
+			},
+			existingObjects: []runtime.Object{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase()),
+			},
+			expectedResult: reconcile.Result{},
+			expectedClusterDeployments: []*hivev1.ClusterDeployment{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+			},
+		},
+		{
+			name: "Multiple unchanged ClusterDeployment case",
+			request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: namespace,
+				},
+			},
+			existingObjects: []runtime.Object{
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("1"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("2"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("3"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+			},
+			expectedResult: reconcile.Result{},
+			expectedClusterDeployments: []*hivev1.ClusterDeployment{
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("1"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("2"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("3"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+			},
+		},
+		{
+			name: "Multiple changed ClusterDeployment case",
+			request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: namespace,
+				},
+			},
+			existingObjects: []runtime.Object{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("1")),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("2")),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("3")),
+			},
+			expectedResult: reconcile.Result{},
+			expectedClusterDeployments: []*hivev1.ClusterDeployment{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("1"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("2"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("3"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+			},
+		},
+		{
+			name: "Multiple changed / unchanged ClusterDeployment case",
+			request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: namespace,
+				},
+			},
+			existingObjects: []runtime.Object{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("1")),
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("1"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("2")),
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("2"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("3")),
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("3"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+			},
+			expectedResult: reconcile.Result{},
+			expectedClusterDeployments: []*hivev1.ClusterDeployment{
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("1"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("1"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("2"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("2"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+				testclusterdeployment.BuildClusterDeployment(changedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("3"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+				testclusterdeployment.BuildClusterDeployment(unchangedClusterDeploymentBase(), testclusterdeployment.WithNamePostfix("3"), testclusterdeployment.WithBackupChecksum(defaultClusterDeploymentChecksumFunc)),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Arrange
+			r := fakeClientReconcileBackup(test.existingObjects)
+
+			// Act
+			actualResult, actualError := r.Reconcile(test.request)
+			actualClusterDeploymentList := &hivev1.ClusterDeploymentList{}
+			r.List(context.TODO(), actualClusterDeploymentList, client.InNamespace(namespace))
+			actualClusterDeployments := toPtrSlice(actualClusterDeploymentList)
+
+			// Assert
+			assert.Equal(t, test.expectedResult, actualResult)
+			assert.Equal(t, test.expectedError, actualError)
+			assert.Equal(t, test.expectedClusterDeployments, actualClusterDeployments)
+		})
+	}
+}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1417,6 +1417,20 @@ rules:
   - patch
   - list
   - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - velero.io
+  resources:
+  - backups
+  verbs:
+  - create
 `)
 
 func configRbacManager_roleYamlBytes() ([]byte, error) {


### PR DESCRIPTION
- [x] Add watch for changes to clusterdeployment objects
- [x] Add reconcile that checks all clusterdeployment objects in a given
      namespace
- [x] Create Velero backup object on ClusterDeployment change so that a
      backup is taken immediately.
- [x] Add unit tests around core functionality
- [x] Test that backup object is created correctly.