### PR TITLE
add missing conversion for non-aws machine pool platforms

### DIFF
--- a/config/crds/hive_v1alpha1_clusterdeployment.yaml
+++ b/config/crds/hive_v1alpha1_clusterdeployment.yaml
@@ -158,6 +158,21 @@ spec:
                               type: string
                             type: array
                         type: object
+                      gcp:
+                        description: GCP is the configuration used when installing
+                          on GCP.
+                        properties:
+                          type:
+                            description: InstanceType defines the GCP instance type.
+                              eg. n1-standard-4
+                            type: string
+                          zones:
+                            description: Zones is list of availability zones that
+                              can be used.
+                            items:
+                              type: string
+                            type: array
+                        type: object
                     type: object
                   replicas:
                     description: Replicas is the count of machines for this machine
@@ -239,6 +254,21 @@ spec:
                         zones:
                           description: Zones is list of availability zones that can
                             be used. eg. ["1", "2", "3"]
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    gcp:
+                      description: GCP is the configuration used when installing on
+                        GCP.
+                      properties:
+                        type:
+                          description: InstanceType defines the GCP instance type.
+                            eg. n1-standard-4
+                          type: string
+                        zones:
+                          description: Zones is list of availability zones that can
+                            be used.
                           items:
                             type: string
                           type: array

--- a/pkg/apis/hive/v1alpha1/machinepools.go
+++ b/pkg/apis/hive/v1alpha1/machinepools.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"github.com/openshift/hive/pkg/apis/hive/v1alpha1/aws"
 	"github.com/openshift/hive/pkg/apis/hive/v1alpha1/azure"
+	"github.com/openshift/hive/pkg/apis/hive/v1alpha1/gcp"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -37,4 +38,6 @@ type MachinePoolPlatform struct {
 	AWS *aws.MachinePoolPlatform `json:"aws,omitempty"`
 	// Azure is the configuration used when installing on Azure.
 	Azure *azure.MachinePool `json:"azure,omitempty"`
+	// GCP is the configuration used when installing on GCP.
+	GCP *gcp.MachinePool `json:"gcp,omitempty"`
 }

--- a/pkg/apis/hive/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/hive/v1alpha1/zz_generated.deepcopy.go
@@ -1616,6 +1616,11 @@ func (in *MachinePoolPlatform) DeepCopyInto(out *MachinePoolPlatform) {
 		*out = new(azure.MachinePool)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.GCP != nil {
+		in, out := &in.GCP, &out.GCP
+		*out = new(gcp.MachinePool)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/install/convertconfig.go
+++ b/pkg/install/convertconfig.go
@@ -102,7 +102,9 @@ func convertMachinePools(pools ...hivev1.MachinePool) []types.MachinePool {
 
 func convertMachinePoolPlatform(p *hivev1.MachinePoolPlatform) *types.MachinePoolPlatform {
 	return &types.MachinePoolPlatform{
-		AWS: convertAWSMachinePool(p.AWS),
+		AWS:   convertAWSMachinePool(p.AWS),
+		Azure: convertAzureMachinePool(p.Azure),
+		GCP:   convertGCPMachinePool(p.GCP),
 	}
 }
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1758,6 +1758,21 @@ spec:
                               type: string
                             type: array
                         type: object
+                      gcp:
+                        description: GCP is the configuration used when installing
+                          on GCP.
+                        properties:
+                          type:
+                            description: InstanceType defines the GCP instance type.
+                              eg. n1-standard-4
+                            type: string
+                          zones:
+                            description: Zones is list of availability zones that
+                              can be used.
+                            items:
+                              type: string
+                            type: array
+                        type: object
                     type: object
                   replicas:
                     description: Replicas is the count of machines for this machine
@@ -1839,6 +1854,21 @@ spec:
                         zones:
                           description: Zones is list of availability zones that can
                             be used. eg. ["1", "2", "3"]
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    gcp:
+                      description: GCP is the configuration used when installing on
+                        GCP.
+                      properties:
+                        type:
+                          description: InstanceType defines the GCP instance type.
+                            eg. n1-standard-4
+                          type: string
+                        zones:
+                          description: Zones is list of availability zones that can
+                            be used.
                           items:
                             type: string
                           type: array


### PR DESCRIPTION
The azure and gcp platform-specific machine pool information was not being converted into the install config.