### PR TITLE
create dummy clusterprovision for legacy clusterdeployment

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -396,17 +396,14 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 			return reconcile.Result{}, nil
 		}
 		if cd.Status.Provision == nil {
-			existingProvisions, err := r.existingProvisions(cd, cdLog)
-			if err != nil {
-				return reconcile.Result{}, err
+			// TODO: Remove the code for creating a dummy clusterprovision once
+			// all legacy clusterdeployments have had clusterprovisions created
+			// for them.
+			if cd.Status.InfraID != "" {
+				cdLog.Info("cluster was created prior to clusterprovisions, creating dummy clusterprovision")
+				return r.createClusterProvisionForLegacyCD(cd, cdLog)
 			}
-			for _, provision := range existingProvisions {
-				if provision.Spec.Stage == hivev1.ClusterProvisionStageComplete {
-					return r.adoptProvision(cd, provision, cdLog)
-				}
-			}
-			cdLog.Warn("cluster is already installed, but provision could not be found")
-			return reconcile.Result{}, nil
+			return r.findAndAdoptRestoredClusterProvision(cd, cdLog)
 		}
 		return r.reconcileExistingProvision(cd, cdLog)
 	}
@@ -1390,6 +1387,92 @@ func (r *ReconcileClusterDeployment) cleanupInstallLogPVC(cd *hivev1.ClusterDepl
 	cdLog.WithField("pvc", pvc.Name).Debug("preserving logs PersistentVolumeClaim for cluster with install restarts for 7 days")
 	return nil
 
+}
+
+func (r *ReconcileClusterDeployment) createClusterProvisionForLegacyCD(cd *hivev1.ClusterDeployment, cdLog log.FieldLogger) (reconcile.Result, error) {
+	labels := cd.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[constants.ClusterDeploymentNameLabel] = cd.Name
+
+	provision := &hivev1.ClusterProvision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      apihelpers.GetResourceName(cd.Name, fmt.Sprintf("0-%s", utilrand.String(5))),
+			Namespace: cd.Namespace,
+			Labels:    labels,
+		},
+		Spec: hivev1.ClusterProvisionSpec{
+			ClusterDeployment: corev1.LocalObjectReference{
+				Name: cd.Name,
+			},
+			Stage:                 hivev1.ClusterProvisionStageComplete,
+			InfraID:               &cd.Status.InfraID,
+			ClusterID:             &cd.Status.ClusterID,
+			AdminKubeconfigSecret: &cd.Status.AdminKubeconfigSecret,
+			AdminPasswordSecret:   &cd.Status.AdminPasswordSecret,
+		},
+	}
+
+	logsConfigMap := &corev1.ConfigMap{}
+	switch err := r.Get(context.TODO(), types.NamespacedName{Namespace: cd.Namespace, Name: fmt.Sprintf("%s-install-log", cd.Name)}, logsConfigMap); {
+	case apierrors.IsNotFound(err):
+		cdLog.Warn("legacy installed clusterdeployment does not have corresponding logs configmap")
+	case err != nil:
+		cdLog.WithError(err).Error("failed to get logs configmap for legacy clusterdeployment")
+	default:
+		if log, ok := logsConfigMap.Data["log"]; ok {
+			provision.Spec.InstallLog = &log
+		} else {
+			cdLog.Warn("logs configmap for legacy clusterdeployment does not have a \"log\" data entry")
+		}
+	}
+
+	metadataConfigMap := &corev1.ConfigMap{}
+	switch err := r.Get(context.TODO(), types.NamespacedName{Namespace: cd.Namespace, Name: fmt.Sprintf("%s-metadata", cd.Name)}, metadataConfigMap); {
+	case apierrors.IsNotFound(err):
+		cdLog.Warn("legacy installed clusterdeployment does not have corresponding metadata configmap")
+	case err != nil:
+		cdLog.WithError(err).Error("failed to get metadata configmap for legacy clusterdeployment")
+	default:
+		if metadata, ok := metadataConfigMap.Data["metadata.json"]; ok {
+			provision.Spec.Metadata = &runtime.RawExtension{
+				Raw: []byte(metadata),
+			}
+		} else {
+			cdLog.Warn("metadata configmap for legacy clusterdeployment does not have a \"metadata.json\" data entry")
+		}
+	}
+
+	if err := controllerutil.SetControllerReference(cd, provision, r.scheme); err != nil {
+		cdLog.WithError(err).Error("could not set the owner ref on provision")
+		return reconcile.Result{}, err
+	}
+
+	r.expectations.ExpectCreations(types.NamespacedName{Namespace: cd.Namespace, Name: cd.Name}.String(), 1)
+	if err := r.Create(context.TODO(), provision); err != nil {
+		cdLog.WithError(err).Error("could not create provision")
+		r.expectations.CreationObserved(types.NamespacedName{Namespace: cd.Namespace, Name: cd.Name}.String())
+		return reconcile.Result{}, err
+	}
+
+	cdLog.WithField("provision", provision.Name).Info("dummy clusterprovision created")
+
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileClusterDeployment) findAndAdoptRestoredClusterProvision(cd *hivev1.ClusterDeployment, cdLog log.FieldLogger) (reconcile.Result, error) {
+	existingProvisions, err := r.existingProvisions(cd, cdLog)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	for _, provision := range existingProvisions {
+		if provision.Spec.Stage == hivev1.ClusterProvisionStageComplete {
+			return r.adoptProvision(cd, provision, cdLog)
+		}
+	}
+	cdLog.Warn("cluster is already installed, but provision could not be found")
+	return reconcile.Result{}, nil
 }
 
 func generateDeprovisionRequest(cd *hivev1.ClusterDeployment) *hivev1.ClusterDeprovisionRequest {

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -314,6 +314,8 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				func() *hivev1.ClusterDeployment {
 					cd := testClusterDeployment()
 					cd.Spec.Installed = true
+					installTime := metav1.Date(2019, 9, 6, 11, 58, 32, 45, time.UTC)
+					cd.Status.InstalledTimestamp = &installTime
 					cd.Status.AdminKubeconfigSecret = corev1.LocalObjectReference{Name: adminKubeconfigSecret}
 					return cd
 				}(),
@@ -769,10 +771,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 		{
 			name: "Do not adopt failed provision",
 			existing: []runtime.Object{
-				func() runtime.Object {
-					cd := testClusterDeployment()
-					return cd
-				}(),
+				testClusterDeployment(),
 				testSecret(corev1.SecretTypeDockerConfigJson, pullSecretSecret, corev1.DockerConfigJsonKey, "{}"),
 				testSecret(corev1.SecretTypeDockerConfigJson, constants.GetMergedPullSecretName(testClusterDeployment()), corev1.DockerConfigJsonKey, "{}"),
 				testSecret(corev1.SecretTypeOpaque, sshKeySecret, adminSSHKeySecretKey, "fakesshkey"),
@@ -913,6 +912,56 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				}
 				deprovision := getDeprovisionRequest(c)
 				assert.NotNil(t, deprovision, "missing deprovision request")
+			},
+		},
+		{
+			name: "Create dummy provision for legacy clusterdeployment",
+			existing: []runtime.Object{
+				func() runtime.Object {
+					cd := testClusterDeployment()
+					cd.Spec.Installed = true
+					cd.Status.InfraID = "test-infra-id"
+					cd.Status.ClusterID = "test-cluster-id"
+					cd.Status.AdminKubeconfigSecret = corev1.LocalObjectReference{Name: "test-kubeconfig"}
+					cd.Status.AdminPasswordSecret = corev1.LocalObjectReference{Name: "test-password"}
+					return cd
+				}(),
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo-lqmsh-install-log",
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						"log": "test-install-log",
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo-lqmsh-metadata",
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						"metadata.json": "\"test-metadata\"",
+					},
+				},
+			},
+			expectPendingCreation: true,
+			validate: func(c client.Client, t *testing.T) {
+				provisions := getProvisions(c)
+				if assert.Len(t, provisions, 1, "expected provision to exist") {
+					expectedSpec := hivev1.ClusterProvisionSpec{
+						ClusterDeployment:     corev1.LocalObjectReference{Name: testName},
+						Stage:                 hivev1.ClusterProvisionStageComplete,
+						InfraID:               pointer.StringPtr("test-infra-id"),
+						ClusterID:             pointer.StringPtr("test-cluster-id"),
+						InstallLog:            pointer.StringPtr("test-install-log"),
+						Metadata:              &runtime.RawExtension{Raw: []byte("\"test-metadata\"")},
+						AdminKubeconfigSecret: &corev1.LocalObjectReference{Name: "test-kubeconfig"},
+						AdminPasswordSecret:   &corev1.LocalObjectReference{Name: "test-password"},
+					}
+					assert.Equal(t, expectedSpec, provisions[0].Spec, "unexpected data in provision spec")
+					assert.True(t, metav1.IsControlledBy(provisions[0], getCD(c)), "expected provision to be owned by cd")
+				}
 			},
 		},
 	}


### PR DESCRIPTION
If a clusterdeployment was installed prior to the changes that brought clusterprovisions to be, then the clusterdeployment will not have a clusterprovision associated with it. This is not a problem for normal operation. However, if the clusterdeployment is backed up and restored, then the clusterdeployment will lose its infra ID and kubeconfig secret reference, since those are stored in the status. Normally, after a restore, these items--along with others--are copied back into the clusterdeployment from the clusterprovision. So, in order for the clusterdeployment to work after being restored, the controller needs to create a dummy clusterprovision for the clusterdeployment with the pertinent data to be restored.