### PR TITLE
Add hiveutil create-cluster support for adopting clusters.

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -118,6 +118,24 @@ kind delete cluster --name hive
 ./hack/create-kind-cluster.sh hive
 ```
 
+## Adopting ClusterDeployments
+
+It is possible to adopt cluster deployments into Hive, potentially even fake or kind clusters. This can be useful for developers who would like to work on functionality separate from actual provisioning.
+
+To create a kind cluster and adopt:
+
+```bash
+./hack/create-kind-cluster.sh cluster1
+bin/hiveutil create-cluster --base-domain=new-installer.openshift.com kind-cluster1 --adopt --adopt-admin-kubeconfig=$(kind get kubeconfig-path --name="cluster1") --adopt-infra-id=fakeinfra --adopt-cluster-id=fakeid
+```
+
+NOTE: when using a kind cluster not all controllers will be functioning properly as it is not an OpenShift cluster and thus lacks some of the CRDs our controllers use. (ClusterState, RemoteMachineSet, etc)
+
+Alternatively you can use any valid kubeconfig for live or since deleted clusters.
+
+Deprovision will run but find nothing to delete if no resources are tagged with your fake infrastructure ID.
+
+
 ## Writing/Testing Code
 
 Our typical approach to manually testing code is to deploy Hive into your current cluster as defined by kubeconfig, scale down the relevant component you wish to test, and then run its code locally.

--- a/hack/create-kind-cluster.sh
+++ b/hack/create-kind-cluster.sh
@@ -70,7 +70,7 @@ function fixup-cluster() {
   local cluster_name=${1} # cluster num
 
   local kubeconfig_path="$(kind get kubeconfig-path --name ${cluster_name})"
-  export KUBECONFIG="${KUBECONFIG:-}:${kubeconfig_path}"
+  export KUBECONFIG="${kubeconfig_path}"
 
   if [ "$OS" != "Darwin" ];then
     # Set container IP address as kube API endpoint in order for clusters to reach kube API servers in other clusters.
@@ -79,6 +79,7 @@ function fixup-cluster() {
 
   # Simplify context name
   kubectl config rename-context "kubernetes-admin@${cluster_name}" "${cluster_name}-context"
+  kubectl config use-context "${cluster_name}-context"
 
   # TODO(font): Need to rename auth user name to avoid conflicts when using
   # multiple cluster kubeconfigs. Remove once


### PR DESCRIPTION
--adopt options allow you to adopt an already installed cluster into
Hive for purposes of using SyncSets, and Hive deprovision code.

This feature is likely most helpful for Hive developers who need are not
looking to explicitly test provisioning and would like to quickly get
valid clusters into hive without waiting for a full provision.

Adds documentation for using a kind cluster as your adopted
ClusterDeployment.