### PR TITLE
add hive-frontend Group to ClusterRoleBinding

### DIFF
--- a/config/rbac/hive_frontend_role_binding.yaml
+++ b/config/rbac/hive_frontend_role_binding.yaml
@@ -11,3 +11,5 @@ subjects:
 - kind: ServiceAccount
   name: hive-frontend
   namespace: hive
+- kind: Group
+  name: hive-frontend

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1287,6 +1287,8 @@ subjects:
 - kind: ServiceAccount
   name: hive-frontend
   namespace: hive
+- kind: Group
+  name: hive-frontend
 `)
 
 func configRbacHive_frontend_role_bindingYamlBytes() ([]byte, error) {


### PR DESCRIPTION
This PR is an attempt to solve https://jira.coreos.com/browse/APPSRE-961.
The plan is to add OCM developers to this group on the integration environment only.

Please let me know what you think.