### PR TITLE
store e2e must-gather logs

### DIFF
--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -185,7 +185,12 @@ else
 	cat "${ARTIFACT_DIR}/hive_install_job.log"
 fi
 
-if [[ "${INSTALL_RESULT}" != "success" ]]; then exit 1; fi
+if [[ "${INSTALL_RESULT}" != "success" ]]
+then
+	mkdir "${ARTIFACT_DIR}/hive"
+	${SRC_ROOT}/hack/logextractor.sh ${CLUSTER_NAME} "${ARTIFACT_DIR}/hive"
+	exit 1
+fi
 
 echo "Running post-install tests"
 make test-e2e-postinstall


### PR DESCRIPTION
When a clusterdeployment install fails during e2e tests, store the must-gather logs that where captured.