### PR TITLE
Add rate limiting to Velero backup controller

### DIFF
--- a/config/crds/hive_v1alpha1_hiveconfig.yaml
+++ b/config/crds/hive_v1alpha1_hiveconfig.yaml
@@ -43,6 +43,15 @@ spec:
               description: Backup specifies configuration for backup integration.
                 If absent, backup integration will be disabled.
               properties:
+                minBackupPeriodSeconds:
+                  description: MinBackupPeriodSeconds specifies that a minimum of
+                    MinBackupPeriodSeconds will occur in between each backup. This
+                    is used to rate limit backups. This potentially batches together
+                    multiple changes into 1 backup. No backups will be lost as changes
+                    that happen during this interval are queued up and will result
+                    in a backup happening once the interval has been completed.
+                  format: int64
+                  type: integer
                 velero:
                   description: Velero specifies configuration for the Velero backup
                     integration.

--- a/pkg/apis/hive/v1alpha1/hiveconfig_types.go
+++ b/pkg/apis/hive/v1alpha1/hiveconfig_types.go
@@ -54,6 +54,13 @@ type BackupConfig struct {
 	// Velero specifies configuration for the Velero backup integration.
 	// +optional
 	Velero VeleroBackupConfig `json:"velero,omitempty"`
+
+	// MinBackupPeriodSeconds specifies that a minimum of MinBackupPeriodSeconds will occur in between each backup.
+	// This is used to rate limit backups. This potentially batches together multiple changes into 1 backup.
+	// No backups will be lost as changes that happen during this interval are queued up and will result in a
+	// backup happening once the interval has been completed.
+	// +optional
+	MinBackupPeriodSeconds *int `json:"minBackupPeriodSeconds,omitempty"`
 }
 
 // VeleroBackupConfig contains settings for the Velero backup integration.

--- a/pkg/apis/hive/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/hive/v1alpha1/zz_generated.deepcopy.go
@@ -120,6 +120,11 @@ func (in *AzureClusterDeprovisionRequest) DeepCopy() *AzureClusterDeprovisionReq
 func (in *BackupConfig) DeepCopyInto(out *BackupConfig) {
 	*out = *in
 	out.Velero = in.Velero
+	if in.MinBackupPeriodSeconds != nil {
+		in, out := &in.MinBackupPeriodSeconds, &out.MinBackupPeriodSeconds
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 
@@ -1498,7 +1503,7 @@ func (in *HiveConfigSpec) DeepCopyInto(out *HiveConfigSpec) {
 		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}
-	out.Backup = in.Backup
+	in.Backup.DeepCopyInto(&out.Backup)
 	out.FailedProvisionConfig = in.FailedProvisionConfig
 	return
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -11,6 +11,9 @@ const (
 	// VeleroBackupEnvVar is the name of the environment variable used to tell the controller manager to enable velero backup integration.
 	VeleroBackupEnvVar = "HIVE_VELERO_BACKUP"
 
+	// MinBackupPeriodSecondsEnvVar is the name of the environment variable used to tell the controller manager the minimum period of time between backups.
+	MinBackupPeriodSecondsEnvVar = "HIVE_MIN_BACKUP_PERIOD_SECONDS"
+
 	// SkipGatherLogsEnvVar is the environment variable which passes the configuration to disable
 	// log gathering on failed cluster installs. The value will be either "true" or "false".
 	// If unset "false" should be assumed. This variable is set by the operator depending on the

--- a/pkg/controller/velerobackup/helpers_test.go
+++ b/pkg/controller/velerobackup/helpers_test.go
@@ -3,6 +3,7 @@ package velerobackup
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
@@ -29,6 +30,10 @@ const (
 )
 
 var (
+	twoMinutesAgo     = metav1.NewTime(time.Now().Add(-twoMinuteDuration))
+	fiveHoursAgo      = metav1.NewTime(time.Now().Add(-5 * time.Hour))
+	twoMinuteDuration = 2 * time.Minute
+
 	statusErr = &kerrors.StatusError{
 		ErrStatus: metav1.Status{},
 	}
@@ -114,9 +119,10 @@ func clusterDeploymentBase() testclusterdeployment.Option {
 
 func fakeClientReconcileBackup(existingObjects []runtime.Object) *ReconcileBackup {
 	return &ReconcileBackup{
-		Client: fake.NewFakeClient(existingObjects...),
-		scheme: scheme.Scheme,
-		logger: log.WithField("controller", controllerName),
+		Client:                     fake.NewFakeClient(existingObjects...),
+		scheme:                     scheme.Scheme,
+		reconcileRateLimitDuration: defaultReconcileRateLimitDuration,
+		logger:                     log.WithField("controller", controllerName),
 	}
 }
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -3206,6 +3206,15 @@ spec:
               description: Backup specifies configuration for backup integration.
                 If absent, backup integration will be disabled.
               properties:
+                minBackupPeriodSeconds:
+                  description: MinBackupPeriodSeconds specifies that a minimum of
+                    MinBackupPeriodSeconds will occur in between each backup. This
+                    is used to rate limit backups. This potentially batches together
+                    multiple changes into 1 backup. No backups will be lost as changes
+                    that happen during this interval are queued up and will result
+                    in a backup happening once the interval has been completed.
+                  format: int64
+                  type: integer
                 velero:
                   description: Velero specifies configuration for the Velero backup
                     integration.

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -90,6 +90,15 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helpe
 		hiveDeployment.Spec.Template.Spec.Containers[0].Env = append(hiveDeployment.Spec.Template.Spec.Containers[0].Env, tmpEnvVar)
 	}
 
+	if instance.Spec.Backup.MinBackupPeriodSeconds != nil {
+		hLog.Infof("MinBackupPeriodSeconds specified.")
+		tmpEnvVar := corev1.EnvVar{
+			Name:  hiveconstants.MinBackupPeriodSecondsEnvVar,
+			Value: strconv.Itoa(*instance.Spec.Backup.MinBackupPeriodSeconds),
+		}
+		hiveDeployment.Spec.Template.Spec.Containers[0].Env = append(hiveDeployment.Spec.Template.Spec.Containers[0].Env, tmpEnvVar)
+	}
+
 	if err := r.includeAdditionalCAs(hLog, h, instance, hiveDeployment); err != nil {
 		return err
 	}


### PR DESCRIPTION
- [x] Add rate limiting to Velero backup controller so that at most 1 backup is
      taken per X seconds where X seconds defaults to 180 (3 minutes) and is
      settable in hiveconfig. This allows for bundling of multiple
      changes into a single backup.
- [x] Fix backup naming so that the backup name has the same datestamp
      as the backup timestamp in the checkpoint object.
- [x] Add and fix current unit tests around the new functionality.
- [x] Manually test rate limiting against a real kube cluster and the
      hiveconfig rate limiting option.