### PR TITLE
set OPENSHIFT_INSTALL_INVOKER when launching install

### DIFF
--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -64,6 +64,12 @@ func GenerateInstallerJob(
 	}
 	env := []corev1.EnvVar{
 		{
+			// OPENSHIFT_INSTALL_INVOKER allows setting who launched the installer
+			// (it is stored in the configmap openshift-config/openshift-install)
+			Name:  "OPENSHIFT_INSTALL_INVOKER",
+			Value: "hive",
+		},
+		{
 			Name: "PULL_SECRET",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{


### PR DESCRIPTION
staticaly set it to 'hive' so we can document that any particular cluster was created through hive.