### PR TITLE
controller: reduce severity of log for missing cert bundle secret

### DIFF
--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -150,7 +150,7 @@ func (r *ReconcileRemoteClusterIngress) Reconcile(request reconcile.Request) (re
 
 	rContext.logger = cdLog
 
-	if cd.Spec.Ingress == nil {
+	if len(cd.Spec.Ingress) == 0 {
 		// the admission controller will ensure that we get valid-looking
 		// Spec.Ingress (ie no missing 'default', no going from a defined
 		// ingress list to an empty list, etc)
@@ -359,9 +359,7 @@ func (r *ReconcileRemoteClusterIngress) getIngressSecrets(rContext *reconcileCon
 
 				if err := r.Get(context.TODO(), searchKey, cbSecret); err != nil {
 					if errors.IsNotFound(err) {
-						msg := fmt.Sprintf("secret %v for certbundle %v was not found", cb.SecretRef.Name, cb.Name)
-						rContext.logger.Error(msg)
-						return cbSecrets, fmt.Errorf(msg)
+						return cbSecrets, fmt.Errorf("secret %v for certbundle %v was not found", cb.SecretRef.Name, cb.Name)
 					}
 					rContext.logger.WithError(err).Error("error while gathering certBundle secret")
 					return cbSecrets, err


### PR DESCRIPTION
If a serving certificate secret cannot be found, the remoteingress controller emits an error-level log entry. However, this is a common occurrence as the serving certificates are created after the
clusterdeployment is created. These changes remove this log entry. The controller will still emit a warning-level log entry with text of "will need to retry until able to find all certBundle secrets".

See https://jira.coreos.com/browse/CO-582.