### PR TITLE
docs: added a note for the creation of secret for AWS

### DIFF
--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -13,8 +13,9 @@
         ```
   1. Create a Kubernetes secret containing your AWS credentials:
         ```bash
-        oc create secret generic test-creds --from-literal=aws_secret_access_key=$AWS_SECRET_ACCESS_KEY --from-literal=aws_access_key_id=$AWS_ACCESS_KEY_ID
+        oc create secret generic mycluster-aws-creds --from-literal=aws_secret_access_key=$AWS_SECRET_ACCESS_KEY --from-literal=aws_access_key_id=$AWS_ACCESS_KEY_ID
         ```
+     **NOTE**: This will be done automatically if using `hiveutil create-cluster`.
   1. Create a [PersistentVolume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) for your `ClusterDeployment` to store the installation logs. The `accessModes` is `ReadWriteOnce` for your `PersistentVolume`. Note that if you do not want to capture must-gather logs then you can set `.spec.failedProvisionConfig.skipGatherLogs` to `true` in the `HiveConfig`.
 ### Using Global Pull Secret
 


### PR DESCRIPTION
The secret will be created from either AWS credential file or from
the env varsi, it was already handled in the create-cluster logic.

/cc @dgoodwin 