### PR TITLE
Fix error in operator logs watching DeploymentConfigs.

### DIFF
--- a/config/operator/operator_role.yaml
+++ b/config/operator/operator_role.yaml
@@ -129,6 +129,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - authorization.openshift.io
   resources:


### PR DESCRIPTION
Looks like there is an implicit watch needed for the controller runtime
client to be able to do the list we use to check if we're running on
OpenShift.