### PR TITLE
Previous cluster ID and infra ID must not be set for pre-installed cluster

### DIFF
--- a/hack/duplicate_cd.sh
+++ b/hack/duplicate_cd.sh
@@ -80,6 +80,8 @@ NEW_PROV_BASE=$(echo ${PROV} | jq \
 			"labels":{"hive.openshift.io/duplicated-from":.name}} |
 		.spec.stage="complete" |
 		del(.spec.podSpec) |
+		del(.spec.prevClusterID) |
+		del(.spec.prevInfraID) |
 		del(.spec.attempt)')
 		
 for (( i=0; i<${COUNT}; i++ ))


### PR DESCRIPTION
The script was failing because of this
```
$ hack/duplicate_cd.sh lalatendum-test-1 20
                                      
Duplicating lalatendum-test-1 20 times
clusterdeployment.hive.openshift.io/lalatendum-test-1-dup-kgdmv created
The ClusterProvision "" is invalid: 
* spec.prevClusterID: Invalid value: "0c7714c9-4052-4b63-b207-ffc1a30dcf25": previous cluster ID must not be set for pre-installed cluster
* spec.prevInfraID: Invalid value: "lalatendum-test-1-xrdcd": previous infra ID must not be set for pre-installed cluster
```
The clusterprovision yaml
```yaml
{
  "apiVersion": "hive.openshift.io/v1alpha1",
  "kind": "ClusterProvision",
  "metadata": {
    "namespace": "default",
    "ownerReferences": [
      {
        "apiVersion": "hive.openshift.io/v1alpha1",
        "blockOwnerDeletion": true,
        "controller": true,
        "kind": "ClusterDeployment",
        "name": "lalatendum-test-1-dup-lnbr5",
        "uid": "a609ba75-04c0-11ea-aa15-12e13b1e6637"
      }
    ],
    "labels": {
      "hive.openshift.io/duplicated-from": "lalatendum-test-1-1-5c8ln",
      "hive.openshift.io/cluster-deployment-name": "lalatendum-test-1-dup-lnbr5"
    },
    "name": "lalatendum-test-1-dup-lnbr5"
  },
  "spec": {
    "adminKubeconfigSecret": {
      "name": "lalatendum-test-1-1-5c8ln-admin-kubeconfig"
    },
    "adminPasswordSecret": {
      "name": "lalatendum-test-1-1-5c8ln-admin-password"
    },
    "clusterDeployment": {
      "name": "lalatendum-test-1"
    },
    "clusterID": "d5c69a47-4428-4f11-b535-d12b3c00b012",
    "infraID": "lalatendum-test-1-dw7wn",
    "installLog": "level=info msg=\"Consuming \\\"Worker Ignition Config\\\" from target directory\"\nlevel=info msg=\"Consuming \\\"Bootstrap Ignition Config\\\" from target directory\"\nlevel=info msg=\"Consuming \\\"Master Ignition Config\\\" from target directory\"\nl
evel=info msg=\"Creating infrastructure resources...\"\nlevel=info msg=\"Waiting up to 30m0s for the Kubernetes API at https://api.lalatendum-test-1.new-installer.openshift.com:6443...\"\nlevel=info msg=\"API v1.14.6+dc8862c up\"\nlevel=info msg=\"Waiting up to 30m0s for 
bootstrapping to complete...\"\nlevel=info msg=\"Destroying the bootstrap resources...\"\nlevel=info msg=\"Waiting up to 30m0s for the cluster at https://api.lalatendum-test-1.new-installer.openshift.com:6443 to initialize...\"\nlevel=info msg=\"Waiting up to 10m0s for th
e openshift-console route to be created...\"\nlevel=info msg=\"Install complete!\"\nlevel=info msg=\"To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/output/auth/kubeconfig'\"\nlevel=info msg=\"Access the OpenShift web-console here: 
https://console-openshift-console.apps.lalatendum-test-1.new-installer.openshift.com\"\nREDACTED LINE OF OUTPUT\n",
    "metadata": {
      "aws": {
        "identifier": [
          {
            "kubernetes.io/cluster/lalatendum-test-1-dw7wn": "owned"
          },
          {
            "openshiftClusterID": "d5c69a47-4428-4f11-b535-d12b3c00b012"
          }
        ],
        "region": "us-east-1"
      },
      "clusterID": "d5c69a47-4428-4f11-b535-d12b3c00b012",
      "clusterName": "lalatendum-test-1",
      "infraID": "lalatendum-test-1-dw7wn"
    },
    "prevClusterID": "0c7714c9-4052-4b63-b207-ffc1a30dcf25",
    "prevInfraID": "lalatendum-test-1-xrdcd",
    "stage": "complete"
  }
}
```
Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>