### PR TITLE
controllers: ensure all status update of clusterdeployment have valid clusterversion

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -1370,7 +1370,6 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 		CLIImage:       pointer.StringPtr("cli:latest"),
 	}
 
-	controllerutils.FixupEmptyClusterVersionFields(&cd.Status.ClusterVersionStatus)
 	return cd
 }
 
@@ -1715,8 +1714,6 @@ func getCDWithoutPullSecret() *hivev1.ClusterDeployment {
 		InstallerImage: pointer.StringPtr("installer-image:latest"),
 	}
 	cd.Status.AdminKubeconfigSecret = corev1.LocalObjectReference{Name: adminKubeconfigSecret}
-
-	controllerutils.FixupEmptyClusterVersionFields(&cd.Status.ClusterVersionStatus)
 	return cd
 }
 

--- a/pkg/controller/clusterversion/clusterversion_controller.go
+++ b/pkg/controller/clusterversion/clusterversion_controller.go
@@ -160,7 +160,6 @@ func (r *ReconcileClusterVersion) Reconcile(request reconcile.Request) (reconcil
 func (r *ReconcileClusterVersion) updateClusterVersionStatus(cd *hivev1.ClusterDeployment, clusterVersion *openshiftapiv1.ClusterVersion, cdLog log.FieldLogger) error {
 	origCD := cd.DeepCopy()
 	cdLog.WithField("clusterversion.status", clusterVersion.Status).Debug("remote cluster version status")
-	controllerutils.FixupEmptyClusterVersionFields(&clusterVersion.Status)
 	clusterVersion.Status.DeepCopyInto(&cd.Status.ClusterVersionStatus)
 
 	if reflect.DeepEqual(cd.Status, origCD.Status) {

--- a/pkg/controller/clusterversion/clusterversion_controller_test.go
+++ b/pkg/controller/clusterversion/clusterversion_controller_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/openshift/hive/pkg/apis"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
 	hivev1aws "github.com/openshift/hive/pkg/apis/hive/v1alpha1/aws"
-	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 )
 
 const (
@@ -75,7 +74,6 @@ func TestClusterVersionReconcile(t *testing.T) {
 			},
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
 				expected := testRemoteClusterVersionStatus()
-				controllerutils.FixupEmptyClusterVersionFields(&expected)
 				if !reflect.DeepEqual(cd.Status.ClusterVersionStatus, expected) {
 					t.Errorf("did not get expected clusterversion status. Expected: \n%#v\nGot: \n%#v", expected, cd.Status.ClusterVersionStatus)
 				}
@@ -161,7 +159,6 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 			},
 		},
 	}
-	controllerutils.FixupEmptyClusterVersionFields(&cd.Status.ClusterVersionStatus)
 	return cd
 }
 

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
@@ -281,7 +281,6 @@ func fakeClusterDeployment() *fakeClusterDeploymentWrapper {
 			BaseDomain:  fakeDomain,
 		},
 	}
-	controllerutils.FixupEmptyClusterVersionFields(&cd.Status.ClusterVersionStatus)
 	return &fakeClusterDeploymentWrapper{cd: cd}
 }
 

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -90,17 +90,6 @@ func BuildDynamicClientFromKubeconfig(kubeconfigData, controllerName string) (dy
 	return client, nil
 }
 
-// FixupEmptyClusterVersionFields will un-'nil' fields that would fail validation in the ClusterVersion.Status
-func FixupEmptyClusterVersionFields(clusterVersionStatus *openshiftapiv1.ClusterVersionStatus) {
-
-	// Fetching clusterVersion object can result in nil clusterVersion.Status.AvailableUpdates
-	// Place an empty list if needed to satisfy the object validation.
-
-	if clusterVersionStatus.AvailableUpdates == nil {
-		clusterVersionStatus.AvailableUpdates = []openshiftapiv1.Update{}
-	}
-}
-
 // HasFinalizer returns true if the given object has the given finalizer
 func HasFinalizer(object metav1.Object, finalizer string) bool {
 	for _, f := range object.GetFinalizers() {


### PR DESCRIPTION
The clusterdeployment controller makes an early attempt to fixup the clusterversion field so that it passes validation. However, there are some other controllers that race with the clusterdeployment controller to write to the status of a clusterdeployment. When one of the other controllers wins the race, that update fails and emits an error log entry. To avoid the race, the logic for fixing up the clusterversion field has been moved to a wrapper around the status client. Consequently, every update of a clusterdeployment by every controller will fixup the clusterversion prior to making the update.