### PR TITLE
Add script to extract cluster logs from PVC after failures.

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,15 @@
 # Troubleshooting
 
+## Cluster Install Failure Logs
+
+In the event a cluster is brought up but overall installation fails, either during bootstrap or cluster initialization, Hive will attempt to gather logs from the cluster itself. These logs are stored in a persistent volume created for every install job. If the install succeeds on the first attempt, the persistent volume claim is immediately deleted. If the install has had any errors along the way, it will be preserved for 7 days and then removed.
+
+You can access these logs gathered from the cluster with the following script found in the hive.git repository:
+
+```bash
+$ hack/logextractor.sh mycluster ./extracted-logs/
+```
+
 ## Deprovision
 
 After deleting your cluster deployment you will see an uninstall job created. If for any reason this job gets stuck you can:

--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -131,6 +131,8 @@ By default this command assumes the latest Hive master CI build, and the latest 
   $ oc exec -c hive <install-pod-name> -- tail -f /tmp/openshift-install-console.log
   ```
 
+In the event of installation failures, please see [Troubleshooting](./troubleshooting.md).
+
 ### Cluster Admin Kubeconfig
 
 Once the cluster is provisioned you will see a CLUSTER_NAME-admin-kubeconfig secret. You can use this with:

--- a/hack/logextractor.sh
+++ b/hack/logextractor.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# This script can be used to extract the failure cluster logs tarball from the PVC created for an install pod.
+#
+# Usage: ./logextractor.sh [CLUSTER_DEPLOYMENT_NAME] [DEST_DIR]
+#
+
+POD_NAME="hive-logextractor"
+PVC_NAME=$(oc get pvc -l hive.openshift.io/cluster-deployment-name=$1 -o jsonpath="{.items[0].metadata.name}" 2> /dev/null)
+
+if [ -z "$PVC_NAME" ]; then echo "Could not find PVC for ClusterDeployment $1"; exit 1; fi
+
+echo "Found PVC for cluster deployment: $PVC_NAME"
+
+echo "apiVersion: v1
+kind: Pod
+metadata:
+  name: $POD_NAME
+spec:
+  volumes:
+  - name: logsvol
+    persistentVolumeClaim:
+      claimName: $PVC_NAME
+  containers:
+  - image: centos:7
+    command: ["/bin/sh"]
+    args: ["-c", "while true\; do sleep 100000000\; done"]
+    imagePullPolicy: Always
+    name: logextractor
+    resources: {}
+    volumeMounts:
+    - mountPath: "/logs"
+      name: logsvol
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File" | oc apply -f -
+
+
+echo "waiting for $POD_NAME pod to be ready"
+
+oc wait --for=condition=Ready --timeout=120s pod/$POD_NAME
+
+echo "copying logs to $2"
+oc cp $POD_NAME:/logs $2
+
+echo "deleting logextractor pod"
+oc delete pod $POD_NAME


### PR DESCRIPTION
If the install pod is no longer running, we need a way to get access to
the logs PVC. This script creates a dummy deployment we can use to copy
from, finds the pod name, waits for it to come online, copies the logs
out, and then deletes the deployment.