### PR TITLE
Support empty global pull secret instead of absent.

### DIFF
--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -214,7 +214,7 @@ func (r *ReconcileHiveConfig) includeAdditionalCAs(hLog log.FieldLogger, h *reso
 }
 
 func (r *ReconcileHiveConfig) includeGlobalPullSecret(hLog log.FieldLogger, h *resource.Helper, instance *hivev1.HiveConfig, hiveDeployment *appsv1.Deployment) {
-	if instance.Spec.GlobalPullSecret == nil {
+	if instance.Spec.GlobalPullSecret == nil || instance.Spec.GlobalPullSecret.Name == "" {
 		hLog.Debug("GlobalPullSecret is not provided in HiveConfig, it will not be deployed")
 		return
 	}


### PR DESCRIPTION
The nil check did not work if globalPullSecret was specified but empty,
which has turned up as a helpful thing to support for AppSRE templates
across environments.

Also check for an empty name and skip global pull secret if this is the
case.