### PR TITLE
Local e2e example and instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,11 @@ test-e2e:
 
 .PHONY: test-e2e-postdeploy
 test-e2e-postdeploy:
-	go test -timeout 0 ./test/e2e/postdeploy/...
+	go test -timeout 0 -count=1 ./test/e2e/postdeploy/...
 
 .PHONY: test-e2e-postinstall
 test-e2e-postinstall:
-	go test -timeout 0 ./test/e2e/postinstall/...
+	go test -timeout 0 -count=1 ./test/e2e/postinstall/...
 
 # Builds all of hive's binaries (including utils).
 .PHONY: build

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -175,6 +175,33 @@ Alternatively, you can run the Dep command directly.
 dep ensure -v
 ```
 
+### Running the e2e test locally
+
+The e2e test deploys Hive on a cluster, tests that all Hive components are working properly, then creates a cluster
+with Hive and ensures that Hive works properly with the installed cluster. It finally tears down the created cluster. It finally tears down the created cluster.
+
+You can run the e2e test by pointing to your own cluster (via the `KUBECONFIG` environment variable).
+
+Ensure that the following environment variables are set:
+
+`KUBECONFIG` - Must point to a valid Kubernetes configuration file that allows communicating with your cluster.
+`AWS_ACCESS_KEY_ID` - AWS access key for your AWS account
+`AWS_SECRET_ACCESS_KEY` - AWS secret access key for your AWS account
+
+`HIVE_IMAGE` - Hive image to deploy to the cluster
+`RELEASE_IMAGE` - OpenShift release image to use for the e2e test cluster
+`CLUSTER_NAMESPACE` - Namespace where clusterdeployment will be created for the e2e test
+`BASE_DOMAIN` - DNS domain to use for the test cluster (a corresponding Route53 public zone must exist on your account).
+`ARTIFACT_DIR` - Directory where logs will be placed by the e2e test
+`SSH_PUBLIC_KEY_FILE` - Path to a public ssh key to use for the test cluster
+`PULL_SECRET_FILE` - Path to file containing a pull secret for the test cluster
+
+For example values for these variables, see `hack/local-e2e-test.sh`
+
+Run the Hive e2e script:
+
+`hack/e2e-test.sh`
+
 ### TIP
 
 * The Dep cache located under *_$GOPATH/pkg/dep_*.

--- a/hack/local-e2e-test.sh
+++ b/hack/local-e2e-test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+# Example script to launch a Hive e2e test on your own cluster
+
+# Image to use for hive operator and controllers
+export HIVE_IMAGE="registry.svc.ci.openshift.org/openshift/hive-v4.0:hive"
+
+# Release image to use. If using the one from CI, your pull secret must include valid creds for api.ci
+export RELEASE_IMAGE="registry.svc.ci.openshift.org/origin/release:4.2"
+
+# Namespace where e2e cluster will be created
+export CLUSTER_NAMESPACE="hive-e2e"
+
+# Base domain for e2e cluster
+export BASE_DOMAIN="new-installer.openshift.com"
+
+# Where artifacts from the test will be placed
+export ARTIFACT_DIR="/tmp"
+
+# Public SSH key for the cluster
+export SSH_PUBLIC_KEY_FILE="${HOME}/.ssh/id_rsa.pub"
+
+# Pull secret to use for installing the cluster
+export PULL_SECRET_FILE="${HOME}/.pull-secret"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+${DIR}/e2e-test.sh


### PR DESCRIPTION
- Modifies the e2e script to allow overriding of environment variables. 
- Adds instructions on how to run the e2e test locally 
- Provides a sample script to run the e2e test locally
- Modifies the `go test` call in the Makefile for post-install and post-deploy tests so that results are not cached