### PR TITLE
controllers: remove code to set spec installed when legacy status installed set

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -306,13 +306,6 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 		}, nil
 	}
 
-	// TODO: Remove once all clusterdeployments have been transitioned to use
-	// the Installed field from Spec instead of from Status.
-	if cd.Status.Installed && !cd.Spec.Installed {
-		cd.Spec.Installed = true
-		return reconcile.Result{}, r.Update(context.TODO(), cd)
-	}
-
 	// Set platform label on the ClusterDeployment
 	if platform := getClusterPlatform(cd); cd.Labels[hivev1.HiveClusterPlatformLabel] != platform {
 		if cd.Labels == nil {

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -1053,22 +1053,6 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 			},
 		},
 		{
-			name: "Test legacy Status Installed sets Spec Installed",
-			existing: []runtime.Object{
-				func() runtime.Object {
-					cd := testClusterDeployment()
-					cd.Status.Installed = true
-					return cd
-				}(),
-			},
-			validate: func(c client.Client, t *testing.T) {
-				cd := getCD(c)
-				if assert.NotNil(t, cd, "missing clusterdeployment") {
-					assert.True(t, cd.Spec.Installed, "expected Spec to have Installed field set")
-				}
-			},
-		},
-		{
 			name: "setSyncSetFailedCondition should be present",
 			existing: []runtime.Object{
 				testInstalledClusterDeployment(time.Now()),


### PR DESCRIPTION
All of the clusterdeployments in prod and stage that have status installed set also have spec installed set.