### PR TITLE
Add support for install retry cleanup of A records in managed DNSZones.

### DIFF
--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -268,6 +268,9 @@ func (c *awsClient) ChangeResourceRecordSets(input *route53.ChangeResourceRecord
 // For authentication the underlying clients will use either the cluster AWS credentials
 // secret if defined (i.e. in the root cluster),
 // otherwise the IAM profile of the master where the actuator will run. (target clusters)
+//
+// Pass a nil client, and empty secret name and namespace to load credentials from the standard
+// AWS environment variables.
 func NewClient(kubeClient client.Client, secretName, namespace, region string) (Client, error) {
 	awsConfig := &aws.Config{Region: aws.String(region)}
 

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -1081,7 +1081,7 @@ func (r *ReconcileClusterDeployment) ensureManagedDNSZoneDeleted(cd *hivev1.Clus
 		return nil, nil
 	}
 	dnsZone := &hivev1.DNSZone{}
-	dnsZoneNamespacedName := types.NamespacedName{Namespace: cd.Namespace, Name: dnsZoneName(cd.Name)}
+	dnsZoneNamespacedName := types.NamespacedName{Namespace: cd.Namespace, Name: controllerutils.DNSZoneName(cd.Name)}
 	err := r.Get(context.TODO(), dnsZoneNamespacedName, dnsZone)
 	if err != nil && !apierrors.IsNotFound(err) {
 		cdLog.WithError(err).Error("error looking up managed dnszone")
@@ -1283,7 +1283,7 @@ func (r *ReconcileClusterDeployment) ensureManagedDNSZone(cd *hivev1.ClusterDepl
 		return nil, errors.New("only AWS managed DNS is supported")
 	}
 	dnsZone := &hivev1.DNSZone{}
-	dnsZoneNamespacedName := types.NamespacedName{Namespace: cd.Namespace, Name: dnsZoneName(cd.Name)}
+	dnsZoneNamespacedName := types.NamespacedName{Namespace: cd.Namespace, Name: controllerutils.DNSZoneName(cd.Name)}
 	logger := cdLog.WithField("zone", dnsZoneNamespacedName.String())
 
 	switch err := r.Get(context.TODO(), dnsZoneNamespacedName, dnsZone); {
@@ -1326,7 +1326,7 @@ func (r *ReconcileClusterDeployment) ensureManagedDNSZone(cd *hivev1.ClusterDepl
 func (r *ReconcileClusterDeployment) createManagedDNSZone(cd *hivev1.ClusterDeployment, logger log.FieldLogger) error {
 	dnsZone := &hivev1.DNSZone{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dnsZoneName(cd.Name),
+			Name:      controllerutils.DNSZoneName(cd.Name),
 			Namespace: cd.Namespace,
 		},
 		Spec: hivev1.DNSZoneSpec{
@@ -1355,10 +1355,6 @@ func (r *ReconcileClusterDeployment) createManagedDNSZone(cd *hivev1.ClusterDepl
 	}
 	logger.Info("dns zone created")
 	return nil
-}
-
-func dnsZoneName(cdName string) string {
-	return apihelpers.GetResourceName(cdName, "zone")
 }
 
 func selectorPodWatchHandler(a handler.MapObject) []reconcile.Request {

--- a/pkg/controller/utils/sa.go
+++ b/pkg/controller/utils/sa.go
@@ -32,6 +32,11 @@ var (
 		},
 		{
 			APIGroups: []string{"hive.openshift.io"},
+			Resources: []string{"dnszones"},
+			Verbs:     []string{"get"},
+		},
+		{
+			APIGroups: []string{"hive.openshift.io"},
 			Resources: []string{"clusterdeployments", "clusterdeployments/finalizers", "clusterdeployments/status"},
 			Verbs:     []string{"get", "update"},
 		},

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -19,6 +19,8 @@ import (
 
 	openshiftapiv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
+
+	apihelpers "github.com/openshift/hive/pkg/apis/helpers"
 )
 
 // BuildClusterAPIClientFromKubeconfig will return a kubeclient with metrics using the provided kubeconfig.
@@ -194,4 +196,9 @@ func GetChecksumOfObject(object interface{}) (string, error) {
 // GetChecksumOfObjects returns the md5sum hash of the objects passed in.
 func GetChecksumOfObjects(objects ...interface{}) (string, error) {
 	return GetChecksumOfObject(objects)
+}
+
+// DNSZoneName returns the predictable name for a DNSZone for the given ClusterDeployment.
+func DNSZoneName(cdName string) string {
+	return apihelpers.GetResourceName(cdName, "zone")
 }

--- a/pkg/installmanager/dnscleanup.go
+++ b/pkg/installmanager/dnscleanup.go
@@ -1,0 +1,56 @@
+package installmanager
+
+import (
+	awsclient "github.com/openshift/hive/pkg/awsclient"
+
+	log "github.com/sirupsen/logrus"
+
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+)
+
+// cleanupDNSZone queries the Route53 zone and deletes any A records found. Other record
+// types may be added in the future, but right now this is the only one we're seeing
+// leak and conflict.
+// May no longer be necessary once https://jira.coreos.com/browse/CORS-1195 is fixed.
+func cleanupDNSZone(dnsZoneID, region string, logger log.FieldLogger) error {
+	zoneLogger := logger.WithField("dnsZoneID", dnsZoneID)
+	zoneLogger.Info("cleaning up DNSZone")
+
+	awsClient, err := awsclient.NewClient(nil, "", "", region)
+	if err != nil {
+		return err
+	}
+	recordsOutput, err := awsClient.ListResourceRecordSets(
+		&route53.ListResourceRecordSetsInput{
+			HostedZoneId: awssdk.String(dnsZoneID),
+		},
+	)
+	if err != nil {
+		return err
+	}
+	for _, r := range recordsOutput.ResourceRecordSets {
+		// We're only experiencing problems with A records, so these are all we cleanup for now:
+		if *r.Type == "A" {
+			zoneLogger.WithFields(log.Fields{"name": *r.Name, "type": *r.Type}).Info("deleting A record")
+			request := &route53.ChangeResourceRecordSetsInput{
+				ChangeBatch: &route53.ChangeBatch{
+					Changes: []*route53.Change{
+						{
+							Action:            awssdk.String("DELETE"),
+							ResourceRecordSet: r,
+						},
+					},
+				},
+				HostedZoneId: awssdk.String(dnsZoneID),
+			}
+			_, err := awsClient.ChangeResourceRecordSets(request)
+			if err != nil {
+				logger.WithError(err).WithField("recordset", r.Name).Warn("error deleting recordset")
+				return err
+			}
+		}
+	}
+	zoneLogger.Info("DNSZone A records deleted")
+	return nil
+}

--- a/pkg/installmanager/installmanager_test.go
+++ b/pkg/installmanager/installmanager_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	installertypes "github.com/openshift/installer/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/openshift/hive/pkg/apis"
@@ -218,7 +219,7 @@ func TestInstallManager(t *testing.T) {
 			}
 
 			// We don't want to run the uninstaller, so stub it out
-			im.runUninstaller = alwaysSucceedUninstall
+			im.cleanupFailedProvision = alwaysSucceedCleanupFailedProvision
 
 			err = im.Run()
 
@@ -334,7 +335,7 @@ func testClusterProvision() *hivev1.ClusterProvision {
 	}
 }
 
-func alwaysSucceedUninstall(*hivev1.ClusterDeployment, string, log.FieldLogger) error {
+func alwaysSucceedCleanupFailedProvision(client.Client, *hivev1.ClusterDeployment, string, log.FieldLogger) error {
 	log.Debugf("running always successful uninstall")
 	return nil
 }


### PR DESCRIPTION
These are leaking due on occasion due to a bug in the installer leading
to an install that cannot complete.

Add code to deprovision A records after we run the installer's
deprovision code. A records are the only ones we're seeing an issue
with, others can be added in future if necessary.

This code is not linked to the standard deprovision for a cluster
deployment deletion. We are confident this is safe during an install,
we're not sure if it is during a deprovision.