### PR TITLE
remove migration of wildcard ingress domains

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"regexp"
 	"sort"
 	"time"
 
@@ -119,10 +118,6 @@ var (
 			Buckets: []float64{10, 30, 60, 300, 600, 1200, 1800},
 		},
 	)
-
-	// regex to find/replace wildcard ingress entries
-	// case-insensitive leading literal '*' followed by a literal '.'
-	wildcardDomain = regexp.MustCompile(`(?i)^\*\.`)
 )
 
 func init() {
@@ -304,19 +299,6 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 			Requeue:      true,
 			RequeueAfter: defaultRequeueTime,
 		}, nil
-	}
-
-	// We previously allowed clusterdeployment.spec.ingress[] entries to have ingress domains with a leading '*'.
-	// Migrate the clusterdeployment to the new format if we find a wildcard ingress domain.
-	// TODO: we can one day remove this once all clusterdeployment are known to have non-wildcard data
-	if migrateWildcardIngress(cd) {
-		cdLog.Info("migrating wildcard ingress entries")
-		err := r.Update(context.TODO(), cd)
-		if err != nil {
-			cdLog.WithError(err).Error("failed to update cluster deployment")
-			return reconcile.Result{}, err
-		}
-		return reconcile.Result{}, nil
 	}
 
 	// TODO: remove this once clusterdeployments have been migrated. We are no longer storing syncset status
@@ -1423,18 +1405,6 @@ func generatePullSecretObj(pullSecret string, pullSecretName string, cd *hivev1.
 			corev1.DockerConfigJsonKey: pullSecret,
 		},
 	}
-}
-
-func migrateWildcardIngress(cd *hivev1.ClusterDeployment) bool {
-	migrated := false
-	for i, ingress := range cd.Spec.Ingress {
-		newIngress := wildcardDomain.ReplaceAllString(ingress.Domain, "")
-		if newIngress != ingress.Domain {
-			cd.Spec.Ingress[i].Domain = newIngress
-			migrated = true
-		}
-	}
-	return migrated
 }
 
 func dnsReadyTransitionTime(dnsZone *hivev1.DNSZone) *time.Time {

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -676,30 +676,6 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 			},
 		},
 		{
-			name: "Migrate wildcard ingress domains",
-			existing: []runtime.Object{
-				func() *hivev1.ClusterDeployment {
-					cd := testClusterDeploymentWithIngress()
-					cd.Spec.Ingress[0].Domain = fmt.Sprintf("*.apps.%s.example.com", cd.Spec.ClusterName)
-					cd.Spec.Ingress = append(cd.Spec.Ingress, hivev1.ClusterIngress{
-						Name:   "extraingress",
-						Domain: fmt.Sprintf("*.moreingress.%s.example.com", cd.Spec.ClusterName),
-					})
-					cd.Spec.Ingress = append(cd.Spec.Ingress, hivev1.ClusterIngress{
-						Name:   "notwildcardingress",
-						Domain: fmt.Sprintf("notwild.%s.example.com", cd.Spec.ClusterName),
-					})
-					return cd
-				}(),
-			},
-			validate: func(c client.Client, t *testing.T) {
-				cd := getCD(c)
-				for _, ingress := range cd.Spec.Ingress {
-					assert.NotRegexp(t, `^\*.*`, ingress.Domain, "Ingress domain %s wasn't migrated from wildcards", ingress.Domain)
-				}
-			},
-		},
-		{
 			name: "Delete legacy install job",
 			existing: []runtime.Object{
 				testClusterDeployment(),
@@ -1372,18 +1348,6 @@ func testAvailableDNSZone() *hivev1.DNSZone {
 	return zone
 }
 
-func testClusterDeploymentWithIngress() *hivev1.ClusterDeployment {
-	cd := testClusterDeployment()
-	cd.Spec.Ingress = []hivev1.ClusterIngress{
-		{
-			Name:   "default",
-			Domain: fmt.Sprintf("apps.%s.example.com", cd.Spec.ClusterName),
-		},
-	}
-
-	return cd
-}
-
 func assertConditionStatus(t *testing.T, cd *hivev1.ClusterDeployment, condType hivev1.ClusterDeploymentConditionType, status corev1.ConditionStatus) {
 	found := false
 	for _, cond := range cd.Status.Conditions {
@@ -1393,70 +1357,6 @@ func assertConditionStatus(t *testing.T, cd *hivev1.ClusterDeployment, condType 
 		}
 	}
 	assert.True(t, found, "did not find expected condition type: %v", condType)
-}
-
-func TestClusterDeploymentWildcardDomainMigration(t *testing.T) {
-	apis.AddToScheme(scheme.Scheme)
-
-	tests := []struct {
-		name              string
-		existing          *hivev1.ClusterDeployment
-		migrationExpected bool
-		expectedDomains   []string // must be same length as the number of ingress entries for the test clusterDeployment
-	}{
-		{
-			name:              "No ingress, no migration",
-			existing:          testClusterDeployment(),
-			migrationExpected: false,
-		},
-		{
-			name:              "No wildcards, no migration",
-			existing:          testClusterDeploymentWithIngress(),
-			migrationExpected: false,
-			expectedDomains:   []string{fmt.Sprintf("apps.%s.example.com", testClusterName)},
-		},
-		{
-			name: "Migrate wildcard domain",
-			existing: func() *hivev1.ClusterDeployment {
-				cd := testClusterDeploymentWithIngress()
-				cd.Spec.Ingress[0].Domain = fmt.Sprintf("*.apps.%s.example.com", cd.Spec.ClusterName)
-
-				return cd
-			}(),
-			migrationExpected: true,
-			expectedDomains:   []string{fmt.Sprintf("apps.%s.example.com", testClusterName)},
-		},
-		{
-			name: "Migrate when only one of two is wildcard",
-			existing: func() *hivev1.ClusterDeployment {
-				cd := testClusterDeploymentWithIngress()
-				cd.Spec.Ingress = append(cd.Spec.Ingress, hivev1.ClusterIngress{
-					Name:   "extraingress",
-					Domain: fmt.Sprintf("*.moreingress.%s.example.com", cd.Spec.ClusterName),
-				})
-
-				return cd
-			}(),
-			migrationExpected: true,
-			expectedDomains: []string{
-				fmt.Sprintf("apps.%s.example.com", testClusterName),
-				fmt.Sprintf("moreingress.%s.example.com", testClusterName),
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-
-			result := migrateWildcardIngress(test.existing)
-
-			assert.Equal(t, test.migrationExpected, result)
-
-			for i, domain := range test.expectedDomains {
-				assert.Equal(t, domain, test.existing.Spec.Ingress[i].Domain)
-			}
-		})
-	}
 }
 
 func getJob(c client.Client, name string) *batchv1.Job {


### PR DESCRIPTION
There are no clusterdeployments in stage or production with wildcards ingress domains.

Stage
```
$ oc get cd --all-namespaces -o json | jq .items[].spec.ingress[].domain
"apps.tparikh-quay-poc.a0a0.s1.devshift.org"
"apps.compliance-soc2-test-201906-take2.o4a5.s1.devshift.org"
"apps.rogbas-stg.o9a7.s1.devshift.org"
"apps.test-liza-aug28.b3i3.s1.devshift.org"
"apps.tzhou-018.a9u8.s1.devshift.org"
"apps.cindytest.d2z5.s1.devshift.org"
"apps.cindymulti.p6w3.s1.devshift.org"
"apps.aaaaa.j8c4.s1.devshift.org"
"apps.lseelye-srep-15.j8i1.s1.devshift.org"
"apps.chcollin.z3j0.s1.devshift.org"
"apps.nmalik1.i4n2.s1.devshift.org"
"apps.nmalik2.o5m1.s1.devshift.org"
"apps.nmalik3.t3e0.s1.devshift.org"
"apps.nmalik4.m5z8.s1.devshift.org"
"apps.nmalik419-1.w7n1.s1.devshift.org"
"apps.nmalik419-2.n5f6.s1.devshift.org"
"apps.nmalik419-3.l8l2.s1.devshift.org"
"apps.nmalik419-4.z7p7.s1.devshift.org"
"apps.yuwan-test-4831.m6v6.s1.devshift.org"
"apps.sdq-aws-onyv.i7a4.s1.devshift.org"
"apps.sdq-aws-tjsp.d3j2.s1.devshift.org"
"apps.sdq-aws-rqqt.l2f2.s1.devshift.org"
"apps.sdq-aws-dvgl.v5n7.s1.devshift.org"
"apps.sdq-aws-thkp.r2q1.s1.devshift.org"
"apps.sdq-aws-ewqb.h7c9.s1.devshift.org"
"apps.pbrookes.v2r4.s1.devshift.org"
"apps.whearn.c9o4.s1.devshift.org"
"apps.ci-cluster-v4-1.b4g5.s1.devshift.org"
"apps.cblecker-aug30.e2t4.s1.devshift.org"
```

Production
```
$ oc get cd --all-namespaces -o json | jq ".items[].spec.ingress | select(. != null) | .[].domain"
"apps.osd-v4stg-aws.z9a9.p1.openshiftapps.com"
"apps.osd-v4prod-aws.n2a0.p1.openshiftapps.com"
"apps.lucky-managed.k1a4.p1.openshiftapps.com"
"apps.kb-jun20-wkld.x1k3.p1.openshiftapps.com"
"apps.osd4-demo.u6k6.p1.openshiftapps.com"
"apps.openshift-web.p0s5.p1.openshiftapps.com"
"apps.jeder-asdf.o9g3.p1.openshiftapps.com"
"apps.insights.h2t2.p1.openshiftapps.com"
"apps.upgradetest.p6j6.p1.openshiftapps.com"
"apps.quaytest.p1l6.p1.openshiftapps.com"
"apps.je-cncf-conform.v3f0.p1.openshiftapps.com"
"apps.oved-14aug.c5w7.p1.openshiftapps.com"
"apps.bhf-vader-dev.p3m4.p1.openshiftapps.com"
"apps.bhf-vader-prod.x4x6.p1.openshiftapps.com"
"apps.oved-rhte-manag.g3i9.p1.openshiftapps.com"
"apps.oved-19aug.f7d6.p1.openshiftapps.com"
"apps.esaas.y5o7.p1.openshiftapps.com"
"apps.ised.j8b1.p1.openshiftapps.com"
"apps.gshereme-aug23.p9n9.p1.openshiftapps.com"
"apps.sgm.e0d9.p1.openshiftapps.com"
"apps.crw-osd4.t7n7.p1.openshiftapps.com"
"apps.ci-cluster-v4-1.j8x0.p1.openshiftapps.com"
```