### PR TITLE
installmanager: gather logs reporting success with empty private ssh key file

### DIFF
--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -731,7 +731,7 @@ func (m *InstallManager) gatherBootstrapNodeLogs(cd *hivev1.ClusterDeployment) e
 
 	if fileInfo.Size() == 0 {
 		m.log.Warn("cannot gather logs/tarball as ssh private key file is empty")
-		return err
+		return errors.New("cannot gather logs/tarball as ssh private key file is empty")
 	}
 
 	// set up ssh private key, and run the log gathering script


### PR DESCRIPTION
When the private ssh key file is empty, the installmanager is reporting that gathering the logs from the bootstrap node was successful even though the logs where not gathered. The `gatherBootstrapNodeLogs` function should be returning a non-nil error in this scenario.