### PR TITLE
add field to HiveConfig for setting log level

### DIFF
--- a/config/crds/hive_v1_hiveconfig.yaml
+++ b/config/crds/hive_v1_hiveconfig.yaml
@@ -109,6 +109,11 @@ spec:
                 with precedence given to the contents of the pull secret for the cluster
                 deployment.
               type: object
+            logLevel:
+              description: LogLevel is the level of logging to use for the Hive controllers.
+                Acceptable levels, from coarsest to finest, are panic, fatal, error,
+                warn, info, debug, and trace. The default level is info.
+              type: string
             managedDomains:
               description: 'ManagedDomains is the list of DNS domains that are allowed
                 to be used by the ''managedDNS'' feature. When specifying ''managedDNS:

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -34,8 +34,6 @@ spec:
             memory: 512Mi
         command:
           - /opt/services/manager
-          - --log-level
-          - info
         volumeMounts:
         - name: kubectl-cache
           mountPath: /var/cache/kubectl

--- a/pkg/apis/hive/v1/hiveconfig_types.go
+++ b/pkg/apis/hive/v1/hiveconfig_types.go
@@ -39,6 +39,12 @@ type HiveConfigSpec struct {
 
 	// FailedProvisionConfig is used to configure settings related to handling provision failures.
 	FailedProvisionConfig FailedProvisionConfig `json:"failedProvisionConfig"`
+
+	// LogLevel is the level of logging to use for the Hive controllers.
+	// Acceptable levels, from coarsest to finest, are panic, fatal, error, warn, info, debug, and trace.
+	// The default level is info.
+	// +optional
+	LogLevel string `json:"logLevel,omitempty"`
 }
 
 // HiveConfigStatus defines the observed state of Hive

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -698,8 +698,6 @@ spec:
             memory: 512Mi
         command:
           - /opt/services/manager
-          - --log-level
-          - info
         volumeMounts:
         - name: kubectl-cache
           mountPath: /var/cache/kubectl
@@ -2932,6 +2930,11 @@ spec:
                 with precedence given to the contents of the pull secret for the cluster
                 deployment.
               type: object
+            logLevel:
+              description: LogLevel is the level of logging to use for the Hive controllers.
+                Acceptable levels, from coarsest to finest, are panic, fatal, error,
+                warn, info, debug, and trace. The default level is info.
+              type: string
             managedDomains:
               description: 'ManagedDomains is the list of DNS domains that are allowed
                 to be used by the ''managedDNS'' feature. When specifying ''managedDNS:

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -70,6 +70,14 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helpe
 		)
 	}
 
+	if level := instance.Spec.LogLevel; level != "" {
+		hiveDeployment.Spec.Template.Spec.Containers[0].Command = append(
+			hiveDeployment.Spec.Template.Spec.Containers[0].Command,
+			"--log-level",
+			level,
+		)
+	}
+
 	if e := instance.Spec.ExternalDNS; e != nil {
 		switch {
 		case e.AWS != nil:


### PR DESCRIPTION
The .spec.logLevel field has been added to the HiveConfig CRD. This field will get passed to the hive-controllers deployment to set the log level used for the controllers.

https://jira.coreos.com/browse/CO-648