### PR TITLE
Prevent crash on compute MachinePool with no platform.

### DIFF
--- a/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook.go
@@ -257,6 +257,12 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateCreate(admissionSpec 
 		if aws.Region == "" {
 			allErrs = append(allErrs, field.Required(awsPath.Child("region"), "must specify AWS region"))
 		}
+		for i, mp := range newObject.Spec.Compute {
+			computePath := specPath.Child("compute").Index(i)
+			if mp.Platform.AWS == nil {
+				allErrs = append(allErrs, field.Required(computePath.Child("aws"), "must specify platform for compute machine sets"))
+			}
+		}
 	}
 	if newObject.Spec.Platform.Azure != nil {
 		numberOfPlatforms++
@@ -270,6 +276,12 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateCreate(admissionSpec 
 		}
 		if azure.BaseDomainResourceGroupName == "" {
 			allErrs = append(allErrs, field.Required(azurePath.Child("baseDomainResourceGroupName"), "must specify the Azure resource group for the base domain"))
+		}
+		for i, mp := range newObject.Spec.Compute {
+			computePath := specPath.Child("compute").Index(i)
+			if mp.Platform.Azure == nil {
+				allErrs = append(allErrs, field.Required(computePath.Child("azure"), "must specify platform for compute machine sets"))
+			}
 		}
 	}
 	if newObject.Spec.Platform.GCP != nil {
@@ -285,6 +297,15 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateCreate(admissionSpec 
 		if gcp.Region == "" {
 			allErrs = append(allErrs, field.Required(gcpPath.Child("region"), "must specify GCP region"))
 		}
+		// TODO: Uncomment once ready for GCP
+		/*
+			for i, mp := range newObject.Spec.Compute {
+				computePath := specPath.Child("compute").Index(i)
+				if mp.Platform.GCP == nil {
+					allErrs = append(allErrs, field.Required(computePath.Child("gcp"), "must specify platform for compute machine sets"))
+				}
+			}
+		*/
 	}
 	switch {
 	case numberOfPlatforms == 0:

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
@@ -53,6 +53,9 @@ func validAWSClusterDeployment() *hivev1.ClusterDeployment {
 			Compute: []hivev1.MachinePool{
 				{
 					Name: "SameMachinePoolName",
+					Platform: hivev1.MachinePoolPlatform{
+						AWS: &hivev1aws.MachinePoolPlatform{},
+					},
 				},
 			},
 			SSHKey: corev1.LocalObjectReference{
@@ -78,6 +81,9 @@ func validAzureClusterDeployment() *hivev1.ClusterDeployment {
 			Compute: []hivev1.MachinePool{
 				{
 					Name: "SameMachinePoolName",
+					Platform: hivev1.MachinePoolPlatform{
+						Azure: &hivev1azure.MachinePool{},
+					},
 				},
 			},
 			SSHKey: corev1.LocalObjectReference{
@@ -449,6 +455,16 @@ func TestClusterDeploymentValidate(t *testing.T) {
 			expectedAllowed: false,
 		},
 		{
+			name: "AWS create missing machine pool platform",
+			newObject: func() *hivev1.ClusterDeployment {
+				cd := validAWSClusterDeployment()
+				cd.Spec.Compute[0].Platform.AWS = nil
+				return cd
+			}(),
+			operation:       admissionv1beta1.Create,
+			expectedAllowed: false,
+		},
+		{
 			name:            "Azure create valid",
 			newObject:       validAzureClusterDeployment(),
 			operation:       admissionv1beta1.Create,
@@ -469,6 +485,16 @@ func TestClusterDeploymentValidate(t *testing.T) {
 			newObject: func() *hivev1.ClusterDeployment {
 				cd := validAzureClusterDeployment()
 				cd.Spec.PlatformSecrets.Azure = nil
+				return cd
+			}(),
+			operation:       admissionv1beta1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "Azure create missing machine pool platform",
+			newObject: func() *hivev1.ClusterDeployment {
+				cd := validAzureClusterDeployment()
+				cd.Spec.Compute[0].Platform.Azure = nil
 				return cd
 			}(),
 			operation:       admissionv1beta1.Create,

--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -346,6 +346,11 @@ func (r *ReconcileRemoteMachineSet) generateMachineSetsFromClusterDeployment(cd 
 	switch ic.Platform.Name() {
 	case "aws":
 		for _, workerPool := range workerPools {
+			// Validation should catch this now but just in-case, do not crash:
+			if workerPool.Platform.AWS == nil {
+				return nil, fmt.Errorf("workpool %s has no platform", workerPool.Name)
+			}
+
 			if len(workerPool.Platform.AWS.Zones) == 0 {
 				awsClient, err := r.getAWSClient(cd)
 				if err != nil {

--- a/pkg/controller/remotemachineset/remotemachineset_controller_test.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller_test.go
@@ -314,7 +314,7 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 		},
 		{
 			// Can't control what a user might do in their cluster.
-			name: "Nil ProviderSpec",
+			name: "Nil ProviderSpec in remote MachineSet",
 			localExisting: []runtime.Object{
 				testClusterDeployment([]hivev1.MachinePool{
 					testMachinePool("worker", 3, []string{}),
@@ -329,6 +329,27 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 					ms.Spec.Template.Spec.ProviderSpec.Value = nil
 					return ms
 				}(),
+			},
+			expectErr: true,
+		},
+		{
+			name: "Nil worker pool platform",
+			localExisting: []runtime.Object{
+				testClusterDeployment([]hivev1.MachinePool{
+					func() hivev1.MachinePool {
+						mp := testMachinePool("worker", 3, []string{})
+						mp.Platform.AWS = nil
+						return mp
+					}(),
+				}),
+				testSecret(adminKubeconfigSecret, adminKubeconfigSecretKey, testName),
+				testSecret(adminPasswordSecret, adminPasswordSecretKey, testName),
+				testSecret(sshKeySecret, sshKeySecretKey, testName),
+			},
+			remoteExisting: []runtime.Object{
+				testMachineSet("foo-12345-worker-us-east-1a", "worker", true, 1, 0),
+				testMachineSet("foo-12345-worker-us-east-1b", "worker", true, 1, 0),
+				testMachineSet("foo-12345-worker-us-east-1c", "worker", true, 1, 0),
 			},
 			expectErr: true,
 		},


### PR DESCRIPTION
Implemented via validation, as well as a safety check in the
remotemachineset_controller at the point we were hitting the nil
pointer.