### PR TITLE
makefile: do not install mockgen automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test-e2e-postinstall:
 
 # Builds all of hive's binaries (including utils).
 .PHONY: build
-build: $(GOPATH)/bin/mockgen manager hiveutil hiveadmission operator
+build: manager hiveutil hiveadmission operator
 
 
 # Build manager binary
@@ -171,7 +171,7 @@ verify-generated:
 
 # Generate code
 .PHONY: generate
-generate: $(GOPATH)/bin/mockgen
+generate:
 	go generate ./pkg/... ./cmd/...
 	hack/update-bindata.sh
 
@@ -207,9 +207,6 @@ buildah-dev-push: build
 buildah-push: buildah-build
 	$(SUDO_CMD) buildah push ${IMG}
 
-$(GOPATH)/bin/mockgen:
-	go get -u github.com/golang/mock/mockgen/...
-
 .PHONY: clean ## Remove all build artifacts
 clean:
 	rm -rf $(BINDIR)
@@ -219,3 +216,7 @@ clean:
 .PHONY: lint
 lint:
 	golangci-lint run -c ./golangci.yml ./pkg/... ./cmd/... ./contrib/...
+
+# Build the build image so that it can be used locally for performing builds.
+build-build-image: build/build-image/Dockerfile
+	$(BUILD_CMD) -t "hive-build:latest" -f build/build-image/Dockerfile .

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -4,6 +4,7 @@
 
 - [Developing Hive](#developing-hive)
   - [Prerequisites](#prerequisites)
+  - [External tools](#external-tools)
   - [Build and run tests](#build-and-run-tests)
   - [Setting up the development environment](#setting-up-the-development-environment)
     - [Cloning the repository](#cloning-the-repository)
@@ -34,7 +35,28 @@
 - Git
 - Make
 - A recent Go distribution (>=1.12)
+
+### External tools
+
 - [kustomize](https://github.com/kubernetes-sigs/kustomize#kustomize)
+- [mockgen](https://github.com/golang/mock)
+- [golangci-lint](https://github.com/golangci/golangci-lint)
+
+If you do not care to install those tools locally, then you can use them from the Hive build image.
+
+To build the image, run:
+
+```bash
+make build-build-image
+```
+
+Then, replace executions of `make` with executions of `hack/make`.
+
+For example, to run the tests you would run the following.
+
+```bash
+hack/make test
+```
 
 ## Build and run tests
 
@@ -245,6 +267,8 @@ Before you can use Dep you need to download and install it from GitHub:
 ```
 
 This will install the `dep` binary into *_$GOPATH/bin_*.
+
+Alternatively, if you would rather not install Dep, you can run from a container using the Hive build image as described in the [External tools](#external-tools) section.
 
 ### Updating Dependencies
 

--- a/hack/make
+++ b/hack/make
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker run --rm --volume "${PWD}:/go/src/github.com/openshift/hive:z" --workdir /go/src/github.com/openshift/hive hive-build:latest make "${@}"
+


### PR DESCRIPTION
As with golintci-lint, it should be left up to the developer to manually install mockgen on their local development environment.

Also, provide a means for running builds locally using the build image.
 * make build-build-image will build the build image
 * ./hack/make script will run make in a container using the build image