### PR TITLE
add a default instance type for GCP

### DIFF
--- a/contrib/pkg/createcluster/gcp.go
+++ b/contrib/pkg/createcluster/gcp.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	gcpCredFile = "osServiceAccount.json"
+	gcpCredFile         = "osServiceAccount.json"
+	defaultInstanceType = "n1-standard-4"
 )
 
 var _ cloudProvider = (*gcpCloudProvider)(nil)
@@ -67,6 +68,20 @@ func (p *gcpCloudProvider) addPlatformDetails(o *Options, cd *hivev1.ClusterDepl
 				Name: p.credsSecretName(o),
 			},
 		},
+	}
+
+	// Set default instance type for both control plane and workers.
+	mpp := &hivev1gcp.MachinePool{
+		InstanceType: defaultInstanceType,
+	}
+
+	cd.Spec.ControlPlane.Platform = hivev1.MachinePoolPlatform{
+		GCP: mpp,
+	}
+	for i := range cd.Spec.Compute {
+		cd.Spec.Compute[i].Platform = hivev1.MachinePoolPlatform{
+			GCP: mpp,
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
mirror what we do for AWS and provide a default instance type for GCP when creating a clusterDeployment