### PR TITLE
controller: no error message on creation when already exists

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -847,7 +847,7 @@ func (r *ReconcileClusterDeployment) createPVC(cd *hivev1.ClusterDeployment, cdL
 	}
 	err := r.Create(context.TODO(), pvc)
 	if err != nil {
-		cdLog.WithError(err).Error("error creating pvc")
+		cdLog.WithError(err).Log(controllerutils.LogLevel(err), "error creating pvc")
 	}
 	return err
 }
@@ -942,7 +942,7 @@ func (r *ReconcileClusterDeployment) resolveInstallerImage(cd *hivev1.ClusterDep
 
 		err = r.Create(context.TODO(), job)
 		if err != nil {
-			jobLog.WithError(err).Error("error creating job")
+			jobLog.WithError(err).Log(controllerutils.LogLevel(err), "error creating job")
 		} else {
 			// kickstartDuration calculates the delay between creation of cd and start of imageset job
 			kickstartDuration := time.Since(cd.CreationTimestamp.Time)
@@ -1184,7 +1184,7 @@ func (r *ReconcileClusterDeployment) syncDeletedClusterDeployment(cd *hivev1.Clu
 			// requeue the clusterdeployment immediately to process the status of the deprovision request
 			return reconcile.Result{Requeue: true}, nil
 		case err != nil:
-			cdLog.WithError(err).Error("error creating deprovision request")
+			cdLog.WithError(err).Log(controllerutils.LogLevel(err), "error creating deprovision request")
 			// Check if namespace is terminated, if so we can give up, remove the finalizer, and let
 			// the cluster go away.
 			ns := &corev1.Namespace{}
@@ -1357,7 +1357,7 @@ func (r *ReconcileClusterDeployment) createManagedDNSZone(cd *hivev1.ClusterDepl
 
 	err := r.Create(context.TODO(), dnsZone)
 	if err != nil {
-		logger.WithError(err).Error("cannot create DNS zone")
+		logger.WithError(err).Log(controllerutils.LogLevel(err), "cannot create DNS zone")
 		return err
 	}
 	logger.Info("dns zone created")

--- a/pkg/controller/clusterdeprovisionrequest/clusterdeprovisionrequest_controller.go
+++ b/pkg/controller/clusterdeprovisionrequest/clusterdeprovisionrequest_controller.go
@@ -167,7 +167,7 @@ func (r *ReconcileClusterDeprovisionRequest) Reconcile(request reconcile.Request
 		rLog.Debug("uninstall job does not exist, creating it")
 		err = r.Create(context.TODO(), uninstallJob)
 		if err != nil {
-			rLog.WithError(err).Errorf("error creating uninstall job")
+			rLog.WithError(err).Log(controllerutils.LogLevel(err), "error creating uninstall job")
 			return reconcile.Result{}, err
 		}
 		return reconcile.Result{}, nil

--- a/pkg/controller/clusterstate/clusterstate_controller.go
+++ b/pkg/controller/clusterstate/clusterstate_controller.go
@@ -140,7 +140,7 @@ func (r *ReconcileClusterState) Reconcile(request reconcile.Request) (reconcile.
 		}
 		err = r.Create(context.TODO(), st)
 		if err != nil {
-			logger.WithError(err).Error("failed to create cluster state")
+			logger.WithError(err).Log(controllerutils.LogLevel(err), "failed to create cluster state")
 			return reconcile.Result{}, err
 		}
 		return reconcile.Result{}, nil

--- a/pkg/controller/dnszone/zonereconciler.go
+++ b/pkg/controller/dnszone/zonereconciler.go
@@ -187,7 +187,7 @@ func (zr *ZoneReconciler) syncParentDomainLink(nameServers []string) error {
 
 	if dnsEndpointNotFound {
 		if err = zr.kubeClient.Create(context.TODO(), linkRecord); err != nil {
-			zr.logger.WithError(err).Error("failed creating DNSEndpoint")
+			zr.logger.WithError(err).Log(controllerutils.LogLevel(err), "failed creating DNSEndpoint")
 			return err
 		}
 		return nil

--- a/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
+++ b/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
@@ -275,7 +275,7 @@ func (r *ReconcileSyncIdentityProviders) syncIdentityProviders(cd *hivev1.Cluste
 		}
 
 		if err := r.Create(context.TODO(), ss); err != nil {
-			contextLogger.WithError(err).Error("error creating syncset")
+			contextLogger.WithError(err).Log(controllerutils.LogLevel(err), "error creating syncset")
 			return err
 		}
 

--- a/pkg/controller/syncset/syncset_controller.go
+++ b/pkg/controller/syncset/syncset_controller.go
@@ -222,7 +222,7 @@ func (r *ReconcileSyncSet) Reconcile(request reconcile.Request) (reconcile.Resul
 		err := r.Create(context.TODO(), syncSetInstance)
 		if err != nil {
 			name := fmt.Sprintf("%s/%s", syncSetInstance.Namespace, syncSetInstance.Name)
-			cdLog.WithError(err).WithField("syncSetInstance", name).Error("cannot create sync set instance")
+			cdLog.WithError(err).WithField("syncSetInstance", name).Log(controllerutils.LogLevel(err), "cannot create sync set instance")
 			return reconcile.Result{}, err
 		}
 	}

--- a/pkg/controller/syncsetinstance/syncsetinstance_controller.go
+++ b/pkg/controller/syncsetinstance/syncsetinstance_controller.go
@@ -28,7 +28,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -300,11 +299,7 @@ func (r *ReconcileSyncSetInstance) addSyncSetInstanceFinalizer(ssi *hivev1.SyncS
 	controllerutils.AddFinalizer(ssi, hivev1.FinalizerSyncSetInstance)
 	err := r.Update(context.TODO(), ssi)
 	if err != nil {
-		level := log.ErrorLevel
-		if apierrors.IsConflict(err) {
-			level = log.InfoLevel
-		}
-		ssiLog.WithError(err).Log(level, "cannot add finalizer")
+		ssiLog.WithError(err).Log(controllerutils.LogLevel(err), "cannot add finalizer")
 	}
 	return err
 }


### PR DESCRIPTION
There are numerous places where a controller tries to get a resource by a known name and, if the resource does not exist, then create said resource. This operation has a race condition where the controller may attempt to reconcile the controlling resource again prior to the local cache being populated with the resource recently created by the controller. When this happens, the controller spits out an error log entry, even though this is not indicative of a problem.

These changes provide a helper GetOrCreate function that can be used by a controller to attempt to get a resource or create it if it is not found. All of the places where a controller does a get/create are changed so that the log entry emitted on the conflicted create is an info-level entry instead of an error-level entry.

See https://jira.coreos.com/browse/CO-582.