### PR TITLE
Fix typo in operator role for syncset admission controller

### DIFF
--- a/config/operator/operator_role.yaml
+++ b/config/operator/operator_role.yaml
@@ -155,7 +155,7 @@ rules:
   - clusterimagesets
   - dnszones
   - selectorsyncsets
-  - rsyncsets
+  - syncsets
   verbs:
   - get
   - list

--- a/config/rbac/hive_admin_role.yaml
+++ b/config/rbac/hive_admin_role.yaml
@@ -59,7 +59,7 @@ rules:
   - clusterimagesets
   - dnszones
   - selectorsyncsets
-  - rsyncsets
+  - syncsets
   verbs:
   - get
   - list

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -872,7 +872,7 @@ rules:
   - clusterimagesets
   - dnszones
   - selectorsyncsets
-  - rsyncsets
+  - syncsets
   verbs:
   - get
   - list


### PR DESCRIPTION
Change the permissions for the operator role to use `sync.admission.hive.operator.io` instead of `rsync.admission.hive.operator.io`.