### PR TITLE
add user-agent to aws and gcp requests

### DIFF
--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
@@ -323,6 +324,11 @@ func NewClientFromSecret(secret *corev1.Secret, region string) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	s.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "openshift.io/hive",
+		Fn:   request.MakeAddToUserAgentHandler("openshift.io hive", "v1"),
+	})
 
 	return &awsClient{
 		ec2Client:     ec2.New(s),

--- a/pkg/gcpclient/client.go
+++ b/pkg/gcpclient/client.go
@@ -233,22 +233,26 @@ func newClient(authJSON []byte) (*gcpClient, error) {
 		return nil, err
 	}
 
-	cloudResourceManagerClient, err := cloudresourcemanager.NewService(ctx, option.WithCredentials(creds))
+	options := []option.ClientOption{
+		option.WithCredentials(creds),
+		option.WithUserAgent("openshift.io hive/v1"),
+	}
+	cloudResourceManagerClient, err := cloudresourcemanager.NewService(ctx, options...)
 	if err != nil {
 		return nil, err
 	}
 
-	computeClient, err := compute.NewService(ctx, option.WithCredentials(creds))
+	computeClient, err := compute.NewService(ctx, options...)
 	if err != nil {
 		return nil, err
 	}
 
-	serviceUsageClient, err := serviceusage.NewService(ctx, option.WithCredentials(creds))
+	serviceUsageClient, err := serviceusage.NewService(ctx, options...)
 	if err != nil {
 		return nil, err
 	}
 
-	dnsClient, err := dns.NewService(ctx, option.WithCredentials(creds))
+	dnsClient, err := dns.NewService(ctx, options...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add user-agent to the requests made to AWS and GCP. The user-agent identifies Hive as the user making the requests.

https://jira.coreos.com/browse/CO-268