### PR TITLE
dnsendpoint: do not reconcile until initial scrape of root domain

### DIFF
--- a/pkg/controller/dnsendpoint/dnsendpoint_controller.go
+++ b/pkg/controller/dnsendpoint/dnsendpoint_controller.go
@@ -145,6 +145,10 @@ func (r *ReconcileDNSEndpoint) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, r.syncDeletedEndpoint(instance, dnsLog)
 	}
 
+	if !r.nameServerScraper.HasBeenScraped(domain) {
+		return reconcile.Result{}, errors.New("name servers have not yet been scraped")
+	}
+
 	if !controllerutils.HasFinalizer(instance, hivev1.FinalizerDNSEndpoint) {
 		controllerutils.AddFinalizer(instance, hivev1.FinalizerDNSEndpoint)
 		if err := r.Update(context.TODO(), instance); err != nil {

--- a/pkg/controller/dnsendpoint/dnsendpoint_controller_test.go
+++ b/pkg/controller/dnsendpoint/dnsendpoint_controller_test.go
@@ -166,6 +166,17 @@ func TestDNSEndpointReconcile(t *testing.T) {
 				rootDomain: nameServersMap{},
 			},
 		},
+		{
+			name:        "name servers not yet scraped",
+			dnsEndpoint: testDNSEndpoint(),
+			nameServers: rootDomainsMap{
+				rootDomain: nil,
+			},
+			expectErr: true,
+			expectedNameServers: rootDomainsMap{
+				rootDomain: nil,
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
When the controllers start, all existing dnsendpoint resources are queued for reconciliation. This happens concurrently with the initial scrape of the name servers. If a dnsendpoint is reconciled prior to the initial scrape, then the controller will determine that the NS records for the dnsendpoint do not exist and attempt to create them. This causes unnecessary and bursty traffic with the cloud provider. These changes force the controller to wait until the initial scrape is complete before reconciling any dnsendpoint resources.

Note that reconciling a deleted dnsendpoint is allowed. We want to allow the delete to go through even if there has not been a scrape so that deletes can still happen in the event of a problem with the scraper. 

https://jira.coreos.com/browse/CO-632