### PR TITLE
Fixing golangci-lint cache permission issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ else # Other distros like RHEL 7 and CentOS 7 currently need sudo.
 	SUDO_CMD = sudo
 endif
 
+# set the cache directory to an accessible location
+ifeq ($(XDG_CACHE_HOME),)
+	export XDG_CACHE_HOME:=/tmp
+endif
+
 .PHONY: default
 default: all
 
@@ -208,5 +213,4 @@ clean:
 # TODO: reenable once the CI permission denied on /.cache is fixed.
 .PHONY: lint
 lint:
-	echo "TODO: make lint target disabled due to CI issues"
-	#golangci-lint run -c ./golangci.yml ./pkg/... ./cmd/... ./contrib/...
+	golangci-lint run -c ./golangci.yml ./pkg/... ./cmd/... ./contrib/...


### PR DESCRIPTION
It seems like an issue when go code running in container as non-root user, and the user does not exist in the container. Go by default disables the cache. It seems we will need to set GOCACHE explicitly when running a build as a nonexistent user (in our case it is root I think) [1] . Not sure what user ID we are expected to use in the CI system.

As per [2] $XDG_CACHE_HOME defines the base directory relative to which user specific non-essential data files should be stored. If $XDG_CACHE_HOME is either not set or empty, a default equal to $HOME/.cache should be used.

The idea is to set it to a location where the go program (in this case golangci-lint) have write access.

[1] golang/go#26280
[2] https://specifications.freedesktop.org/basedir-spec/0.6/ar01s03.html

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>