### PR TITLE
Add SyncSet metrics.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ docker-build:
 
 # Build the docker image
 .PHONY: docker-dev-push
-docker-dev-push: build
+docker-dev-push: manifests generate build
 	$(DOCKER_CMD) build -t ${IMG} -f Dockerfile.dev .
 	$(DOCKER_CMD) push ${IMG}
 

--- a/config/crds/hive_v1alpha1_syncsetinstance.yaml
+++ b/config/crds/hive_v1alpha1_syncsetinstance.yaml
@@ -6,6 +6,10 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: syncsetinstances.hive.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.applied
+    name: Applied
+    type: boolean
   group: hive.openshift.io
   names:
     kind: SyncSetInstance
@@ -60,6 +64,10 @@ spec:
           type: object
         status:
           properties:
+            applied:
+              description: Applied will be true if all resources, patches, or secrets
+                have successfully been applied on last attempt.
+              type: boolean
             conditions:
               description: Conditions is the list of SyncConditions used to indicate
                 UnknownObject when a resource type cannot be determined from a SyncSet

--- a/pkg/apis/hive/v1alpha1/syncsetinstance_types.go
+++ b/pkg/apis/hive/v1alpha1/syncsetinstance_types.go
@@ -82,6 +82,9 @@ type SyncSetInstanceStatus struct {
 	// when a resource type cannot be determined from a SyncSet resource.
 	// +optional
 	Conditions []SyncCondition `json:"conditions,omitempty"`
+
+	// Applied will be true if all resources, patches, or secrets have successfully been applied on last attempt.
+	Applied bool `json:"applied"`
 }
 
 // +genclient
@@ -90,6 +93,7 @@ type SyncSetInstanceStatus struct {
 // SyncSetInstance is the Schema for the syncsetinstances API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Applied",type="boolean",JSONPath=".status.applied"
 // +kubebuilder:resource:path=syncsetinstances,shortName=ssi
 type SyncSetInstance struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/controller/syncsetinstance/syncsetinstance_controller.go
+++ b/pkg/controller/syncsetinstance/syncsetinstance_controller.go
@@ -258,6 +258,8 @@ func (r *ReconcileSyncSetInstance) Reconcile(request reconcile.Request) (reconci
 	original := ssi.DeepCopy()
 	applier := r.applierBuilder(kubeConfig, ssiLog)
 	applyErr := r.applySyncSet(ssi, spec, dynamicClient, applier, kubeConfig, ssiLog)
+	ssi.Status.Applied = applyErr == nil
+
 	err = r.updateSyncSetInstanceStatus(ssi, original, ssiLog)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -4622,6 +4622,10 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: syncsetinstances.hive.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.applied
+    name: Applied
+    type: boolean
   group: hive.openshift.io
   names:
     kind: SyncSetInstance
@@ -4676,6 +4680,10 @@ spec:
           type: object
         status:
           properties:
+            applied:
+              description: Applied will be true if all resources, patches, or secrets
+                have successfully been applied on last attempt.
+              type: boolean
             conditions:
               description: Conditions is the list of SyncConditions used to indicate
                 UnknownObject when a resource type cannot be determined from a SyncSet

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -146,9 +146,15 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helpe
 
 		// Due to bug with OLM not updating CRDs on upgrades, we are re-applying
 		// the latest in the operator to ensure updates roll out.
+		// TODO: Attempt removing this once Hive is running purely on 4.x,
+		// as it requires a significant privilege escalation we would rather
+		// leave in the hands of OLM.
+		"config/crds/hive_v1alpha1_checkpoint.yaml",
 		"config/crds/hive_v1alpha1_clusterdeployment.yaml",
 		"config/crds/hive_v1alpha1_clusterdeprovisionrequest.yaml",
 		"config/crds/hive_v1alpha1_clusterimageset.yaml",
+		"config/crds/hive_v1alpha1_clusterprovision.yaml",
+		"config/crds/hive_v1alpha1_clusterstate.yaml",
 		"config/crds/hive_v1alpha1_dnsendpoint.yaml",
 		"config/crds/hive_v1alpha1_dnszone.yaml",
 		"config/crds/hive_v1alpha1_hiveconfig.yaml",
@@ -156,6 +162,7 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helpe
 		"config/crds/hive_v1alpha1_selectorsyncset.yaml",
 		"config/crds/hive_v1alpha1_syncidentityprovider.yaml",
 		"config/crds/hive_v1alpha1_syncset.yaml",
+		"config/crds/hive_v1alpha1_syncsetinstance.yaml",
 
 		"config/configmaps/install-log-regexes-configmap.yaml",
 	}


### PR DESCRIPTION
Adds four new metrics, and SyncSetInstance.Status.Applied for a simpler
API to determine if everything in the SyncSet is applying properly.
Currently you must interpret at least 4 conditions, some of which are
errors and one of which is success. The new field is displayed as a
column in kubectl get output.

hive_selectorsyncset_clusters_total is a gauge labeled by name showing
the number of clusters that matched the label selector.
hive_selectorsyncset_clusters_unapplied_total is similar but for the
number that are not currently applying. Both are calculated by
examining SyncSetInstances.

hive_syncsets_total is a gauge that shows the total number of SyncSets,
and hive_syncsets_unapplied_total the number that are not currently
applying. This is also calculated by examining SyncSetInstances.