### PR TITLE
dnszone: info level for log when deleting non-empty hosted zone

### DIFF
--- a/pkg/controller/dnsendpoint/nameserver/gcp.go
+++ b/pkg/controller/dnsendpoint/nameserver/gcp.go
@@ -2,6 +2,7 @@ package nameserver
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/pkg/errors"
 	dns "google.golang.org/api/dns/v1"
@@ -101,10 +102,10 @@ func (q *gcpQuery) Delete(rootDomain string, domain string, values sets.String) 
 		if !ok {
 			return errors.Wrap(err, "error deleting the name server")
 		}
-		if gcpErr.Code == gcpclient.ErrCodeNotFound {
+		if gcpErr.Code == http.StatusNotFound {
 			return nil
 		}
-		if gcpErr.Code != 412 {
+		if gcpErr.Code != http.StatusPreconditionFailed {
 			return errors.Wrap(err, "error deleting the name server")
 		}
 	}

--- a/pkg/controller/dnszone/awsactuator.go
+++ b/pkg/controller/dnszone/awsactuator.go
@@ -402,7 +402,11 @@ func (a *AWSActuator) Delete() error {
 		Id: a.zoneID,
 	})
 	if err != nil {
-		log.WithError(err).Error("Cannot delete hosted zone")
+		logLevel := log.ErrorLevel
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == route53.ErrCodeHostedZoneNotEmpty {
+			logLevel = log.InfoLevel
+		}
+		log.WithError(err).Log(logLevel, "Cannot delete hosted zone")
 	}
 	return err
 }

--- a/pkg/controller/dnszone/dnszone_controller.go
+++ b/pkg/controller/dnszone/dnszone_controller.go
@@ -199,7 +199,6 @@ func (r *ReconcileDNSZone) reconcileDNSProvider(actuator Actuator, dnsZone *hive
 			r.logger.Debug("DNSZone resource is deleted, deleting hosted zone")
 			err := actuator.Delete()
 			if err != nil {
-				r.logger.WithError(err).Error("Failed to delete hosted zone")
 				return reconcile.Result{}, err
 			}
 		}

--- a/pkg/controller/dnszone/gcpactuator.go
+++ b/pkg/controller/dnszone/gcpactuator.go
@@ -1,6 +1,7 @@
 package dnszone
 
 import (
+	"net/http"
 	"strings"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
@@ -13,6 +14,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+)
+
+const (
+	zoneNotEmptyReason = "containerNotEmpty"
 )
 
 // GCPActuator attempts to make the current state reflect the given desired state.
@@ -93,7 +98,16 @@ func (a *GCPActuator) Delete() error {
 	logger.Info("Deleting managed zone")
 	err := a.gcpClient.DeleteManagedZone(a.managedZone.Name)
 	if err != nil {
-		log.WithError(err).Error("Cannot delete managed zone")
+		logLevel := log.ErrorLevel
+		if gcpErr, ok := err.(*googleapi.Error); ok && gcpErr.Code == http.StatusBadRequest {
+			for _, e := range gcpErr.Errors {
+				if e.Reason == zoneNotEmptyReason {
+					logLevel = log.InfoLevel
+					break
+				}
+			}
+		}
+		log.WithError(err).Log(logLevel, "Cannot delete managed zone")
 	}
 	return err
 }
@@ -153,7 +167,7 @@ func (a *GCPActuator) Refresh() error {
 	resp, err := a.gcpClient.GetManagedZone(zoneName)
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok {
-			if gerr.Code == gcpclient.ErrCodeNotFound {
+			if gerr.Code == http.StatusNotFound {
 				logger.Debug("Zone not found, clearing out the cached object")
 				a.managedZone = nil
 				return nil

--- a/pkg/gcpclient/client.go
+++ b/pkg/gcpclient/client.go
@@ -64,10 +64,6 @@ type gcpClient struct {
 
 const (
 	defaultCallTimeout = 2 * time.Minute
-
-	// ErrCodeNotFound is what the google api returns when a resource doesn't exist.
-	// googleapi does not give us a constant for this.
-	ErrCodeNotFound = 404
 )
 
 func contextWithTimeout(ctx context.Context) (context.Context, context.CancelFunc) {


### PR DESCRIPTION
When a cluster with managed DNS is deleted, the DNSZone is deleted concurrently with the deprovision of the cluster. However, the cloud zone cannot be deleted until the deprovision has removed all of the records from cloud zone. The changes in this commit reduce the level of the log entry emitted when the hosted-zone delete fails from Error to Info when the delete fails due to the zone not being empty.

https://jira.coreos.com/browse/CO-609