### PR TITLE
Update makefile to run golangci lint bydefault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ SRC_DIRS = pkg contrib
 GOFILES = $(shell find $(SRC_DIRS) -name '*.go' | grep -v bindata)
 VERIFY_IMPORTS_CONFIG = build/verify-imports/import-rules.yaml
 
+FIRST_GOPATH:=$(firstword $(subst :, ,$(shell go env GOPATH)))
+GOLANGCI_LINT_BIN=$(FIRST_GOPATH)/bin/golangci-lint
+GOLANGCI_LINT_VERSION=v1.17.1
+
 # To use docker build, specify BUILD_CMD="docker build"
 BUILD_CMD ?= imagebuilder
 
@@ -34,7 +38,7 @@ vendor:
 
 # Run tests
 .PHONY: test
-test: generate fmt vet crd rbac
+test: generate fmt vet crd rbac lint
 	go test ./pkg/... ./cmd/... ./contrib/... -coverprofile cover.out
 
 .PHONY: test-integration
@@ -208,11 +212,13 @@ $(GOPATH)/bin/mockgen:
 clean:
 	rm -rf $(BINDIR)
 
-$(GOPATH)/bin/golangci-lint:
-	GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1
+$(GOLANGCI_LINT_BIN):
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh \
+		| sed -e '/install -d/d' \
+| sh -s -- -b $(FIRST_GOPATH)/bin $(GOLANGCI_LINT_VERSION)
 
 # Run golangci-lint against code
 # TODO replace verify (except verify-generated), vet, fmt targets with lint as it covers all of it
 .PHONY: lint
-lint: $(GOPATH)/bin/golangci-lint
-	golangci-lint run -c ./golangci.yml ./pkg/... ./cmd/... ./contrib/...
+lint: $(GOLANGCI_LINT_BIN)
+	$(GOLANGCI_LINT_BIN) run -c ./golangci.yml ./pkg/... ./cmd/... ./contrib/...

--- a/golangci.yml
+++ b/golangci.yml
@@ -5,24 +5,24 @@ linters:
   disable-all: true
   enable:
   - gofmt
-  - goimports
+#  - goimports
   - golint
-  - gosimple
+#  - gosimple
   - ineffassign
   - misspell
   - unused
   - deadcode
   - govet
-  - gocyclo
+#  - gocyclo
   - varcheck
   - structcheck
-  - maligned
-  - errcheck
-  - interfacer
-  - unconvert
-  - goconst
-  - gosec
-  - megacheck
+#  - maligned
+#  - errcheck
+#  - interfacer
+#  - unconvert
+#  - goconst
+#  - gosec
+#  - megacheck
 
 linters-settings:
   goimports:

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook.go
@@ -186,10 +186,8 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateCreate(admissionSpec 
 		}
 	}
 
-	if newObject != nil {
-		// Add the new data to the contextLogger
-		contextLogger.Data["object.Name"] = newObject.Name
-	}
+	// Add the new data to the contextLogger
+	contextLogger.Data["object.Name"] = newObject.Name
 
 	// TODO: Put Create Validation Here (or in openAPIV3Schema validation section of crd)
 
@@ -265,10 +263,8 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateUpdate(admissionSpec 
 		}
 	}
 
-	if newObject != nil {
-		// Add the new data to the contextLogger
-		contextLogger.Data["object.Name"] = newObject.Name
-	}
+	// Add the new data to the contextLogger
+	contextLogger.Data["object.Name"] = newObject.Name
 
 	oldObject := &hivev1.ClusterDeployment{}
 	err = json.Unmarshal(admissionSpec.OldObject.Raw, oldObject)
@@ -283,10 +279,8 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateUpdate(admissionSpec 
 		}
 	}
 
-	if oldObject != nil {
-		// Add the new data to the contextLogger
-		contextLogger.Data["oldObject.Name"] = oldObject.Name
-	}
+	// Add the new data to the contextLogger
+	contextLogger.Data["oldObject.Name"] = oldObject.Name
 
 	hasChangedImmutableField, changedFieldName := hasChangedImmutableField(&oldObject.Spec, &newObject.Spec)
 	if hasChangedImmutableField {

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/clusterimageset_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/clusterimageset_validating_admission_hook.go
@@ -2,8 +2,9 @@ package validatingwebhooks
 
 import (
 	"encoding/json"
-	log "github.com/sirupsen/logrus"
 	"reflect"
+
+	log "github.com/sirupsen/logrus"
 
 	"net/http"
 
@@ -144,10 +145,8 @@ func (a *ClusterImageSetValidatingAdmissionHook) validateCreate(admissionSpec *a
 		}
 	}
 
-	if newObject != nil {
-		// Add the new data to the contextLogger
-		contextLogger.Data["object.Name"] = newObject.Name
-	}
+	// Add the new data to the contextLogger
+	contextLogger.Data["object.Name"] = newObject.Name
 
 	if newObject.Spec.InstallerImage == nil && newObject.Spec.ReleaseImage == nil {
 		message := "Failed validation: you must specify either an installer image or a release image"
@@ -191,10 +190,8 @@ func (a *ClusterImageSetValidatingAdmissionHook) validateUpdate(admissionSpec *a
 		}
 	}
 
-	if newObject != nil {
-		// Add the new data to the contextLogger
-		contextLogger.Data["object.Name"] = newObject.Name
-	}
+	// Add the new data to the contextLogger
+	contextLogger.Data["object.Name"] = newObject.Name
 
 	oldObject := &hivev1.ClusterImageSet{}
 	err = json.Unmarshal(admissionSpec.OldObject.Raw, oldObject)
@@ -209,10 +206,8 @@ func (a *ClusterImageSetValidatingAdmissionHook) validateUpdate(admissionSpec *a
 		}
 	}
 
-	if oldObject != nil {
-		// Add the new data to the contextLogger
-		contextLogger.Data["oldObject.Name"] = oldObject.Name
-	}
+	// Add the new data to the contextLogger
+	contextLogger.Data["oldObject.Name"] = oldObject.Name
 
 	if !reflect.DeepEqual(oldObject.Spec, newObject.Spec) {
 		message := "ClusterImageSet.Spec is immutable"

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/dnszone_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/dnszone_validating_admission_hook.go
@@ -3,8 +3,9 @@ package validatingwebhooks
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 
 	"net/http"
 
@@ -147,10 +148,8 @@ func (a *DNSZoneValidatingAdmissionHook) validateCreate(admissionSpec *admission
 		}
 	}
 
-	if newObject != nil {
-		// Add the new data to the contextLogger
-		contextLogger.Data["object.Name"] = newObject.Name
-	}
+	// Add the new data to the contextLogger
+	contextLogger.Data["object.Name"] = newObject.Name
 
 	strErrs := dnsvalidation.IsDNS1123Subdomain(newObject.Spec.Zone)
 	if len(strErrs) != 0 {
@@ -195,10 +194,8 @@ func (a *DNSZoneValidatingAdmissionHook) validateUpdate(admissionSpec *admission
 		}
 	}
 
-	if newObject != nil {
-		// Add the new data to the contextLogger
-		contextLogger.Data["object.Name"] = newObject.Name
-	}
+	// Add the new data to the contextLogger
+	contextLogger.Data["object.Name"] = newObject.Name
 
 	oldObject := &hivev1.DNSZone{}
 	err = json.Unmarshal(admissionSpec.OldObject.Raw, oldObject)
@@ -213,10 +210,8 @@ func (a *DNSZoneValidatingAdmissionHook) validateUpdate(admissionSpec *admission
 		}
 	}
 
-	if oldObject != nil {
-		// Add the new data to the contextLogger
-		contextLogger.Data["oldObject.Name"] = oldObject.Name
-	}
+	// Add the new data to the contextLogger
+	contextLogger.Data["oldObject.Name"] = oldObject.Name
 
 	if oldObject.Spec.Zone != newObject.Spec.Zone {
 		message := "DNSZone.Spec.Zone is immutable"

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/selector_syncset_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/selector_syncset_validating_admission_hook.go
@@ -147,10 +147,8 @@ func (a *SelectorSyncSetValidatingAdmissionHook) validateCreate(admissionSpec *a
 		}
 	}
 
-	if newObject != nil {
-		// Add the new data to the contextLogger
-		contextLogger.Data["object.Name"] = newObject.Name
-	}
+	// Add the new data to the contextLogger
+	contextLogger.Data["object.Name"] = newObject.Name
 
 	if invalid, ok := checkValidPatchTypes(newObject.Spec.Patches); !ok {
 		message := fmt.Sprintf("Failed validation: Invalid patch type detected: %s. Valid patch types are: json, merge, and strategic", invalid)
@@ -203,10 +201,8 @@ func (a *SelectorSyncSetValidatingAdmissionHook) validateUpdate(admissionSpec *a
 		}
 	}
 
-	if newObject != nil {
-		// Add the new data to the contextLogger
-		contextLogger.Data["object.Name"] = newObject.Name
-	}
+	// Add the new data to the contextLogger
+	contextLogger.Data["object.Name"] = newObject.Name
 
 	if invalid, ok := checkValidPatchTypes(newObject.Spec.Patches); !ok {
 		message := fmt.Sprintf("Failed validation: Invalid patch type detected: %s. Valid patch types are: json, merge, and strategic", invalid)

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/syncset_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/syncset_validating_admission_hook.go
@@ -148,10 +148,8 @@ func (a *SyncSetValidatingAdmissionHook) validateCreate(admissionSpec *admission
 		}
 	}
 
-	if newObject != nil {
-		// Add the new data to the contextLogger
-		contextLogger.Data["object.Name"] = newObject.Name
-	}
+	// Add the new data to the contextLogger
+	contextLogger.Data["object.Name"] = newObject.Name
 
 	if invalid, ok := checkValidPatchTypes(newObject.Spec.Patches); !ok {
 		message := fmt.Sprintf("Failed validation: Invalid patch type detected: %s. Valid patch types are: json, merge, and strategic", invalid)
@@ -204,10 +202,8 @@ func (a *SyncSetValidatingAdmissionHook) validateUpdate(admissionSpec *admission
 		}
 	}
 
-	if newObject != nil {
-		// Add the new data to the contextLogger
-		contextLogger.Data["object.Name"] = newObject.Name
-	}
+	// Add the new data to the contextLogger
+	contextLogger.Data["object.Name"] = newObject.Name
 
 	if invalid, ok := checkValidPatchTypes(newObject.Spec.Patches); !ok {
 		message := fmt.Sprintf("Failed validation: Invalid patch type detected: %s. Valid patch types are: json, merge, and strategic", invalid)

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -1491,7 +1491,7 @@ func (r *ReconcileClusterDeployment) mergePullSecrets(cd *hivev1.ClusterDeployme
 	if len(globalPullSecretName) != 0 {
 		globalPullSecret, err = controllerutils.LoadSecretData(r.Client, globalPullSecretName, constants.HiveNamespace, corev1.DockerConfigJsonKey)
 		if err != nil {
-			return "", errors.Wrap(err, "global pull secret could not be retrived")
+			return "", errors.Wrap(err, "global pull secret could not be retrieved")
 		}
 	}
 

--- a/pkg/controller/clusterstate/clusterstate_controller.go
+++ b/pkg/controller/clusterstate/clusterstate_controller.go
@@ -165,6 +165,10 @@ func (r *ReconcileClusterState) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{}, err
 	}
 	kubeconfig, err := controllerutils.FixupKubeconfigSecretData(kubeconfigSecret.Data)
+	if err != nil {
+		logger.WithError(err).Error("cannot fixup kubeconfig for remote cluster")
+		return reconcile.Result{}, err
+	}
 	remoteClient, err := r.remoteClientBuilder(string(kubeconfig), controllerName)
 	if err != nil {
 		logger.WithError(err).Error("error building remote cluster client connection")

--- a/pkg/controller/syncsetinstance/syncsetinstance_controller.go
+++ b/pkg/controller/syncsetinstance/syncsetinstance_controller.go
@@ -552,10 +552,6 @@ func (r *ReconcileSyncSetInstance) applySyncSetResources(ssi *hivev1.SyncSetInst
 	if applyErr != nil {
 		return applyErr
 	}
-	if delErr != nil {
-		return delErr
-	}
-
 	return nil
 }
 

--- a/pkg/controller/syncsetinstance/syncsetinstance_controller_test.go
+++ b/pkg/controller/syncsetinstance/syncsetinstance_controller_test.go
@@ -68,7 +68,6 @@ func TestSyncSetReconcile(t *testing.T) {
 	tests := []struct {
 		name                   string
 		status                 hivev1.SyncSetInstanceStatus
-		ssi                    *hivev1.SyncSetInstance
 		syncSet                *hivev1.SyncSet
 		deletedSyncSet         *hivev1.SyncSet
 		selectorSyncSet        *hivev1.SelectorSyncSet

--- a/pkg/controller/utils/secrets_test.go
+++ b/pkg/controller/utils/secrets_test.go
@@ -6,12 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TesCheckSums(t *testing.T) {
+func TestCheckSums(t *testing.T) {
 	tests := []struct {
-		name       string
-		jsonStr1   string
-		jsonStr2   string
-		isMismatch bool
+		name     string
+		jsonStr1 string
+		jsonStr2 string
 	}{
 		{
 			name:     "check checksum 01",

--- a/pkg/controller/velerobackup/helpers_test.go
+++ b/pkg/controller/velerobackup/helpers_test.go
@@ -12,7 +12,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/pkg/errors"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,8 +26,7 @@ const (
 )
 
 var (
-	errDefault = errors.New("Not a real error")
-	errStatus  = kerrors.StatusError{
+	errStatus = kerrors.StatusError{
 		ErrStatus: metav1.Status{},
 	}
 )

--- a/pkg/controller/velerobackup/velerobackup_controller_test.go
+++ b/pkg/controller/velerobackup/velerobackup_controller_test.go
@@ -5,7 +5,6 @@ import (
 
 	velerov1 "github.com/heptio/velero/pkg/apis/velero/v1"
 	"github.com/openshift/hive/pkg/apis"
-	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	testclusterdeployment "github.com/openshift/hive/pkg/test/clusterdeployment"
 	"github.com/openshift/hive/pkg/test/generic"
 	testsyncset "github.com/openshift/hive/pkg/test/syncset"
@@ -176,11 +175,10 @@ func TestGetChangedInNamespace(t *testing.T) {
 	apis.AddToScheme(scheme.Scheme)
 
 	tests := []struct {
-		name                 string
-		getHashOfObjectsFunc controllerutils.ChecksumOfObjectsFunc
-		existingObjects      []runtime.Object
-		expectedHiveObjects  []*hiveObject
-		expectedError        error
+		name                string
+		existingObjects     []runtime.Object
+		expectedHiveObjects []*hiveObject
+		expectedError       error
 	}{
 		{
 			name:                "No Hive objects",
@@ -334,7 +332,6 @@ func TestGetRuntimeObjects(t *testing.T) {
 	tests := []struct {
 		name            string
 		existingObjects []runtime.Object
-		expectedError   error
 		expectedObjects []runtime.Object
 	}{
 		{

--- a/pkg/operator/hive/hive_controller.go
+++ b/pkg/operator/hive/hive_controller.go
@@ -269,7 +269,7 @@ func (r *ReconcileHiveConfig) Reconcile(request reconcile.Request) (reconcile.Re
 		case err != nil:
 			cmLog.WithError(err).Errorf("cannot retrieve configmap")
 			return reconcile.Result{}, err
-		case err == nil:
+		default:
 			caHash := computeHash(aggregatorCAConfigMap.Data)
 			cmLog.WithField("hash", caHash).Debugf("computed hash for configmap")
 			if instance.Status.AggregatorClientCAHash != caHash {
@@ -287,10 +287,6 @@ func (r *ReconcileHiveConfig) Reconcile(request reconcile.Request) (reconcile.Re
 		}
 	}
 
-	if err != nil {
-		hLog.WithError(err).Error("error serializing kubeconfig")
-		return reconcile.Result{}, err
-	}
 	h := resource.NewHelperFromRESTConfig(r.restConfig, hLog)
 	err = r.deployHive(hLog, h, instance, recorder)
 	if err != nil {


### PR DESCRIPTION
Also updated the installation method to make it work in CI systems as per https://github.com/golangci/golangci-lint#ci-installation

Commented some of the check in `golangci.yml` because either these need more effort to fix or not critical as compared to making `golangci-lint` default in `make test`. 

Once  `golangci-lint` is enabled it will help fixing incoming code for lint issues and we can gradually add more checks by removing the comments in  `golangci.yml`. 