### PR TITLE
Add labels used for ownership reconciliation

### DIFF
--- a/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -28,10 +28,6 @@ const (
 	// value will not be added as a label, only used for metrics vectors.
 	DefaultClusterType = "unspecified"
 
-	// HiveClusterDeploymentNameLabel is used on various objects created by Hive to link to their associated
-	// ClusterDeployment
-	HiveClusterDeploymentNameLabel = "hive.openshift.io/cluster-deployment-name"
-
 	// HiveInstallLogLabel is used on ConfigMaps uploaded by the install manager which contain an install log.
 	HiveInstallLogLabel = "hive.openshift.io/install-log"
 

--- a/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
@@ -29,10 +29,6 @@ const (
 	// value will not be added as a label, only used for metrics vectors.
 	DefaultClusterType = "unspecified"
 
-	// HiveClusterDeploymentNameLabel is used on various objects created by Hive to link to their associated
-	// ClusterDeployment
-	HiveClusterDeploymentNameLabel = "hive.openshift.io/cluster-deployment-name"
-
 	// HiveInstallLogLabel is used on ConfigMaps uploaded by the install manager which contain an install log.
 	HiveInstallLogLabel = "hive.openshift.io/install-log"
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -27,8 +27,62 @@ const (
 	// UninstallJobLabel is the label used for artifacts specific to Hive cluster deprovision.
 	UninstallJobLabel = "hive.openshift.io/uninstall"
 
-	// ClusterDeploymentNameLabel is the label that is used to identify the installer pod of a particular cluster deployment
+	// ClusterDeploymentNameLabel is the label that is used to identify a relationship to a given cluster deployment object.
 	ClusterDeploymentNameLabel = "hive.openshift.io/cluster-deployment-name"
+
+	// ClusterDeprovisionNameLabel is the label that is used to identify a relationship to a given cluster deprovision object.
+	ClusterDeprovisionNameLabel = "hive.openshift.io/cluster-deprovision-name"
+
+	// ClusterProvisionNameLabel is the label that is used to identify a relationship to a given cluster provision object.
+	ClusterProvisionNameLabel = "hive.openshift.io/cluster-provision-name"
+
+	// PVCTypeLabel is the label that is used to identify what a PVC is being used for.
+	PVCTypeLabel = "hive.openshift.io/pvc-type"
+
+	// PVCTypeInstallLogs is used as a value of PVCTypeLabel that says the PVC specifically stores installer logs.
+	PVCTypeInstallLogs = "installlogs"
+
+	// JobTypeLabel is the label that is used to identify what a Job is being used for.
+	JobTypeLabel = "hive.openshift.io/job-type"
+
+	// JobTypeImageSet is used as a value of JobTypeLabel that says the Job is specifically running to determine which imageset to use.
+	JobTypeImageSet = "imageset"
+
+	// JobTypeDeprovision is used as a value of JobTypeLabel that says the Job is specifically running the deprovisioner.
+	JobTypeDeprovision = "deprovision"
+
+	// JobTypeProvision is used as a value of JobTypeLabel that says the Job is specifically running the provisioner.
+	JobTypeProvision = "provision"
+
+	// DNSZoneTypeLabel is the label that is used to identify what a DNSZone is being used for.
+	DNSZoneTypeLabel = "hive.openshift.io/dnszone-type"
+
+	// DNSZoneTypeChild is used as a value of DNSZoneTypeLabel that says the DNSZone is specifically used as the forwarding zone for the target cluster.
+	DNSZoneTypeChild = "child"
+
+	// SecretTypeLabel is the label that is used to identify what a Secret is being used for.
+	SecretTypeLabel = "hive.openshift.io/secret-type"
+
+	// SecretTypeMergedPullSecret is used as a value of SecretTypeLabel that says the secret is specifically used for storing a pull secret.
+	SecretTypeMergedPullSecret = "merged-pull-secret"
+
+	// SecretTypeKubeConfig is used as a value of SecretTypeLabel that says the secret is specifically used for storing a kubeconfig.
+	SecretTypeKubeConfig = "kubeconfig"
+
+	// SecretTypeKubeAdminCreds is used as a value of SecretTypeLabel that says the secret is specifically used for storing kubeadmin credentials.
+	SecretTypeKubeAdminCreds = "kubeadmincreds"
+
+	// SyncSetTypeLabel is the label that is used to identify what a SyncSet is being used for.
+	SyncSetTypeLabel = "hive.openshift.io/syncset-type"
+
+	// SyncSetTypeControlPlaneCerts is used as a value of SyncSetTypeLabel that says the syncset is specifically used to distribute control plane certificates.
+	SyncSetTypeControlPlaneCerts = "controlplanecerts"
+
+	// SyncSetTypeRemoteIngress is used as a value of SyncSetTypeLabel that says the syncset is specifically used to distribute remote ingress information.
+	SyncSetTypeRemoteIngress = "remoteingress"
+
+	// SyncSetTypeIdentityProvider is used as a value of SyncSetTypeLabel that says the syncset is specifically used to distribute identity provider information.
+	SyncSetTypeIdentityProvider = "identityprovider"
 
 	// GlobalPullSecret is the environment variable for controllers to get the global pull secret
 	GlobalPullSecret = "GLOBAL_PULL_SECRET"

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/install"
@@ -170,6 +171,9 @@ func (r *ReconcileClusterDeprovision) Reconcile(request reconcile.Request) (reco
 	}
 
 	rLog.Debug("setting uninstall job controller reference")
+	rLog.WithField("derivedObject", uninstallJob.Name).Debug("Setting labels on derived object")
+	controllerutils.AddLabel(uninstallJob, constants.ClusterDeprovisionNameLabel, instance.Name)
+	controllerutils.AddLabel(uninstallJob, constants.JobTypeLabel, constants.JobTypeDeprovision)
 	err = controllerutil.SetControllerReference(instance, uninstallJob, r.scheme)
 	if err != nil {
 		rLog.Errorf("error setting controller reference on job: %v", err)

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller_test.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -21,6 +23,7 @@ import (
 
 	"github.com/openshift/hive/pkg/apis"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/install"
 )
@@ -259,6 +262,10 @@ func validateJobExists(t *testing.T, c client.Client) {
 	if err != nil {
 		t.Errorf("cannot get expected job")
 	}
+
+	require.NotNil(t, job, "expected job")
+	assert.Equal(t, testClusterDeprovision().Name, job.Labels[constants.ClusterDeprovisionNameLabel], "incorrect cluster deprovision name label")
+	assert.Equal(t, constants.JobTypeDeprovision, job.Labels[constants.JobTypeLabel], "incorrect job type label")
 }
 
 func validateNotCompleted(t *testing.T, c client.Client) {

--- a/pkg/controller/clusterprovision/clusterprovision_controller.go
+++ b/pkg/controller/clusterprovision/clusterprovision_controller.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/install"
@@ -198,6 +199,9 @@ func (r *ReconcileClusterProvision) createJob(instance *hivev1.ClusterProvision,
 
 	pLog = pLog.WithField("job", job.Name)
 
+	pLog.WithField("derivedObject", job.Name).Debug("Setting labels on derived object")
+	controllerutils.AddLabel(job, constants.ClusterProvisionNameLabel, instance.Name)
+	controllerutils.AddLabel(job, constants.JobTypeLabel, constants.JobTypeProvision)
 	if err = controllerutil.SetControllerReference(instance, job, r.scheme); err != nil {
 		pLog.WithError(err).Error("error setting controller reference on job")
 		return reconcile.Result{}, err

--- a/pkg/controller/clusterprovision/clusterprovision_controller_test.go
+++ b/pkg/controller/clusterprovision/clusterprovision_controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -65,6 +66,13 @@ func TestClusterProvisionReconcile(t *testing.T) {
 			expectedStage:         hivev1.ClusterProvisionStageInitializing,
 			expectNoJobReference:  true,
 			expectPendingCreation: true,
+			validate: func(c client.Client, t *testing.T) {
+				job := getJob(c)
+
+				require.NotNil(t, job, "expected job")
+				assert.Equal(t, testProvision().Name, job.Labels[constants.ClusterProvisionNameLabel], "incorrect cluster provision name label")
+				assert.Equal(t, constants.JobTypeProvision, job.Labels[constants.JobTypeLabel], "incorrect job type label")
+			},
 		},
 		{
 			name: "job not created when pending create",

--- a/pkg/controller/clusterstate/clusterstate_controller.go
+++ b/pkg/controller/clusterstate/clusterstate_controller.go
@@ -23,6 +23,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/remoteclient"
@@ -143,6 +144,9 @@ func (r *ReconcileClusterState) Reconcile(request reconcile.Request) (reconcile.
 		logger.Info("Creating cluster state resource for cluster deployment")
 		st.Name = cd.Name
 		st.Namespace = cd.Namespace
+
+		logger.WithField("derivedObject", st.Name).Debug("Setting label on derived object")
+		controllerutils.AddLabel(st, constants.ClusterDeploymentNameLabel, cd.Name)
 		if err = controllerutil.SetControllerReference(cd, st, r.scheme); err != nil {
 			logger.WithError(err).Error("error setting controller reference on cluster state")
 			return reconcile.Result{}, err

--- a/pkg/controller/clusterstate/clusterstate_controller_test.go
+++ b/pkg/controller/clusterstate/clusterstate_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang/mock/gomock"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -23,6 +24,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/hive/pkg/apis"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/remoteclient"
 	remoteclientmock "github.com/openshift/hive/pkg/remoteclient/mock"
 )
@@ -69,7 +71,8 @@ func TestClusterStateReconcile(t *testing.T) {
 			noRemoteCall: true,
 			validate: func(t *testing.T, c client.Client, result reconcile.Result) {
 				st := cs(t, c)
-				assert.NotNil(t, st, "clusterstate should have been created")
+				require.NotNil(t, st, "clusterstate should have been created")
+				assert.Equal(t, testClusterDeployment().Name, st.Labels[constants.ClusterDeploymentNameLabel], "incorrect cluster deployment name label")
 			},
 		},
 		{

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller.go
@@ -29,6 +29,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	apihelpers "github.com/openshift/hive/pkg/apis/helpers"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/resource"
@@ -321,6 +322,9 @@ func (r *ReconcileControlPlaneCerts) generateControlPlaneCertsSyncSet(cd *hivev1
 	syncSet.Spec.Patches = []hivev1.SyncObjectPatch{kubeAPIServerPatch}
 
 	// ensure the syncset gets cleaned up when the clusterdeployment is deleted
+	cdLog.WithField("derivedObject", syncSet.Name).Debug("Setting labels on derived object")
+	controllerutils.AddLabel(syncSet, constants.ClusterDeploymentNameLabel, cd.Name)
+	controllerutils.AddLabel(syncSet, constants.SyncSetTypeLabel, constants.SyncSetTypeControlPlaneCerts)
 	if err := controllerutil.SetControllerReference(cd, syncSet, r.scheme); err != nil {
 		cdLog.WithError(err).Error("error setting owner reference")
 		return nil, err

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
@@ -24,6 +24,7 @@ import (
 	openshiftapiv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/hive/pkg/apis"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/resource"
 )
@@ -69,6 +70,12 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 				cd := getFakeClusterDeployment(t, c)
 				assert.Empty(t, cd.Status.Conditions, "no conditions should be set")
 				validateAppliedSyncSet(t, applied, "", additionalCert(fakeAPIURL, "default-secret"))
+
+				ss := applied[0].(metav1.Object)
+				labels := ss.GetLabels()
+
+				assert.Equal(t, fakeClusterDeployment().obj().Name, labels[constants.ClusterDeploymentNameLabel], "incorrect cluster deployment name label")
+				assert.Equal(t, constants.SyncSetTypeControlPlaneCerts, labels[constants.SyncSetTypeLabel], "incorrect syncset type label")
 			},
 		},
 		{

--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -29,8 +29,10 @@ import (
 	ingresscontroller "github.com/openshift/api/operator/v1"
 	apihelpers "github.com/openshift/hive/pkg/apis/helpers"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	"github.com/openshift/hive/pkg/controller/utils"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/resource"
 )
 
@@ -269,6 +271,9 @@ func (r *ReconcileRemoteClusterIngress) syncSyncSet(rContext *reconcileContext, 
 	}
 
 	// ensure the syncset gets cleaned up when the clusterdeployment is deleted
+	r.logger.WithField("derivedObject", syncSet.Name).Debug("Setting labels on derived object")
+	controllerutils.AddLabel(syncSet, constants.ClusterDeploymentNameLabel, rContext.clusterDeployment.Name)
+	controllerutils.AddLabel(syncSet, constants.SyncSetTypeLabel, constants.SyncSetTypeRemoteIngress)
 	if err := controllerutil.SetControllerReference(rContext.clusterDeployment, syncSet, r.scheme); err != nil {
 		r.logger.WithError(err).Error("error setting owner reference")
 		return err

--- a/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
+++ b/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
@@ -9,6 +9,7 @@ import (
 
 	openshiftapiv1 "github.com/openshift/api/config/v1"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	log "github.com/sirupsen/logrus"
@@ -269,6 +270,9 @@ func (r *ReconcileSyncIdentityProviders) syncIdentityProviders(cd *hivev1.Cluste
 		}
 
 		// ensure the syncset gets cleaned up when the clusterdeployment is deleted
+		r.logger.WithField("derivedObject", ss.Name).Debug("Setting labels on derived object")
+		controllerutils.AddLabel(ss, constants.ClusterDeploymentNameLabel, cd.Name)
+		controllerutils.AddLabel(ss, constants.SyncSetTypeLabel, constants.SyncSetTypeIdentityProvider)
 		if err := controllerutil.SetControllerReference(cd, ss, r.scheme); err != nil {
 			contextLogger.WithError(err).Error("error setting controller reference on syncset")
 			return err

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -122,3 +122,15 @@ func LogLevel(err error) log.Level {
 		err = cause
 	}
 }
+
+// AddLabel sets the specified label on the object. If the label key is already present, then it is over written with the value. If the labels map is nil, a new labels map is created.
+func AddLabel(object metav1.Object, key, value string) {
+	objLabels := object.GetLabels()
+	if objLabels == nil {
+		objLabels = map[string]string{}
+	}
+
+	// Set the new labels in the existing labels.
+	objLabels[key] = value
+	object.SetLabels(objLabels)
+}

--- a/pkg/hive/apis/hive/clusterdeployment_types.go
+++ b/pkg/hive/apis/hive/clusterdeployment_types.go
@@ -29,10 +29,6 @@ const (
 	// value will not be added as a label, only used for metrics vectors.
 	DefaultClusterType = "unspecified"
 
-	// HiveClusterDeploymentNameLabel is used on various objects created by Hive to link to their associated
-	// ClusterDeployment
-	HiveClusterDeploymentNameLabel = "hive.openshift.io/cluster-deployment-name"
-
 	// HiveInstallLogLabel is used on ConfigMaps uploaded by the install manager which contain an install log.
 	HiveInstallLogLabel = "hive.openshift.io/install-log"
 

--- a/pkg/imageset/generate.go
+++ b/pkg/imageset/generate.go
@@ -50,9 +50,6 @@ exit 0
 `
 	// ImagesetJobLabel is the label used for counting the number of imageset jobs in Hive
 	ImagesetJobLabel = "hive.openshift.io/imageset"
-
-	// ClusterDeploymentNameLabel is the label that is used to identify the imageset pod of a particular cluster deployment
-	ClusterDeploymentNameLabel = "hive.openshift.io/cluster-deployment-name"
 )
 
 // GenerateImageSetJob creates a job to determine the installer image for a ClusterImageSet
@@ -157,8 +154,8 @@ func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAcco
 	deadline := int64((24 * time.Hour).Seconds())
 	backoffLimit := int32(123456)
 	labels := map[string]string{
-		ImagesetJobLabel:           "true",
-		ClusterDeploymentNameLabel: cd.Name,
+		ImagesetJobLabel:                     "true",
+		constants.ClusterDeploymentNameLabel: cd.Name,
 	}
 	if cd.Labels != nil {
 		typeStr, ok := cd.Labels[hivev1.HiveClusterTypeLabel]

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -989,6 +989,9 @@ func uploadAdminKubeconfig(provision *hivev1.ClusterProvision, m *InstallManager
 		},
 	}
 
+	m.log.WithField("derivedObject", kubeconfigSecret.Name).Debug("Setting labels on derived object")
+	controllerutils.AddLabel(kubeconfigSecret, constants.ClusterProvisionNameLabel, provision.Name)
+	controllerutils.AddLabel(kubeconfigSecret, constants.SecretTypeLabel, constants.SecretTypeKubeConfig)
 	if err := controllerutil.SetControllerReference(provision, kubeconfigSecret, scheme.Scheme); err != nil {
 		m.log.WithError(err).Error("error setting controller reference on kubeconfig secret")
 		return nil, err
@@ -1030,6 +1033,9 @@ func uploadAdminPassword(provision *hivev1.ClusterProvision, m *InstallManager) 
 		},
 	}
 
+	m.log.WithField("derivedObject", s.Name).Debug("Setting labels on derived object")
+	controllerutils.AddLabel(s, constants.ClusterProvisionNameLabel, provision.Name)
+	controllerutils.AddLabel(s, constants.SecretTypeLabel, constants.SecretTypeKubeAdminCreds)
 	if err := controllerutil.SetControllerReference(provision, s, scheme.Scheme); err != nil {
 		m.log.WithError(err).Error("error setting controller reference on kubeconfig secret")
 		return nil, err

--- a/pkg/installmanager/installmanager_test.go
+++ b/pkg/installmanager/installmanager_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/openshift/hive/pkg/apis"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
 )
 
 const (
@@ -257,6 +258,9 @@ func TestInstallManager(t *testing.T) {
 					if assert.True(t, ok) {
 						assert.Equal(t, []byte("fakekubeconfig\n"), kubeconfig, "unexpected kubeconfig")
 					}
+
+					assert.Equal(t, testClusterProvision().Name, adminKubeconfig.Labels[constants.ClusterProvisionNameLabel], "incorrect cluster provision name label")
+					assert.Equal(t, constants.SecretTypeKubeConfig, adminKubeconfig.Labels[constants.SecretTypeLabel], "incorrect secret type label")
 				}
 			} else {
 				assert.True(t, apierrors.IsNotFound(err), "unexpected response from getting kubeconfig secret: %v", err)
@@ -279,6 +283,9 @@ func TestInstallManager(t *testing.T) {
 					if assert.True(t, ok) {
 						assert.Equal(t, []byte("fakepassword"), password, "unexpected admin password")
 					}
+
+					assert.Equal(t, testClusterProvision().Name, adminPassword.Labels[constants.ClusterProvisionNameLabel], "incorrect cluster provision name label")
+					assert.Equal(t, constants.SecretTypeKubeAdminCreds, adminPassword.Labels[constants.SecretTypeLabel], "incorrect secret type label")
 				}
 			} else {
 				assert.True(t, apierrors.IsNotFound(err), "unexpected response from getting password secret: %v", err)


### PR DESCRIPTION
- [x] Add relevant labels where controller owners are added so that
      controller ownership relationships can be reconciled
- [x] Consolidate cluster-deployment-name label to a single golang constant
- [x] Add unit tests to ensure labels are set correctly
- [x] Manually test that labels are applied.