### PR TITLE
vendor updated installer

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -678,7 +678,7 @@
   version = "v1.14.0"
 
 [[projects]]
-  digest = "1:66ba117c9a077511121e4a980c11712402b92baed8d0e1a0af1bd9b98ecf26a3"
+  digest = "1:2df7f3427c2bd044b207d209484a897e583152cd2d2b18b052b392528b484267"
   name = "github.com/openshift/installer"
   packages = [
     "pkg/asset/installconfig/aws",
@@ -690,6 +690,7 @@
     "pkg/types/aws",
     "pkg/types/aws/validation",
     "pkg/types/azure",
+    "pkg/types/baremetal",
     "pkg/types/gcp",
     "pkg/types/libvirt",
     "pkg/types/none",
@@ -698,7 +699,7 @@
     "pkg/version",
   ]
   pruneopts = "NUT"
-  revision = "63c63a0015f8f7cd894a93c0a6c0d6565ee8d05a"
+  revision = "ae2baf820f22b9bf1ed40932e7b702d790087574"
 
 [[projects]]
   branch = "master"
@@ -1857,6 +1858,7 @@
     "github.com/openshift/library-go/pkg/operator/events",
     "github.com/openshift/library-go/pkg/operator/resource/resourcemerge",
     "github.com/openshift/library-go/pkg/operator/resource/resourceread",
+    "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",
@@ -1876,6 +1878,8 @@
     "k8s.io/apimachinery/pkg/api/equality",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",
+    "k8s.io/apimachinery/pkg/api/resource",
+    "k8s.io/apimachinery/pkg/api/validation",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
     "k8s.io/apimachinery/pkg/fields",
@@ -1885,10 +1889,12 @@
     "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/runtime/serializer/json",
     "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/diff",
     "k8s.io/apimachinery/pkg/util/errors",
     "k8s.io/apimachinery/pkg/util/rand",
     "k8s.io/apimachinery/pkg/util/sets",
     "k8s.io/apimachinery/pkg/util/validation",
+    "k8s.io/apimachinery/pkg/util/validation/field",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/cli-runtime/pkg/genericclioptions",
@@ -1906,7 +1912,9 @@
     "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/clientcmd/api",
+    "k8s.io/client-go/tools/watch",
     "k8s.io/client-go/util/retry",
+    "k8s.io/client-go/util/workqueue",
     "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1",
     "k8s.io/code-generator/cmd/deepcopy-gen",
     "k8s.io/klog",
@@ -1929,8 +1937,8 @@
     "sigs.k8s.io/controller-runtime/pkg/handler",
     "sigs.k8s.io/controller-runtime/pkg/manager",
     "sigs.k8s.io/controller-runtime/pkg/metrics",
-    "sigs.k8s.io/controller-runtime/pkg/predicate",
     "sigs.k8s.io/controller-runtime/pkg/reconcile",
+    "sigs.k8s.io/controller-runtime/pkg/runtime/inject",
     "sigs.k8s.io/controller-runtime/pkg/runtime/scheme",
     "sigs.k8s.io/controller-runtime/pkg/runtime/signals",
     "sigs.k8s.io/controller-runtime/pkg/source",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -102,7 +102,7 @@ version="v1.4.7"
 
 [[constraint]]
   name = "github.com/openshift/installer"
-  revision = "63c63a0015f8f7cd894a93c0a6c0d6565ee8d05a"
+  revision = "ae2baf820f22b9bf1ed40932e7b702d790087574"
 
 [[constraint]]
   name = "github.com/openshift/generic-admission-server"

--- a/vendor/github.com/openshift/installer/pkg/asset/machines/aws/machinesets.go
+++ b/vendor/github.com/openshift/installer/pkg/asset/machines/aws/machinesets.go
@@ -58,10 +58,8 @@ func MachineSets(clusterID string, config *types.InstallConfig, pool *types.Mach
 				Replicas: &replicas,
 				Selector: metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						"machine.openshift.io/cluster-api-machineset":   name,
-						"machine.openshift.io/cluster-api-cluster":      clusterID,
-						"machine.openshift.io/cluster-api-machine-role": role,
-						"machine.openshift.io/cluster-api-machine-type": role,
+						"machine.openshift.io/cluster-api-machineset": name,
+						"machine.openshift.io/cluster-api-cluster":    clusterID,
 					},
 				},
 				Template: machineapi.MachineTemplateSpec{

--- a/vendor/github.com/openshift/installer/pkg/destroy/aws/aws.go
+++ b/vendor/github.com/openshift/installer/pkg/destroy/aws/aws.go
@@ -922,7 +922,7 @@ func deleteEC2Snapshot(client *ec2.EC2, id string, logger logrus.FieldLogger) er
 		SnapshotId: &id,
 	})
 	if err != nil {
-		if err.(awserr.Error).Code() == "InvalidSnapshotID.NotFound" {
+		if err.(awserr.Error).Code() == "InvalidSnapshot.NotFound" {
 			return nil
 		}
 		return err

--- a/vendor/github.com/openshift/installer/pkg/types/aws/platform.go
+++ b/vendor/github.com/openshift/installer/pkg/types/aws/platform.go
@@ -3,6 +3,10 @@ package aws
 // Platform stores all the global configuration that all machinesets
 // use.
 type Platform struct {
+	// AMIID is the AMI that should be used to boot machines for the cluster.
+	// If set, the AMI should belong to the same region as the cluster.
+	AMIID string `json:"amiID,omitempty"`
+
 	// Region specifies the AWS region where the cluster will be created.
 	Region string `json:"region"`
 

--- a/vendor/github.com/openshift/installer/pkg/types/azure/machinepool.go
+++ b/vendor/github.com/openshift/installer/pkg/types/azure/machinepool.go
@@ -3,6 +3,10 @@ package azure
 // MachinePool stores the configuration for a machine pool installed
 // on Azure.
 type MachinePool struct {
+	// Zones is list of availability zones that can be used.
+	// eg. ["1", "2", "3"]
+	Zones []string `json:"zones,omitempty"`
+
 	// InstanceType defines the azure instance type.
 	// eg. Standard_DS_V2
 	InstanceType string `json:"type"`
@@ -21,6 +25,10 @@ type OSDisk struct {
 func (a *MachinePool) Set(required *MachinePool) {
 	if required == nil || a == nil {
 		return
+	}
+
+	if len(required.Zones) > 0 {
+		a.Zones = required.Zones
 	}
 
 	if required.InstanceType != "" {

--- a/vendor/github.com/openshift/installer/pkg/types/baremetal/doc.go
+++ b/vendor/github.com/openshift/installer/pkg/types/baremetal/doc.go
@@ -1,0 +1,6 @@
+// Package baremetal contains baremetal-specific structures for
+// installer configuration and management.
+package baremetal
+
+// Name is the name for the baremetal platform.
+const Name string = "baremetal"

--- a/vendor/github.com/openshift/installer/pkg/types/baremetal/machinepool.go
+++ b/vendor/github.com/openshift/installer/pkg/types/baremetal/machinepool.go
@@ -1,0 +1,13 @@
+package baremetal
+
+// MachinePool stores the configuration for a machine pool installed
+// on bare metal.
+type MachinePool struct {
+}
+
+// Set sets the values from `required` to `a`.
+func (l *MachinePool) Set(required *MachinePool) {
+	if required == nil || l == nil {
+		return
+	}
+}

--- a/vendor/github.com/openshift/installer/pkg/types/baremetal/metadata.go
+++ b/vendor/github.com/openshift/installer/pkg/types/baremetal/metadata.go
@@ -1,0 +1,8 @@
+package baremetal
+
+// Metadata contains baremetal metadata (e.g. for uninstalling the cluster).
+type Metadata struct {
+	LibvirtURI              string `json:"libvirtURI"`
+	BootstrapProvisioningIP string `json:"bootstrapProvisioningIP"`
+	ClusterProvisioningIP   string `json:"provisioningHostIP"`
+}

--- a/vendor/github.com/openshift/installer/pkg/types/baremetal/platform.go
+++ b/vendor/github.com/openshift/installer/pkg/types/baremetal/platform.go
@@ -1,0 +1,64 @@
+package baremetal
+
+// BMC stores the information about a baremetal host's management controller.
+type BMC struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Address  string `json:"address"`
+}
+
+// Host stores all the configuration data for a baremetal host.
+type Host struct {
+	Name            string `json:"name,omitempty"`
+	BMC             BMC    `json:"bmc"`
+	Role            string `json:"role"`
+	BootMACAddress  string `json:"bootMACAddress"`
+	HardwareProfile string `json:"hardwareProfile"`
+}
+
+// Platform stores all the global configuration that all machinesets use.
+type Platform struct {
+	// LibvirtURI is the identifier for the libvirtd connection.  It must be
+	// reachable from the host where the installer is run.
+	// +optional
+	// Default is qemu:///system
+	LibvirtURI string `json:"libvirtURI,omitempty"`
+
+	// ClusterProvisioningIP is the IP on the dedicated provisioning network
+	// where the baremetal-operator pod runs provisioning services,
+	// and an http server to cache some downloaded content e.g RHCOS/IPA images
+	// +optional
+	ClusterProvisioningIP string `json:"provisioningHostIP,omitempty"`
+
+	// BootstrapProvisioningIP is the IP used on the bootstrap VM to
+	// bring up provisioning services that are used to create the
+	// control-plane machines
+	// +optional
+	BootstrapProvisioningIP string `json:"bootstrapProvisioningIP,omitempty"`
+
+	// External bridge is used for external communication.
+	// +optional
+	ExternalBridge string `json:"externalBridge,omitempty"`
+
+	// Provisioning bridge is used for provisioning nodes.
+	// +optional
+	ProvisioningBridge string `json:"provisioningBridge,omitempty"`
+
+	// Hosts is the information needed to create the objects in Ironic.
+	Hosts []*Host `json:"hosts"`
+
+	// DefaultMachinePlatform is the default configuration used when
+	// installing on bare metal for machine pools which do not define their own
+	// platform configuration.
+	// +optional
+	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
+
+	// APIVIP is the VIP to use for internal API communication
+	APIVIP string `json:"apiVIP"`
+
+	// IngressVIP is the VIP to use for ingress traffic
+	IngressVIP string `json:"ingressVIP"`
+
+	// DNSVIP is the VIP to use for internal DNS communication
+	DNSVIP string `json:"dnsVIP"`
+}

--- a/vendor/github.com/openshift/installer/pkg/types/clustermetadata.go
+++ b/vendor/github.com/openshift/installer/pkg/types/clustermetadata.go
@@ -3,6 +3,8 @@ package types
 import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/types/baremetal"
+	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/libvirt"
 	"github.com/openshift/installer/pkg/types/openstack"
 )
@@ -25,6 +27,8 @@ type ClusterPlatformMetadata struct {
 	OpenStack *openstack.Metadata `json:"openstack,omitempty"`
 	Libvirt   *libvirt.Metadata   `json:"libvirt,omitempty"`
 	Azure     *azure.Metadata     `json:"azure,omitempty"`
+	GCP       *gcp.Metadata       `json:"gcp,omitempty"`
+	BareMetal *baremetal.Metadata `json:"baremetal,omitempty"`
 }
 
 // Platform returns a string representation of the platform
@@ -35,16 +39,22 @@ func (cpm *ClusterPlatformMetadata) Platform() string {
 		return ""
 	}
 	if cpm.AWS != nil {
-		return "aws"
+		return aws.Name
 	}
 	if cpm.Libvirt != nil {
-		return "libvirt"
+		return libvirt.Name
 	}
 	if cpm.OpenStack != nil {
-		return "openstack"
+		return openstack.Name
 	}
 	if cpm.Azure != nil {
-		return "azure"
+		return azure.Name
+	}
+	if cpm.GCP != nil {
+		return gcp.Name
+	}
+	if cpm.BareMetal != nil {
+		return "baremetal"
 	}
 	return ""
 }

--- a/vendor/github.com/openshift/installer/pkg/types/gcp/clouduid.go
+++ b/vendor/github.com/openshift/installer/pkg/types/gcp/clouduid.go
@@ -1,0 +1,13 @@
+package gcp
+
+import (
+	"crypto/md5"
+	"fmt"
+)
+
+// CloudControllerUID generates a UID used by the GCP cloud controller provider
+// to generate certain load balancing resources
+func CloudControllerUID(infraID string) string {
+	hash := md5.Sum([]byte(infraID))
+	return fmt.Sprintf("%x", hash)[:16]
+}

--- a/vendor/github.com/openshift/installer/pkg/types/gcp/machinepools.go
+++ b/vendor/github.com/openshift/installer/pkg/types/gcp/machinepools.go
@@ -9,3 +9,18 @@ type MachinePool struct {
 	// eg. n1-standard-4
 	InstanceType string `json:"type"`
 }
+
+// Set sets the values from `required` to `a`.
+func (a *MachinePool) Set(required *MachinePool) {
+	if required == nil || a == nil {
+		return
+	}
+
+	if len(required.Zones) > 0 {
+		a.Zones = required.Zones
+	}
+
+	if required.InstanceType != "" {
+		a.InstanceType = required.InstanceType
+	}
+}

--- a/vendor/github.com/openshift/installer/pkg/types/gcp/metadata.go
+++ b/vendor/github.com/openshift/installer/pkg/types/gcp/metadata.go
@@ -1,0 +1,7 @@
+package gcp
+
+// Metadata contains GCP metadata (e.g. for uninstalling the cluster).
+type Metadata struct {
+	Region    string `json:"region"`
+	ProjectID string `json:"projectID"`
+}

--- a/vendor/github.com/openshift/installer/pkg/types/machinepools.go
+++ b/vendor/github.com/openshift/installer/pkg/types/machinepools.go
@@ -3,6 +3,7 @@ package types
 import (
 	"github.com/openshift/installer/pkg/types/aws"
 	"github.com/openshift/installer/pkg/types/azure"
+	"github.com/openshift/installer/pkg/types/baremetal"
 	"github.com/openshift/installer/pkg/types/gcp"
 	"github.com/openshift/installer/pkg/types/libvirt"
 	"github.com/openshift/installer/pkg/types/openstack"
@@ -45,8 +46,11 @@ type MachinePoolPlatform struct {
 	// AWS is the configuration used when installing on AWS.
 	AWS *aws.MachinePool `json:"aws,omitempty"`
 
-	// Azure is the configuration used when installing on OpenStack.
+	// Azure is the configuration used when installing on Azure.
 	Azure *azure.MachinePool `json:"azure,omitempty"`
+
+	// BareMetal is the configuration used when installing on bare metal.
+	BareMetal *baremetal.MachinePool `json:"baremetal,omitempty"`
 
 	// GCP is the configuration used when installing on GCP
 	GCP *gcp.MachinePool `json:"gcp,omitempty"`
@@ -72,6 +76,8 @@ func (p *MachinePoolPlatform) Name() string {
 		return aws.Name
 	case p.Azure != nil:
 		return azure.Name
+	case p.BareMetal != nil:
+		return baremetal.Name
 	case p.GCP != nil:
 		return gcp.Name
 	case p.Libvirt != nil:

--- a/vendor/github.com/openshift/installer/pkg/types/openstack/platform.go
+++ b/vendor/github.com/openshift/installer/pkg/types/openstack/platform.go
@@ -31,4 +31,8 @@ type Platform struct {
 	// TrunkSupport
 	// Whether OpenStack ports can be trunked
 	TrunkSupport string `json:"trunkSupport"`
+
+	// OctaviaSupport
+	// Whether OpenStack has Octavia support
+	OctaviaSupport string `json:"octaviaSupport"`
 }


### PR DESCRIPTION
we want the fix for the AWS deprovisioning in https://github.com/openshift/installer/pull/2284

update installer hash to ae2baf820f22b9bf1ed40932e7b702d790087574 (latest as of this writing), and `dep ensure -update`.