### PR TITLE
installmanager: fix check for whether bootstrap is complete

### DIFF
--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -848,7 +848,7 @@ func (m *InstallManager) isBootstrapComplete() bool {
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "./openshift-install", "wait-for", "bootstrap-complete")
 	cmd.Dir = m.WorkDir
-	return cmd.Run() != nil
+	return cmd.Run() == nil
 }
 
 func getBootstrapIP(m *InstallManager) (string, error) {


### PR DESCRIPTION
The isBootstrapComplete check in InstallManager is returning true when there was an error validating that the bootstrap is complete. This is backwards: It should be returning false in this case.