### PR TITLE
add webhook validation for GCP to ensure the instance types are provided

### DIFF
--- a/contrib/pkg/createcluster/gcp.go
+++ b/contrib/pkg/createcluster/gcp.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	gcpCredFile = "osServiceAccount.json"
+	gcpCredFile         = "osServiceAccount.json"
+	defaultInstanceType = "n1-standard-4"
 )
 
 var _ cloudProvider = (*gcpCloudProvider)(nil)
@@ -68,6 +69,21 @@ func (p *gcpCloudProvider) addPlatformDetails(o *Options, cd *hivev1.ClusterDepl
 			},
 		},
 	}
+
+	// Set default instance type for both control plane and workers.
+	mpp := &hivev1gcp.MachinePool{
+		InstanceType: defaultInstanceType,
+	}
+
+	cd.Spec.ControlPlane.Platform = hivev1.MachinePoolPlatform{
+		GCP: mpp,
+	}
+	for i := range cd.Spec.Compute {
+		cd.Spec.Compute[i].Platform = hivev1.MachinePoolPlatform{
+			GCP: mpp,
+		}
+	}
+
 	return nil
 }
 

--- a/contrib/pkg/createcluster/gcp.go
+++ b/contrib/pkg/createcluster/gcp.go
@@ -75,13 +75,10 @@ func (p *gcpCloudProvider) addPlatformDetails(o *Options, cd *hivev1.ClusterDepl
 		InstanceType: defaultInstanceType,
 	}
 
-	cd.Spec.ControlPlane.Platform = hivev1.MachinePoolPlatform{
-		GCP: mpp,
-	}
+	cd.Spec.ControlPlane.Platform.GCP = mpp
+
 	for i := range cd.Spec.Compute {
-		cd.Spec.Compute[i].Platform = hivev1.MachinePoolPlatform{
-			GCP: mpp,
-		}
+		cd.Spec.Compute[i].Platform.GCP = mpp
 	}
 
 	return nil


### PR DESCRIPTION
to be able to build MachineSets to sync out to GCP clusters, we need to know the instance-type to put into the MachineSet.

make the instance-type field mandatory for GCP.