### PR TITLE
e2e tests for azure and gcp

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         name: manager
         resources:
           requests:
-            cpu: 500m
+            cpu: 50m
             memory: 512Mi
         command:
           - /opt/services/manager

--- a/contrib/pkg/createcluster/azure.go
+++ b/contrib/pkg/createcluster/azure.go
@@ -25,9 +25,15 @@ type azureCloudProvider struct {
 }
 
 func (p *azureCloudProvider) generateCredentialsSecret(o *Options) (*corev1.Secret, error) {
-	spFile := filepath.Join(os.Getenv("HOME"), ".azure", azureCredFile)
-	log.Infof("Loading Azure service principal from: %s", spFile)
-	spFileContents, err := ioutil.ReadFile(spFile)
+	credsFilePath := filepath.Join(os.Getenv("HOME"), ".azure", azureCredFile)
+	if l := os.Getenv("AZURE_AUTH_LOCATION"); l != "" {
+		credsFilePath = l
+	}
+	if o.CredsFile != "" {
+		credsFilePath = o.CredsFile
+	}
+	log.Infof("Loading Azure service principal from: %s", credsFilePath)
+	spFileContents, err := ioutil.ReadFile(credsFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/contrib/pkg/createcluster/gcp.go
+++ b/contrib/pkg/createcluster/gcp.go
@@ -25,9 +25,15 @@ type gcpCloudProvider struct {
 }
 
 func (p *gcpCloudProvider) generateCredentialsSecret(o *Options) (*corev1.Secret, error) {
-	saFile := filepath.Join(os.Getenv("HOME"), ".gcp", gcpCredFile)
-	log.Infof("Loading gcp service account from: %s", saFile)
-	saFileContents, err := ioutil.ReadFile(saFile)
+	credsFilePath := filepath.Join(os.Getenv("HOME"), ".gcp", gcpCredFile)
+	if l := os.Getenv("GCP_SHARED_CREDENTIALS_FILE"); l != "" {
+		credsFilePath = l
+	}
+	if o.CredsFile != "" {
+		credsFilePath = o.CredsFile
+	}
+	log.Infof("Loading gcp service account from: %s", credsFilePath)
+	saFileContents, err := ioutil.ReadFile(credsFilePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -614,7 +614,7 @@ spec:
         name: manager
         resources:
           requests:
-            cpu: 500m
+            cpu: 50m
             memory: 512Mi
         command:
           - /opt/services/manager

--- a/test/e2e/postinstall/machinesets/infra_test.go
+++ b/test/e2e/postinstall/machinesets/infra_test.go
@@ -18,6 +18,11 @@ import (
 func TestManageMachineSets(t *testing.T) {
 	cd := common.MustGetInstalledClusterDeployment()
 
+	if cd.Spec.Platform.AWS == nil {
+		t.Log("Remote machineset management is only implemented for AWS")
+		return
+	}
+
 	c := common.MustGetClient()
 	found := -1
 	for i, machinePool := range cd.Spec.Compute {


### PR DESCRIPTION
When running e2e tests, create a cluster on azure and gcp as well as aws.