### PR TITLE
remove gcp project_id from clusterdeployment

### DIFF
--- a/config/crds/hive_v1_clusterdeployment.yaml
+++ b/config/crds/hive_v1_clusterdeployment.yaml
@@ -328,10 +328,6 @@ spec:
                             type: string
                           type: array
                       type: object
-                    projectID:
-                      description: ProjectID is the the project that will be used
-                        for the cluster.
-                      type: string
                     region:
                       description: Region specifies the GCP region where the cluster
                         will be created.

--- a/config/crds/hive_v1_clusterdeprovision.yaml
+++ b/config/crds/hive_v1_clusterdeprovision.yaml
@@ -83,10 +83,6 @@ spec:
                       description: CredentialsSecretRef is the GCP account credentials
                         to use for deprovisioning the cluster
                       type: object
-                    projectID:
-                      description: ProjectID is the ID of the GCP project in which
-                        the cluster exists
-                      type: string
                     region:
                       description: Region is the GCP region for this deprovision
                       type: string

--- a/contrib/pkg/createcluster/create.go
+++ b/contrib/pkg/createcluster/create.go
@@ -141,9 +141,6 @@ type Options struct {
 	// Azure
 	AzureBaseDomainResourceGroupName string
 
-	// GCP
-	GCPProjectID string
-
 	homeDir       string
 	cloudProvider cloudProvider
 }
@@ -170,7 +167,7 @@ func NewCreateClusterCommand() *cobra.Command {
 		Use: `create-cluster CLUSTER_DEPLOYMENT_NAME
 create-cluster CLUSTER_DEPLOYMENT_NAME --cloud=aws
 create-cluster CLUSTER_DEPLOYMENT_NAME --cloud=azure --azure-base-domain-resource-group-name=RESOURCE_GROUP_NAME
-create-cluster CLUSTER_DEPLOYMENT_NAME --cloud=gcp --gcp-project-id=PROJECT_ID`,
+create-cluster CLUSTER_DEPLOYMENT_NAME --cloud=gcp`,
 		Short: "Creates a new Hive cluster deployment",
 		Long:  fmt.Sprintf(longDesc, defaultSSHPublicKeyFile, defaultPullSecretFile),
 		Args:  cobra.ExactArgs(1),
@@ -227,9 +224,6 @@ create-cluster CLUSTER_DEPLOYMENT_NAME --cloud=gcp --gcp-project-id=PROJECT_ID`,
 	// Azure flags
 	flags.StringVar(&opt.AzureBaseDomainResourceGroupName, "azure-base-domain-resource-group-name", "os4-common", "Resource group where the azure DNS zone for the base domain is found")
 
-	// GCP flags
-	flags.StringVar(&opt.GCPProjectID, "gcp-project-id", "", "Project ID is the ID of the GCP project to use")
-
 	return cmd
 }
 
@@ -260,15 +254,6 @@ func (o *Options) Validate(cmd *cobra.Command) error {
 		cmd.Usage()
 		log.Infof("Unsupported cloud: %s", o.Cloud)
 		return fmt.Errorf("Unsupported cloud: %s", o.Cloud)
-	}
-	switch o.Cloud {
-	case cloudGCP:
-		if o.GCPProjectID == "" {
-			cmd.Usage()
-			log.Infof("Must specify the GCP project ID when installing on GCP. Use the --gcp-project-id flag.")
-			return fmt.Errorf("gcp requires gcp-project-id flag")
-
-		}
 	}
 
 	if o.Adopt {

--- a/contrib/pkg/createcluster/gcp.go
+++ b/contrib/pkg/createcluster/gcp.go
@@ -13,6 +13,7 @@ import (
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	hivev1gcp "github.com/openshift/hive/pkg/apis/hive/v1/gcp"
 	"github.com/openshift/hive/pkg/constants"
+	"github.com/openshift/hive/pkg/gcpclient"
 )
 
 const (
@@ -52,13 +53,21 @@ func (p *gcpCloudProvider) addPlatformDetails(
 	machinePool *hivev1.MachinePool,
 	installConfig *installertypes.InstallConfig,
 ) error {
+	creds, err := gcputils.GetCreds(o.CredsFile)
+	if err != nil {
+		return err
+	}
+	projectID, err := gcpclient.ProjectID(creds)
+	if err != nil {
+		return err
+	}
+
 	cd.Spec.Platform = hivev1.Platform{
 		GCP: &hivev1gcp.Platform{
 			CredentialsSecretRef: corev1.LocalObjectReference{
 				Name: p.credsSecretName(o),
 			},
-			ProjectID: o.GCPProjectID,
-			Region:    gcpRegion,
+			Region: gcpRegion,
 		},
 	}
 
@@ -68,7 +77,7 @@ func (p *gcpCloudProvider) addPlatformDetails(
 
 	installConfig.Platform = installertypes.Platform{
 		GCP: &installergcp.Platform{
-			ProjectID: o.GCPProjectID,
+			ProjectID: projectID,
 			Region:    gcpRegion,
 		},
 	}

--- a/contrib/pkg/deprovision/gcp.go
+++ b/contrib/pkg/deprovision/gcp.go
@@ -4,11 +4,15 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
 	"github.com/openshift/installer/pkg/destroy/gcp"
 	"github.com/openshift/installer/pkg/types"
 	typesgcp "github.com/openshift/installer/pkg/types/gcp"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
+
+	"github.com/openshift/hive/pkg/gcpclient"
 )
 
 // gcpOptions is the set of options to deprovision a GCP cluster
@@ -41,7 +45,6 @@ func NewDeprovisionGCPCommand() *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVar(&opt.logLevel, "loglevel", "info", "log level, one of: debug, info, warn, error, fatal, panic")
 	flags.StringVar(&opt.region, "region", "", "GCP region where the cluster is installed")
-	flags.StringVar(&opt.projectID, "gcp-project-id", "", "ID of the GCP project in which the cluster is installed")
 	return cmd
 }
 
@@ -58,11 +61,12 @@ func (o *gcpOptions) Validate(cmd *cobra.Command) error {
 		log.Info("Region is required")
 		return fmt.Errorf("missing region")
 	}
-	if o.projectID == "" {
-		cmd.Usage()
-		log.Info("GCP project ID is required")
-		return fmt.Errorf("missing project ID")
+	credsFile := os.Getenv("GOOGLE_CREDENTIALS")
+	projectID, err := gcpclient.ProjectIDFromFile(credsFile)
+	if err != nil {
+		return errors.Wrap(err, "could not get GCP project ID")
 	}
+	o.projectID = projectID
 	return nil
 }
 

--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -140,10 +140,8 @@ bin/hiveutil create-cluster --base-domain=mydomain.example.com --cloud=aws myclu
 Credentials will be read from `~/.azure/osServicePrincipal.json` typically created via the `az login` command.
 
 ```bash
-bin/hiveutil create-cluster --base-domain=mydomain.example.com --cloud=azure --azure-base-domain-resource-group-name=myresourcegroup --release-image=registry.svc.ci.openshift.org/origin/release:4.2 mycluster
+bin/hiveutil create-cluster --base-domain=mydomain.example.com --cloud=azure --azure-base-domain-resource-group-name=myresourcegroup mycluster
 ```
-
-`--release-image` is used above as Azure installer support is only present in 4.2 dev preview builds.
 
 #### Create Cluster on GCP
 
@@ -156,10 +154,8 @@ Credentials will be read from `~/.gcp/osServiceAccount.json`, this can be create
  1. Download resulting JSON file and save to `~/.gcp/osServiceAccount.json`.
 
 ```bash
-bin/hiveutil create-cluster --base-domain=mydomain.example.com --cloud=gcp --gcp-project-id=myproject --release-image=registry.svc.ci.openshift.org/origin/release:4.2 mycluster
+bin/hiveutil create-cluster --base-domain=mydomain.example.com --cloud=gcp mycluster
 ```
-
-`--release-image` is used above as GCP installer support is only present in 4.2 dev preview builds.
 
 ### Monitor the Install Job
 

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -115,7 +115,6 @@ case "${CLOUD}" in
 "gcp")
 	CREDS_FILE="${CLOUD_CREDS_DIR}/gce.json"
 	BASE_DOMAIN="${BASE_DOMAIN:-origin-ci-int-gce.dev.openshift.com}"
-	EXTRA_CREATE_CLUSTER_ARGS=" --gcp-project-id=openshift-gce-devel-ci"
 	;;
 *)
 	echo "unknown cloud: ${CLOUD}"

--- a/pkg/apis/hive/v1/clusterdeprovision_types.go
+++ b/pkg/apis/hive/v1/clusterdeprovision_types.go
@@ -53,8 +53,6 @@ type AzureClusterDeprovision struct {
 type GCPClusterDeprovision struct {
 	// Region is the GCP region for this deprovision
 	Region string `json:"region"`
-	// ProjectID is the ID of the GCP project in which the cluster exists
-	ProjectID string `json:"projectID"`
 	// CredentialsSecretRef is the GCP account credentials to use for deprovisioning the cluster
 	CredentialsSecretRef *corev1.LocalObjectReference `json:"credentialsSecretRef,omitempty"`
 }

--- a/pkg/apis/hive/v1/gcp/platform.go
+++ b/pkg/apis/hive/v1/gcp/platform.go
@@ -11,9 +11,6 @@ type Platform struct {
 	// credentials.
 	CredentialsSecretRef corev1.LocalObjectReference `json:"credentialsSecretRef"`
 
-	// ProjectID is the the project that will be used for the cluster.
-	ProjectID string `json:"projectID"`
-
 	// Region specifies the GCP region where the cluster will be created.
 	Region string `json:"region"`
 

--- a/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook.go
+++ b/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook.go
@@ -278,9 +278,6 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateCreate(admissionSpec 
 		if gcp.CredentialsSecretRef.Name == "" {
 			allErrs = append(allErrs, field.Required(gcpPath.Child("credentialsSecretRef", "name"), "must specify secrets for GCP access"))
 		}
-		if gcp.ProjectID == "" {
-			allErrs = append(allErrs, field.Required(gcpPath.Child("projectID"), "must specify GCP project ID"))
-		}
 		if gcp.Region == "" {
 			allErrs = append(allErrs, field.Required(gcpPath.Child("region"), "must specify GCP region"))
 		}

--- a/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
@@ -64,7 +64,6 @@ func validGCPClusterDeployment() *hivev1.ClusterDeployment {
 	cd := clusterDeploymentTemplate()
 	cd.Spec.Platform.GCP = &hivev1gcp.Platform{
 		CredentialsSecretRef: corev1.LocalObjectReference{Name: "fake-creds-secret"},
-		ProjectID:            "my-test-project",
 		Region:               "us-central1",
 	}
 	return cd

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -1411,7 +1411,6 @@ func generateDeprovision(cd *hivev1.ClusterDeployment) (*hivev1.ClusterDeprovisi
 	case cd.Spec.Platform.GCP != nil:
 		req.Spec.Platform.GCP = &hivev1.GCPClusterDeprovision{
 			Region:               cd.Spec.Platform.GCP.Region,
-			ProjectID:            cd.Spec.Platform.GCP.ProjectID,
 			CredentialsSecretRef: &cd.Spec.Platform.GCP.CredentialsSecretRef,
 		}
 	default:

--- a/pkg/controller/dnsendpoint/nameserver/gcp.go
+++ b/pkg/controller/dnsendpoint/nameserver/gcp.go
@@ -20,19 +20,15 @@ import (
 func NewGCPQuery(c client.Client, credsSecretName string) Query {
 	return &gcpQuery{
 		getGCPClient: func() (gcpclient.Client, error) {
-			secret := &corev1.Secret{}
+			credsSecret := &corev1.Secret{}
 			if err := c.Get(
 				context.Background(),
 				client.ObjectKey{Namespace: constants.HiveNamespace, Name: credsSecretName},
-				secret,
+				credsSecret,
 			); err != nil {
 				return nil, errors.Wrap(err, "could not get the creds secret")
 			}
-			authJSON, ok := secret.Data[constants.GCPCredentialsName]
-			if !ok {
-				return nil, errors.New("creds secret does not contain \"" + constants.GCPCredentialsName + "\" data")
-			}
-			gcpClient, err := gcpclient.NewClientWithDefaultProject(authJSON)
+			gcpClient, err := gcpclient.NewClientFromSecret(credsSecret)
 			return gcpClient, errors.Wrap(err, "error creating GCP client")
 		},
 	}

--- a/pkg/controller/dnsendpoint/nameserver/gcp_live_test.go
+++ b/pkg/controller/dnsendpoint/nameserver/gcp_live_test.go
@@ -2,7 +2,6 @@ package nameserver
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/user"
@@ -133,13 +132,10 @@ func (s *LiveGCPTestSuite) getCUT() *gcpQuery {
 	if err != nil {
 		s.T().Fatalf("could not get the current user: %v", err)
 	}
-	authJSON, err := ioutil.ReadFile(filepath.Join(usr.HomeDir, ".gcp", constants.GCPCredentialsName))
-	if err != nil {
-		s.T().Fatalf("could not read gcp creds: %v", err)
-	}
+	credsFile := filepath.Join(usr.HomeDir, ".gcp", constants.GCPCredentialsName)
 	return &gcpQuery{
 		getGCPClient: func() (gcpclient.Client, error) {
-			return gcpclient.NewClientWithDefaultProject(authJSON)
+			return gcpclient.NewClientFromFile(credsFile)
 		},
 	}
 }

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -525,8 +525,6 @@ func completeGCPDeprovisionJob(req *hivev1.ClusterDeprovision, job *batchv1.Job)
 				"debug",
 				"--region",
 				req.Spec.Platform.GCP.Region,
-				"--gcp-project-id",
-				req.Spec.Platform.GCP.ProjectID,
 				req.Spec.InfraID,
 			},
 			VolumeMounts: volumeMounts,

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/hive/pkg/gcpclient"
 	"io"
 	"io/ioutil"
 	"os"
@@ -491,12 +492,17 @@ func cleanupFailedProvision(dynClient client.Client, cd *hivev1.ClusterDeploymen
 
 		return uninstaller.Run()
 	case cd.Spec.Platform.GCP != nil:
+		credsFile := os.Getenv("GOOGLE_CREDENTIALS")
+		projectID, err := gcpclient.ProjectIDFromFile(credsFile)
+		if err != nil {
+			return errors.Wrap(err, "could not get GCP project ID")
+		}
 		metadata := &installertypes.ClusterMetadata{
 			InfraID: infraID,
 			ClusterPlatformMetadata: installertypes.ClusterPlatformMetadata{
 				GCP: &installertypesgcp.Metadata{
 					Region:    cd.Spec.Platform.GCP.Region,
-					ProjectID: cd.Spec.Platform.GCP.ProjectID,
+					ProjectID: projectID,
 				},
 			},
 		}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1893,10 +1893,6 @@ spec:
                             type: string
                           type: array
                       type: object
-                    projectID:
-                      description: ProjectID is the the project that will be used
-                        for the cluster.
-                      type: string
                     region:
                       description: Region specifies the GCP region where the cluster
                         will be created.
@@ -2289,10 +2285,6 @@ spec:
                       description: CredentialsSecretRef is the GCP account credentials
                         to use for deprovisioning the cluster
                       type: object
-                    projectID:
-                      description: ProjectID is the ID of the GCP project in which
-                        the cluster exists
-                      type: string
                     region:
                       description: Region is the GCP region for this deprovision
                       type: string


### PR DESCRIPTION
The GCP Project ID can be obtained from the GCP credentials. So, rather than requiring that the user supply the Project ID again in the ClusterDeployment, Hive will get the Project ID from the credentials.

https://jira.coreos.com/browse/CO-636