### PR TITLE
validation: reject machinepool with pool name of master

### DIFF
--- a/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook.go
+++ b/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook.go
@@ -29,6 +29,7 @@ const (
 	machinePoolVersion  = "v1"
 	machinePoolResource = "machinepools"
 
+	defaultMasterPoolName = "master"
 	defaultWorkerPoolName = "worker"
 )
 
@@ -228,6 +229,9 @@ func validateMachinePoolName(pool *hivev1.MachinePool) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if pool.Name != fmt.Sprintf("%s-%s", pool.Spec.ClusterDeploymentRef.Name, pool.Spec.Name) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), pool.Name, "name must be ${CD_NAME}-${POOL_NAME}, where ${CD_NAME} is the name of the clusterdeployment and ${POOL_NAME} is the name of the remote machine pool"))
+	}
+	if pool.Spec.Name == defaultMasterPoolName {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "name"), pool.Spec.Name, fmt.Sprintf("pool name cannot be %q", defaultMasterPoolName)))
 	}
 	return allErrs
 }

--- a/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook_test.go
@@ -139,9 +139,19 @@ func Test_MachinePoolAdmission_Validate_Create(t *testing.T) {
 			}(),
 		},
 		{
+			name: "master pool name",
+			provision: func() *hivev1.MachinePool {
+				pool := testMachinePool()
+				pool.Name = fmt.Sprintf("%s-%s", pool.Spec.ClusterDeploymentRef.Name, defaultMasterPoolName)
+				pool.Spec.Name = defaultMasterPoolName
+				return pool
+			}(),
+		},
+		{
 			name: "invalid name",
 			provision: func() *hivev1.MachinePool {
 				pool := testMachinePool()
+				pool.Name = ""
 				pool.Name = "bad-name"
 				return pool
 			}(),


### PR DESCRIPTION
The "master" pool name is used by the control-plane, which cannot be configured via a MachinePool CR.

https://jira.coreos.com/browse/CO-198