### PR TITLE
semver complains if the prerelease first char is a 0

### DIFF
--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -34,6 +34,7 @@ if [[ "$REMOVE_UNDEPLOYED" == true ]]; then
 
         if [[ "$delete" == false ]]; then
             short_hash=$(echo $version | cut -d- -f2)
+            short_hash=${short_hash##sha}
 
             if [[ "$DEPLOYED_HASH" == "${short_hash}"* ]]; then
                 delete=true

--- a/hack/generate-operator-bundle.py
+++ b/hack/generate-operator-bundle.py
@@ -30,7 +30,7 @@ git_num_commits = sys.argv[3]
 git_hash = sys.argv[4]
 hive_image = sys.argv[5]
 
-full_version = "%s.%s-%s" % (VERSION_BASE, git_num_commits, git_hash)
+full_version = "%s.%s-sha%s" % (VERSION_BASE, git_num_commits, git_hash)
 print("Generating CSV for version: %s" % full_version)
 
 if not os.path.exists(outdir):


### PR DESCRIPTION
OLM parses the version and uses github.com/blang/semver to validate it
as a semver.

We have found out that if the prerelease starts with
`0` it raises this error:

https://github.com/blang/semver/blob/1a9109f8c4a1d669a78442f567dfe8eedf982793/semver.go#L376

When this happens OLM refuses to deploy the CSV and no further updates
will happen.

After some testing, we decided to prepend the prerelease with the string
`sha` so this error is not raised.

```go
package main

import (
	"fmt"
	"os"

	"github.com/blang/semver"
)

func main() {
	v, err := semver.Parse(os.Args[1])
	if err != nil {
		panic(err)
	}

	fmt.Printf("%v\n", v)
}
```

```
$ ./testsemver 0.1.1036-0152295
panic: Numeric PreRelease version must not contain leading zeroes "0152295"

goroutine 1 [running]:
main.main()
	/home/jmelis/borrar/testsemver/main.go:13 +0x216

$ ./testsemver 0.1.1036-sha0152295
0.1.1036-sha0152295
```