### PR TITLE
Moving the installation of golangci-lint to Dockerfile

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -21,3 +21,7 @@ RUN export version=1.0.8 && \
 
 # Get rid of "go: disabling cache ..." errors.
 RUN mkdir -p /go && chgrp -R root /go && chmod -R g+rwX /go
+
+RUN export GOLANGCI_LINT_VERSION=v1.17.1 &&\
+    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s $(GOLANGCI_LINT_VERSION) && \
+    mv ./bin/golangci-lint /usr/local/bin/golangci-lint


### PR DESCRIPTION
Sending the PR to just change the Dockerfile as without this is merged the unit tests will never pass for the Makefile change in https://github.com/openshift/hive/pull/528

Fixes part of  https://jira.coreos.com/browse/CO-539

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>