### PR TITLE
do not allow more than one compute machine pool on GCP

### DIFF
--- a/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook.go
@@ -607,7 +607,7 @@ func validateMachinePools(cd *hivev1.ClusterDeployment) field.ErrorList {
 
 	vErrs = append(vErrs, validateMachinePool(cd, &cd.Spec.ControlPlane, field.NewPath("spec", "controlPlane"))...)
 
-	vErrs = append(vErrs, validateComputeMachinePoolRequirements(cd)...)
+	vErrs = append(vErrs, validateComputeMachinePoolRequirements(cd, field.NewPath("spec", "compute"))...)
 
 	for i, mp := range cd.Spec.Compute {
 		vErrs = append(vErrs, validateMachinePool(cd, &mp, field.NewPath("spec", "compute").Index(i))...)
@@ -616,43 +616,28 @@ func validateMachinePools(cd *hivev1.ClusterDeployment) field.ErrorList {
 	return vErrs
 }
 
-func validateComputeMachinePoolRequirements(cd *hivev1.ClusterDeployment) field.ErrorList {
+func validateComputeMachinePoolRequirements(cd *hivev1.ClusterDeployment, path *field.Path) field.ErrorList {
 	vErrs := field.ErrorList{}
-	path := field.NewPath("spec")
 
 	if cd.Spec.Platform.GCP != nil {
-		// Only restrict the length of compute machine pools on GCP.
+		// Only restrict the name of compute machine pools on GCP.
 		// Restriction can be removed once proper handling of reuse or creation
 		// of necessary subnets is resolved.
-		if len(cd.Spec.Compute) > 1 {
-			vErrs = append(vErrs, field.Invalid(path, cd.Spec.Compute, "length of compute machine pools must not be greather than 1"))
-		}
-
-		if len(cd.Spec.Compute) > 0 {
-			// make sure we have a compute pool named 'worker'
-			foundWorkerPool := false
-			for _, mp := range cd.Spec.Compute {
-				if mp.Name == "worker" {
-					foundWorkerPool = true
-					break
-				}
-			}
-			if !foundWorkerPool {
-				vErrs = append(vErrs, field.Invalid(path, cd.Spec.Compute, "must have one compute pool named 'worker'"))
+		for i, mp := range cd.Spec.Compute {
+			if mp.Name != "worker" {
+				vErrs = append(vErrs, field.Invalid(path.Index(i).Child("name"), mp.Name,
+					"name of compute pool must be \"worker\""))
 			}
 		}
 	}
 
 	// ensure machinePool names are unique
-	names := map[string]int{}
-	for _, mp := range cd.Spec.Compute {
-		names[mp.Name]++
-	}
-	for k, v := range names {
-		if v > 1 {
-			validationMsg := fmt.Sprintf("compute pool with name %s used more than once", k)
-			vErrs = append(vErrs, field.Invalid(path, cd.Spec.Compute, validationMsg))
+	names := map[string]bool{}
+	for i, mp := range cd.Spec.Compute {
+		if names[mp.Name] {
+			vErrs = append(vErrs, field.Invalid(path.Index(i).Child("name"), mp.Name, "name must be unique"))
 		}
+		names[mp.Name] = true
 	}
 
 	return vErrs

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
@@ -738,6 +738,40 @@ func TestClusterDeploymentValidate(t *testing.T) {
 			operation:       admissionv1beta1.Update,
 			expectedAllowed: false,
 		},
+		{
+			name: "only one compute machine pool for GCP",
+			newObject: func() *hivev1.ClusterDeployment {
+				cd := validGCPClusterDeployment()
+				cd.Spec.Compute = append(cd.Spec.Compute, hivev1.MachinePool{
+					Name: "extramachinepool",
+					Platform: hivev1.MachinePoolPlatform{
+						GCP: &hivev1gcp.MachinePool{
+							InstanceType: "someinstancetype",
+						},
+					},
+				})
+				return cd
+			}(),
+			operation:       admissionv1beta1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name: "no update to multiple machine pools for GCP",
+			newObject: func() *hivev1.ClusterDeployment {
+				cd := validGCPClusterDeployment()
+				cd.Spec.Compute = append(cd.Spec.Compute, hivev1.MachinePool{
+					Name: "extramachinepool",
+					Platform: hivev1.MachinePoolPlatform{
+						GCP: &hivev1gcp.MachinePool{
+							InstanceType: "someinstancetype",
+						},
+					},
+				})
+				return cd
+			}(),
+			operation:       admissionv1beta1.Update,
+			expectedAllowed: false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
@@ -14,12 +14,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/pointer"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
 	hivev1aws "github.com/openshift/hive/pkg/apis/hive/v1alpha1/aws"
 	hivev1azure "github.com/openshift/hive/pkg/apis/hive/v1alpha1/azure"
 	hivev1gcp "github.com/openshift/hive/pkg/apis/hive/v1alpha1/gcp"
 	"github.com/openshift/hive/pkg/constants"
+)
+
+const (
+	defaultWorkerPoolName = "worker"
 )
 
 var validTestManagedDomains = []string{
@@ -36,7 +41,7 @@ func clusterDeploymentTemplate() *hivev1.ClusterDeployment {
 			ClusterName: "SameClusterName",
 			Compute: []hivev1.MachinePool{
 				{
-					Name: "SameMachinePoolName",
+					Name: defaultWorkerPoolName,
 				},
 			},
 			SSHKey: corev1.LocalObjectReference{
@@ -75,7 +80,7 @@ func validGCPClusterDeployment() *hivev1.ClusterDeployment {
 	}
 	cd.Spec.Compute = []hivev1.MachinePool{
 		{
-			Name: "SameMachinePoolName",
+			Name: defaultWorkerPoolName,
 			Platform: hivev1.MachinePoolPlatform{
 				GCP: &hivev1gcp.MachinePool{
 					InstanceType: "n1-standard",
@@ -99,11 +104,6 @@ func validGCPClusterDeployment() *hivev1.ClusterDeployment {
 
 func validAWSClusterDeployment() *hivev1.ClusterDeployment {
 	cd := clusterDeploymentTemplate()
-	cd.Spec.Compute = []hivev1.MachinePool{
-		{
-			Name: "SameMachinePoolName",
-		},
-	}
 	cd.Spec.Platform = hivev1.Platform{
 		AWS: &hivev1aws.Platform{
 			Region: "test-region",
@@ -117,11 +117,6 @@ func validAWSClusterDeployment() *hivev1.ClusterDeployment {
 
 func validAzureClusterDeployment() *hivev1.ClusterDeployment {
 	cd := clusterDeploymentTemplate()
-	cd.Spec.Compute = []hivev1.MachinePool{
-		{
-			Name: "SameMachinePoolName",
-		},
-	}
 	cd.Spec.Platform = hivev1.Platform{
 		Azure: &hivev1azure.Platform{
 			Region:                      "test-region",
@@ -158,7 +153,8 @@ func validClusterDeploymentDifferentMutableValue() *hivev1.ClusterDeployment {
 	cd := validAWSClusterDeployment()
 	cd.Spec.Compute = []hivev1.MachinePool{
 		{
-			Name: "DifferentMachinePoolName",
+			Name:     defaultWorkerPoolName,
+			Replicas: pointer.Int64Ptr(100),
 		},
 	}
 	return cd
@@ -739,7 +735,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 			expectedAllowed: false,
 		},
 		{
-			name: "only one compute machine pool for GCP",
+			name: "only allow one compute machine pool for GCP",
 			newObject: func() *hivev1.ClusterDeployment {
 				cd := validGCPClusterDeployment()
 				cd.Spec.Compute = append(cd.Spec.Compute, hivev1.MachinePool{
@@ -770,6 +766,27 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				return cd
 			}(),
 			operation:       admissionv1beta1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "ensure unique compute machine pool names",
+			newObject: func() *hivev1.ClusterDeployment {
+				cd := validAWSClusterDeployment()
+				cd.Spec.Compute = append(cd.Spec.Compute, hivev1.MachinePool{
+					Name: "extramachinepool",
+					Platform: hivev1.MachinePoolPlatform{
+						AWS: &hivev1aws.MachinePoolPlatform{},
+					},
+				})
+				cd.Spec.Compute = append(cd.Spec.Compute, hivev1.MachinePool{
+					Name: "extramachinepool",
+					Platform: hivev1.MachinePoolPlatform{
+						AWS: &hivev1aws.MachinePoolPlatform{},
+					},
+				})
+				return cd
+			}(),
+			operation:       admissionv1beta1.Create,
 			expectedAllowed: false,
 		},
 	}


### PR DESCRIPTION
Need to figure out how we handle extra compute machine pools. Either reuse existing subnets, or handle creating of new subnets as needed.

For now simply only allow the single original machine pool.