### PR TITLE
controllers: dummy provision for clusterdeployment with installed timestamp

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -403,12 +403,12 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 			return reconcile.Result{}, nil
 		}
 
-		if cd.Status.InstalledTimestamp != nil {
-			cdLog.Debug("cluster is already installed, no processing of provision needed")
-			r.cleanupInstallLogPVC(cd, cdLog)
-			return reconcile.Result{}, nil
-		}
 		if cd.Status.Provision != nil {
+			if cd.Status.InstalledTimestamp != nil {
+				cdLog.Debug("cluster is already installed, no processing of provision needed")
+				r.cleanupInstallLogPVC(cd, cdLog)
+				return reconcile.Result{}, nil
+			}
 			return r.reconcileExistingProvision(cd, cdLog)
 		}
 		if !r.expectations.SatisfiedExpectations(request.String()) {
@@ -426,6 +426,9 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 			// for them.
 			cdLog.Info("cluster was created prior to clusterprovisions, creating dummy clusterprovision")
 			return r.createClusterProvisionForLegacyCD(cd, cdLog)
+		default:
+			cdLog.Warn("cluster is installed but does not have an infra ID or a clusterprovision")
+			return reconcile.Result{}, nil
 		}
 	}
 


### PR DESCRIPTION
A dummy provision should be created for all legacy clusterdeployments. However, a dummy provision is not being created for legacy clusterdeployments that have an installed timestamp. To remedy this, the check for the installed timestamp has been moved inside the if statement verifying that the clusterdeployment has a link to a clusterprovision.

Additionally, the clusterdeployment controller has been changed to stop reconciling a clusterdeployment that is installed, has no clusterprovision to adopt, and has no infra ID. This is likely to happen when a clusterdeployment is restored prior to its clusterprovision being restored. The clusterdeployment controller should under no circumstances create a new clusterprovision when the spec of the clusterdeployment indicates that the cluster is installed.