### PR TITLE
Fix baremetal provisioning when run on OpenShift.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,17 @@ COPY --from=builder /go/src/github.com/openshift/hive/bin/hive-operator /opt/ser
 # file and unblock ssh.
 RUN chmod g+rw /etc/passwd
 
+# Hacks to allow writing known_hosts, homedir is / by default in OpenShift.
+# Bare metal installs need to write to $HOME/.cache, and $HOME/.ssh for as long as
+# we're hitting libvirt over ssh. OpenShift will not let you write these directories
+# by default so we must setup some permissions here, and at runtime add our random UID
+# to /etc/passwd. (in installmanager.go)
+ENV HOME /home/hive
+RUN mkdir -p /home/hive && \
+    chgrp -R 0 /home/hive && \
+    chmod -R g=u /home/hive
+RUN chmod g=u /etc/passwd
+
+
 # TODO: should this be the operator?
 ENTRYPOINT ["/opt/services/manager"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,10 +9,22 @@ RUN if ! rpm -q openssh-clients; then yum install -y openssh-clients && yum clea
 # libvirt libraries required for running bare metal installer.
 RUN yum install -y libvirt-devel && yum clean all && rm -rf /var/cache/yum/*
 
+
 ADD bin/hiveadmission /opt/services/
 ADD bin/hive-operator /opt/services/
 ADD bin/manager /opt/services/
 ADD bin/hiveutil /usr/bin/
+
+# Hacks to allow writing known_hosts, homedir is / by default in OpenShift.
+# Bare metal installs need to write to $HOME/.cache, and $HOME/.ssh for as long as
+# we're hitting libvirt over ssh. OpenShift will not let you write these directories
+# by default so we must setup some permissions here, and at runtime add our random UID
+# to /etc/passwd. (in installmanager.go)
+ENV HOME /home/hive
+RUN mkdir -p /home/hive && \
+    chgrp -R 0 /home/hive && \
+    chmod -R g=u /home/hive
+RUN chmod g=u /etc/passwd
 
 # TODO: should this be the operator?
 ENTRYPOINT ["/opt/services/manager"]

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -204,28 +204,29 @@ func InstallerPodSpec(
 			Name:      "logs",
 			MountPath: "/logs",
 		})
-		if cd.Spec.Provisioning.SSHPrivateKeySecretRef != nil {
-			volumes = append(volumes, corev1.Volume{
-				Name: "sshkeys",
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: cd.Spec.Provisioning.SSHPrivateKeySecretRef.Name,
-					},
-				},
-			})
-			volumeMounts = append(volumeMounts, corev1.VolumeMount{
-				Name:      "sshkeys",
-				MountPath: SSHPrivateKeyDir,
-			})
-			env = append(env, corev1.EnvVar{
-				Name:  "SSH_PRIV_KEY_PATH",
-				Value: SSHPrivateKeyFilePath,
-			})
-		}
 	} else {
 		env = append(env, corev1.EnvVar{
 			Name:  constants.SkipGatherLogsEnvVar,
 			Value: "true",
+		})
+	}
+
+	if cd.Spec.Provisioning.SSHPrivateKeySecretRef != nil {
+		volumes = append(volumes, corev1.Volume{
+			Name: "sshkeys",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: cd.Spec.Provisioning.SSHPrivateKeySecretRef.Name,
+				},
+			},
+		})
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      "sshkeys",
+			MountPath: SSHPrivateKeyDir,
+		})
+		env = append(env, corev1.EnvVar{
+			Name:  "SSH_PRIV_KEY_PATH",
+			Value: SSHPrivateKeyFilePath,
 		})
 	}
 

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -1149,15 +1149,40 @@ func waitForProvisioningStage(provision *hivev1.ClusterProvision, m *InstallMana
 
 func (m *InstallManager) setupSSHKnownHost(knownHost string) error {
 
-	if err := os.MkdirAll("/root/.ssh", 0700); err != nil {
-		m.log.WithError(err).Error("error creating /root/.ssh directory")
+	// Add our potentially random UID to /etc/passwd so ssh works. Need to shell out here as
+	// the go libraries for user info appear to rely on /etc/passwd, which our user is not in.
+	// TODO: temporary work so we can use libvirt over ssh, this whole function can go once we're no longer doing that.
+	out, err := exec.Command("id", "-u").Output()
+	if err != nil {
+		m.log.WithError(err).Error("error running id -u")
 		return err
 	}
-	if err := ioutil.WriteFile("/root/.ssh/known_hosts", []byte(knownHost), 0644); err != nil {
+	uid := strings.TrimSpace(string(out))
+	m.log.Infof("Adding user ID to passwd file: %s", uid)
+	f, err := os.OpenFile("/etc/passwd",
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		m.log.WithError(err).Error("error opening /etc/passwd")
+		return err
+	}
+	defer f.Close()
+	passwdLine := fmt.Sprintf("default:x:%s:0:default user:/home/hive:/sbin/nologin\n", uid)
+	m.log.Infof("Wrote passwd line: %s", passwdLine)
+	if _, err := f.WriteString(passwdLine); err != nil {
+		m.log.WithError(err).Error("error writing to /etc/passwd")
+		return err
+	}
+
+	sshDir := "/home/hive/.ssh"
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		m.log.WithError(err).Errorf("error creating %s directory", sshDir)
+		return err
+	}
+	if err := ioutil.WriteFile(filepath.Join(sshDir, "known_hosts"), []byte(knownHost), 0644); err != nil {
 		m.log.WithError(err).Error("error writing ssh known_hosts")
 		return err
 	}
-	m.log.Infof("Wrote known host to /root/.ssh/known_hosts: %s", knownHost)
+	m.log.Infof("Wrote known host to %s/known_hosts: %s", sshDir, knownHost)
 	return nil
 }
 


### PR DESCRIPTION
This was fine in Kube but in OpenShift both ssh to libvirt, and .cache
image copying broke due to the security constraints in OpenShift.

This change adds a home dir, changes it's permissions so it will work
with a random UID, and adds that random runtime UID to /etc/passwd so
SSH will work.

Also moved mounting of the ssh private key such that it will always
happen even if log gathering is disabled.