### PR TITLE
remove unnecessary warning about dnszone not getting deleted

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -1091,7 +1091,6 @@ func (r *ReconcileClusterDeployment) ensureManagedDNSZoneDeleted(cd *hivev1.Clus
 		cdLog.Debug("dnszone has been deleted or is getting deleted")
 		return nil, nil
 	}
-	cdLog.Warn("managed dnszone did not get a deletionTimestamp when parent cluster deployment was deleted, deleting manually")
 	err = r.Delete(context.TODO(), dnsZone,
 		client.PropagationPolicy(metav1.DeletePropagationForeground))
 	if err != nil {

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -740,7 +740,6 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testSecret(corev1.SecretTypeOpaque, sshKeySecret, adminSSHKeySecretKey, "fakesshkey"),
 				testDNSZone(),
 			},
-			expectedRequeueAfter: defaultRequeueTime,
 			validate: func(c client.Client, t *testing.T) {
 				dnsZone := getDNSZone(c)
 				assert.Nil(t, dnsZone, "dnsZone should not exist")


### PR DESCRIPTION
Revert 9ad718b.

Only remove the unnecessary warning: Revert the rest of the superfluous changes.