### PR TITLE
Add basic support for bare metal cluster provisioning.

### DIFF
--- a/config/crds/hive_v1_clusterdeployment.yaml
+++ b/config/crds/hive_v1_clusterdeployment.yaml
@@ -300,6 +300,10 @@ spec:
                         will be created.
                       type: string
                   type: object
+                bareMetal:
+                  description: BareMetal is the configuration used when installing
+                    on bare metal.
+                  type: object
                 gcp:
                   description: GCP is the configuration used when installing on Google
                     Cloud Platform.

--- a/pkg/apis/hive/v1/baremetal/machinepool.go
+++ b/pkg/apis/hive/v1/baremetal/machinepool.go
@@ -1,0 +1,6 @@
+package baremetal
+
+// MachinePoolPlatform stores the configuration for a machine pool
+// installed on bare metal.
+type MachinePoolPlatform struct {
+}

--- a/pkg/apis/hive/v1/baremetal/platform.go
+++ b/pkg/apis/hive/v1/baremetal/platform.go
@@ -1,0 +1,5 @@
+package baremetal
+
+// Platform stores the global configuration for the cluster.
+type Platform struct {
+}

--- a/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -7,6 +7,7 @@ import (
 	openshiftapiv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/hive/pkg/apis/hive/v1/aws"
 	"github.com/openshift/hive/pkg/apis/hive/v1/azure"
+	"github.com/openshift/hive/pkg/apis/hive/v1/baremetal"
 	"github.com/openshift/hive/pkg/apis/hive/v1/gcp"
 )
 
@@ -314,6 +315,9 @@ type Platform struct {
 	// GCP is the configuration used when installing on Google Cloud Platform.
 	// +optional
 	GCP *gcp.Platform `json:"gcp,omitempty"`
+
+	// BareMetal is the configuration used when installing on bare metal.
+	BareMetal *baremetal.Platform `json:"bareMetal,omitempty"`
 }
 
 // ClusterIngress contains the configurable pieces for any ClusterIngress objects

--- a/pkg/apis/hive/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/hive/v1/zz_generated.deepcopy.go
@@ -8,6 +8,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	aws "github.com/openshift/hive/pkg/apis/hive/v1/aws"
 	azure "github.com/openshift/hive/pkg/apis/hive/v1/azure"
+	baremetal "github.com/openshift/hive/pkg/apis/hive/v1/baremetal"
 	gcp "github.com/openshift/hive/pkg/apis/hive/v1/gcp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1790,6 +1791,11 @@ func (in *Platform) DeepCopyInto(out *Platform) {
 		in, out := &in.GCP, &out.GCP
 		*out = new(gcp.Platform)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.BareMetal != nil {
+		in, out := &in.BareMetal, &out.BareMetal
+		*out = new(baremetal.Platform)
+		**out = **in
 	}
 	return
 }

--- a/pkg/imageset/generate.go
+++ b/pkg/imageset/generate.go
@@ -1,6 +1,7 @@
 package imageset
 
 import (
+	"fmt"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -23,9 +24,12 @@ type ImageSpec struct {
 }
 
 const (
-	extractImageScript = `#/bin/bash
+	// extractImageScriptTemplate is a minimal shell script we run in the imageset job to determine the images to
+	// use for various OpenShift components involved in the provisioning. A string value will be formatted in
+	// for which installer image we need to use. (regular vs baremetal)
+	extractImageScriptTemplate = `#/bin/bash
 echo "About to run oc adm release info"
-if oc adm release info --image-for="installer" --registry-config "${PULL_SECRET}" "${RELEASE_IMAGE}" > /common/installer-image.txt 2> /common/error.log; then
+if oc adm release info --image-for="%s" --registry-config "${PULL_SECRET}" "${RELEASE_IMAGE}" > /common/installer-image.txt 2> /common/error.log; then
   echo "installer image resolved successfully"
 else
   echo "installer image resolution failed"
@@ -99,6 +103,14 @@ func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAcco
 		},
 	}
 
+	installerImageKey := "installer"
+	// If this is a bare metal install, we need to get the openshift-install binary from a different image with
+	// bare metal functionality compiled in. The binary is named the same and in the same location, so after swapping
+	// out what image to get it from, we can proceed with the code as we normally would.
+	if cd.Spec.Platform.BareMetal != nil {
+		installerImageKey = "baremetal-installer"
+	}
+
 	// This container just needs to copy the required install binaries to the shared emptyDir volume,
 	// where our container will run them. This is effectively downloading the all-in-one installer.
 	containers := []corev1.Container{
@@ -108,7 +120,7 @@ func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAcco
 			ImagePullPolicy: cli.PullPolicy,
 			Env:             env,
 			Command:         []string{"/bin/sh", "-c"},
-			Args:            []string{extractImageScript},
+			Args:            []string{fmt.Sprintf(extractImageScriptTemplate, installerImageKey)},
 			VolumeMounts:    volumeMounts,
 		},
 		{

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1867,6 +1867,10 @@ spec:
                         will be created.
                       type: string
                   type: object
+                bareMetal:
+                  description: BareMetal is the configuration used when installing
+                    on bare metal.
+                  type: object
                 gcp:
                   description: GCP is the configuration used when installing on Google
                     Cloud Platform.


### PR DESCRIPTION
Adds a new platform, currently just an empty struct, for BareMetal.

If we're provisioning bare metal we need to lookup a ref for a different
installer image. Using this image the openshift-install binary will be
in the exact same location with the exact same name as we normally use,
so we just need to swap out the image reference and everything else can
remain the same.

There is a pending need for installing mkisofs which is hopefully going
to be handled by the requirement being removed upstream soon.