### PR TITLE
Fixing the error logs caused by DeploymentConfig

### DIFF
--- a/config/operator/operator_role.yaml
+++ b/config/operator/operator_role.yaml
@@ -121,14 +121,6 @@ rules:
   - update
   - patch
   - delete
-# Used to determine if we're running on OpenShift:
-- apiGroups:
-  - apps.openshift.io
-  resources:
-  - deploymentconfigs
-  verbs:
-  - get
-  - list
 - apiGroups:
   - authorization.openshift.io
   resources:


### PR DESCRIPTION
https://jira.coreos.com/browse/CO-611

This is not an actual fix, but removing the code around deploymentconfigs, till we find a better solution to see if Hive is running on OpenShift

```
time="2019-10-25T12:39:19Z" level=info msg="validating webhook \"config/hiveadmission/clusterdeployment-webhook.yaml\" applied (unchanged)" controller=hive                                                        
E1025 12:39:19.210809       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
time="2019-10-25T12:39:19Z" level=info msg="validating webhook \"config/hiveadmission/clusterimageset-webhook.yaml\" applied (unchanged)" controller=hive                                                          
time="2019-10-25T12:39:19Z" level=info msg="validating webhook \"config/hiveadmission/clusterprovision-webhook.yaml\" applied (unchanged)" controller=hive                                                         
time="2019-10-25T12:39:19Z" level=info msg="validating webhook \"config/hiveadmission/dnszones-webhook.yaml\" applied (unchanged)" controller=hive                                                                 
time="2019-10-25T12:39:19Z" level=info msg="validating webhook \"config/hiveadmission/syncset-webhook.yaml\" applied (unchanged)" controller=hive                                                                  
time="2019-10-25T12:39:19Z" level=info msg="validating webhook \"config/hiveadmission/selectorsyncset-webhook.yaml\" applied (unchanged)" controller=hive                                                          
time="2019-10-25T12:39:19Z" level=info msg="hiveadmission components reconciled successfully" controller=hive                                                                                                      
E1025 12:39:20.215852       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:21.218832       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:22.247078       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:23.250357       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:24.263133       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:25.272878       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:26.283814       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:27.307606       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:28.311891       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:29.320238       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:30.329198       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:31.333218       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:32.343645       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:33.354565       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:34.359814       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:35.369449       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:36.372980       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:37.403341       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:38.416303       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:39.425167       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:40.431484       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:41.446134       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:42.456301       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:43.466336       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
E1025 12:39:44.474166       1 reflector.go:270] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: Failed to watch *v1.DeploymentConfig: unknown (get deploymentconfigs.apps.openshift.io)    
```