### PR TITLE
fix install job creation race

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -226,7 +226,7 @@ type ReconcileClusterDeployment struct {
 	scheme *runtime.Scheme
 	logger log.FieldLogger
 
-	// A TTLCache of clusterprovision creates/deletes each clusterdeployment expects to see
+	// A TTLCache of clusterprovision creates each clusterdeployment expects to see
 	expectations controllerutils.ExpectationsInterface
 
 	// remoteClusterAPIClientBuilder is a function pointer to the function that builds a client for the

--- a/pkg/controller/clusterprovision/clusterprovision_controller.go
+++ b/pkg/controller/clusterprovision/clusterprovision_controller.go
@@ -39,6 +39,9 @@ const (
 )
 
 var (
+	// controllerKind contains the schema.GroupVersionKind for this controller type.
+	controllerKind = hivev1.SchemeGroupVersion.WithKind("ClusterProvision")
+
 	metricInstallErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "hive_install_errors",
 		Help: "Counter incremented every time we observe certain errors strings in install logs.",
@@ -59,11 +62,22 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileClusterProvision{Client: controllerutils.NewClientWithMetricsOrDie(mgr, controllerName), scheme: mgr.GetScheme()}
+	logger := log.WithField("controller", controllerName)
+	return &ReconcileClusterProvision{
+		Client:       controllerutils.NewClientWithMetricsOrDie(mgr, controllerName),
+		scheme:       mgr.GetScheme(),
+		logger:       logger,
+		expectations: controllerutils.NewExpectations(logger),
+	}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	provisionReconciler, ok := r.(*ReconcileClusterProvision)
+	if !ok {
+		return errors.New("reconciler supplied is not a ReconcileClusterProvision")
+	}
+
 	// Create a new controller
 	c, err := controller.New("clusterprovision-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
@@ -76,10 +90,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for install jobs created for ClusterProvision
-	if err := c.Watch(&source.Kind{Type: &batchv1.Job{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &hivev1.ClusterProvision{},
-	}); err != nil {
+	if err := provisionReconciler.watchJobs(c); err != nil {
 		return errors.Wrap(err, "could not watch jobs")
 	}
 
@@ -99,6 +110,9 @@ var _ reconcile.Reconciler = &ReconcileClusterProvision{}
 type ReconcileClusterProvision struct {
 	client.Client
 	scheme *runtime.Scheme
+	logger log.FieldLogger
+	// A TTLCache of job creates each clusterprovision expects to see
+	expectations controllerutils.ExpectationsInterface
 }
 
 // Reconcile reads that state of the cluster for a ClusterProvision object and makes changes based on the state read
@@ -107,10 +121,7 @@ type ReconcileClusterProvision struct {
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 func (r *ReconcileClusterProvision) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	start := time.Now()
-	pLog := log.WithFields(log.Fields{
-		"name":       request.NamespacedName.String(),
-		"controller": controllerName,
-	})
+	pLog := r.logger.WithField("name", request.NamespacedName)
 
 	// For logging, we need to see when the reconciliation loop starts and ends.
 	pLog.Info("reconciling cluster provision")
@@ -126,6 +137,7 @@ func (r *ReconcileClusterProvision) Reconcile(request reconcile.Request) (reconc
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			pLog.Debug("ClusterProvision not found, skipping")
+			r.expectations.DeleteExpectations(request.NamespacedName.String())
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
@@ -135,6 +147,11 @@ func (r *ReconcileClusterProvision) Reconcile(request reconcile.Request) (reconc
 
 	if !instance.DeletionTimestamp.IsZero() {
 		pLog.Debug("ClusterProvision being deleted, skipping")
+		return reconcile.Result{}, nil
+	}
+
+	if !r.expectations.SatisfiedExpectations(request.String()) {
+		pLog.Debug("waiting for expectations to be satisfied")
 		return reconcile.Result{}, nil
 	}
 
@@ -189,8 +206,10 @@ func (r *ReconcileClusterProvision) createJob(instance *hivev1.ClusterProvision,
 	}
 
 	pLog.Infof("creating install job")
+	r.expectations.ExpectCreations(types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}.String(), 1)
 	if err := r.Create(context.TODO(), job); err != nil {
 		pLog.WithError(err).Error("error creating job")
+		r.expectations.CreationObserved(types.NamespacedName{Namespace: instance.Namespace, Name: instance.Name}.String())
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/clusterprovision/jobexpectations.go
+++ b/pkg/controller/clusterprovision/jobexpectations.go
@@ -1,0 +1,82 @@
+package clusterprovision
+
+import (
+	"context"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+)
+
+func (r *ReconcileClusterProvision) watchJobs(c controller.Controller) error {
+	handler := &jobEventHandler{
+		EnqueueRequestForOwner: handler.EnqueueRequestForOwner{
+			IsController: true,
+			OwnerType:    &hivev1.ClusterProvision{},
+		},
+		reconciler: r,
+	}
+	return c.Watch(&source.Kind{Type: &batchv1.Job{}}, handler)
+}
+
+var _ handler.EventHandler = &jobEventHandler{}
+
+type jobEventHandler struct {
+	handler.EnqueueRequestForOwner
+	reconciler *ReconcileClusterProvision
+}
+
+// Create implements handler.EventHandler
+func (h *jobEventHandler) Create(e event.CreateEvent, q workqueue.RateLimitingInterface) {
+	h.reconciler.logger.Info("Job created")
+	h.reconciler.trackJobAdd(e.Object)
+	h.EnqueueRequestForOwner.Create(e, q)
+}
+
+// resolveControllerRef returns the controller referenced by a ControllerRef,
+// or nil if the ControllerRef could not be resolved to a matching controller
+// of the correct Kind.
+func (r *ReconcileClusterProvision) resolveControllerRef(namespace string, controllerRef *metav1.OwnerReference) *hivev1.ClusterProvision {
+	// We can't look up by UID, so look up by Name and then verify UID.
+	// Don't even try to look up by Name if it's the wrong Kind.
+	if controllerRef.Kind != controllerKind.Kind {
+		return nil
+	}
+	provision := &hivev1.ClusterProvision{}
+	if err := r.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: controllerRef.Name}, provision); err != nil {
+		return nil
+	}
+	if provision.UID != controllerRef.UID {
+		// The controller we found with this Name is not the same one that the
+		// ControllerRef points to.
+		return nil
+	}
+	return provision
+}
+
+// When a job is created, update the expectations of the clusterprovision that owns the job.
+func (r *ReconcileClusterProvision) trackJobAdd(obj interface{}) {
+	job := obj.(*batchv1.Job)
+	if job.DeletionTimestamp != nil {
+		// on a restart of the controller, it's possible a new object shows up in a state that
+		// is already pending deletion. Prevent the object from being a creation observation.
+		return
+	}
+
+	// If it has a ControllerRef, that's all that matters.
+	if controllerRef := metav1.GetControllerOf(job); controllerRef != nil {
+		provision := r.resolveControllerRef(job.Namespace, controllerRef)
+		if provision == nil {
+			return
+		}
+		provisionKey := types.NamespacedName{Namespace: provision.Namespace, Name: provision.Name}.String()
+		r.expectations.CreationObserved(provisionKey)
+	}
+}


### PR DESCRIPTION
Use expectations to ensure that clusterProvision controller does not create multiple overlapping install jobs.

There is currently a race condition where the controller will create a
second install job if the first install job has not been added
to the local cache by the time the clusterprovision is reconciled again
after creating the first install job. To prevent this, these changes
use expectations to block the controller from creating the second install job
unitl the controller sees that the first install job has been created.

When the clusterProvision controller creates an install job, the controller
will increase the number of creation expectations for the clusterprovision.
When the controller sees an add event for the job, the controller
will reduce the number of creation expectations for the clusterprovision.
During a reconcile loop, the controller will not look at jobs
while there are outstanding creation expectations for the clusterprovision
being reconciled.