### PR TITLE
controllers: ensure valid cd status for imageset jobs

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -444,6 +444,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 					cd.Status.InstallerImage = nil
 					cd.Spec.Images.InstallerImage = ""
 					cd.Spec.ImageSet = &hivev1.ClusterImageSetReference{Name: testClusterImageSetName}
+					cd.Status.ClusterVersionStatus.AvailableUpdates = []openshiftapiv1.Update{}
 					return cd
 				}(),
 				testClusterImageSet(),
@@ -477,6 +478,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 					cd.Spec.Images.InstallerImage = ""
 					cd.Spec.Images.ReleaseImage = "embedded-release-image:latest"
 					cd.Spec.ImageSet = &hivev1.ClusterImageSetReference{Name: testClusterImageSetName}
+					cd.Status.ClusterVersionStatus.AvailableUpdates = []openshiftapiv1.Update{}
 					return cd
 				}(),
 				testClusterImageSet(),


### PR DESCRIPTION
The clusterdeployment status needs special massaging for it to be acceptable to the validator. The controllers do this massaging automatically, but the imageset job does not. To ensure that status updates from the imageset job are accepted, these changes have the clusterdeployment controller update the status prior to creating the imageset job if the massaging has not yet been done.