### PR TITLE
types: remove DefaultMachinePlatform

### DIFF
--- a/config/crds/hive_v1_clusterdeployment.yaml
+++ b/config/crds/hive_v1_clusterdeployment.yaml
@@ -200,37 +200,6 @@ spec:
                       description: CredentialsSecretRef refers to a secret that contains
                         the AWS account access credentials.
                       type: object
-                    defaultMachinePlatform:
-                      description: DefaultMachinePlatform is the default configuration
-                        used when installing on AWS for machine pools which do not
-                        define their own platform configuration.
-                      properties:
-                        rootVolume:
-                          description: EC2RootVolume defines the storage for ec2 instance.
-                          properties:
-                            iops:
-                              description: IOPS defines the iops for the storage.
-                              format: int64
-                              type: integer
-                            size:
-                              description: Size defines the size of the storage.
-                              format: int64
-                              type: integer
-                            type:
-                              description: Type defines the type of the storage.
-                              type: string
-                          type: object
-                        type:
-                          description: InstanceType defines the ec2 instance type.
-                            eg. m4-large
-                          type: string
-                        zones:
-                          description: Zones is list of availability zones that can
-                            be used.
-                          items:
-                            type: string
-                          type: array
-                      type: object
                     region:
                       description: Region specifies the AWS region where the cluster
                         will be created.
@@ -252,31 +221,6 @@ spec:
                       description: CredentialsSecretRef refers to a secret that contains
                         the Azure account access credentials.
                       type: object
-                    defaultMachinePlatform:
-                      description: DefaultMachinePlatform is the default configuration
-                        used when installing on Azure for machine pools which do not
-                        define their own platform configuration.
-                      properties:
-                        osDisk:
-                          description: OSDisk defines the storage for instance.
-                          properties:
-                            diskSizeGB:
-                              description: DiskSizeGB defines the size of disk in
-                                GB.
-                              format: int32
-                              type: integer
-                          type: object
-                        type:
-                          description: InstanceType defines the azure instance type.
-                            eg. Standard_DS_V2
-                          type: string
-                        zones:
-                          description: Zones is list of availability zones that can
-                            be used. eg. ["1", "2", "3"]
-                          items:
-                            type: string
-                          type: array
-                      type: object
                     region:
                       description: Region specifies the Azure region where the cluster
                         will be created.
@@ -293,22 +237,6 @@ spec:
                     credentialsSecretRef:
                       description: CredentialsSecretRef refers to a secret that contains
                         the GCP account access credentials.
-                      type: object
-                    defaultMachinePlatform:
-                      description: DefaultMachinePlatform is the default configuration
-                        used when installing on GCP for machine pools which do not
-                        define their own platform configuration.
-                      properties:
-                        type:
-                          description: InstanceType defines the GCP instance type.
-                            eg. n1-standard-4
-                          type: string
-                        zones:
-                          description: Zones is list of availability zones that can
-                            be used.
-                          items:
-                            type: string
-                          type: array
                       type: object
                     region:
                       description: Region specifies the GCP region where the cluster

--- a/pkg/apis/hive/v1/aws/platform.go
+++ b/pkg/apis/hive/v1/aws/platform.go
@@ -17,9 +17,4 @@ type Platform struct {
 	// UserTags specifies additional tags for AWS resources created for the cluster.
 	// +optional
 	UserTags map[string]string `json:"userTags,omitempty"`
-
-	// DefaultMachinePlatform is the default configuration used when
-	// installing on AWS for machine pools which do not define their own
-	// platform configuration.
-	DefaultMachinePlatform *MachinePoolPlatform `json:"defaultMachinePlatform,omitempty"`
 }

--- a/pkg/apis/hive/v1/aws/zz_generated.deepcopy.go
+++ b/pkg/apis/hive/v1/aws/zz_generated.deepcopy.go
@@ -53,11 +53,6 @@ func (in *Platform) DeepCopyInto(out *Platform) {
 			(*out)[key] = val
 		}
 	}
-	if in.DefaultMachinePlatform != nil {
-		in, out := &in.DefaultMachinePlatform, &out.DefaultMachinePlatform
-		*out = new(MachinePoolPlatform)
-		(*in).DeepCopyInto(*out)
-	}
 	return
 }
 

--- a/pkg/apis/hive/v1/azure/platform.go
+++ b/pkg/apis/hive/v1/azure/platform.go
@@ -18,11 +18,6 @@ type Platform struct {
 
 	// BaseDomainResourceGroupName specifies the resource group where the azure DNS zone for the base domain is found
 	BaseDomainResourceGroupName string `json:"baseDomainResourceGroupName,omitempty"`
-	// DefaultMachinePlatform is the default configuration used when
-	// installing on Azure for machine pools which do not define their own
-	// platform configuration.
-	// +optional
-	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
 }
 
 //SetBaseDomain parses the baseDomainID and sets the related fields on azure.Platform

--- a/pkg/apis/hive/v1/azure/zz_generated.deepcopy.go
+++ b/pkg/apis/hive/v1/azure/zz_generated.deepcopy.go
@@ -62,11 +62,6 @@ func (in *OSDisk) DeepCopy() *OSDisk {
 func (in *Platform) DeepCopyInto(out *Platform) {
 	*out = *in
 	out.CredentialsSecretRef = in.CredentialsSecretRef
-	if in.DefaultMachinePlatform != nil {
-		in, out := &in.DefaultMachinePlatform, &out.DefaultMachinePlatform
-		*out = new(MachinePool)
-		(*in).DeepCopyInto(*out)
-	}
 	return
 }
 

--- a/pkg/apis/hive/v1/gcp/platform.go
+++ b/pkg/apis/hive/v1/gcp/platform.go
@@ -13,10 +13,4 @@ type Platform struct {
 
 	// Region specifies the GCP region where the cluster will be created.
 	Region string `json:"region"`
-
-	// DefaultMachinePlatform is the default configuration used when
-	// installing on GCP for machine pools which do not define their own
-	// platform configuration.
-	// +optional
-	DefaultMachinePlatform *MachinePool `json:"defaultMachinePlatform,omitempty"`
 }

--- a/pkg/apis/hive/v1/gcp/zz_generated.deepcopy.go
+++ b/pkg/apis/hive/v1/gcp/zz_generated.deepcopy.go
@@ -45,11 +45,6 @@ func (in *Metadata) DeepCopy() *Metadata {
 func (in *Platform) DeepCopyInto(out *Platform) {
 	*out = *in
 	out.CredentialsSecretRef = in.CredentialsSecretRef
-	if in.DefaultMachinePlatform != nil {
-		in, out := &in.DefaultMachinePlatform, &out.DefaultMachinePlatform
-		*out = new(MachinePool)
-		(*in).DeepCopyInto(*out)
-	}
 	return
 }
 

--- a/pkg/apis/hive/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/hive/v1/zz_generated.deepcopy.go
@@ -1703,12 +1703,12 @@ func (in *Platform) DeepCopyInto(out *Platform) {
 	if in.Azure != nil {
 		in, out := &in.Azure, &out.Azure
 		*out = new(azure.Platform)
-		(*in).DeepCopyInto(*out)
+		**out = **in
 	}
 	if in.GCP != nil {
 		in, out := &in.GCP, &out.GCP
 		*out = new(gcp.Platform)
-		(*in).DeepCopyInto(*out)
+		**out = **in
 	}
 	if in.BareMetal != nil {
 		in, out := &in.BareMetal, &out.BareMetal

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1763,37 +1763,6 @@ spec:
                       description: CredentialsSecretRef refers to a secret that contains
                         the AWS account access credentials.
                       type: object
-                    defaultMachinePlatform:
-                      description: DefaultMachinePlatform is the default configuration
-                        used when installing on AWS for machine pools which do not
-                        define their own platform configuration.
-                      properties:
-                        rootVolume:
-                          description: EC2RootVolume defines the storage for ec2 instance.
-                          properties:
-                            iops:
-                              description: IOPS defines the iops for the storage.
-                              format: int64
-                              type: integer
-                            size:
-                              description: Size defines the size of the storage.
-                              format: int64
-                              type: integer
-                            type:
-                              description: Type defines the type of the storage.
-                              type: string
-                          type: object
-                        type:
-                          description: InstanceType defines the ec2 instance type.
-                            eg. m4-large
-                          type: string
-                        zones:
-                          description: Zones is list of availability zones that can
-                            be used.
-                          items:
-                            type: string
-                          type: array
-                      type: object
                     region:
                       description: Region specifies the AWS region where the cluster
                         will be created.
@@ -1815,31 +1784,6 @@ spec:
                       description: CredentialsSecretRef refers to a secret that contains
                         the Azure account access credentials.
                       type: object
-                    defaultMachinePlatform:
-                      description: DefaultMachinePlatform is the default configuration
-                        used when installing on Azure for machine pools which do not
-                        define their own platform configuration.
-                      properties:
-                        osDisk:
-                          description: OSDisk defines the storage for instance.
-                          properties:
-                            diskSizeGB:
-                              description: DiskSizeGB defines the size of disk in
-                                GB.
-                              format: int32
-                              type: integer
-                          type: object
-                        type:
-                          description: InstanceType defines the azure instance type.
-                            eg. Standard_DS_V2
-                          type: string
-                        zones:
-                          description: Zones is list of availability zones that can
-                            be used. eg. ["1", "2", "3"]
-                          items:
-                            type: string
-                          type: array
-                      type: object
                     region:
                       description: Region specifies the Azure region where the cluster
                         will be created.
@@ -1856,22 +1800,6 @@ spec:
                     credentialsSecretRef:
                       description: CredentialsSecretRef refers to a secret that contains
                         the GCP account access credentials.
-                      type: object
-                    defaultMachinePlatform:
-                      description: DefaultMachinePlatform is the default configuration
-                        used when installing on GCP for machine pools which do not
-                        define their own platform configuration.
-                      properties:
-                        type:
-                          description: InstanceType defines the GCP instance type.
-                            eg. n1-standard-4
-                          type: string
-                        zones:
-                          description: Zones is list of availability zones that can
-                            be used.
-                          items:
-                            type: string
-                          type: array
                       type: object
                     region:
                       description: Region specifies the GCP region where the cluster


### PR DESCRIPTION
The use of this field was lost in either the change to v1 or the change to the MachinePool CRD. It was never working entirely correctly. It does not seem too onerous to require the user to fill out each MachinePool fully rather than relying on ClusterDeployment-wide defaults. So, these changes remove the DefaultMachinePlatform fields from ClusterDeployment.

https://jira.coreos.com/browse/CO-580