### PR TITLE
Modifying admission validator names to make the plural names of CRDs to work

### DIFF
--- a/config/hiveadmission/clusterdeployment-webhook.yaml
+++ b/config/hiveadmission/clusterdeployment-webhook.yaml
@@ -2,15 +2,15 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: clusterdeployments.admission.hive.openshift.io
+  name: clusterdeploymentvalidators.admission.hive.openshift.io
 webhooks:
-- name: clusterdeployments.admission.hive.openshift.io
+- name: clusterdeploymentvalidators.admission.hive.openshift.io
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
       namespace: default
       name: kubernetes
-      path: /apis/admission.hive.openshift.io/v1alpha1/clusterdeployments
+      path: /apis/admission.hive.openshift.io/v1alpha1/clusterdeploymentvalidators
   rules:
   - operations:
     - CREATE

--- a/config/hiveadmission/clusterimageset-webhook.yaml
+++ b/config/hiveadmission/clusterimageset-webhook.yaml
@@ -2,15 +2,15 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: clusterimagesets.admission.hive.openshift.io
+  name: clusterimagesetvalidators.admission.hive.openshift.io
 webhooks:
-- name: clusterimagesets.admission.hive.openshift.io
+- name: clusterimagesetvalidators.admission.hive.openshift.io
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
       namespace: default
       name: kubernetes
-      path: /apis/admission.hive.openshift.io/v1alpha1/clusterimagesets
+      path: /apis/admission.hive.openshift.io/v1alpha1/clusterimagesetvalidators
   rules:
   - operations:
     - CREATE

--- a/config/hiveadmission/dnszones-webhook.yaml
+++ b/config/hiveadmission/dnszones-webhook.yaml
@@ -3,15 +3,15 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: dnszones.admission.hive.openshift.io
+  name: dnszonevalidators.admission.hive.openshift.io
 webhooks:
-- name: dnszones.admission.hive.openshift.io
+- name: dnszonevalidators.admission.hive.openshift.io
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
       namespace: default
       name: kubernetes
-      path: /apis/admission.hive.openshift.io/v1alpha1/dnszones
+      path: /apis/admission.hive.openshift.io/v1alpha1/dnszonevalidators
   rules:
   - operations:
     - CREATE

--- a/config/hiveadmission/selectorsyncset-webhook.yaml
+++ b/config/hiveadmission/selectorsyncset-webhook.yaml
@@ -2,15 +2,15 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: selectorsyncsets.admission.hive.openshift.io
+  name: selectorsyncsetvalidators.admission.hive.openshift.io
 webhooks:
-- name: selectorsyncsets.admission.hive.openshift.io
+- name: selectorsyncsetvalidators.admission.hive.openshift.io
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
       namespace: default
       name: kubernetes
-      path: /apis/admission.hive.openshift.io/v1alpha1/selectorsyncsets
+      path: /apis/admission.hive.openshift.io/v1alpha1/selectorsyncsetvalidators
   rules:
   - operations:
     - CREATE

--- a/config/hiveadmission/syncset-webhook.yaml
+++ b/config/hiveadmission/syncset-webhook.yaml
@@ -2,15 +2,15 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: syncsets.admission.hive.openshift.io
+  name: syncsetvalidators.admission.hive.openshift.io
 webhooks:
-- name: syncsets.admission.hive.openshift.io
+- name: syncsetvalidators.admission.hive.openshift.io
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
       namespace: default
       name: kubernetes
-      path: /apis/admission.hive.openshift.io/v1alpha1/syncsets
+      path: /apis/admission.hive.openshift.io/v1alpha1/syncsetvalidators
   rules:
   - operations:
     - CREATE

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook.go
@@ -28,9 +28,8 @@ const (
 	clusterDeploymentVersion  = "v1alpha1"
 	clusterDeploymentResource = "clusterdeployments"
 
-	clusterDeploymentAdmissionGroup    = "admission.hive.openshift.io"
-	clusterDeploymentAdmissionVersion  = "v1alpha1"
-	clusterDeploymentAdmissionResource = "clusterdeployments"
+	clusterDeploymentAdmissionGroup   = "admission.hive.openshift.io"
+	clusterDeploymentAdmissionVersion = "v1alpha1"
 
 	// ManagedDomainsFileEnvVar if present, points to a simple text
 	// file that includes a valid managed domain per line. Cluster deployments
@@ -69,22 +68,22 @@ func NewClusterDeploymentValidatingAdmissionHook() *ClusterDeploymentValidatingA
 
 // ValidatingResource is called by generic-admission-server on startup to register the returned REST resource through which the
 //                    webhook is accessed by the kube apiserver.
-// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.hive.openshift.io/v1alpha1/clusterdeployments".
+// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.hive.openshift.io/v1alpha1/clusterdeploymentvalidators".
 //              When the kube apiserver calls this registered REST resource, the generic-admission-server calls the Validate() method below.
 func (a *ClusterDeploymentValidatingAdmissionHook) ValidatingResource() (plural schema.GroupVersionResource, singular string) {
 	log.WithFields(log.Fields{
 		"group":    clusterDeploymentAdmissionGroup,
 		"version":  clusterDeploymentAdmissionVersion,
-		"resource": clusterDeploymentAdmissionResource,
+		"resource": "clusterdeploymentvalidator",
 	}).Info("Registering validation REST resource")
 
 	// NOTE: This GVR is meant to be different than the ClusterDeployment CRD GVR which has group "hive.openshift.io".
 	return schema.GroupVersionResource{
 			Group:    clusterDeploymentAdmissionGroup,
 			Version:  clusterDeploymentAdmissionVersion,
-			Resource: clusterDeploymentAdmissionResource,
+			Resource: "clusterdeploymentvalidators",
 		},
-		"clusterdeployment"
+		"clusterdeploymentvalidator"
 }
 
 // Initialize is called by generic-admission-server on startup to setup any special initialization that your webhook needs.
@@ -92,7 +91,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) Initialize(kubeClientConfig *
 	log.WithFields(log.Fields{
 		"group":    clusterDeploymentAdmissionGroup,
 		"version":  clusterDeploymentAdmissionVersion,
-		"resource": clusterDeploymentAdmissionResource,
+		"resource": "clusterdeploymentvalidator",
 	}).Info("Initializing validation REST resource")
 	return nil // No initialization needed right now.
 }

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
@@ -132,9 +132,9 @@ func TestClusterDeploymentValidatingResource(t *testing.T) {
 	expectedPlural := schema.GroupVersionResource{
 		Group:    "admission.hive.openshift.io",
 		Version:  "v1alpha1",
-		Resource: "clusterdeployments",
+		Resource: "clusterdeploymentvalidators",
 	}
-	expectedSingular := "clusterdeployment"
+	expectedSingular := "clusterdeploymentvalidator"
 
 	// Act
 	plural, singular := data.ValidatingResource()

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/clusterimageset_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/clusterimageset_validating_admission_hook.go
@@ -27,21 +27,21 @@ type ClusterImageSetValidatingAdmissionHook struct{}
 
 // ValidatingResource is called by generic-admission-server on startup to register the returned REST resource through which the
 //                    webhook is accessed by the kube apiserver.
-// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.hive.openshift.io/v1alpha1/clusterimagesets".
+// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.hive.openshift.io/v1alpha1/clusterimagesetvalidators".
 //              When the kube apiserver calls this registered REST resource, the generic-admission-server calls the Validate() method below.
 func (a *ClusterImageSetValidatingAdmissionHook) ValidatingResource() (plural schema.GroupVersionResource, singular string) {
 	log.WithFields(log.Fields{
 		"group":    "admission.hive.openshift.io",
 		"version":  "v1alpha1",
-		"resource": "clusterimagesets",
+		"resource": "clusterimagesetvalidator",
 	}).Info("Registering validation REST resource")
 	// NOTE: This GVR is meant to be different than the ClusterImageSet CRD GVR which has group "hive.openshift.io".
 	return schema.GroupVersionResource{
 			Group:    "admission.hive.openshift.io",
 			Version:  "v1alpha1",
-			Resource: "clusterimagesets",
+			Resource: "clusterimagesetvalidators",
 		},
-		"clusterimageset"
+		"clusterimagesetvalidator"
 }
 
 // Initialize is called by generic-admission-server on startup to setup any special initialization that your webhook needs.
@@ -49,7 +49,7 @@ func (a *ClusterImageSetValidatingAdmissionHook) Initialize(kubeClientConfig *re
 	log.WithFields(log.Fields{
 		"group":    "admission.hive.openshift.io",
 		"version":  "v1alpha1",
-		"resource": "clusterimagesets",
+		"resource": "clusterimagesetvalidator",
 	}).Info("Initializing validation REST resource")
 	return nil // No initialization needed right now.
 }

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/clusterimageset_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/clusterimageset_validating_admission_hook_test.go
@@ -18,9 +18,9 @@ func TestClusterImageSetValidatingResource(t *testing.T) {
 	expectedPlural := schema.GroupVersionResource{
 		Group:    "admission.hive.openshift.io",
 		Version:  "v1alpha1",
-		Resource: "clusterimagesets",
+		Resource: "clusterimagesetvalidators",
 	}
-	expectedSingular := "clusterimageset"
+	expectedSingular := "clusterimagesetvalidator"
 
 	// Act
 	plural, singular := data.ValidatingResource()

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/clusterprovision_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/clusterprovision_validating_admission_hook.go
@@ -50,21 +50,21 @@ type ClusterProvisionValidatingAdmissionHook struct {
 
 // ValidatingResource is called by generic-admission-server on startup to register the returned REST resource through which the
 // webhook is accessed by the kube apiserver.
-// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.hive.openshift.io/v1alpha1/clusterprovisions".
+// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.hive.openshift.io/v1alpha1/clusterprovisionvalidators".
 // When the kube apiserver calls this registered REST resource, the generic-admission-server calls the Validate() method below.
 func (a *ClusterProvisionValidatingAdmissionHook) ValidatingResource() (plural schema.GroupVersionResource, singular string) {
 	log.WithFields(log.Fields{
 		"group":    "admission.hive.openshift.io",
 		"version":  "v1alpha1",
-		"resource": "clusterprovisions",
+		"resource": "clusterprovisionvalidator",
 	}).Info("Registering validation REST resource")
 	// NOTE: This GVR is meant to be different than the ClusterProvision CRD GVR which has group "hive.openshift.io".
 	return schema.GroupVersionResource{
 			Group:    "admission.hive.openshift.io",
 			Version:  "v1alpha1",
-			Resource: "clusterprovisions",
+			Resource: "clusterprovisionvalidators",
 		},
-		"clusterprovision"
+		"clusterprovisionvalidator"
 }
 
 // Initialize is called by generic-admission-server on startup to setup any special initialization that your webhook needs.
@@ -72,7 +72,7 @@ func (a *ClusterProvisionValidatingAdmissionHook) Initialize(kubeClientConfig *r
 	log.WithFields(log.Fields{
 		"group":    "admission.hive.openshift.io",
 		"version":  "v1alpha1",
-		"resource": "clusterprovisions",
+		"resource": "clusterprovisionvalidator",
 	}).Info("Initializing validation REST resource")
 
 	scheme := runtime.NewScheme()

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/dnszone_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/dnszone_validating_admission_hook.go
@@ -30,21 +30,21 @@ type DNSZoneValidatingAdmissionHook struct{}
 
 // ValidatingResource is called by generic-admission-server on startup to register the returned REST resource through which the
 //                    webhook is accessed by the kube apiserver.
-// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.hive.openshift.io/v1alpha1/dnszones".
+// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.hive.openshift.io/v1alpha1/dnszonevalidators".
 //              When the kube apiserver calls this registered REST resource, the generic-admission-server calls the Validate() method below.
 func (a *DNSZoneValidatingAdmissionHook) ValidatingResource() (plural schema.GroupVersionResource, singular string) {
 	log.WithFields(log.Fields{
 		"group":    "admission.hive.openshift.io",
 		"version":  "v1alpha1",
-		"resource": "dnszones",
+		"resource": "dnszonevalidator",
 	}).Info("Registering validation REST resource")
 	// NOTE: This GVR is meant to be different than the DNSZone CRD GVR which has group "hive.openshift.io".
 	return schema.GroupVersionResource{
 			Group:    "admission.hive.openshift.io",
 			Version:  "v1alpha1",
-			Resource: "dnszones",
+			Resource: "dnszonevalidators",
 		},
-		"dnszone"
+		"dnszonevalidator"
 }
 
 // Initialize is called by generic-admission-server on startup to setup any special initialization that your webhook needs.
@@ -52,7 +52,7 @@ func (a *DNSZoneValidatingAdmissionHook) Initialize(kubeClientConfig *rest.Confi
 	log.WithFields(log.Fields{
 		"group":    "admission.hive.openshift.io",
 		"version":  "v1alpha1",
-		"resource": "dnszones",
+		"resource": "dnszonevalidator",
 	}).Info("Initializing validation REST resource")
 	return nil // No initialization needed right now.
 }

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/dnszone_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/dnszone_validating_admission_hook_test.go
@@ -18,9 +18,9 @@ func TestDNSZoneValidatingResource(t *testing.T) {
 	expectedPlural := schema.GroupVersionResource{
 		Group:    "admission.hive.openshift.io",
 		Version:  "v1alpha1",
-		Resource: "dnszones",
+		Resource: "dnszonevalidators",
 	}
-	expectedSingular := "dnszone"
+	expectedSingular := "dnszonevalidator"
 
 	// Act
 	plural, singular := data.ValidatingResource()

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/selector_syncset_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/selector_syncset_validating_admission_hook.go
@@ -28,21 +28,21 @@ type SelectorSyncSetValidatingAdmissionHook struct{}
 
 // ValidatingResource is called by generic-admission-server on startup to register the returned REST resource through which the
 //                    webhook is accessed by the kube apiserver.
-// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.hive.openshift.io/v1alpha1/selectorsyncsets".
+// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.hive.openshift.io/v1alpha1/selectorsyncsetvalidators".
 //              When the kube apiserver calls this registered REST resource, the generic-admission-server calls the Validate() method below.
 func (a *SelectorSyncSetValidatingAdmissionHook) ValidatingResource() (plural schema.GroupVersionResource, singular string) {
 	log.WithFields(log.Fields{
 		"group":    "admission.hive.openshift.io",
 		"version":  "v1alpha1",
-		"resource": "selectorsyncsets",
+		"resource": "selectorsyncsetvalidator",
 	}).Info("Registering validation REST resource")
 	// NOTE: This GVR is meant to be different than the SelectorSyncSet CRD GVR which has group "hive.openshift.io".
 	return schema.GroupVersionResource{
 			Group:    "admission.hive.openshift.io",
 			Version:  "v1alpha1",
-			Resource: "selectorsyncsets",
+			Resource: "selectorsyncsetvalidators",
 		},
-		"selectorsyncset"
+		"selectorsyncsetvalidator"
 }
 
 // Initialize is called by generic-admission-server on startup to setup any special initialization that your webhook needs.
@@ -50,7 +50,7 @@ func (a *SelectorSyncSetValidatingAdmissionHook) Initialize(kubeClientConfig *re
 	log.WithFields(log.Fields{
 		"group":    "admission.hive.openshift.io",
 		"version":  "v1alpha1",
-		"resource": "selectorsyncsets",
+		"resource": "selectorsyncsetvalidator",
 	}).Info("Initializing validation REST resource")
 	return nil // No initialization needed right now.
 }

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/selector_syncset_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/selector_syncset_validating_admission_hook_test.go
@@ -19,9 +19,9 @@ func TestSelectorSyncSetValidatingResource(t *testing.T) {
 	expectedPlural := schema.GroupVersionResource{
 		Group:    "admission.hive.openshift.io",
 		Version:  "v1alpha1",
-		Resource: "selectorsyncsets",
+		Resource: "selectorsyncsetvalidators",
 	}
-	expectedSingular := "selectorsyncset"
+	expectedSingular := "selectorsyncsetvalidator"
 
 	// Act
 	plural, singular := data.ValidatingResource()

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/syncset_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/syncset_validating_admission_hook.go
@@ -48,21 +48,21 @@ type SyncSetValidatingAdmissionHook struct{}
 
 // ValidatingResource is called by generic-admission-server on startup to register the returned REST resource through which the
 //                    webhook is accessed by the kube apiserver.
-// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.hive.openshift.io/v1alpha1/syncsets".
+// For example, generic-admission-server uses the data below to register the webhook on the REST resource "/apis/admission.hive.openshift.io/v1alpha1/syncsetvalidators".
 //              When the kube apiserver calls this registered REST resource, the generic-admission-server calls the Validate() method below.
 func (a *SyncSetValidatingAdmissionHook) ValidatingResource() (plural schema.GroupVersionResource, singular string) {
 	log.WithFields(log.Fields{
 		"group":    "admission.hive.openshift.io",
 		"version":  "v1alpha1",
-		"resource": "syncsets",
+		"resource": "syncsetvalidator",
 	}).Info("Registering validation REST resource")
 	// NOTE: This GVR is meant to be different than the SyncSet CRD GVR which has group "hive.openshift.io".
 	return schema.GroupVersionResource{
 			Group:    "admission.hive.openshift.io",
 			Version:  "v1alpha1",
-			Resource: "syncsets",
+			Resource: "syncsetvalidators",
 		},
-		"syncset"
+		"syncsetvalidator"
 }
 
 // Initialize is called by generic-admission-server on startup to setup any special initialization that your webhook needs.
@@ -70,7 +70,7 @@ func (a *SyncSetValidatingAdmissionHook) Initialize(kubeClientConfig *rest.Confi
 	log.WithFields(log.Fields{
 		"group":    "admission.hive.openshift.io",
 		"version":  "v1alpha1",
-		"resource": "syncsets",
+		"resource": "syncsetvalidator",
 	}).Info("Initializing validation REST resource")
 	return nil // No initialization needed right now.
 }

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/syncset_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/syncset_validating_admission_hook_test.go
@@ -19,9 +19,9 @@ func TestSyncSetValidatingResource(t *testing.T) {
 	expectedPlural := schema.GroupVersionResource{
 		Group:    "admission.hive.openshift.io",
 		Version:  "v1alpha1",
-		Resource: "syncsets",
+		Resource: "syncsetvalidators",
 	}
-	expectedSingular := "syncset"
+	expectedSingular := "syncsetvalidator"
 
 	// Act
 	plural, singular := data.ValidatingResource()

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -130,15 +130,15 @@ var _configHiveadmissionClusterdeploymentWebhookYaml = []byte(`---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: clusterdeployments.admission.hive.openshift.io
+  name: clusterdeploymentvalidators.admission.hive.openshift.io
 webhooks:
-- name: clusterdeployments.admission.hive.openshift.io
+- name: clusterdeploymentvalidators.admission.hive.openshift.io
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
       namespace: default
       name: kubernetes
-      path: /apis/admission.hive.openshift.io/v1alpha1/clusterdeployments
+      path: /apis/admission.hive.openshift.io/v1alpha1/clusterdeploymentvalidators
   rules:
   - operations:
     - CREATE
@@ -171,15 +171,15 @@ var _configHiveadmissionClusterimagesetWebhookYaml = []byte(`---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: clusterimagesets.admission.hive.openshift.io
+  name: clusterimagesetvalidators.admission.hive.openshift.io
 webhooks:
-- name: clusterimagesets.admission.hive.openshift.io
+- name: clusterimagesetvalidators.admission.hive.openshift.io
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
       namespace: default
       name: kubernetes
-      path: /apis/admission.hive.openshift.io/v1alpha1/clusterimagesets
+      path: /apis/admission.hive.openshift.io/v1alpha1/clusterimagesetvalidators
   rules:
   - operations:
     - CREATE
@@ -284,15 +284,15 @@ var _configHiveadmissionDnszonesWebhookYaml = []byte(`---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: dnszones.admission.hive.openshift.io
+  name: dnszonevalidators.admission.hive.openshift.io
 webhooks:
-- name: dnszones.admission.hive.openshift.io
+- name: dnszonevalidators.admission.hive.openshift.io
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
       namespace: default
       name: kubernetes
-      path: /apis/admission.hive.openshift.io/v1alpha1/dnszones
+      path: /apis/admission.hive.openshift.io/v1alpha1/dnszonevalidators
   rules:
   - operations:
     - CREATE
@@ -449,15 +449,15 @@ var _configHiveadmissionSelectorsyncsetWebhookYaml = []byte(`---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: selectorsyncsets.admission.hive.openshift.io
+  name: selectorsyncsetvalidators.admission.hive.openshift.io
 webhooks:
-- name: selectorsyncsets.admission.hive.openshift.io
+- name: selectorsyncsetvalidators.admission.hive.openshift.io
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
       namespace: default
       name: kubernetes
-      path: /apis/admission.hive.openshift.io/v1alpha1/selectorsyncsets
+      path: /apis/admission.hive.openshift.io/v1alpha1/selectorsyncsetvalidators
   rules:
   - operations:
     - CREATE
@@ -545,15 +545,15 @@ var _configHiveadmissionSyncsetWebhookYaml = []byte(`---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: syncsets.admission.hive.openshift.io
+  name: syncsetvalidators.admission.hive.openshift.io
 webhooks:
-- name: syncsets.admission.hive.openshift.io
+- name: syncsetvalidators.admission.hive.openshift.io
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
       namespace: default
       name: kubernetes
-      path: /apis/admission.hive.openshift.io/v1alpha1/syncsets
+      path: /apis/admission.hive.openshift.io/v1alpha1/syncsetvalidators
   rules:
   - operations:
     - CREATE


### PR DESCRIPTION
The names need to be different else kubectl get <resource name>
will get rejected by the admission controller

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>