### PR TITLE
 allow for restoring clusterdeployment and clusterprovision

### DIFF
--- a/config/crds/hive_v1alpha1_clusterdeployment.yaml
+++ b/config/crds/hive_v1alpha1_clusterdeployment.yaml
@@ -16,7 +16,7 @@ spec:
   - JSONPath: .spec.baseDomain
     name: BaseDomain
     type: string
-  - JSONPath: .status.installed
+  - JSONPath: .spec.installed
     name: Installed
     type: boolean
   - JSONPath: .status.infraID
@@ -384,6 +384,9 @@ spec:
                 - domain
                 type: object
               type: array
+            installed:
+              description: Installed is true if the cluster has been installed
+              type: boolean
             manageDNS:
               description: ManageDNS specifies whether a DNSZone should be created
                 and managed automatically for this ClusterDeployment
@@ -792,7 +795,7 @@ spec:
               type: integer
             installed:
               description: Installed is true if the installer job has successfully
-                completed for this cluster.
+                completed for this cluster. Deprecated.
               type: boolean
             installedTimestamp:
               description: InstalledTimestamp is the time we first detected that the

--- a/hack/duplicate_cd.sh
+++ b/hack/duplicate_cd.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# This script will duplicate an installed clusterdeployment for testing purposes.
+# The duplicated cluster will have a generated name that starts with the name
+# of the original clusterdeployment followed by "-dup"
+#
+
+set -e
+
+usage(){
+	echo "Usage: $0 [CLUSTERDEPLOYMENT_NAMESPACE/]CLUSTERDEPLOYMENT_NAME [COUNT]"
+	exit 1
+}
+
+
+# Get the name and namespace for the clusterdeployment to duplicate.
+CD_NAME_ARG=${1?missing ClusterDeployment name}
+CD_NAME_ARR=(${CD_NAME_ARG//// })
+case ${#CD_NAME_ARR[@]} in
+1)
+	CD_NAME=${CD_NAME_ARR[0]}
+	;;
+2)
+	CD_NAMESPACE=${CD_NAME_ARR[0]}
+	CD_NAME=${CD_NAME_ARR[1]}
+	;;
+*)
+	echo "Could not determine namespace and name of ClusterDeployment"
+	usage
+	;;
+esac
+
+# Get the duplication count
+COUNT=${2:-1}
+if [[ "${COUNT}" -le 0 ]]
+then
+	echo "COUNT must be a positive integer: ${COUNT}"
+	usage
+	exit 1
+fi
+
+echo "Duplicating ${CD_NAMESPACE}${CD_NAMESPACE:+/}${CD_NAME} ${COUNT} times"
+
+# Argument to supply to oc commands to provide the namespace. This is empty if
+# the user did not specify a namespace.
+NAMESPACE_ARG="${CD_NAMESPACE:+--namespace }${CD_NAMESPACE}"
+
+# Get the clusterdeployment to duplicate.
+CD=$(oc get cd ${NAMESPACE_ARG} ${CD_NAME} -ojson)
+
+# Ensure that the cluster has been installed.
+if [ "$(echo ${CD} | jq .spec.installed)" != "true" ]
+then
+	echo "Cluster is not installed"
+	exit 1
+fi
+
+# Get the clusterprovision to duplicate.
+PROV=$(oc get clusterprovision ${NAMESPACE_ARG} $(echo ${CD} | jq -r .status.provision.name) -ojson)
+
+# Create the json for the new clusterdeployment.
+NEW_CD=$(echo ${CD} | jq \
+	'del(.status) |
+		.metadata|={
+			"namespace":.namespace,
+			"generateName":.name,
+			"labels":{"hive.openshift.io/duplicated-from":.name}} |
+		.metadata.generateName|=.+"-dup-" |
+		.spec.installed=true |
+		.spec.manageDNS=false |
+		.spec.preserveOnDelete=true |
+		.spec.certificateBundles[]?.generate=false')
+
+# Create the json for the new clusterprovision, without the name or UID of the clusterdeployment.
+NEW_PROV_BASE=$(echo ${PROV} | jq \
+	'del(.status) |
+		.metadata|={
+			"namespace":.namespace,
+			"ownerReferences":(.ownerReferences | select(.[].controller=true)),
+			"labels":{"hive.openshift.io/duplicated-from":.name}} |
+		.spec.stage="complete" |
+		del(.spec.podSpec) |
+		del(.spec.attempt)')
+		
+for (( i=0; i<${COUNT}; i++ ))
+do
+	# Create the new clusterdeployment, and save the name of the new clusterdeployment.
+	CD_CREATE_OUTPUT=$(echo $NEW_CD | oc create -f -)
+	echo ${CD_CREATE_OUTPUT}
+	CD_CREATE_OUTPUT_ARR=(${CD_CREATE_OUTPUT//// })
+	NEW_CD_NAME=${CD_CREATE_OUTPUT_ARR[1]}
+	
+	# Get the UID of the new clusterdeployment.
+	NEW_CD_UID=$(oc get cd ${NAMESPACE_ARG} ${NEW_CD_NAME} -ojsonpath={.metadata.uid})
+	
+	# Fill out the clusterdeployment name and UID for the new clusterprovision.
+	NEW_PROV=$(echo ${NEW_PROV_BASE} | jq \
+		--arg name "${NEW_CD_NAME}" \
+		--arg cd_uid "${NEW_CD_UID}" \
+		'.metadata.name=$name |
+			.metadata.ownerReferences[0].name=$name |
+			.metadata.ownerReferences[0].uid=$cd_uid |
+			.metadata.labels|=.+{"hive.openshift.io/cluster-deployment-name": $name}')
+	
+	# Create the new clusterprovision.
+	echo $NEW_PROV | oc create -f -
+done
+

--- a/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
@@ -103,6 +103,9 @@ type ClusterDeploymentSpec struct {
 	// for this ClusterDeployment
 	// +optional
 	ManageDNS bool `json:"manageDNS,omitempty"`
+
+	// Installed is true if the cluster has been installed
+	Installed bool `json:"installed"`
 }
 
 // ProvisionImages allows overriding the default images used to provision a cluster.
@@ -150,6 +153,7 @@ type ClusterDeploymentStatus struct {
 	InfraID string `json:"infraID,omitempty"`
 
 	// Installed is true if the installer job has successfully completed for this cluster.
+	// Deprecated.
 	Installed bool `json:"installed"`
 
 	// Federated is true if the cluster deployment has been federated with the host cluster.
@@ -279,7 +283,7 @@ var AllClusterDeploymentConditions = []ClusterDeploymentConditionType{
 // +kubebuilder:printcolumn:name="ClusterName",type="string",JSONPath=".spec.clusterName"
 // +kubebuilder:printcolumn:name="ClusterType",type="string",JSONPath=".metadata.labels.hive\.openshift\.io/cluster-type"
 // +kubebuilder:printcolumn:name="BaseDomain",type="string",JSONPath=".spec.baseDomain"
-// +kubebuilder:printcolumn:name="Installed",type="boolean",JSONPath=".status.installed"
+// +kubebuilder:printcolumn:name="Installed",type="boolean",JSONPath=".spec.installed"
 // +kubebuilder:printcolumn:name="InfraID",type="string",JSONPath=".status.infraID"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=clusterdeployments,shortName=cd

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
@@ -156,6 +156,28 @@ func TestClusterDeploymentValidate(t *testing.T) {
 			expectedAllowed: true,
 		},
 		{
+			name:      "Test setting installed flag",
+			oldObject: validClusterDeployment(),
+			newObject: func() *hivev1.ClusterDeployment {
+				cd := validClusterDeployment()
+				cd.Spec.Installed = true
+				return cd
+			}(),
+			operation:       admissionv1beta1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "Test clearing installed flag",
+			oldObject: func() *hivev1.ClusterDeployment {
+				cd := validClusterDeployment()
+				cd.Spec.Installed = true
+				return cd
+			}(),
+			newObject:       validClusterDeployment(),
+			operation:       admissionv1beta1.Update,
+			expectedAllowed: false,
+		},
+		{
 			name:      "Test Update PreserveOnDelete",
 			oldObject: validClusterDeployment(),
 			newObject: func() *hivev1.ClusterDeployment {

--- a/pkg/controller/clusterstate/clusterstate_controller.go
+++ b/pkg/controller/clusterstate/clusterstate_controller.go
@@ -117,7 +117,7 @@ func (r *ReconcileClusterState) Reconcile(request reconcile.Request) (reconcile.
 		logger.Debug("ClusterDeployment resource has been deleted")
 		return reconcile.Result{}, nil
 	}
-	if !cd.Status.Installed || len(cd.Status.AdminKubeconfigSecret.Name) == 0 {
+	if !cd.Spec.Installed || len(cd.Status.AdminKubeconfigSecret.Name) == 0 {
 		logger.Debug("ClusterDeployment is not yet ready")
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controller/clusterstate/clusterstate_controller_test.go
+++ b/pkg/controller/clusterstate/clusterstate_controller_test.go
@@ -213,8 +213,10 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 			Namespace: testNamespace,
 			Name:      testName,
 		},
-		Status: hivev1.ClusterDeploymentStatus{
+		Spec: hivev1.ClusterDeploymentSpec{
 			Installed: true,
+		},
+		Status: hivev1.ClusterDeploymentStatus{
 			AdminKubeconfigSecret: corev1.LocalObjectReference{
 				Name: testKubeconfigSecretName,
 			},

--- a/pkg/controller/clusterversion/clusterversion_controller.go
+++ b/pkg/controller/clusterversion/clusterversion_controller.go
@@ -115,7 +115,7 @@ func (r *ReconcileClusterVersion) Reconcile(request reconcile.Request) (reconcil
 	}
 
 	// If the cluster is not installed, do not reconcile.
-	if !cd.Status.Installed {
+	if !cd.Spec.Installed {
 		cdLog.Debug("cluster installation is not complete")
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controller/clusterversion/clusterversion_controller_test.go
+++ b/pkg/controller/clusterversion/clusterversion_controller_test.go
@@ -151,10 +151,10 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 					},
 				},
 			},
+			Installed: true,
 		},
 		Status: hivev1.ClusterDeploymentStatus{
 			ClusterID: testClusterID,
-			Installed: true,
 			AdminKubeconfigSecret: corev1.LocalObjectReference{
 				Name: "kubeconfig-secret",
 			},

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -166,7 +166,7 @@ func (mc *Calculator) Start(stopCh <-chan struct{}) error {
 				accumulator.processCluster(&cd)
 
 				if cd.DeletionTimestamp == nil {
-					if !cd.Status.Installed {
+					if !cd.Spec.Installed {
 						// Similarly for installing clusters we report the seconds since
 						// cluster was created. clusterdeployment_controller should set to 0
 						// once we know we've first observed install success, and then this
@@ -426,7 +426,7 @@ func (ca *clusterAccumulator) processCluster(cd *hivev1.ClusterDeployment) {
 		}
 	}
 
-	if cd.Status.Installed {
+	if cd.Spec.Installed {
 		ca.installed[clusterType]++
 	} else {
 		// Sort uninstall clusters into buckets based on how long since

--- a/pkg/controller/metrics/metrics_test.go
+++ b/pkg/controller/metrics/metrics_test.go
@@ -162,7 +162,7 @@ func testClusterDeployment(name, clusterType string, created metav1.Time, instal
 			CreationTimestamp: created,
 			Labels:            map[string]string{hivev1.HiveClusterTypeLabel: clusterType},
 		},
-		Status: hivev1.ClusterDeploymentStatus{
+		Spec: hivev1.ClusterDeploymentSpec{
 			Installed: installed,
 		},
 	}

--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -139,7 +139,7 @@ func (r *ReconcileRemoteMachineSet) Reconcile(request reconcile.Request) (reconc
 		return reconcile.Result{}, nil
 	}
 
-	if !cd.Status.Installed {
+	if !cd.Spec.Installed {
 		// Cluster isn't installed yet, return
 		cdLog.Debug("cluster installation is not complete")
 		return reconcile.Result{}, nil

--- a/pkg/controller/remotemachineset/remotemachineset_controller_test.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller_test.go
@@ -535,9 +535,9 @@ func testClusterDeployment(computePools []hivev1.MachinePool) *hivev1.ClusterDep
 					},
 				},
 			},
+			Installed: true,
 		},
 		Status: hivev1.ClusterDeploymentStatus{
-			Installed:             true,
 			AdminKubeconfigSecret: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-admin-kubeconfig", testName)},
 			ClusterID:             testClusterID,
 			InfraID:               testInfraID,

--- a/pkg/controller/syncset/syncset_controller.go
+++ b/pkg/controller/syncset/syncset_controller.go
@@ -168,7 +168,7 @@ func (r *ReconcileSyncSet) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, nil
 	}
 
-	if !cd.Status.Installed {
+	if !cd.Spec.Installed {
 		// Cluster isn't installed yet, return
 		cdLog.Debug("cluster installation is not complete")
 		return reconcile.Result{}, nil

--- a/pkg/controller/syncset/syncset_controller_test.go
+++ b/pkg/controller/syncset/syncset_controller_test.go
@@ -183,7 +183,7 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 			Namespace: testNamespace,
 			Labels:    map[string]string{"foo": "bar"},
 		},
-		Status: hivev1.ClusterDeploymentStatus{
+		Spec: hivev1.ClusterDeploymentSpec{
 			Installed: true,
 		},
 	}

--- a/pkg/controller/syncsetinstance/syncsetinstance_controller.go
+++ b/pkg/controller/syncsetinstance/syncsetinstance_controller.go
@@ -200,7 +200,7 @@ func (r *ReconcileSyncSetInstance) Reconcile(request reconcile.Request) (reconci
 		return reconcile.Result{}, nil
 	}
 
-	if !cd.Status.Installed {
+	if !cd.Spec.Installed {
 		ssiLog.Debug("cluster installation is not complete")
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controller/syncsetinstance/syncsetinstance_controller_test.go
+++ b/pkg/controller/syncsetinstance/syncsetinstance_controller_test.go
@@ -447,9 +447,10 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 				"region": "us-east-1",
 			},
 		},
-		Spec: hivev1.ClusterDeploymentSpec{},
+		Spec: hivev1.ClusterDeploymentSpec{
+			Installed: true,
+		},
 		Status: hivev1.ClusterDeploymentStatus{
-			Installed:             true,
 			AdminKubeconfigSecret: corev1.LocalObjectReference{Name: adminKubeconfigSecret},
 		},
 	}

--- a/pkg/controller/unreachable/unreachable_controller.go
+++ b/pkg/controller/unreachable/unreachable_controller.go
@@ -134,7 +134,7 @@ func (r *ReconcileRemoteMachineSet) Reconcile(request reconcile.Request) (reconc
 		return reconcile.Result{}, nil
 	}
 
-	if !cd.Status.Installed {
+	if !cd.Spec.Installed {
 		cdLog.Debug("cluster installation is not complete")
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controller/unreachable/unreachable_controller_test.go
+++ b/pkg/controller/unreachable/unreachable_controller_test.go
@@ -377,7 +377,7 @@ func getClusterDeployment() *hivev1.ClusterDeployment {
 			},
 		},
 	}
-	cd.Status.Installed = true
+	cd.Spec.Installed = true
 	return cd
 }
 

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -293,7 +293,7 @@ func GetUninstallJobName(name string) string {
 func GenerateUninstallerJobForClusterDeployment(cd *hivev1.ClusterDeployment) (*batchv1.Job, error) {
 
 	if cd.Spec.PreserveOnDelete {
-		if cd.Status.Installed {
+		if cd.Spec.Installed {
 			return nil, fmt.Errorf("no creation of uninstaller job, because of PreserveOnDelete")
 		}
 	}

--- a/pkg/install/generate_test.go
+++ b/pkg/install/generate_test.go
@@ -26,7 +26,7 @@ func init() {
 
 func TestGenerate(t *testing.T) {
 	cd := testClusterDeployment()
-	cd.Status.Installed = true
+	cd.Spec.Installed = true
 	cd.Spec.PreserveOnDelete = true
 	job, err := GenerateUninstallerJobForClusterDeployment(cd)
 	assert.Nil(t, job)

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -229,7 +229,7 @@ func (m *InstallManager) Run() error {
 	if err != nil {
 		m.log.WithError(err).Fatal("error looking up cluster deployment")
 	}
-	if cd.Status.Installed {
+	if cd.Spec.Installed {
 		// This should not be possible but just in-case we can somehow
 		// run the install job for a cluster already installed, exit early,
 		// and don't delete *anything*.

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1544,7 +1544,7 @@ spec:
   - JSONPath: .spec.baseDomain
     name: BaseDomain
     type: string
-  - JSONPath: .status.installed
+  - JSONPath: .spec.installed
     name: Installed
     type: boolean
   - JSONPath: .status.infraID
@@ -1912,6 +1912,9 @@ spec:
                 - domain
                 type: object
               type: array
+            installed:
+              description: Installed is true if the cluster has been installed
+              type: boolean
             manageDNS:
               description: ManageDNS specifies whether a DNSZone should be created
                 and managed automatically for this ClusterDeployment
@@ -2320,7 +2323,7 @@ spec:
               type: integer
             installed:
               description: Installed is true if the installer job has successfully
-                completed for this cluster.
+                completed for this cluster. Deprecated.
               type: boolean
             installedTimestamp:
               description: InstalledTimestamp is the time we first detected that the

--- a/test/e2e/common/clusterdeployment.go
+++ b/test/e2e/common/clusterdeployment.go
@@ -36,7 +36,7 @@ func MustGetClusterDeployment() *hivev1.ClusterDeployment {
 
 func MustGetInstalledClusterDeployment() *hivev1.ClusterDeployment {
 	cd := MustGetClusterDeployment()
-	if !cd.Status.Installed || len(cd.Status.AdminKubeconfigSecret.Name) == 0 {
+	if !cd.Spec.Installed || len(cd.Status.AdminKubeconfigSecret.Name) == 0 {
 		log.WithField("clusterdeployment", fmt.Sprintf("%s/%s", cd.Namespace, cd.Name)).Fatalf("cluster deployment is not installed")
 	}
 	return cd


### PR DESCRIPTION
* The installed field in clusterdeployment has been moved from the status to the spec. This allows the field to be retained when a clusterdeployment is restored. The installed field in status is deprecated but will be retained until all existing clusterdeployments are converted to use the installed field in spec.

* Adjust the validation for clusterprovision to accommodate adopting an existing cluster. When adopting, the expectation is that the podSpec field will be omitted. So when the podSpec field is empty, the validation ensures that the stage is "complete", that the attempt number if 0, and that there is not a previous infra ID or cluster ID.

* If the clusterdeployment is marked as installed but there is not a reference to the clusterprovision, then the controller will attempt to adopt an existing completed clusterprovision. Upon adoption, the infra ID, cluster ID, admin kubeconfig secret, and admin password secret will be copied from the clusterprovision to the clusterdeployment.