### PR TITLE
Adding a log when we change the platform label

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -311,6 +311,10 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 		if cd.Labels == nil {
 			cd.Labels = make(map[string]string)
 		}
+		if cd.Labels[hivev1.HiveClusterPlatformLabel] != "" {
+			cdLog.Warnf("changing the value of %s from %s to %s", hivev1.HiveClusterPlatformLabel,
+				cd.Labels[hivev1.HiveClusterPlatformLabel], platform)
+		}
 		cd.Labels[hivev1.HiveClusterPlatformLabel] = platform
 		err := r.Update(context.TODO(), cd)
 		if err != nil {


### PR DESCRIPTION
Adding the logging to inform the user when we overwrite the value of label. Communicating this in log will make the user aware of the overwrite and help understand the behavior of Hive. 

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>