### PR TITLE
Add ssh-agent to hive container for log gathering.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,11 @@ RUN go build -o bin/hiveutil github.com/openshift/hive/contrib/cmd/hiveutil
 RUN go build -o bin/hiveadmission github.com/openshift/hive/cmd/hiveadmission
 RUN go build -o bin/hive-operator github.com/openshift/hive/cmd/operator
 
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base as hive
+FROM registry.access.redhat.com/ubi7/ubi
+
+# ssh-agent required for gathering logs in some situations:
+RUN if ! rpm -q openssh-clients; then yum install -y openssh-clients && yum clean all && rm -rf /var/cache/yum/*; fi
+
 COPY --from=builder /go/src/github.com/openshift/hive/bin/manager /opt/services/
 COPY --from=builder /go/src/github.com/openshift/hive/bin/hiveadmission /opt/services/
 COPY --from=builder /go/src/github.com/openshift/hive/bin/hiveutil /usr/bin

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,9 @@
-FROM openshift/origin-release:golang-1.12 as builder
+FROM registry.access.redhat.com/ubi7/ubi
 
 RUN chmod g+rw /etc/passwd
+
+# ssh-agent required for gathering logs in some situations:
+RUN if ! rpm -q openssh-clients; then yum install -y openssh-clients && yum clean all && rm -rf /var/cache/yum/*; fi
 
 ADD bin/hiveadmission /opt/services/
 ADD bin/hive-operator /opt/services/


### PR DESCRIPTION
This was present in the Dockerfile.dev we were using, but not in the
final layer we based on for official builds. Unfortunately RHEL based
containers cannot run yum during builds due to lack of entitlements.
With this PR we lose the ability to build the main Dockerfile locally,
but we still have the much faster Dockerfile.dev and associated make
targets.