### PR TITLE
Skip minor OpenShift specific assets when running on vanilla Kube.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ VERIFY_IMPORTS_CONFIG = build/verify-imports/import-rules.yaml
 # To use docker build, specify BUILD_CMD="docker build"
 BUILD_CMD ?= imagebuilder
 
+DOCKER_CMD ?= docker
+
 # Image URL to use all building/pushing image targets
 IMG ?= hive-controller:latest
 
@@ -108,12 +110,6 @@ deploy: manifests install generate
 .PHONY: manifests
 manifests: crd
 
-# Deploy controller in the configured Kubernetes cluster in ~/.kube/config
-.PHONY: deploy-sd-dev
-deploy-sd-dev: crd
-	oc apply -f config/crds
-	kustomize build overlays/sd-dev | oc apply -f -
-
 # Generate CRD yaml from our api types:
 .PHONY: crd
 crd:
@@ -179,6 +175,12 @@ generate: $(GOPATH)/bin/mockgen
 .PHONY: docker-build
 docker-build:
 	$(BUILD_CMD) -t ${IMG} .
+
+# Build the docker image
+.PHONY: docker-dev-push
+docker-dev-push: build
+	$(DOCKER_CMD) build -t ${IMG} -f Dockerfile.dev .
+	$(DOCKER_CMD) push ${IMG}
 
 # Push the docker image
 .PHONY: docker-push

--- a/config/operator/operator_role.yaml
+++ b/config/operator/operator_role.yaml
@@ -121,6 +121,14 @@ rules:
   - update
   - patch
   - delete
+# Used to determine if we're running on OpenShift:
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
 - apiGroups:
   - authorization.openshift.io
   resources:

--- a/config/rbac/hive_admin_role_binding.yaml
+++ b/config/rbac/hive_admin_role_binding.yaml
@@ -1,3 +1,6 @@
+# NOTE: This binding uses the openshift apigroup as it is the only way to link
+# to an openshift user group. This will not work if running hive on vanilla Kube,
+# but the Hive operator will detect this and skip creation of the binding.
 apiVersion: authorization.openshift.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/config/rbac/hive_reader_role_binding.yaml
+++ b/config/rbac/hive_reader_role_binding.yaml
@@ -1,3 +1,6 @@
+# NOTE: This binding uses the openshift apigroup as it is the only way to link
+# to an openshift user group. This will not work if running hive on vanilla Kube,
+# but the Hive operator will detect this and skip creation of the binding.
 apiVersion: authorization.openshift.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -971,7 +971,10 @@ func configRbacHive_admin_roleYaml() (*asset, error) {
 	return a, nil
 }
 
-var _configRbacHive_admin_role_bindingYaml = []byte(`apiVersion: authorization.openshift.io/v1
+var _configRbacHive_admin_role_bindingYaml = []byte(`# NOTE: This binding uses the openshift apigroup as it is the only way to link
+# to an openshift user group. This will not work if running hive on vanilla Kube,
+# but the Hive operator will detect this and skip creation of the binding.
+apiVersion: authorization.openshift.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: hive-admin
@@ -1541,7 +1544,10 @@ func configRbacHive_reader_roleYaml() (*asset, error) {
 	return a, nil
 }
 
-var _configRbacHive_reader_role_bindingYaml = []byte(`apiVersion: authorization.openshift.io/v1
+var _configRbacHive_reader_role_bindingYaml = []byte(`# NOTE: This binding uses the openshift apigroup as it is the only way to link
+# to an openshift user group. This will not work if running hive on vanilla Kube,
+# but the Hive operator will detect this and skip creation of the binding.
+apiVersion: authorization.openshift.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: hive-reader

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/hive/pkg/operator/util"
 	"github.com/openshift/hive/pkg/resource"
 
+	oappsv1 "github.com/openshift/api/apps/v1"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 
@@ -27,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -115,12 +117,6 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helpe
 	applyAssets := []string{
 		"config/manager/service.yaml",
 
-		// Deploy the desired ClusterImageSets representing installable releases of OpenShift.
-		// TODO: in future this should be pipelined somehow.
-		"config/rbac/hive_admin_role.yaml",
-		"config/rbac/hive_admin_role_binding.yaml",
-		"config/rbac/hive_reader_role.yaml",
-		"config/rbac/hive_reader_role_binding.yaml",
 		"config/rbac/hive_frontend_role.yaml",
 		"config/rbac/hive_frontend_role_binding.yaml",
 		"config/rbac/hive_frontend_serviceaccount.yaml",
@@ -140,11 +136,33 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helpe
 
 		"config/configmaps/install-log-regexes-configmap.yaml",
 	}
+
+	// In very rare cases we use OpenShift specific types which will not apply if running on
+	// vanilla Kubernetes. Detect this and skip if so.
+	openshiftSpecificAssets := []string{
+		"config/rbac/hive_admin_role.yaml",
+		"config/rbac/hive_admin_role_binding.yaml",
+		"config/rbac/hive_reader_role.yaml",
+		"config/rbac/hive_reader_role_binding.yaml",
+	}
+
 	for _, a := range applyAssets {
 		err = util.ApplyAsset(h, a, hLog)
 		if err != nil {
 			return err
 		}
+	}
+
+	if r.runningOnOpenShift(hLog) {
+		hLog.Info("deploying OpenShift specific assets")
+		for _, a := range openshiftSpecificAssets {
+			err = util.ApplyAsset(h, a, hLog)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		hLog.Warn("hive is not running on OpenShift, some optional assets will not be deployed")
 	}
 
 	// Remove legacy ClusterImageSets we do not want installable anymore.
@@ -263,4 +281,15 @@ func (r *ReconcileHiveConfig) includeGlobalPullSecret(hLog log.FieldLogger, h *r
 		Value: instance.Spec.GlobalPullSecret.Name,
 	}
 	hiveDeployment.Spec.Template.Spec.Containers[0].Env = append(hiveDeployment.Spec.Template.Spec.Containers[0].Env, globalPullSecretEnvVar)
+}
+
+func (r *ReconcileHiveConfig) runningOnOpenShift(hLog log.FieldLogger) bool {
+	// DeploymentConfig is an OpenShift specific type we have go types vendored for, see
+	// if we can list them to determine if we're running on OpenShift or vanilla Kube.
+	dcs := &oappsv1.DeploymentConfigList{}
+	err := r.List(context.Background(), dcs, client.InNamespace(constants.HiveNamespace))
+	if err != nil {
+		hLog.WithError(err).Debug("error listing DeploymentConfig to determine if running on OpenShift")
+	}
+	return err == nil
 }


### PR DESCRIPTION
We deploy two ClusterRoles and ClusterRoleBindings intended to be mapped
to hive-admin and hive-reader groups in Hive clusters. Because these
groups only exist as OpenShift types, it appears using the OpenShift
variant of ClusterRole and ClusterRoleBinding is the only way to map to
them.

These two roles however are not required or useful for development, and
as such can be safely skipped.

hive-operator now checks if we're running on OpenShift by attempting to
list DeploymentConfigs. If this fails, these assets will not be
deployed and a warning is logged.

This change does not get the operator fully working on vanilla Kube,
next up will be fixed for hiveadmission certs.