### PR TITLE
vendor: Bump installer to destroy untagged subnets

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -678,7 +678,7 @@
   version = "v1.14.0"
 
 [[projects]]
-  digest = "1:2df7f3427c2bd044b207d209484a897e583152cd2d2b18b052b392528b484267"
+  digest = "1:9a534a24bb6e27a51fb71d7dac2602bd8660c98b6321090dd37adeb7fbc7442a"
   name = "github.com/openshift/installer"
   packages = [
     "pkg/asset/installconfig/aws",
@@ -699,7 +699,7 @@
     "pkg/version",
   ]
   pruneopts = "NUT"
-  revision = "ae2baf820f22b9bf1ed40932e7b702d790087574"
+  revision = "6fdffbb9c21d90ba97fc79dff3ccbeac22fb2a0e"
 
 [[projects]]
   branch = "master"
@@ -1889,6 +1889,7 @@
     "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/runtime/serializer/json",
     "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/clock",
     "k8s.io/apimachinery/pkg/util/diff",
     "k8s.io/apimachinery/pkg/util/errors",
     "k8s.io/apimachinery/pkg/util/rand",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -102,7 +102,7 @@ version="v1.4.7"
 
 [[constraint]]
   name = "github.com/openshift/installer"
-  revision = "ae2baf820f22b9bf1ed40932e7b702d790087574"
+  revision = "6fdffbb9c21d90ba97fc79dff3ccbeac22fb2a0e"
 
 [[constraint]]
   name = "github.com/openshift/generic-admission-server"

--- a/vendor/github.com/openshift/installer/pkg/asset/installconfig/aws/permissions.go
+++ b/vendor/github.com/openshift/installer/pkg/asset/installconfig/aws/permissions.go
@@ -26,6 +26,7 @@ var installPermissions = []string{
 	"ec2:CreateDhcpOptions",
 	"ec2:CreateInternetGateway",
 	"ec2:CreateNatGateway",
+	"ec2:CreateNetworkInterface",
 	"ec2:CreateRoute",
 	"ec2:CreateRouteTable",
 	"ec2:CreateSecurityGroup",

--- a/vendor/github.com/openshift/installer/pkg/types/aws/machinepool.go
+++ b/vendor/github.com/openshift/installer/pkg/types/aws/machinepool.go
@@ -10,7 +10,7 @@ type MachinePool struct {
 	// eg. m4-large
 	InstanceType string `json:"type"`
 
-	// EC2RootVolume defines the storage for ec2 instance.
+	// EC2RootVolume defines the root volume for EC2 instances in the machine pool.
 	EC2RootVolume `json:"rootVolume"`
 }
 
@@ -41,10 +41,11 @@ func (a *MachinePool) Set(required *MachinePool) {
 
 // EC2RootVolume defines the storage for an ec2 instance.
 type EC2RootVolume struct {
-	// IOPS defines the iops for the storage.
+	// IOPS defines the amount of provisioned IOPS. This is only valid
+	// for type io1.
 	IOPS int `json:"iops"`
-	// Size defines the size of the storage.
+	// Size defines the size of the volume in gibibytes (GiB).
 	Size int `json:"size"`
-	// Type defines the type of the storage.
+	// Type defines the type of the volume.
 	Type string `json:"type"`
 }

--- a/vendor/github.com/openshift/installer/pkg/types/aws/platform.go
+++ b/vendor/github.com/openshift/installer/pkg/types/aws/platform.go
@@ -10,7 +10,9 @@ type Platform struct {
 	// Region specifies the AWS region where the cluster will be created.
 	Region string `json:"region"`
 
-	// UserTags specifies additional tags for AWS resources created for the cluster.
+	// UserTags additional keys and values that the installer will add
+	// as tags to all resources that it creates. Resources created by the
+	// cluster itself may not include these tags.
 	// +optional
 	UserTags map[string]string `json:"userTags,omitempty"`
 

--- a/vendor/github.com/openshift/installer/pkg/types/azure/platform.go
+++ b/vendor/github.com/openshift/installer/pkg/types/azure/platform.go
@@ -8,7 +8,7 @@ type Platform struct {
 	// Region specifies the Azure region where the cluster will be created.
 	Region string `json:"region"`
 
-	// BaseDomainResourceGroupName specifies the resource group where the azure DNS zone for the base domain is found
+	// BaseDomainResourceGroupName specifies the resource group where the Azure DNS zone for the base domain is found.
 	BaseDomainResourceGroupName string `json:"baseDomainResourceGroupName,omitempty"`
 	// DefaultMachinePlatform is the default configuration used when
 	// installing on Azure for machine pools which do not define their own

--- a/vendor/github.com/openshift/installer/pkg/types/installconfig.go
+++ b/vendor/github.com/openshift/installer/pkg/types/installconfig.go
@@ -54,14 +54,15 @@ type InstallConfig struct {
 	// +optional
 	AdditionalTrustBundle string `json:"additionalTrustBundle,omitempty"`
 
-	// SSHKey is the public ssh key to provide access to instances.
+	// SSHKey is the public Secure Shell (SSH) key to provide access to instances.
 	// +optional
 	SSHKey string `json:"sshKey,omitempty"`
 
 	// BaseDomain is the base domain to which the cluster should belong.
 	BaseDomain string `json:"baseDomain"`
 
-	// Networking defines the pod network provider in the cluster.
+	// Networking is the configuration for the pod network provider in
+	// the cluster.
 	*Networking `json:"networking,omitempty"`
 
 	// ControlPlane is the configuration for the machines that comprise the
@@ -69,7 +70,8 @@ type InstallConfig struct {
 	// +optional
 	ControlPlane *MachinePool `json:"controlPlane,omitempty"`
 
-	// Compute is the list of compute MachinePools that need to be installed.
+	// Compute is the configuration for the machines that comprise the
+	// compute nodes.
 	// +optional
 	Compute []MachinePool `json:"compute,omitempty"`
 
@@ -86,6 +88,7 @@ type InstallConfig struct {
 	Proxy *Proxy `json:"proxy,omitempty"`
 
 	// ImageContentSources lists sources/repositories for the release-image content.
+	// +optional
 	ImageContentSources []ImageContentSource `json:"imageContentSources,omitempty"`
 }
 
@@ -160,10 +163,10 @@ func (p *Platform) Name() string {
 
 // Networking defines the pod network provider in the cluster.
 type Networking struct {
-	// MachineCIDR is the IP address space from which to assign machine IPs.
+	// MachineCIDR is the IP address pool for machines.
 	// +optional
-	// Default is 10.0.0.0/16 for all platforms other than Libvirt.
-	// For Libvirt, the default is 192.168.126.0/24.
+	// Default is 10.0.0.0/16 for all platforms other than libvirt.
+	// For libvirt, the default is 192.168.126.0/24.
 	MachineCIDR *ipnet.IPNet `json:"machineCIDR,omitempty"`
 
 	// NetworkType is the type of network to install.
@@ -171,14 +174,14 @@ type Networking struct {
 	// Default is OpenShiftSDN.
 	NetworkType string `json:"networkType,omitempty"`
 
-	// ClusterNetwork is the IP address pool to use for pod IPs.
+	// ClusterNetwork is the IP address pool for pods.
 	// +optional
-	// Default is 10.128.0.0/14 and a host prefix of /23
+	// Default is 10.128.0.0/14 and a host prefix of /23.
 	ClusterNetwork []ClusterNetworkEntry `json:"clusterNetwork,omitempty"`
 
-	// ServiceNetwork is the IP address pool to use for service IPs.
+	// ServiceNetwork is the IP address pool for services.
 	// +optional
-	// Default is 172.30.0.0/16
+	// Default is 172.30.0.0/16.
 	// NOTE: currently only one entry is supported.
 	ServiceNetwork []ipnet.IPNet `json:"serviceNetwork,omitempty"`
 
@@ -200,7 +203,7 @@ type Networking struct {
 // ClusterNetworkEntry is a single IP address block for pod IP blocks. IP blocks
 // are allocated with size 2^HostSubnetLength.
 type ClusterNetworkEntry struct {
-	// The IP block address pool
+	// CIDR is the IP block address pool.
 	CIDR ipnet.IPNet `json:"cidr"`
 
 	// HostPrefix is the prefix size to allocate to each node from the CIDR.

--- a/vendor/github.com/openshift/installer/pkg/types/machinepools.go
+++ b/vendor/github.com/openshift/installer/pkg/types/machinepools.go
@@ -27,13 +27,13 @@ type MachinePool struct {
 	// For the compute machine pools, the only valid name is "worker".
 	Name string `json:"name"`
 
-	// Replicas is the count of machines for this machine pool.
+	// Replicas is the machine count for the machine pool.
 	Replicas *int64 `json:"replicas,omitempty"`
 
 	// Platform is configuration for machine pool specific to the platform.
 	Platform MachinePoolPlatform `json:"platform"`
 
-	// Hyperthreading determines the mode of hyperthreading that machines in this
+	// Hyperthreading determines the mode of hyperthreading that machines in the
 	// pool will utilize.
 	// +optional
 	// Default is for hyperthreading to be enabled.


### PR DESCRIPTION
... and security groups.  Pulling in openshift/installer@55630a304 (openshift/installer#2214).

Generated with:

```console
$ sed -i 's/ae2baf820f22b9bf1ed40932e7b702d790087574/6fdffbb9c21d90ba97fc79dff3ccbeac22fb2a0e/' Gopkg.toml
$ dep ensure
```

The k8s.io/apimachinery/pkg/util/clock addition in Gopkg.lock is probably catching up with c759bfa2d2 (#518).