### PR TITLE
create dummy clusterprovision for legacy clusterdeployment

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -395,20 +395,25 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 			r.cleanupInstallLogPVC(cd, cdLog)
 			return reconcile.Result{}, nil
 		}
-		if cd.Status.Provision == nil {
-			existingProvisions, err := r.existingProvisions(cd, cdLog)
-			if err != nil {
-				return reconcile.Result{}, err
-			}
-			for _, provision := range existingProvisions {
-				if provision.Spec.Stage == hivev1.ClusterProvisionStageComplete {
-					return r.adoptProvision(cd, provision, cdLog)
-				}
-			}
-			cdLog.Warn("cluster is already installed, but provision could not be found")
+		if cd.Status.Provision != nil {
+			return r.reconcileExistingProvision(cd, cdLog)
+		}
+		if !r.expectations.SatisfiedExpectations(request.String()) {
+			cdLog.Debug("waiting for expectations to be satisfied")
 			return reconcile.Result{}, nil
 		}
-		return r.reconcileExistingProvision(cd, cdLog)
+		switch adopted, err := r.findAndAdoptRestoredClusterProvision(cd, cdLog); {
+		case err != nil:
+			return reconcile.Result{}, err
+		case adopted:
+			return reconcile.Result{}, nil
+		case cd.Status.InfraID != "":
+			// TODO: Remove the code for creating a dummy clusterprovision once
+			// all legacy clusterdeployments have had clusterprovisions created
+			// for them.
+			cdLog.Info("cluster was created prior to clusterprovisions, creating dummy clusterprovision")
+			return r.createClusterProvisionForLegacyCD(cd, cdLog)
+		}
 	}
 
 	// Indicate that the cluster is still installing:
@@ -470,7 +475,7 @@ func (r *ReconcileClusterDeployment) startNewProvision(
 
 	for _, provision := range existingProvisions {
 		if provision.Spec.Stage != hivev1.ClusterProvisionStageFailed {
-			return r.adoptProvision(cd, provision, cdLog)
+			return reconcile.Result{}, r.adoptProvision(cd, provision, cdLog)
 		}
 	}
 
@@ -1407,6 +1412,92 @@ func (r *ReconcileClusterDeployment) cleanupInstallLogPVC(cd *hivev1.ClusterDepl
 
 }
 
+func (r *ReconcileClusterDeployment) createClusterProvisionForLegacyCD(cd *hivev1.ClusterDeployment, cdLog log.FieldLogger) (reconcile.Result, error) {
+	labels := cd.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[constants.ClusterDeploymentNameLabel] = cd.Name
+
+	provision := &hivev1.ClusterProvision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      apihelpers.GetResourceName(cd.Name, fmt.Sprintf("0-%s", utilrand.String(5))),
+			Namespace: cd.Namespace,
+			Labels:    labels,
+		},
+		Spec: hivev1.ClusterProvisionSpec{
+			ClusterDeployment: corev1.LocalObjectReference{
+				Name: cd.Name,
+			},
+			Stage:                 hivev1.ClusterProvisionStageComplete,
+			InfraID:               &cd.Status.InfraID,
+			ClusterID:             &cd.Status.ClusterID,
+			AdminKubeconfigSecret: &cd.Status.AdminKubeconfigSecret,
+			AdminPasswordSecret:   &cd.Status.AdminPasswordSecret,
+		},
+	}
+
+	logsConfigMap := &corev1.ConfigMap{}
+	switch err := r.Get(context.TODO(), types.NamespacedName{Namespace: cd.Namespace, Name: fmt.Sprintf("%s-install-log", cd.Name)}, logsConfigMap); {
+	case apierrors.IsNotFound(err):
+		cdLog.Warn("legacy installed clusterdeployment does not have corresponding logs configmap")
+	case err != nil:
+		cdLog.WithError(err).Error("failed to get logs configmap for legacy clusterdeployment")
+	default:
+		if log, ok := logsConfigMap.Data["log"]; ok {
+			provision.Spec.InstallLog = &log
+		} else {
+			cdLog.Warn("logs configmap for legacy clusterdeployment does not have a \"log\" data entry")
+		}
+	}
+
+	metadataConfigMap := &corev1.ConfigMap{}
+	switch err := r.Get(context.TODO(), types.NamespacedName{Namespace: cd.Namespace, Name: fmt.Sprintf("%s-metadata", cd.Name)}, metadataConfigMap); {
+	case apierrors.IsNotFound(err):
+		cdLog.Warn("legacy installed clusterdeployment does not have corresponding metadata configmap")
+	case err != nil:
+		cdLog.WithError(err).Error("failed to get metadata configmap for legacy clusterdeployment")
+	default:
+		if metadata, ok := metadataConfigMap.Data["metadata.json"]; ok {
+			provision.Spec.Metadata = &runtime.RawExtension{
+				Raw: []byte(metadata),
+			}
+		} else {
+			cdLog.Warn("metadata configmap for legacy clusterdeployment does not have a \"metadata.json\" data entry")
+		}
+	}
+
+	if err := controllerutil.SetControllerReference(cd, provision, r.scheme); err != nil {
+		cdLog.WithError(err).Error("could not set the owner ref on provision")
+		return reconcile.Result{}, err
+	}
+
+	r.expectations.ExpectCreations(types.NamespacedName{Namespace: cd.Namespace, Name: cd.Name}.String(), 1)
+	if err := r.Create(context.TODO(), provision); err != nil {
+		cdLog.WithError(err).Error("could not create provision")
+		r.expectations.CreationObserved(types.NamespacedName{Namespace: cd.Namespace, Name: cd.Name}.String())
+		return reconcile.Result{}, err
+	}
+
+	cdLog.WithField("provision", provision.Name).Info("dummy clusterprovision created")
+
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileClusterDeployment) findAndAdoptRestoredClusterProvision(cd *hivev1.ClusterDeployment, cdLog log.FieldLogger) (bool, error) {
+	existingProvisions, err := r.existingProvisions(cd, cdLog)
+	if err != nil {
+		return false, err
+	}
+	for _, provision := range existingProvisions {
+		if provision.Spec.Stage == hivev1.ClusterProvisionStageComplete {
+			return true, r.adoptProvision(cd, provision, cdLog)
+		}
+	}
+	cdLog.Warn("cluster is already installed, but provision could not be found")
+	return false, nil
+}
+
 func generateDeprovisionRequest(cd *hivev1.ClusterDeployment) *hivev1.ClusterDeprovisionRequest {
 	req := &hivev1.ClusterDeprovisionRequest{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1630,15 +1721,15 @@ func (r *ReconcileClusterDeployment) getFirstProvision(cd *hivev1.ClusterDeploym
 	return nil
 }
 
-func (r *ReconcileClusterDeployment) adoptProvision(cd *hivev1.ClusterDeployment, provision *hivev1.ClusterProvision, cdLog log.FieldLogger) (reconcile.Result, error) {
+func (r *ReconcileClusterDeployment) adoptProvision(cd *hivev1.ClusterDeployment, provision *hivev1.ClusterProvision, cdLog log.FieldLogger) error {
 	pLog := cdLog.WithField("provision", provision.Name)
 	cd.Status.Provision = &corev1.LocalObjectReference{Name: provision.Name}
 	if err := r.Status().Update(context.TODO(), cd); err != nil {
 		pLog.WithError(err).Error("could not adopt provision")
-		return reconcile.Result{}, err
+		return err
 	}
 	pLog.Info("adopted provision")
-	return reconcile.Result{}, nil
+	return nil
 }
 
 func (r *ReconcileClusterDeployment) deleteStaleProvisions(provs []*hivev1.ClusterProvision, cdLog log.FieldLogger) {

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -315,6 +315,8 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				func() *hivev1.ClusterDeployment {
 					cd := testClusterDeployment()
 					cd.Spec.Installed = true
+					installTime := metav1.Date(2019, 9, 6, 11, 58, 32, 45, time.UTC)
+					cd.Status.InstalledTimestamp = &installTime
 					cd.Status.AdminKubeconfigSecret = corev1.LocalObjectReference{Name: adminKubeconfigSecret}
 					return cd
 				}(),
@@ -832,10 +834,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 		{
 			name: "Do not adopt failed provision",
 			existing: []runtime.Object{
-				func() runtime.Object {
-					cd := testClusterDeployment()
-					return cd
-				}(),
+				testClusterDeployment(),
 				testSecret(corev1.SecretTypeDockerConfigJson, pullSecretSecret, corev1.DockerConfigJsonKey, "{}"),
 				testSecret(corev1.SecretTypeDockerConfigJson, constants.GetMergedPullSecretName(testClusterDeployment()), corev1.DockerConfigJsonKey, "{}"),
 				testSecret(corev1.SecretTypeOpaque, sshKeySecret, adminSSHKeySecretKey, "fakesshkey"),
@@ -976,6 +975,95 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				}
 				deprovision := getDeprovisionRequest(c)
 				assert.NotNil(t, deprovision, "missing deprovision request")
+			},
+		},
+		{
+			name: "Create dummy provision for legacy clusterdeployment",
+			existing: []runtime.Object{
+				func() runtime.Object {
+					cd := testClusterDeployment()
+					cd.Spec.Installed = true
+					cd.Status.InfraID = "test-infra-id"
+					cd.Status.ClusterID = "test-cluster-id"
+					cd.Status.AdminKubeconfigSecret = corev1.LocalObjectReference{Name: "test-kubeconfig"}
+					cd.Status.AdminPasswordSecret = corev1.LocalObjectReference{Name: "test-password"}
+					return cd
+				}(),
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo-lqmsh-install-log",
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						"log": "test-install-log",
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo-lqmsh-metadata",
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						"metadata.json": "\"test-metadata\"",
+					},
+				},
+			},
+			expectPendingCreation: true,
+			validate: func(c client.Client, t *testing.T) {
+				provisions := getProvisions(c)
+				if assert.Len(t, provisions, 1, "expected provision to exist") {
+					expectedSpec := hivev1.ClusterProvisionSpec{
+						ClusterDeployment:     corev1.LocalObjectReference{Name: testName},
+						Stage:                 hivev1.ClusterProvisionStageComplete,
+						InfraID:               pointer.StringPtr("test-infra-id"),
+						ClusterID:             pointer.StringPtr("test-cluster-id"),
+						InstallLog:            pointer.StringPtr("test-install-log"),
+						Metadata:              &runtime.RawExtension{Raw: []byte("\"test-metadata\"")},
+						AdminKubeconfigSecret: &corev1.LocalObjectReference{Name: "test-kubeconfig"},
+						AdminPasswordSecret:   &corev1.LocalObjectReference{Name: "test-password"},
+					}
+					assert.Equal(t, expectedSpec, provisions[0].Spec, "unexpected data in provision spec")
+					assert.True(t, metav1.IsControlledBy(provisions[0], getCD(c)), "expected provision to be owned by cd")
+				}
+			},
+		},
+		{
+			name: "Adopt dummy provision for legacy clusterdeployment",
+			existing: []runtime.Object{
+				func() runtime.Object {
+					cd := testClusterDeployment()
+					cd.Spec.Installed = true
+					cd.Status.InfraID = testInfraID
+					return cd
+				}(),
+				testSuccessfulProvision(),
+			},
+			validate: func(c client.Client, t *testing.T) {
+				cd := getCD(c)
+				if assert.NotNil(t, cd, "missing cluster deployment") {
+					if assert.NotNil(t, cd.Status.Provision, "expected reference to provision") {
+						assert.Equal(t, provisionName, cd.Status.Provision.Name, "unexpected name in provision reference")
+					}
+				}
+				provisions := getProvisions(c)
+				assert.Len(t, provisions, 1, "unexpected number of provisions")
+			},
+		},
+		{
+			name: "Dummy provision not created when pending create",
+			existing: []runtime.Object{
+				func() runtime.Object {
+					cd := testClusterDeployment()
+					cd.Spec.Installed = true
+					cd.Status.InfraID = testInfraID
+					return cd
+				}(),
+			},
+			pendingCreation:       true,
+			expectPendingCreation: true,
+			validate: func(c client.Client, t *testing.T) {
+				provisions := getProvisions(c)
+				assert.Empty(t, provisions, "expected provision to not exist")
 			},
 		},
 		{


### PR DESCRIPTION
Redo of https://github.com/openshift/hive/pull/533 with a fix for the hot loop creating. The clusterDeployment controller will attempt to adopt an existing provision prior to creating a dummy provision. The controller will also use expectations to protect against creating a second clusterprovision in the interregnum between creation of the first and fetching of it from the API server.

---
If a clusterdeployment was installed prior to the changes that brought
clusterprovisions to be, then the clusterdeployment will not have a
clusterprovision associated with it. This is not a problem for normal
operation. However, if the clusterdeployment is backed up and restored,
then the clusterdeployment will lose its infra ID and kubeconfig
secret reference, since those are stored in the status. Normally,
after a restore, these items--along with others--are copied back into
the clusterdeployment from the clusterprovision. So, in order for the
clusterdeployment to work after being restored, the controller needs
to create a dummy clusterprovision for the clusterdeployment with
the pertinent data to be restored.