### PR TITLE
Fix secretReference kind validation.

### DIFF
--- a/pkg/apis/hive/v1alpha1/validating-webhooks/selector_syncset_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/selector_syncset_validating_admission_hook_test.go
@@ -98,92 +98,212 @@ func TestSelectorSyncSetValidate(t *testing.T) {
 			expectedAllowed: true,
 		},
 		{
-			name:      "Test valid SecretReference kind create",
+			name:            "Test valid SecretReference create",
+			operation:       admissionv1beta1.Create,
+			selectorSyncSet: testSecretReferenceSelectorSyncSet(),
+			expectedAllowed: true,
+		},
+		{
+			name:            "Test valid SecretReference update",
+			operation:       admissionv1beta1.Update,
+			selectorSyncSet: testSecretReferenceSelectorSyncSet(),
+			expectedAllowed: true,
+		},
+		{
+			name:      "Test valid SecretReference source kind create",
 			operation: admissionv1beta1.Create,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSecretReferenceSelectorSyncSet()
-				ss.Spec.SecretReferences[0].Source.Kind = "secret"
-				ss.Spec.SecretReferences[0].Target.Kind = "secret"
+				ss.Spec.SecretReferences[0].Source.Kind = "Secret"
 				return ss
 			}(),
 			expectedAllowed: true,
 		},
 		{
-			name:      "Test valid SecretReference kind update",
-			operation: admissionv1beta1.Update,
+			name:      "Test valid SecretReference target kind create",
+			operation: admissionv1beta1.Create,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSecretReferenceSelectorSyncSet()
-				ss.Spec.SecretReferences[0].Source.Kind = "secret"
-				ss.Spec.SecretReferences[0].Target.Kind = "secret"
+				ss.Spec.SecretReferences[0].Target.Kind = "Secret"
 				return ss
 			}(),
 			expectedAllowed: true,
 		},
 		{
-			name:      "Test invalid SecretReference kind create",
-			operation: admissionv1beta1.Create,
-			selectorSyncSet: func() *hivev1.SelectorSyncSet {
-				ss := testSecretReferenceSelectorSyncSet()
-				ss.Spec.SecretReferences[0].Source.Kind = "wrongkind"
-				ss.Spec.SecretReferences[0].Target.Kind = "wrongkind"
-				return ss
-			}(),
-			expectedAllowed: false,
-		},
-		{
-			name:      "Test invalid SecretReference kind update",
+			name:      "Test valid SecretReference source kind update",
 			operation: admissionv1beta1.Update,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSecretReferenceSelectorSyncSet()
-				ss.Spec.SecretReferences[0].Source.Kind = "wrongkind"
-				ss.Spec.SecretReferences[0].Target.Kind = "wrongkind"
+				ss.Spec.SecretReferences[0].Source.Kind = "Secret"
+				return ss
+			}(),
+			expectedAllowed: true,
+		},
+		{
+			name:      "Test valid SecretReference target kind update",
+			operation: admissionv1beta1.Update,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSecretReferenceSelectorSyncSet()
+				ss.Spec.SecretReferences[0].Target.Kind = "Secret"
+				return ss
+			}(),
+			expectedAllowed: true,
+		},
+		{
+			name:      "Test invalid SecretReference source kind create",
+			operation: admissionv1beta1.Create,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSecretReferenceSelectorSyncSet()
+				ss.Spec.SecretReferences[0].Source.Kind = "Wrong"
 				return ss
 			}(),
 			expectedAllowed: false,
 		},
 		{
-			name:      "Test invalid SecretReference no name create",
+			name:      "Test invalid SecretReference target kind create",
+			operation: admissionv1beta1.Create,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSecretReferenceSelectorSyncSet()
+				ss.Spec.SecretReferences[0].Target.Kind = "Wrong"
+				return ss
+			}(),
+			expectedAllowed: false,
+		},
+		{
+			name:      "Test invalid SecretReference source kind update",
+			operation: admissionv1beta1.Update,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSecretReferenceSelectorSyncSet()
+				ss.Spec.SecretReferences[0].Source.Kind = "Wrong"
+				return ss
+			}(),
+			expectedAllowed: false,
+		},
+		{
+			name:      "Test invalid SecretReference target kind update",
+			operation: admissionv1beta1.Update,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSecretReferenceSelectorSyncSet()
+				ss.Spec.SecretReferences[0].Target.Kind = "Wrong"
+				return ss
+			}(),
+			expectedAllowed: false,
+		},
+		{
+			name:      "Test invalid SecretReference no source name create",
 			operation: admissionv1beta1.Create,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSecretReferenceSelectorSyncSet()
 				ss.Spec.SecretReferences[0].Source.Name = ""
+				return ss
+			}(),
+			expectedAllowed: false,
+		},
+		{
+			name:      "Test invalid SecretReference no target name create",
+			operation: admissionv1beta1.Create,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSecretReferenceSelectorSyncSet()
 				ss.Spec.SecretReferences[0].Target.Name = ""
 				return ss
 			}(),
 			expectedAllowed: false,
 		},
 		{
-			name:      "Test invalid SecretReference no name update",
+			name:      "Test invalid SecretReference no source name update",
 			operation: admissionv1beta1.Update,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSecretReferenceSelectorSyncSet()
 				ss.Spec.SecretReferences[0].Source.Name = ""
+				return ss
+			}(),
+			expectedAllowed: false,
+		},
+		{
+			name:      "Test invalid SecretReference no target name update",
+			operation: admissionv1beta1.Update,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSecretReferenceSelectorSyncSet()
 				ss.Spec.SecretReferences[0].Target.Name = ""
 				return ss
 			}(),
 			expectedAllowed: false,
 		},
 		{
-			name:      "Test invalid SecretReference invalid fields set create",
+			name:      "Test invalid SecretReference source fieldPath set create",
 			operation: admissionv1beta1.Create,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSecretReferenceSelectorSyncSet()
 				ss.Spec.SecretReferences[0].Source.FieldPath = "dontset"
+				return ss
+			}(),
+			expectedAllowed: false,
+		},
+		{
+			name:      "Test invalid SecretReference source UID set create",
+			operation: admissionv1beta1.Create,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSecretReferenceSelectorSyncSet()
 				ss.Spec.SecretReferences[0].Source.UID = "dontset"
+				return ss
+			}(),
+			expectedAllowed: false,
+		},
+		{
+			name:      "Test invalid SecretReference target fieldPath set create",
+			operation: admissionv1beta1.Create,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSecretReferenceSelectorSyncSet()
 				ss.Spec.SecretReferences[0].Target.FieldPath = "dontset"
+				return ss
+			}(),
+			expectedAllowed: false,
+		},
+		{
+			name:      "Test invalid SecretReference target UID set create",
+			operation: admissionv1beta1.Create,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSecretReferenceSelectorSyncSet()
 				ss.Spec.SecretReferences[0].Target.UID = "dontset"
 				return ss
 			}(),
 			expectedAllowed: false,
 		},
 		{
-			name:      "Test invalid SecretReference invalid fields set update",
+			name:      "Test invalid SecretReference source fieldPath set update",
 			operation: admissionv1beta1.Update,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSecretReferenceSelectorSyncSet()
 				ss.Spec.SecretReferences[0].Source.FieldPath = "dontset"
+				return ss
+			}(),
+			expectedAllowed: false,
+		},
+		{
+			name:      "Test invalid SecretReference source UID set update",
+			operation: admissionv1beta1.Update,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSecretReferenceSelectorSyncSet()
 				ss.Spec.SecretReferences[0].Source.UID = "dontset"
+				return ss
+			}(),
+			expectedAllowed: false,
+		},
+		{
+			name:      "Test invalid SecretReference target fieldPath set update",
+			operation: admissionv1beta1.Update,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSecretReferenceSelectorSyncSet()
 				ss.Spec.SecretReferences[0].Target.FieldPath = "dontset"
+				return ss
+			}(),
+			expectedAllowed: false,
+		},
+		{
+			name:      "Test invalid SecretReference target UID set update",
+			operation: admissionv1beta1.Update,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSecretReferenceSelectorSyncSet()
 				ss.Spec.SecretReferences[0].Target.UID = "dontset"
 				return ss
 			}(),

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/syncset_validating_admission_hook.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/syncset_validating_admission_hook.go
@@ -284,8 +284,8 @@ func validateSecretReferences(secrets []hivev1.SecretReference, fldPath *field.P
 
 func validateSecretRef(ref corev1.ObjectReference, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if len(ref.Kind) > 0 && ref.Kind != "secret" {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("kind"), ref.Kind, []string{"secret"}))
+	if len(ref.Kind) > 0 && ref.Kind != "Secret" {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("kind"), ref.Kind, []string{"Secret"}))
 	}
 	if ref.GroupVersionKind().Group != "" {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("apiVersion"), ref.APIVersion, "Group part of API version must be empty"))

--- a/pkg/apis/hive/v1alpha1/validating-webhooks/syncset_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1alpha1/validating-webhooks/syncset_validating_admission_hook_test.go
@@ -102,7 +102,7 @@ func TestSyncSetValidate(t *testing.T) {
 			operation: admissionv1beta1.Create,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSecretReferenceSyncSet()
-				ss.Spec.SecretReferences[0].Source.Kind = "secret"
+				ss.Spec.SecretReferences[0].Source.Kind = "Secret"
 				return ss
 			}(),
 			expectedAllowed: true,
@@ -112,7 +112,7 @@ func TestSyncSetValidate(t *testing.T) {
 			operation: admissionv1beta1.Create,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSecretReferenceSyncSet()
-				ss.Spec.SecretReferences[0].Target.Kind = "secret"
+				ss.Spec.SecretReferences[0].Target.Kind = "Secret"
 				return ss
 			}(),
 			expectedAllowed: true,
@@ -122,7 +122,7 @@ func TestSyncSetValidate(t *testing.T) {
 			operation: admissionv1beta1.Update,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSecretReferenceSyncSet()
-				ss.Spec.SecretReferences[0].Source.Kind = "secret"
+				ss.Spec.SecretReferences[0].Source.Kind = "Secret"
 				return ss
 			}(),
 			expectedAllowed: true,
@@ -132,7 +132,7 @@ func TestSyncSetValidate(t *testing.T) {
 			operation: admissionv1beta1.Update,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSecretReferenceSyncSet()
-				ss.Spec.SecretReferences[0].Target.Kind = "secret"
+				ss.Spec.SecretReferences[0].Target.Kind = "Secret"
 				return ss
 			}(),
 			expectedAllowed: true,
@@ -142,7 +142,7 @@ func TestSyncSetValidate(t *testing.T) {
 			operation: admissionv1beta1.Create,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSecretReferenceSyncSet()
-				ss.Spec.SecretReferences[0].Source.Kind = "wrongkind"
+				ss.Spec.SecretReferences[0].Source.Kind = "Wrong"
 				return ss
 			}(),
 			expectedAllowed: false,
@@ -152,7 +152,7 @@ func TestSyncSetValidate(t *testing.T) {
 			operation: admissionv1beta1.Create,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSecretReferenceSyncSet()
-				ss.Spec.SecretReferences[0].Target.Kind = "wrongkind"
+				ss.Spec.SecretReferences[0].Target.Kind = "Wrong"
 				return ss
 			}(),
 			expectedAllowed: false,
@@ -162,7 +162,7 @@ func TestSyncSetValidate(t *testing.T) {
 			operation: admissionv1beta1.Update,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSecretReferenceSyncSet()
-				ss.Spec.SecretReferences[0].Source.Kind = "wrongkind"
+				ss.Spec.SecretReferences[0].Source.Kind = "Wrong"
 				return ss
 			}(),
 			expectedAllowed: false,
@@ -172,7 +172,7 @@ func TestSyncSetValidate(t *testing.T) {
 			operation: admissionv1beta1.Update,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSecretReferenceSyncSet()
-				ss.Spec.SecretReferences[0].Target.Kind = "wrongkind"
+				ss.Spec.SecretReferences[0].Target.Kind = "Wrong"
 				return ss
 			}(),
 			expectedAllowed: false,

--- a/pkg/controller/syncmachineset/syncmachineset_controller_test.go
+++ b/pkg/controller/syncmachineset/syncmachineset_controller_test.go
@@ -3,8 +3,9 @@ package syncmachineset
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/golang/mock/gomock"
 	log "github.com/sirupsen/logrus"
@@ -412,7 +413,6 @@ func TestNewMachineSetActuator(t *testing.T) {
 		clusterDeployment *hivev1.ClusterDeployment
 		existingObjects   []runtime.Object
 		expectErr         bool
-		validate          func(*testing.T)
 	}{
 		{
 			name:              "return an actuator",


### PR DESCRIPTION
Fixes `secretReference.Kind` validation.

The `SelectorSyncSet` tests were unseparated so I fixed that and also needed to make a change in `syncmachineset_controller_test.go` for golint.