### PR TITLE
apiserver: updating existing object when converting

### DIFF
--- a/pkg/hive/apis/hive/hiveconversion/conversion.go
+++ b/pkg/hive/apis/hive/hiveconversion/conversion.go
@@ -13,7 +13,7 @@ import (
 
 	hiveapi "github.com/openshift/hive/pkg/hive/apis/hive"
 	hiveapiaws "github.com/openshift/hive/pkg/hive/apis/hive/aws"
-	hiveapiaazure "github.com/openshift/hive/pkg/hive/apis/hive/azure"
+	hiveapiazure "github.com/openshift/hive/pkg/hive/apis/hive/azure"
 	hiveapigcp "github.com/openshift/hive/pkg/hive/apis/hive/gcp"
 )
 
@@ -77,33 +77,48 @@ func Convert_v1alpha1_ClusterDeployment_To_v1_ClusterDeployment(in *hiveapi.Clus
 	out.Spec.ClusterName = in.Spec.ClusterName
 	out.Spec.BaseDomain = in.Spec.BaseDomain
 	if inAWS := in.Spec.Platform.AWS; inAWS != nil {
-		outAWS := &hivev1aws.Platform{
-			Region:   inAWS.Region,
-			UserTags: inAWS.UserTags,
+		if out.Spec.Platform.AWS == nil {
+			out.Spec.Platform.AWS = &hivev1aws.Platform{}
 		}
+		outAWS := out.Spec.Platform.AWS
+		outAWS.Region = inAWS.Region
+		outAWS.UserTags = inAWS.UserTags
 		if creds := in.Spec.PlatformSecrets.AWS; creds != nil {
 			outAWS.CredentialsSecretRef = creds.Credentials
+		} else {
+			outAWS.CredentialsSecretRef = corev1.LocalObjectReference{}
 		}
-		out.Spec.Platform.AWS = outAWS
+	} else {
+		out.Spec.Platform.AWS = nil
 	}
 	if inAzure := in.Spec.Platform.Azure; inAzure != nil {
-		outAzure := &hivev1azure.Platform{
-			Region:                      inAzure.Region,
-			BaseDomainResourceGroupName: inAzure.BaseDomainResourceGroupName,
+		if out.Spec.Platform.Azure == nil {
+			out.Spec.Platform.Azure = &hivev1azure.Platform{}
 		}
+		outAzure := out.Spec.Platform.Azure
+		outAzure.Region = inAzure.Region
+		outAzure.BaseDomainResourceGroupName = inAzure.BaseDomainResourceGroupName
 		if creds := in.Spec.PlatformSecrets.Azure; creds != nil {
 			outAzure.CredentialsSecretRef = creds.Credentials
+		} else {
+			outAzure.CredentialsSecretRef = corev1.LocalObjectReference{}
 		}
-		out.Spec.Platform.Azure = outAzure
+	} else {
+		out.Spec.Platform.Azure = nil
 	}
 	if inGCP := in.Spec.Platform.GCP; inGCP != nil {
-		outGCP := &hivev1gcp.Platform{
-			Region: inGCP.Region,
+		if out.Spec.Platform.GCP == nil {
+			out.Spec.Platform.GCP = &hivev1gcp.Platform{}
 		}
+		outGCP := out.Spec.Platform.GCP
+		outGCP.Region = inGCP.Region
 		if creds := in.Spec.PlatformSecrets.GCP; creds != nil {
 			outGCP.CredentialsSecretRef = creds.Credentials
+		} else {
+			outGCP.CredentialsSecretRef = corev1.LocalObjectReference{}
 		}
-		out.Spec.Platform.GCP = outGCP
+	} else {
+		out.Spec.Platform.GCP = nil
 	}
 	out.Spec.PullSecretRef = in.Spec.PullSecret
 	out.Spec.PreserveOnDelete = in.Spec.PreserveOnDelete
@@ -138,20 +153,27 @@ func Convert_v1alpha1_ClusterDeployment_To_v1_ClusterDeployment(in *hiveapi.Clus
 			AdminKubeconfigSecretRef: in.Status.AdminKubeconfigSecret,
 			AdminPasswordSecretRef:   in.Status.AdminPasswordSecret,
 		}
+	} else {
+		out.Spec.ClusterMetadata = nil
 	}
 	out.Spec.Installed = in.Spec.Installed
-	out.Spec.Provisioning = &hivev1.Provisioning{
-		ReleaseImage: in.Spec.Images.ReleaseImage,
+	if out.Spec.Provisioning == nil {
+		out.Spec.Provisioning = &hivev1.Provisioning{}
 	}
+	out.Spec.Provisioning.ReleaseImage = in.Spec.Images.ReleaseImage
 	if is := in.Spec.ImageSet; is != nil {
 		out.Spec.Provisioning.ImageSetRef = &hivev1.ClusterImageSetReference{
 			Name: is.Name,
 		}
+	} else {
+		out.Spec.Provisioning.ImageSetRef = nil
 	}
 	if ssh := in.Spec.SSHKey.Name; ssh != "" {
 		out.Spec.Provisioning.SSHPrivateKeySecretRef = &corev1.LocalObjectReference{
 			Name: ssh,
 		}
+	} else {
+		out.Spec.Provisioning.SSHPrivateKeySecretRef = nil
 	}
 	out.Status.InstallRestarts = in.Status.InstallRestarts
 	out.Status.ClusterVersionStatus = in.Status.ClusterVersionStatus
@@ -185,36 +207,52 @@ func Convert_v1_ClusterDeployment_To_v1alpha1_ClusterDeployment(in *hivev1.Clust
 	out.Spec.ClusterName = in.Spec.ClusterName
 	if p := in.Spec.Provisioning; p != nil && p.SSHPrivateKeySecretRef != nil {
 		out.Spec.SSHKey.Name = p.SSHPrivateKeySecretRef.Name
+	} else {
+		out.Spec.SSHKey.Name = ""
 	}
 	out.Spec.BaseDomain = in.Spec.BaseDomain
 	if inAWS := in.Spec.Platform.AWS; inAWS != nil {
-		outAWS := &hiveapiaws.Platform{
-			Region:   inAWS.Region,
-			UserTags: inAWS.UserTags,
+		if out.Spec.Platform.AWS == nil {
+			out.Spec.Platform.AWS = &hiveapiaws.Platform{}
 		}
-		out.Spec.PlatformSecrets.AWS = &hiveapiaws.PlatformSecrets{
-			Credentials: inAWS.CredentialsSecretRef,
+		outAWS := out.Spec.Platform.AWS
+		outAWS.Region = inAWS.Region
+		outAWS.UserTags = inAWS.UserTags
+		if out.Spec.PlatformSecrets.AWS == nil {
+			out.Spec.PlatformSecrets.AWS = &hiveapiaws.PlatformSecrets{}
 		}
-		out.Spec.Platform.AWS = outAWS
+		out.Spec.PlatformSecrets.AWS.Credentials = inAWS.CredentialsSecretRef
+	} else {
+		out.Spec.Platform.AWS = nil
+		out.Spec.PlatformSecrets.AWS = nil
 	}
 	if inAzure := in.Spec.Platform.Azure; inAzure != nil {
-		outAzure := &hiveapiaazure.Platform{
-			Region:                      inAzure.Region,
-			BaseDomainResourceGroupName: inAzure.BaseDomainResourceGroupName,
+		if out.Spec.Platform.Azure == nil {
+			out.Spec.Platform.Azure = &hiveapiazure.Platform{}
 		}
-		out.Spec.PlatformSecrets.Azure = &hiveapiaazure.PlatformSecrets{
-			Credentials: inAzure.CredentialsSecretRef,
+		outAzure := out.Spec.Platform.Azure
+		outAzure.Region = inAzure.Region
+		outAzure.BaseDomainResourceGroupName = inAzure.BaseDomainResourceGroupName
+		if out.Spec.PlatformSecrets.Azure == nil {
+			out.Spec.PlatformSecrets.Azure = &hiveapiazure.PlatformSecrets{}
 		}
-		out.Spec.Platform.Azure = outAzure
+		out.Spec.PlatformSecrets.Azure.Credentials = inAzure.CredentialsSecretRef
+	} else {
+		out.Spec.Platform.Azure = nil
+		out.Spec.PlatformSecrets.Azure = nil
 	}
 	if inGCP := in.Spec.Platform.GCP; inGCP != nil {
-		outGCP := &hiveapigcp.Platform{
-			Region: inGCP.Region,
+		if out.Spec.Platform.GCP == nil {
+			out.Spec.Platform.GCP = &hiveapigcp.Platform{}
 		}
-		out.Spec.PlatformSecrets.GCP = &hiveapigcp.PlatformSecrets{
-			Credentials: inGCP.CredentialsSecretRef,
+		out.Spec.Platform.GCP.Region = inGCP.Region
+		if out.Spec.PlatformSecrets.GCP == nil {
+			out.Spec.PlatformSecrets.GCP = &hiveapigcp.PlatformSecrets{}
 		}
-		out.Spec.Platform.GCP = outGCP
+		out.Spec.PlatformSecrets.GCP.Credentials = inGCP.CredentialsSecretRef
+	} else {
+		out.Spec.Platform.GCP = nil
+		out.Spec.PlatformSecrets.GCP = nil
 	}
 	out.Spec.PullSecret = in.Spec.PullSecretRef
 	if p := in.Spec.Provisioning; p != nil {
@@ -223,7 +261,12 @@ func Convert_v1_ClusterDeployment_To_v1alpha1_ClusterDeployment(in *hivev1.Clust
 			out.Spec.ImageSet = &hiveapi.ClusterImageSetReference{
 				Name: imageSet.Name,
 			}
+		} else {
+			out.Spec.ImageSet = nil
 		}
+	} else {
+		out.Spec.Images.ReleaseImage = ""
+		out.Spec.ImageSet = nil
 	}
 	out.Spec.PreserveOnDelete = in.Spec.PreserveOnDelete
 	out.Spec.ControlPlaneConfig.ServingCertificates.Default = in.Spec.ControlPlaneConfig.ServingCertificates.Default
@@ -256,6 +299,11 @@ func Convert_v1_ClusterDeployment_To_v1alpha1_ClusterDeployment(in *hivev1.Clust
 		out.Status.InfraID = meta.InfraID
 		out.Status.AdminKubeconfigSecret = meta.AdminKubeconfigSecretRef
 		out.Status.AdminPasswordSecret = meta.AdminPasswordSecretRef
+	} else {
+		out.Status.ClusterID = ""
+		out.Status.InfraID = ""
+		out.Status.AdminKubeconfigSecret = corev1.LocalObjectReference{}
+		out.Status.AdminPasswordSecret = corev1.LocalObjectReference{}
 	}
 	out.Status.Installed = in.Spec.Installed
 	out.Status.InstallRestarts = in.Status.InstallRestarts
@@ -289,6 +337,8 @@ func Convert_v1alpha1_ClusterImageSet_To_v1_ClusterImageSet(in *hiveapi.ClusterI
 	out.ObjectMeta = in.ObjectMeta
 	if in.Spec.ReleaseImage != nil {
 		out.Spec.ReleaseImage = *in.Spec.ReleaseImage
+	} else {
+		out.Spec.ReleaseImage = ""
 	}
 	return nil
 }
@@ -304,21 +354,30 @@ func Convert_v1alpha1_ClusterDeprovisionRequest_To_v1_ClusterDeprovision(in *hiv
 	out.Spec.InfraID = in.Spec.InfraID
 	out.Spec.ClusterID = in.Spec.ClusterID
 	if aws := in.Spec.Platform.AWS; aws != nil {
-		out.Spec.Platform.AWS = &hivev1.AWSClusterDeprovision{
-			Region:               aws.Region,
-			CredentialsSecretRef: aws.Credentials,
+		if out.Spec.Platform.AWS == nil {
+			out.Spec.Platform.AWS = &hivev1.AWSClusterDeprovision{}
 		}
+		out.Spec.Platform.AWS.Region = aws.Region
+		out.Spec.Platform.AWS.CredentialsSecretRef = aws.Credentials
+	} else {
+		out.Spec.Platform.AWS = nil
 	}
 	if azure := in.Spec.Platform.Azure; azure != nil {
-		out.Spec.Platform.Azure = &hivev1.AzureClusterDeprovision{
-			CredentialsSecretRef: azure.Credentials,
+		if out.Spec.Platform.Azure == nil {
+			out.Spec.Platform.Azure = &hivev1.AzureClusterDeprovision{}
 		}
+		out.Spec.Platform.Azure.CredentialsSecretRef = azure.Credentials
+	} else {
+		out.Spec.Platform.Azure = nil
 	}
 	if gcp := in.Spec.Platform.GCP; gcp != nil {
-		out.Spec.Platform.GCP = &hivev1.GCPClusterDeprovision{
-			Region:               gcp.Region,
-			CredentialsSecretRef: gcp.Credentials,
+		if out.Spec.Platform.GCP == nil {
+			out.Spec.Platform.GCP = &hivev1.GCPClusterDeprovision{}
 		}
+		out.Spec.Platform.GCP.Region = gcp.Region
+		out.Spec.Platform.GCP.CredentialsSecretRef = gcp.Credentials
+	} else {
+		out.Spec.Platform.GCP = nil
 	}
 	out.Status.Completed = in.Status.Completed
 	return nil
@@ -329,21 +388,28 @@ func Convert_v1_ClusterDeprovision_To_v1alpha1_ClusterDeprovisionRequest(in *hiv
 	out.Spec.InfraID = in.Spec.InfraID
 	out.Spec.ClusterID = in.Spec.ClusterID
 	if aws := in.Spec.Platform.AWS; aws != nil {
-		out.Spec.Platform.AWS = &hiveapi.AWSClusterDeprovisionRequest{
-			Region:      aws.Region,
-			Credentials: aws.CredentialsSecretRef,
+		if out.Spec.Platform.AWS == nil {
+			out.Spec.Platform.AWS = &hiveapi.AWSClusterDeprovisionRequest{}
 		}
+		out.Spec.Platform.AWS.Region = aws.Region
+		out.Spec.Platform.AWS.Credentials = aws.CredentialsSecretRef
+	} else {
+		out.Spec.Platform.AWS = nil
 	}
 	if azure := in.Spec.Platform.Azure; azure != nil {
-		out.Spec.Platform.Azure = &hiveapi.AzureClusterDeprovisionRequest{
-			Credentials: azure.CredentialsSecretRef,
+		if out.Spec.Platform.Azure == nil {
+			out.Spec.Platform.Azure = &hiveapi.AzureClusterDeprovisionRequest{}
 		}
+		out.Spec.Platform.Azure.Credentials = azure.CredentialsSecretRef
+	} else {
+		out.Spec.Platform.Azure = nil
 	}
 	if gcp := in.Spec.Platform.GCP; gcp != nil {
-		out.Spec.Platform.GCP = &hiveapi.GCPClusterDeprovisionRequest{
-			Region:      gcp.Region,
-			Credentials: gcp.CredentialsSecretRef,
+		if out.Spec.Platform.GCP == nil {
+			out.Spec.Platform.GCP = &hiveapi.GCPClusterDeprovisionRequest{}
 		}
+		out.Spec.Platform.GCP.Region = gcp.Region
+		out.Spec.Platform.GCP.Credentials = gcp.CredentialsSecretRef
 	}
 	out.Status.Completed = in.Status.Completed
 	return nil
@@ -434,35 +500,47 @@ func Convert_v1alpha1_DNSZone_To_v1_DNSZone(in *hiveapi.DNSZone, out *hivev1.DNS
 	out.Spec.Zone = in.Spec.Zone
 	out.Spec.LinkToParentDomain = in.Spec.LinkToParentDomain
 	if inAWS := in.Spec.AWS; inAWS != nil {
-		outAWS := &hivev1.AWSDNSZoneSpec{
-			CredentialsSecretRef: inAWS.AccountSecret,
-			AdditionalTags:       make([]hivev1.AWSResourceTag, len(inAWS.AdditionalTags)),
+		if out.Spec.AWS == nil {
+			out.Spec.AWS = &hivev1.AWSDNSZoneSpec{}
 		}
+		outAWS := out.Spec.AWS
+		outAWS.CredentialsSecretRef = inAWS.AccountSecret
+		outAWS.AdditionalTags = make([]hivev1.AWSResourceTag, len(inAWS.AdditionalTags))
 		for i, tag := range inAWS.AdditionalTags {
 			outAWS.AdditionalTags[i] = hivev1.AWSResourceTag{
 				Key:   tag.Key,
 				Value: tag.Value,
 			}
 		}
-		out.Spec.AWS = outAWS
+	} else {
+		out.Spec.AWS = nil
 	}
 	if inGCP := in.Spec.GCP; inGCP != nil {
-		out.Spec.GCP = &hivev1.GCPDNSZoneSpec{
-			CredentialsSecretRef: inGCP.CredentialsSecretRef,
+		if out.Spec.GCP == nil {
+			out.Spec.GCP = &hivev1.GCPDNSZoneSpec{}
 		}
+		out.Spec.GCP.CredentialsSecretRef = inGCP.CredentialsSecretRef
+	} else {
+		out.Spec.GCP = nil
 	}
 	out.Status.LastSyncTimestamp = in.Status.LastSyncTimestamp
 	out.Status.LastSyncGeneration = in.Status.LastSyncGeneration
 	out.Status.NameServers = in.Status.NameServers
 	if aws := in.Status.AWS; aws != nil {
-		out.Status.AWS = &hivev1.AWSDNSZoneStatus{
-			ZoneID: aws.ZoneID,
+		if out.Status.AWS == nil {
+			out.Status.AWS = &hivev1.AWSDNSZoneStatus{}
 		}
+		out.Status.AWS.ZoneID = aws.ZoneID
+	} else {
+		out.Status.AWS = nil
 	}
 	if gcp := in.Status.GCP; gcp != nil {
-		out.Status.GCP = &hivev1.GCPDNSZoneStatus{
-			ZoneName: gcp.ZoneName,
+		if out.Status.GCP == nil {
+			out.Status.GCP = &hivev1.GCPDNSZoneStatus{}
 		}
+		out.Status.GCP.ZoneName = gcp.ZoneName
+	} else {
+		out.Status.GCP = nil
 	}
 	out.Status.Conditions = make([]hivev1.DNSZoneCondition, len(in.Status.Conditions))
 	for i, inCond := range in.Status.Conditions {
@@ -482,35 +560,47 @@ func Convert_v1_DNSZone_To_v1alpha1_DNSZone(in *hivev1.DNSZone, out *hiveapi.DNS
 	out.Spec.Zone = in.Spec.Zone
 	out.Spec.LinkToParentDomain = in.Spec.LinkToParentDomain
 	if inAWS := in.Spec.AWS; inAWS != nil {
-		outAWS := &hiveapi.AWSDNSZoneSpec{
-			AccountSecret:  inAWS.CredentialsSecretRef,
-			AdditionalTags: make([]hiveapi.AWSResourceTag, len(inAWS.AdditionalTags)),
+		if out.Spec.AWS == nil {
+			out.Spec.AWS = &hiveapi.AWSDNSZoneSpec{}
 		}
+		outAWS := out.Spec.AWS
+		outAWS.AccountSecret = inAWS.CredentialsSecretRef
+		outAWS.AdditionalTags = make([]hiveapi.AWSResourceTag, len(inAWS.AdditionalTags))
 		for i, tag := range inAWS.AdditionalTags {
 			outAWS.AdditionalTags[i] = hiveapi.AWSResourceTag{
 				Key:   tag.Key,
 				Value: tag.Value,
 			}
 		}
-		out.Spec.AWS = outAWS
+	} else {
+		out.Spec.AWS = nil
 	}
 	if inGCP := in.Spec.GCP; inGCP != nil {
-		out.Spec.GCP = &hiveapi.GCPDNSZoneSpec{
-			CredentialsSecretRef: inGCP.CredentialsSecretRef,
+		if out.Spec.GCP == nil {
+			out.Spec.GCP = &hiveapi.GCPDNSZoneSpec{}
 		}
+		out.Spec.GCP.CredentialsSecretRef = inGCP.CredentialsSecretRef
+	} else {
+		out.Spec.GCP = nil
 	}
 	out.Status.LastSyncTimestamp = in.Status.LastSyncTimestamp
 	out.Status.LastSyncGeneration = in.Status.LastSyncGeneration
 	out.Status.NameServers = in.Status.NameServers
 	if aws := in.Status.AWS; aws != nil {
-		out.Status.AWS = &hiveapi.AWSDNSZoneStatus{
-			ZoneID: aws.ZoneID,
+		if out.Status.AWS == nil {
+			out.Status.AWS = &hiveapi.AWSDNSZoneStatus{}
 		}
+		out.Status.AWS.ZoneID = aws.ZoneID
+	} else {
+		out.Status.AWS = nil
 	}
 	if gcp := in.Status.GCP; gcp != nil {
-		out.Status.GCP = &hiveapi.GCPDNSZoneStatus{
-			ZoneName: gcp.ZoneName,
+		if out.Status.GCP == nil {
+			out.Status.GCP = &hiveapi.GCPDNSZoneStatus{}
 		}
+		out.Status.GCP.ZoneName = gcp.ZoneName
+	} else {
+		out.Status.GCP = nil
 	}
 	out.Status.Conditions = make([]hiveapi.DNSZoneCondition, len(in.Status.Conditions))
 	for i, inCond := range in.Status.Conditions {
@@ -542,6 +632,8 @@ func Convert_v1alpha1_HiveConfig_To_v1_HiveConfig(in *hiveapi.HiveConfig, out *h
 				CredentialsSecretRef: gcp.Credentials,
 			}
 		}
+	} else {
+		out.Spec.ManagedDomains = nil
 	}
 	out.Spec.AdditionalCertificateAuthoritiesSecretRef = in.Spec.AdditionalCertificateAuthorities
 	out.Spec.GlobalPullSecretRef = in.Spec.GlobalPullSecret
@@ -557,18 +649,29 @@ func Convert_v1_HiveConfig_To_v1alpha1_HiveConfig(in *hivev1.HiveConfig, out *hi
 	if len(in.Spec.ManagedDomains) > 0 {
 		inDNS := in.Spec.ManagedDomains[0]
 		out.Spec.ManagedDomains = inDNS.Domains
-		outDNS := &hiveapi.ExternalDNSConfig{}
+		if out.Spec.ExternalDNS == nil {
+			out.Spec.ExternalDNS = &hiveapi.ExternalDNSConfig{}
+		}
+		outDNS := out.Spec.ExternalDNS
 		if aws := inDNS.AWS; aws != nil {
-			outDNS.AWS = &hiveapi.ExternalDNSAWSConfig{
-				Credentials: aws.CredentialsSecretRef,
+			if outDNS.AWS == nil {
+				outDNS.AWS = &hiveapi.ExternalDNSAWSConfig{}
 			}
+			outDNS.AWS.Credentials = aws.CredentialsSecretRef
+		} else {
+			outDNS.AWS = nil
 		}
 		if gcp := inDNS.GCP; gcp != nil {
-			outDNS.GCP = &hiveapi.ExternalDNSGCPConfig{
-				Credentials: gcp.CredentialsSecretRef,
+			if outDNS.GCP == nil {
+				outDNS.GCP = &hiveapi.ExternalDNSGCPConfig{}
 			}
+			outDNS.GCP.Credentials = gcp.CredentialsSecretRef
+		} else {
+			outDNS.GCP = nil
 		}
-		out.Spec.ExternalDNS = outDNS
+	} else {
+		out.Spec.ManagedDomains = nil
+		out.Spec.ExternalDNS = nil
 	}
 	out.Spec.AdditionalCertificateAuthorities = in.Spec.AdditionalCertificateAuthoritiesSecretRef
 	out.Spec.GlobalPullSecret = in.Spec.GlobalPullSecretRef
@@ -759,6 +862,8 @@ func Convert_v1alpha1_SyncSetInstance_To_v1_SyncSetInstance(in *hiveapi.SyncSetI
 		out.Spec.SelectorSyncSetRef = &hivev1.SelectorSyncSetReference{
 			Name: ref.Name,
 		}
+	} else {
+		out.Spec.SelectorSyncSetRef = nil
 	}
 	out.Spec.ResourceApplyMode = hivev1.SyncSetResourceApplyMode(in.Spec.ResourceApplyMode)
 	out.Spec.SyncSetHash = in.Spec.SyncSetHash
@@ -777,6 +882,8 @@ func Convert_v1_SyncSetInstance_To_v1alpha1_SyncSetInstance(in *hivev1.SyncSetIn
 		out.Spec.SelectorSyncSet = &hiveapi.SelectorSyncSetReference{
 			Name: ref.Name,
 		}
+	} else {
+		out.Spec.SelectorSyncSet = nil
 	}
 	out.Spec.ResourceApplyMode = hiveapi.SyncSetResourceApplyMode(in.Spec.ResourceApplyMode)
 	out.Spec.SyncSetHash = in.Spec.SyncSetHash

--- a/pkg/hive/apiserver/registry/checkpoint/proxy.go
+++ b/pkg/hive/apiserver/registry/checkpoint/proxy.go
@@ -3,6 +3,7 @@ package checkpoint
 import (
 	"context"
 
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	hivev1client "github.com/openshift/hive/pkg/client/clientset-generated/clientset/typed/hive/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -65,13 +66,14 @@ func (s *REST) List(ctx context.Context, options *metainternal.ListOptions) (run
 		return nil, err
 	}
 
-	ret := &hiveapi.CheckpointList{ListMeta: checkpoints.ListMeta}
-	for _, curr := range checkpoints.Items {
-		checkpoint, err := util.CheckpointFromHiveV1(&curr)
-		if err != nil {
+	ret := &hiveapi.CheckpointList{
+		ListMeta: checkpoints.ListMeta,
+		Items:    make([]hiveapi.Checkpoint, len(checkpoints.Items)),
+	}
+	for i, curr := range checkpoints.Items {
+		if err := util.CheckpointFromHiveV1(&curr, &ret.Items[i]); err != nil {
 			return nil, err
 		}
-		ret.Items = append(ret.Items, *checkpoint)
 	}
 	return ret, nil
 }
@@ -87,8 +89,8 @@ func (s *REST) Get(ctx context.Context, name string, options *metav1.GetOptions)
 		return nil, err
 	}
 
-	checkpoint, err := util.CheckpointFromHiveV1(ret)
-	if err != nil {
+	checkpoint := &hiveapi.Checkpoint{}
+	if err := util.CheckpointFromHiveV1(ret, checkpoint); err != nil {
 		return nil, err
 	}
 	return checkpoint, nil
@@ -113,8 +115,8 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, err
 	}
 
-	convertedObj, err := util.CheckpointToHiveV1(obj.(*hiveapi.Checkpoint))
-	if err != nil {
+	convertedObj := &hivev1.Checkpoint{}
+	if err := util.CheckpointToHiveV1(obj.(*hiveapi.Checkpoint), convertedObj); err != nil {
 		return nil, err
 	}
 
@@ -123,8 +125,8 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, err
 	}
 
-	checkpoint, err := util.CheckpointFromHiveV1(ret)
-	if err != nil {
+	checkpoint := &hiveapi.Checkpoint{}
+	if err := util.CheckpointFromHiveV1(ret, checkpoint); err != nil {
 		return nil, err
 	}
 	return checkpoint, nil
@@ -136,36 +138,35 @@ func (s *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 		return nil, false, err
 	}
 
-	old, err := client.Get(name, metav1.GetOptions{})
+	checkpoint, err := client.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return nil, false, err
 	}
 
-	oldCheckpoint, err := util.CheckpointFromHiveV1(old)
+	old := &hiveapi.Checkpoint{}
+	if err := util.CheckpointFromHiveV1(checkpoint, old); err != nil {
+		return nil, false, err
+	}
+
+	obj, err := objInfo.UpdatedObject(ctx, old)
 	if err != nil {
 		return nil, false, err
 	}
 
-	obj, err := objInfo.UpdatedObject(ctx, oldCheckpoint)
+	if err := util.CheckpointToHiveV1(obj.(*hiveapi.Checkpoint), checkpoint); err != nil {
+		return nil, false, err
+	}
+
+	ret, err := client.Update(checkpoint)
 	if err != nil {
 		return nil, false, err
 	}
 
-	updatedCheckpoint, err := util.CheckpointToHiveV1(obj.(*hiveapi.Checkpoint))
-	if err != nil {
+	new := &hiveapi.Checkpoint{}
+	if err := util.CheckpointFromHiveV1(ret, new); err != nil {
 		return nil, false, err
 	}
-
-	ret, err := client.Update(updatedCheckpoint)
-	if err != nil {
-		return nil, false, err
-	}
-
-	checkpoint, err := util.CheckpointFromHiveV1(ret)
-	if err != nil {
-		return nil, false, err
-	}
-	return checkpoint, false, err
+	return new, false, err
 }
 
 func (s *REST) getClient(ctx context.Context) (hivev1client.CheckpointInterface, error) {

--- a/pkg/hive/apiserver/registry/clusterdeployment/proxy.go
+++ b/pkg/hive/apiserver/registry/clusterdeployment/proxy.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 
-	hivev1client "github.com/openshift/hive/pkg/client/clientset-generated/clientset/typed/hive/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -19,8 +18,11 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 
-	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	hivev1client "github.com/openshift/hive/pkg/client/clientset-generated/clientset/typed/hive/v1"
+
 	installtypes "github.com/openshift/installer/pkg/types"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 
 	hiveapi "github.com/openshift/hive/pkg/hive/apis/hive"
 	"github.com/openshift/hive/pkg/hive/apiserver/registry"
@@ -76,14 +78,15 @@ func (s *REST) List(ctx context.Context, options *metainternal.ListOptions) (run
 		return nil, err
 	}
 
-	ret := &hiveapi.ClusterDeploymentList{ListMeta: clusterDeployments.ListMeta}
-	for _, curr := range clusterDeployments.Items {
+	ret := &hiveapi.ClusterDeploymentList{
+		ListMeta: clusterDeployments.ListMeta,
+		Items:    make([]hiveapi.ClusterDeployment, len(clusterDeployments.Items)),
+	}
+	for i, curr := range clusterDeployments.Items {
 		installConfig, _ := getInstallConfig(&curr, secretClient)
-		clusterDeployment, err := util.ClusterDeploymentFromHiveV1(&curr, installConfig)
-		if err != nil {
+		if err := util.ClusterDeploymentFromHiveV1(&curr, installConfig, &ret.Items[i]); err != nil {
 			return nil, err
 		}
-		ret.Items = append(ret.Items, *clusterDeployment)
 	}
 	return ret, nil
 }
@@ -101,8 +104,8 @@ func (s *REST) Get(ctx context.Context, name string, options *metav1.GetOptions)
 
 	installConfig, _ := getInstallConfig(ret, secretClient)
 
-	clusterDeployment, err := util.ClusterDeploymentFromHiveV1(ret, installConfig)
-	if err != nil {
+	clusterDeployment := &hiveapi.ClusterDeployment{}
+	if err := util.ClusterDeploymentFromHiveV1(ret, installConfig, clusterDeployment); err != nil {
 		return nil, err
 	}
 	return clusterDeployment, nil
@@ -131,8 +134,9 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 
 	sshKey := getSSHKey(orig, secretClient)
 
-	convertedObj, installConfig, err := util.ClusterDeploymentToHiveV1(orig, sshKey)
-	if err != nil {
+	convertedObj := &hivev1.ClusterDeployment{}
+	installConfig := &installtypes.InstallConfig{}
+	if err := util.ClusterDeploymentToHiveV1(orig, sshKey, convertedObj, installConfig); err != nil {
 		return nil, err
 	}
 
@@ -158,6 +162,12 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err == nil {
+			return
+		}
+		cdClient.Delete(convertedObj.Name, &metav1.DeleteOptions{})
+	}()
 
 	installConfigSecret.OwnerReferences = append(installConfigSecret.OwnerReferences,
 		metav1.OwnerReference{
@@ -172,8 +182,8 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, err
 	}
 
-	clusterDeployment, err := util.ClusterDeploymentFromHiveV1(ret, installConfig)
-	if err != nil {
+	clusterDeployment := &hiveapi.ClusterDeployment{}
+	if err := util.ClusterDeploymentFromHiveV1(ret, installConfig, clusterDeployment); err != nil {
 		return nil, err
 	}
 	return clusterDeployment, nil
@@ -185,19 +195,19 @@ func (s *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 		return nil, false, err
 	}
 
-	old, err := cdClient.Get(name, metav1.GetOptions{})
+	clusterDeployment, err := cdClient.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return nil, false, err
 	}
 
-	oldInstallConfig, oldInstallConfigData := getInstallConfig(old, secretClient)
+	installConfig, oldInstallConfigData := getInstallConfig(clusterDeployment, secretClient)
 
-	oldClusterDeployment, err := util.ClusterDeploymentFromHiveV1(old, oldInstallConfig)
-	if err != nil {
+	old := &hiveapi.ClusterDeployment{}
+	if err := util.ClusterDeploymentFromHiveV1(clusterDeployment, installConfig, old); err != nil {
 		return nil, false, err
 	}
 
-	obj, err := objInfo.UpdatedObject(ctx, oldClusterDeployment)
+	obj, err := objInfo.UpdatedObject(ctx, old)
 	if err != nil {
 		return nil, false, err
 	}
@@ -206,32 +216,31 @@ func (s *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 
 	sshKey := getSSHKey(newClusterDeployment, secretClient)
 
-	updatedClusterDeployment, updatedInstallConfig, err := util.ClusterDeploymentToHiveV1(newClusterDeployment, sshKey)
+	if err := util.ClusterDeploymentToHiveV1(newClusterDeployment, sshKey, clusterDeployment, installConfig); err != nil {
+		return nil, false, err
+	}
+
+	newInstallConfigData, err := yaml.Marshal(installConfig)
 	if err != nil {
 		return nil, false, err
 	}
 
-	updatedInstallConfigData, err := yaml.Marshal(updatedInstallConfig)
-	if err != nil {
-		return nil, false, err
-	}
-
-	if !bytes.Equal(oldInstallConfigData, updatedInstallConfigData) {
-		if err := updateInstallConfigSecret(updatedInstallConfigData, old, secretClient); err != nil {
+	if !bytes.Equal(oldInstallConfigData, newInstallConfigData) {
+		if err := updateInstallConfigSecret(newInstallConfigData, clusterDeployment, secretClient); err != nil {
 			return nil, false, err
 		}
 	}
 
-	ret, err := cdClient.Update(updatedClusterDeployment)
+	ret, err := cdClient.Update(clusterDeployment)
 	if err != nil {
 		return nil, false, err
 	}
 
-	clusterDeployment, err := util.ClusterDeploymentFromHiveV1(ret, updatedInstallConfig)
-	if err != nil {
+	new := &hiveapi.ClusterDeployment{}
+	if err := util.ClusterDeploymentFromHiveV1(ret, installConfig, new); err != nil {
 		return nil, false, err
 	}
-	return clusterDeployment, false, err
+	return new, false, err
 }
 
 func (s *REST) getClients(ctx context.Context) (hivev1client.ClusterDeploymentInterface, corev1client.SecretInterface, error) {

--- a/pkg/hive/apiserver/registry/clusterimageset/proxy.go
+++ b/pkg/hive/apiserver/registry/clusterimageset/proxy.go
@@ -3,13 +3,15 @@ package clusterimageset
 import (
 	"context"
 
-	hivev1client "github.com/openshift/hive/pkg/client/clientset-generated/clientset/typed/hive/v1"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/printers"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	hivev1client "github.com/openshift/hive/pkg/client/clientset-generated/clientset/typed/hive/v1"
 
 	hiveapi "github.com/openshift/hive/pkg/hive/apis/hive"
 	"github.com/openshift/hive/pkg/hive/apiserver/registry"
@@ -63,13 +65,14 @@ func (s *REST) List(ctx context.Context, options *metainternal.ListOptions) (run
 		return nil, err
 	}
 
-	ret := &hiveapi.ClusterImageSetList{ListMeta: clusterImageSets.ListMeta}
-	for _, curr := range clusterImageSets.Items {
-		clusterImageSet, err := util.ClusterImageSetFromHiveV1(&curr)
-		if err != nil {
+	ret := &hiveapi.ClusterImageSetList{
+		ListMeta: clusterImageSets.ListMeta,
+		Items:    make([]hiveapi.ClusterImageSet, len(clusterImageSets.Items)),
+	}
+	for i, curr := range clusterImageSets.Items {
+		if err := util.ClusterImageSetFromHiveV1(&curr, &ret.Items[i]); err != nil {
 			return nil, err
 		}
-		ret.Items = append(ret.Items, *clusterImageSet)
 	}
 	return ret, nil
 }
@@ -85,8 +88,8 @@ func (s *REST) Get(ctx context.Context, name string, options *metav1.GetOptions)
 		return nil, err
 	}
 
-	clusterImageSet, err := util.ClusterImageSetFromHiveV1(ret)
-	if err != nil {
+	clusterImageSet := &hiveapi.ClusterImageSet{}
+	if err := util.ClusterImageSetFromHiveV1(ret, clusterImageSet); err != nil {
 		return nil, err
 	}
 	return clusterImageSet, nil
@@ -111,8 +114,8 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, err
 	}
 
-	convertedObj, err := util.ClusterImageSetToHiveV1(obj.(*hiveapi.ClusterImageSet))
-	if err != nil {
+	convertedObj := &hivev1.ClusterImageSet{}
+	if err := util.ClusterImageSetToHiveV1(obj.(*hiveapi.ClusterImageSet), convertedObj); err != nil {
 		return nil, err
 	}
 
@@ -121,8 +124,8 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, err
 	}
 
-	clusterImageSet, err := util.ClusterImageSetFromHiveV1(ret)
-	if err != nil {
+	clusterImageSet := &hiveapi.ClusterImageSet{}
+	if err := util.ClusterImageSetFromHiveV1(ret, clusterImageSet); err != nil {
 		return nil, err
 	}
 	return clusterImageSet, nil
@@ -134,36 +137,35 @@ func (s *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 		return nil, false, err
 	}
 
-	old, err := client.Get(name, metav1.GetOptions{})
+	clusterImageSet, err := client.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return nil, false, err
 	}
 
-	oldClusterImageSet, err := util.ClusterImageSetFromHiveV1(old)
+	old := &hiveapi.ClusterImageSet{}
+	if err := util.ClusterImageSetFromHiveV1(clusterImageSet, old); err != nil {
+		return nil, false, err
+	}
+
+	obj, err := objInfo.UpdatedObject(ctx, old)
 	if err != nil {
 		return nil, false, err
 	}
 
-	obj, err := objInfo.UpdatedObject(ctx, oldClusterImageSet)
+	if err := util.ClusterImageSetToHiveV1(obj.(*hiveapi.ClusterImageSet), clusterImageSet); err != nil {
+		return nil, false, err
+	}
+
+	ret, err := client.Update(clusterImageSet)
 	if err != nil {
 		return nil, false, err
 	}
 
-	updatedClusterImageSet, err := util.ClusterImageSetToHiveV1(obj.(*hiveapi.ClusterImageSet))
-	if err != nil {
+	new := &hiveapi.ClusterImageSet{}
+	if err := util.ClusterImageSetFromHiveV1(ret, new); err != nil {
 		return nil, false, err
 	}
-
-	ret, err := client.Update(updatedClusterImageSet)
-	if err != nil {
-		return nil, false, err
-	}
-
-	clusterImageSet, err := util.ClusterImageSetFromHiveV1(ret)
-	if err != nil {
-		return nil, false, err
-	}
-	return clusterImageSet, false, err
+	return new, false, err
 }
 
 func (s *REST) getClient(ctx context.Context) (hivev1client.ClusterImageSetInterface, error) {

--- a/pkg/hive/apiserver/registry/clusterprovision/proxy.go
+++ b/pkg/hive/apiserver/registry/clusterprovision/proxy.go
@@ -3,7 +3,6 @@ package clusterprovision
 import (
 	"context"
 
-	hivev1client "github.com/openshift/hive/pkg/client/clientset-generated/clientset/typed/hive/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,6 +11,9 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/printers"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	hivev1client "github.com/openshift/hive/pkg/client/clientset-generated/clientset/typed/hive/v1"
 
 	hiveapi "github.com/openshift/hive/pkg/hive/apis/hive"
 	"github.com/openshift/hive/pkg/hive/apiserver/registry"
@@ -65,13 +67,14 @@ func (s *REST) List(ctx context.Context, options *metainternal.ListOptions) (run
 		return nil, err
 	}
 
-	ret := &hiveapi.ClusterProvisionList{ListMeta: clusterProvisions.ListMeta}
-	for _, curr := range clusterProvisions.Items {
-		clusterProvision, err := util.ClusterProvisionFromHiveV1(&curr)
-		if err != nil {
+	ret := &hiveapi.ClusterProvisionList{
+		ListMeta: clusterProvisions.ListMeta,
+		Items:    make([]hiveapi.ClusterProvision, len(clusterProvisions.Items)),
+	}
+	for i, curr := range clusterProvisions.Items {
+		if err := util.ClusterProvisionFromHiveV1(&curr, &ret.Items[i]); err != nil {
 			return nil, err
 		}
-		ret.Items = append(ret.Items, *clusterProvision)
 	}
 	return ret, nil
 }
@@ -87,8 +90,8 @@ func (s *REST) Get(ctx context.Context, name string, options *metav1.GetOptions)
 		return nil, err
 	}
 
-	clusterProvision, err := util.ClusterProvisionFromHiveV1(ret)
-	if err != nil {
+	clusterProvision := &hiveapi.ClusterProvision{}
+	if err := util.ClusterProvisionFromHiveV1(ret, clusterProvision); err != nil {
 		return nil, err
 	}
 	return clusterProvision, nil
@@ -113,8 +116,8 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, err
 	}
 
-	convertedObj, err := util.ClusterProvisionToHiveV1(obj.(*hiveapi.ClusterProvision))
-	if err != nil {
+	convertedObj := &hivev1.ClusterProvision{}
+	if err := util.ClusterProvisionToHiveV1(obj.(*hiveapi.ClusterProvision), convertedObj); err != nil {
 		return nil, err
 	}
 
@@ -123,8 +126,8 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, err
 	}
 
-	clusterProvision, err := util.ClusterProvisionFromHiveV1(ret)
-	if err != nil {
+	clusterProvision := &hiveapi.ClusterProvision{}
+	if err := util.ClusterProvisionFromHiveV1(ret, clusterProvision); err != nil {
 		return nil, err
 	}
 	return clusterProvision, nil
@@ -136,36 +139,35 @@ func (s *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 		return nil, false, err
 	}
 
-	old, err := client.Get(name, metav1.GetOptions{})
+	clusterProvision, err := client.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return nil, false, err
 	}
 
-	oldClusterProvision, err := util.ClusterProvisionFromHiveV1(old)
+	old := &hiveapi.ClusterProvision{}
+	if err := util.ClusterProvisionFromHiveV1(clusterProvision, old); err != nil {
+		return nil, false, err
+	}
+
+	obj, err := objInfo.UpdatedObject(ctx, old)
 	if err != nil {
 		return nil, false, err
 	}
 
-	obj, err := objInfo.UpdatedObject(ctx, oldClusterProvision)
+	if err := util.ClusterProvisionToHiveV1(obj.(*hiveapi.ClusterProvision), clusterProvision); err != nil {
+		return nil, false, err
+	}
+
+	ret, err := client.Update(clusterProvision)
 	if err != nil {
 		return nil, false, err
 	}
 
-	updatedClusterProvision, err := util.ClusterProvisionToHiveV1(obj.(*hiveapi.ClusterProvision))
-	if err != nil {
+	new := &hiveapi.ClusterProvision{}
+	if err := util.ClusterProvisionFromHiveV1(ret, new); err != nil {
 		return nil, false, err
 	}
-
-	ret, err := client.Update(updatedClusterProvision)
-	if err != nil {
-		return nil, false, err
-	}
-
-	clusterProvision, err := util.ClusterProvisionFromHiveV1(ret)
-	if err != nil {
-		return nil, false, err
-	}
-	return clusterProvision, false, err
+	return new, false, err
 }
 
 func (s *REST) getClient(ctx context.Context) (hivev1client.ClusterProvisionInterface, error) {

--- a/pkg/hive/apiserver/registry/clusterstate/proxy.go
+++ b/pkg/hive/apiserver/registry/clusterstate/proxy.go
@@ -3,7 +3,6 @@ package clusterstate
 import (
 	"context"
 
-	hivev1client "github.com/openshift/hive/pkg/client/clientset-generated/clientset/typed/hive/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,6 +11,9 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/printers"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	hivev1client "github.com/openshift/hive/pkg/client/clientset-generated/clientset/typed/hive/v1"
 
 	hiveapi "github.com/openshift/hive/pkg/hive/apis/hive"
 	"github.com/openshift/hive/pkg/hive/apiserver/registry"
@@ -65,13 +67,14 @@ func (s *REST) List(ctx context.Context, options *metainternal.ListOptions) (run
 		return nil, err
 	}
 
-	ret := &hiveapi.ClusterStateList{ListMeta: clusterStates.ListMeta}
-	for _, curr := range clusterStates.Items {
-		clusterState, err := util.ClusterStateFromHiveV1(&curr)
-		if err != nil {
+	ret := &hiveapi.ClusterStateList{
+		ListMeta: clusterStates.ListMeta,
+		Items:    make([]hiveapi.ClusterState, len(clusterStates.Items)),
+	}
+	for i, curr := range clusterStates.Items {
+		if err := util.ClusterStateFromHiveV1(&curr, &ret.Items[i]); err != nil {
 			return nil, err
 		}
-		ret.Items = append(ret.Items, *clusterState)
 	}
 	return ret, nil
 }
@@ -87,8 +90,8 @@ func (s *REST) Get(ctx context.Context, name string, options *metav1.GetOptions)
 		return nil, err
 	}
 
-	clusterState, err := util.ClusterStateFromHiveV1(ret)
-	if err != nil {
+	clusterState := &hiveapi.ClusterState{}
+	if err := util.ClusterStateFromHiveV1(ret, clusterState); err != nil {
 		return nil, err
 	}
 	return clusterState, nil
@@ -113,8 +116,8 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, err
 	}
 
-	convertedObj, err := util.ClusterStateToHiveV1(obj.(*hiveapi.ClusterState))
-	if err != nil {
+	convertedObj := &hivev1.ClusterState{}
+	if err := util.ClusterStateToHiveV1(obj.(*hiveapi.ClusterState), convertedObj); err != nil {
 		return nil, err
 	}
 
@@ -123,8 +126,8 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, err
 	}
 
-	clusterState, err := util.ClusterStateFromHiveV1(ret)
-	if err != nil {
+	clusterState := &hiveapi.ClusterState{}
+	if err := util.ClusterStateFromHiveV1(ret, clusterState); err != nil {
 		return nil, err
 	}
 	return clusterState, nil
@@ -136,36 +139,35 @@ func (s *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 		return nil, false, err
 	}
 
-	old, err := client.Get(name, metav1.GetOptions{})
+	clusterState, err := client.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return nil, false, err
 	}
 
-	oldClusterState, err := util.ClusterStateFromHiveV1(old)
+	old := &hiveapi.ClusterState{}
+	if err := util.ClusterStateFromHiveV1(clusterState, old); err != nil {
+		return nil, false, err
+	}
+
+	obj, err := objInfo.UpdatedObject(ctx, old)
 	if err != nil {
 		return nil, false, err
 	}
 
-	obj, err := objInfo.UpdatedObject(ctx, oldClusterState)
+	if err := util.ClusterStateToHiveV1(obj.(*hiveapi.ClusterState), clusterState); err != nil {
+		return nil, false, err
+	}
+
+	ret, err := client.Update(clusterState)
 	if err != nil {
 		return nil, false, err
 	}
 
-	updatedClusterState, err := util.ClusterStateToHiveV1(obj.(*hiveapi.ClusterState))
-	if err != nil {
+	new := &hiveapi.ClusterState{}
+	if err := util.ClusterStateFromHiveV1(ret, new); err != nil {
 		return nil, false, err
 	}
-
-	ret, err := client.Update(updatedClusterState)
-	if err != nil {
-		return nil, false, err
-	}
-
-	clusterState, err := util.ClusterStateFromHiveV1(ret)
-	if err != nil {
-		return nil, false, err
-	}
-	return clusterState, false, err
+	return new, false, err
 }
 
 func (s *REST) getClient(ctx context.Context) (hivev1client.ClusterStateInterface, error) {

--- a/pkg/hive/apiserver/registry/selectorsyncset/proxy.go
+++ b/pkg/hive/apiserver/registry/selectorsyncset/proxy.go
@@ -3,13 +3,15 @@ package selectorsyncset
 import (
 	"context"
 
-	hivev1client "github.com/openshift/hive/pkg/client/clientset-generated/clientset/typed/hive/v1"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/printers"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	hivev1client "github.com/openshift/hive/pkg/client/clientset-generated/clientset/typed/hive/v1"
 
 	hiveapi "github.com/openshift/hive/pkg/hive/apis/hive"
 	"github.com/openshift/hive/pkg/hive/apiserver/registry"
@@ -63,13 +65,14 @@ func (s *REST) List(ctx context.Context, options *metainternal.ListOptions) (run
 		return nil, err
 	}
 
-	ret := &hiveapi.SelectorSyncSetList{ListMeta: selectorSyncSets.ListMeta}
-	for _, curr := range selectorSyncSets.Items {
-		selectorSyncSet, err := util.SelectorSyncSetFromHiveV1(&curr)
-		if err != nil {
+	ret := &hiveapi.SelectorSyncSetList{
+		ListMeta: selectorSyncSets.ListMeta,
+		Items:    make([]hiveapi.SelectorSyncSet, len(selectorSyncSets.Items)),
+	}
+	for i, curr := range selectorSyncSets.Items {
+		if err := util.SelectorSyncSetFromHiveV1(&curr, &ret.Items[i]); err != nil {
 			return nil, err
 		}
-		ret.Items = append(ret.Items, *selectorSyncSet)
 	}
 	return ret, nil
 }
@@ -85,8 +88,8 @@ func (s *REST) Get(ctx context.Context, name string, options *metav1.GetOptions)
 		return nil, err
 	}
 
-	selectorSyncSet, err := util.SelectorSyncSetFromHiveV1(ret)
-	if err != nil {
+	selectorSyncSet := &hiveapi.SelectorSyncSet{}
+	if err := util.SelectorSyncSetFromHiveV1(ret, selectorSyncSet); err != nil {
 		return nil, err
 	}
 	return selectorSyncSet, nil
@@ -111,8 +114,8 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, err
 	}
 
-	convertedObj, err := util.SelectorSyncSetToHiveV1(obj.(*hiveapi.SelectorSyncSet))
-	if err != nil {
+	convertedObj := &hivev1.SelectorSyncSet{}
+	if err := util.SelectorSyncSetToHiveV1(obj.(*hiveapi.SelectorSyncSet), convertedObj); err != nil {
 		return nil, err
 	}
 
@@ -121,8 +124,8 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, err
 	}
 
-	selectorSyncSet, err := util.SelectorSyncSetFromHiveV1(ret)
-	if err != nil {
+	selectorSyncSet := &hiveapi.SelectorSyncSet{}
+	if err := util.SelectorSyncSetFromHiveV1(ret, selectorSyncSet); err != nil {
 		return nil, err
 	}
 	return selectorSyncSet, nil
@@ -134,36 +137,35 @@ func (s *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 		return nil, false, err
 	}
 
-	old, err := client.Get(name, metav1.GetOptions{})
+	selectorSyncSet, err := client.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return nil, false, err
 	}
 
-	oldSelectorSyncSet, err := util.SelectorSyncSetFromHiveV1(old)
+	old := &hiveapi.SelectorSyncSet{}
+	if err := util.SelectorSyncSetFromHiveV1(selectorSyncSet, old); err != nil {
+		return nil, false, err
+	}
+
+	obj, err := objInfo.UpdatedObject(ctx, old)
 	if err != nil {
 		return nil, false, err
 	}
 
-	obj, err := objInfo.UpdatedObject(ctx, oldSelectorSyncSet)
+	if err := util.SelectorSyncSetToHiveV1(obj.(*hiveapi.SelectorSyncSet), selectorSyncSet); err != nil {
+		return nil, false, err
+	}
+
+	ret, err := client.Update(selectorSyncSet)
 	if err != nil {
 		return nil, false, err
 	}
 
-	updatedSelectorSyncSet, err := util.SelectorSyncSetToHiveV1(obj.(*hiveapi.SelectorSyncSet))
-	if err != nil {
+	new := &hiveapi.SelectorSyncSet{}
+	if err := util.SelectorSyncSetFromHiveV1(ret, new); err != nil {
 		return nil, false, err
 	}
-
-	ret, err := client.Update(updatedSelectorSyncSet)
-	if err != nil {
-		return nil, false, err
-	}
-
-	selectorSyncSet, err := util.SelectorSyncSetFromHiveV1(ret)
-	if err != nil {
-		return nil, false, err
-	}
-	return selectorSyncSet, false, err
+	return new, false, err
 }
 
 func (s *REST) getClient(ctx context.Context) (hivev1client.SelectorSyncSetInterface, error) {

--- a/pkg/hive/apiserver/registry/syncsetinstance/proxy.go
+++ b/pkg/hive/apiserver/registry/syncsetinstance/proxy.go
@@ -3,7 +3,6 @@ package syncsetinstance
 import (
 	"context"
 
-	hivev1client "github.com/openshift/hive/pkg/client/clientset-generated/clientset/typed/hive/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,6 +11,9 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/printers"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	hivev1client "github.com/openshift/hive/pkg/client/clientset-generated/clientset/typed/hive/v1"
 
 	hiveapi "github.com/openshift/hive/pkg/hive/apis/hive"
 	"github.com/openshift/hive/pkg/hive/apiserver/registry"
@@ -65,13 +67,14 @@ func (s *REST) List(ctx context.Context, options *metainternal.ListOptions) (run
 		return nil, err
 	}
 
-	ret := &hiveapi.SyncSetInstanceList{ListMeta: syncSetInstances.ListMeta}
-	for _, curr := range syncSetInstances.Items {
-		syncSetInstance, err := util.SyncSetInstanceFromHiveV1(&curr)
-		if err != nil {
+	ret := &hiveapi.SyncSetInstanceList{
+		ListMeta: syncSetInstances.ListMeta,
+		Items:    make([]hiveapi.SyncSetInstance, len(syncSetInstances.Items)),
+	}
+	for i, curr := range syncSetInstances.Items {
+		if err := util.SyncSetInstanceFromHiveV1(&curr, &ret.Items[i]); err != nil {
 			return nil, err
 		}
-		ret.Items = append(ret.Items, *syncSetInstance)
 	}
 	return ret, nil
 }
@@ -87,8 +90,8 @@ func (s *REST) Get(ctx context.Context, name string, options *metav1.GetOptions)
 		return nil, err
 	}
 
-	syncSetInstance, err := util.SyncSetInstanceFromHiveV1(ret)
-	if err != nil {
+	syncSetInstance := &hiveapi.SyncSetInstance{}
+	if err := util.SyncSetInstanceFromHiveV1(ret, syncSetInstance); err != nil {
 		return nil, err
 	}
 	return syncSetInstance, nil
@@ -113,8 +116,8 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, err
 	}
 
-	convertedObj, err := util.SyncSetInstanceToHiveV1(obj.(*hiveapi.SyncSetInstance))
-	if err != nil {
+	convertedObj := &hivev1.SyncSetInstance{}
+	if err := util.SyncSetInstanceToHiveV1(obj.(*hiveapi.SyncSetInstance), convertedObj); err != nil {
 		return nil, err
 	}
 
@@ -123,8 +126,8 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 		return nil, err
 	}
 
-	syncSetInstance, err := util.SyncSetInstanceFromHiveV1(ret)
-	if err != nil {
+	syncSetInstance := &hiveapi.SyncSetInstance{}
+	if err := util.SyncSetInstanceFromHiveV1(ret, syncSetInstance); err != nil {
 		return nil, err
 	}
 	return syncSetInstance, nil
@@ -136,36 +139,35 @@ func (s *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 		return nil, false, err
 	}
 
-	old, err := client.Get(name, metav1.GetOptions{})
+	syncSetInstance, err := client.Get(name, metav1.GetOptions{})
 	if err != nil {
 		return nil, false, err
 	}
 
-	oldSyncSetInstance, err := util.SyncSetInstanceFromHiveV1(old)
+	old := &hiveapi.SyncSetInstance{}
+	if err := util.SyncSetInstanceFromHiveV1(syncSetInstance, old); err != nil {
+		return nil, false, err
+	}
+
+	obj, err := objInfo.UpdatedObject(ctx, old)
 	if err != nil {
 		return nil, false, err
 	}
 
-	obj, err := objInfo.UpdatedObject(ctx, oldSyncSetInstance)
+	if err := util.SyncSetInstanceToHiveV1(obj.(*hiveapi.SyncSetInstance), syncSetInstance); err != nil {
+		return nil, false, err
+	}
+
+	ret, err := client.Update(syncSetInstance)
 	if err != nil {
 		return nil, false, err
 	}
 
-	updatedSyncSetInstance, err := util.SyncSetInstanceToHiveV1(obj.(*hiveapi.SyncSetInstance))
-	if err != nil {
+	new := &hiveapi.SyncSetInstance{}
+	if err := util.SyncSetInstanceFromHiveV1(ret, new); err != nil {
 		return nil, false, err
 	}
-
-	ret, err := client.Update(updatedSyncSetInstance)
-	if err != nil {
-		return nil, false, err
-	}
-
-	syncSetInstance, err := util.SyncSetInstanceFromHiveV1(ret)
-	if err != nil {
-		return nil, false, err
-	}
-	return syncSetInstance, false, err
+	return new, false, err
 }
 
 func (s *REST) getClient(ctx context.Context) (hivev1client.SyncSetInstanceInterface, error) {


### PR DESCRIPTION
Updating the existing object is necessary to preserve fields that v1alpha1 does not populate. For example, if a ClusterDeployment has a non-nil .spec.provisioning.manifestsConfigMapRef, then an update of the ClusterDeployment via the v1alpha1 API needs to leave that field untouched.