### PR TITLE
Removing downloading of golangci-lint in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,6 @@ SRC_DIRS = pkg contrib
 GOFILES = $(shell find $(SRC_DIRS) -name '*.go' | grep -v bindata)
 VERIFY_IMPORTS_CONFIG = build/verify-imports/import-rules.yaml
 
-FIRST_GOPATH:=$(firstword $(subst :, ,$(shell go env GOPATH)))
-GOLANGCI_LINT_BIN=$(FIRST_GOPATH)/bin/golangci-lint
-GOLANGCI_LINT_VERSION=v1.17.1
-
 # To use docker build, specify BUILD_CMD="docker build"
 BUILD_CMD ?= imagebuilder
 
@@ -212,13 +208,8 @@ $(GOPATH)/bin/mockgen:
 clean:
 	rm -rf $(BINDIR)
 
-$(GOLANGCI_LINT_BIN):
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/$(GOLANGCI_LINT_VERSION)/install.sh \
-		| sed -e '/install -d/d' \
-| sh -s -- -b $(FIRST_GOPATH)/bin $(GOLANGCI_LINT_VERSION)
-
 # Run golangci-lint against code
 # TODO replace verify (except verify-generated), vet, fmt targets with lint as it covers all of it
 .PHONY: lint
-lint: $(GOLANGCI_LINT_BIN)
-	$(GOLANGCI_LINT_BIN) run -c ./golangci.yml ./pkg/... ./cmd/... ./contrib/...
+lint:
+	golangci-lint run -c ./golangci.yml ./pkg/... ./cmd/... ./contrib/...


### PR DESCRIPTION
Fixes https://jira.coreos.com/browse/CO-539

Can be merged after https://github.com/openshift/hive/pull/514 is merged. 