### PR TITLE
New command to retrieve kubeadmin's password

### DIFF
--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -192,9 +192,9 @@ oc get nodes
   oc get cd ${CLUSTER_NAME} -o jsonpath='{ .status.webConsoleURL }'
   ```
 
-* Retrive the password for `kubeadmin` user
+* Retrieve the password for `kubeadmin` user
   ```
-  oc get secret `oc get cd ${CLUSTER_NAME} -o jsonpath='{ .status.adminPasswordSecret.name }'` -o jsonpath='{ .data.password }' | base64 --decode
+  oc extract secret/$(oc get cd -o jsonpath='{.items[].spec.clusterMetadata.adminPasswordSecretRef.name}') --to=-
   ```
 
 ## DNS Management


### PR DESCRIPTION
The old command doesn't work. Replacing with a
functioning command.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>