### PR TITLE
Use latest hive image for processing image resolution job.

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -422,7 +422,7 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 		return reconcile.Result{Requeue: true}, nil
 	}
 
-	if cd.Status.InstallerImage == nil {
+	if !cd.Status.Installed && (cd.Status.InstallerImage == nil || cd.Status.CLIImage == nil) {
 		return r.resolveInstallerImage(cd, imageSet, releaseImage, hiveImage, cdLog)
 	}
 
@@ -766,7 +766,7 @@ func (r *ReconcileClusterDeployment) resolveInstallerImage(cd *hivev1.ClusterDep
 	// If job exists and is finished, delete so we can recreate it
 	case err == nil && controllerutils.IsFinished(existingJob):
 		jobLog.WithField("successful", controllerutils.IsSuccessful(existingJob)).
-			Warning("Finished job found, but installer image is not yet resolved. Deleting.")
+			Warning("Finished job found, but all images not yet resolved. Deleting.")
 		err := r.Delete(context.Background(), existingJob,
 			client.PropagationPolicy(metav1.DeletePropagationForeground))
 		if err != nil {


### PR DESCRIPTION
The log gathering PR merged earlier today missed the fact that image
resolution jobs use the new script, but an old hive image to process the
results of the script (if the ClusterImageSet predates the change). This
causes the CLI image to be resolved but never set on the
ClusterDeployment status. As a result the new code will not create an
install job until the CLI image is resolved and saved in status.

Temporary fix that will probably need to be cleaned up in this commit.
Uses the latest Hive image (i.e. what we're running the controllers
from, as set by the operator), falling back to the hive image in the
ClusterImageSet. This change is likely permanent considering the work
we're doing this week, only the fallback will likely be removed.