### PR TITLE
handle changing managed domains in hiveConfig

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2301,6 +2301,7 @@
     "k8s.io/kubernetes/pkg/apis/core/validation",
     "k8s.io/kubernetes/pkg/capabilities",
     "k8s.io/kubernetes/pkg/client/metrics/prometheus",
+    "k8s.io/kubernetes/pkg/kubectl",
     "k8s.io/kubernetes/pkg/kubectl/cmd/apply",
     "k8s.io/kubernetes/pkg/kubectl/cmd/patch",
     "k8s.io/kubernetes/pkg/kubectl/cmd/util",

--- a/config/crds/hive_v1_hiveconfig.yaml
+++ b/config/crds/hive_v1_hiveconfig.yaml
@@ -149,6 +149,15 @@ spec:
                 client CA configmap data from the openshift-config-managed namespace.
                 When the configmap changes, admission is redeployed.
               type: string
+            configApplied:
+              description: ConfigApplied will be set by the hive operator to indicate
+                whether or not the LastGenerationObserved was successfully reconciled.
+              type: boolean
+            observedGeneration:
+              description: ObservedGeneration will record the most recently processed
+                HiveConfig object's generation.
+              format: int64
+              type: integer
           type: object
   version: v1
 status:

--- a/contrib/pkg/createcluster/create.go
+++ b/contrib/pkg/createcluster/create.go
@@ -179,6 +179,7 @@ create-cluster CLUSTER_DEPLOYMENT_NAME --cloud=gcp`,
 			err := opt.Run()
 			if err != nil {
 				log.WithError(err).Error("Error")
+				os.Exit(1)
 			}
 		},
 	}
@@ -332,7 +333,10 @@ func (o *Options) Run() error {
 			return err
 		}
 		accessor.SetNamespace(o.Namespace)
-		rh.ApplyRuntimeObject(obj, scheme.Scheme)
+		if _, err := rh.ApplyRuntimeObject(obj, scheme.Scheme); err != nil {
+			return err
+		}
+
 	}
 	return nil
 }

--- a/pkg/apis/hive/v1/hiveconfig_types.go
+++ b/pkg/apis/hive/v1/hiveconfig_types.go
@@ -62,6 +62,13 @@ type HiveConfigStatus struct {
 	// configmap data from the openshift-config-managed namespace. When the configmap changes,
 	// admission is redeployed.
 	AggregatorClientCAHash string `json:"aggregatorClientCAHash,omitempty"`
+
+	// ObservedGeneration will record the most recently processed HiveConfig object's generation.
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// ConfigApplied will be set by the hive operator to indicate whether or not the LastGenerationObserved
+	// was successfully reconciled.
+	ConfigApplied bool `json:"configApplied,omitempty"`
 }
 
 // BackupConfig contains settings for the Velero backup integration.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -108,6 +108,10 @@ const (
 	// that is a direct child of one of the valid domains.
 	ManagedDomainsFileEnvVar = "MANAGED_DOMAINS_FILE"
 
+	// ManagedDomainsVolumeName is the name of the volume that will point
+	// to the configmap containing the managed domain configuration.
+	ManagedDomainsVolumeName = "managed-domains"
+
 	// GCPCredentialsName is the name of the GCP credentials file or secret key.
 	GCPCredentialsName = "osServiceAccount.json"
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -3140,6 +3140,15 @@ spec:
                 client CA configmap data from the openshift-config-managed namespace.
                 When the configmap changes, admission is redeployed.
               type: string
+            configApplied:
+              description: ConfigApplied will be set by the hive operator to indicate
+                whether or not the LastGenerationObserved was successfully reconciled.
+              type: boolean
+            observedGeneration:
+              description: ObservedGeneration will record the most recently processed
+                HiveConfig object's generation.
+              format: int64
+              type: integer
           type: object
   version: v1
 status:

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -40,7 +40,7 @@ const (
 	hiveAdditionalCASecret = "hive-additional-ca"
 )
 
-func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helper, instance *hivev1.HiveConfig, recorder events.Recorder) error {
+func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helper, instance *hivev1.HiveConfig, recorder events.Recorder, mdConfigMap *corev1.ConfigMap) error {
 
 	asset := assets.MustAsset("config/manager/deployment.yaml")
 	hLog.Debug("reading deployment")
@@ -86,9 +86,7 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helpe
 		hiveContainer.Env = append(hiveContainer.Env, syncsetReapplyIntervalEnvVar)
 	}
 
-	if len(instance.Spec.ManagedDomains) > 0 {
-		addManagedDomainsVolume(&hiveDeployment.Spec.Template.Spec)
-	}
+	addManagedDomainsVolume(&hiveDeployment.Spec.Template.Spec, mdConfigMap.Name)
 
 	// By default we will try to gather logs on failed installs:
 	logsEnvVar := corev1.EnvVar{

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -47,7 +47,7 @@ var (
 	}
 )
 
-func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h *resource.Helper, instance *hivev1.HiveConfig, recorder events.Recorder) error {
+func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h *resource.Helper, instance *hivev1.HiveConfig, recorder events.Recorder, mdConfigMap *corev1.ConfigMap) error {
 	asset := assets.MustAsset("config/hiveadmission/deployment.yaml")
 	hLog.Debug("reading deployment")
 	hiveAdmDeployment := resourceread.ReadDeploymentV1OrDie(asset)
@@ -77,9 +77,7 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h *resou
 	hiveAdmDeployment.Annotations[aggregatorClientCAHashAnnotation] = instance.Status.AggregatorClientCAHash
 	hiveAdmDeployment.Spec.Template.ObjectMeta.Annotations[aggregatorClientCAHashAnnotation] = instance.Status.AggregatorClientCAHash
 
-	if len(instance.Spec.ManagedDomains) > 0 {
-		addManagedDomainsVolume(&hiveAdmDeployment.Spec.Template.Spec)
-	}
+	addManagedDomainsVolume(&hiveAdmDeployment.Spec.Template.Spec, mdConfigMap.Name)
 
 	result, err := h.ApplyRuntimeObject(hiveAdmDeployment, scheme.Scheme)
 	if err != nil {

--- a/pkg/operator/hive/manageddns.go
+++ b/pkg/operator/hive/manageddns.go
@@ -1,7 +1,10 @@
 package hive
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"reflect"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -10,7 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
@@ -19,7 +21,10 @@ import (
 )
 
 const (
-	managedDomainsConfigMapName = "managed-domains"
+	managedDomainsConfigMapNamePrefix = "managed-domains-"
+	managedDomainsConfigMapKey        = "managed-domains"
+	configMapLabel                    = "managed-domains"
+	configMapMountPath                = "/data/config"
 )
 
 func (r *ReconcileHiveConfig) teardownLegacyExternalDNS(hLog log.FieldLogger) error {
@@ -37,38 +42,110 @@ func (r *ReconcileHiveConfig) teardownLegacyExternalDNS(hLog log.FieldLogger) er
 	return nil
 }
 
-func deployManagedDomainsConfigMap(h *resource.Helper, instance *hivev1.HiveConfig) error {
-	cm := &corev1.ConfigMap{}
-	cm.Kind = "ConfigMap"
-	cm.APIVersion = "v1"
-	cm.Name = managedDomainsConfigMapName
-	cm.Namespace = constants.HiveNamespace
-
-	domains, err := json.Marshal(instance.Spec.ManagedDomains)
-	if err != nil {
-		return errors.Wrap(err, "failed to marshal managed domains list into the configmap")
+func (r *ReconcileHiveConfig) teardownLegacyMangedDomainsConfigMap(hLog log.FieldLogger) error {
+	key := client.ObjectKey{Namespace: constants.HiveNamespace, Name: "managed-domains"}
+	if err := resource.DeleteAnyExistingObject(r, key, &corev1.ConfigMap{}, hLog); err != nil {
+		hLog.WithError(err).Error("failed to delete legacy managed domains configmap")
 	}
-
-	cm.Data = map[string]string{"managed-domains": string(domains)}
-	_, err = h.ApplyRuntimeObject(cm, scheme.Scheme)
-	return errors.Wrap(err, "error applying managed domains configmap")
+	return nil
 }
 
-func addManagedDomainsVolume(podSpec *corev1.PodSpec) {
+// configureManagedDomains will create a new configmap holding the managed domains settings (if necessary), or simply
+// return the current configmap of the current deployment if the settings it contains match the desired settings.
+func (r *ReconcileHiveConfig) configureManagedDomains(logger log.FieldLogger, instance *hivev1.HiveConfig) (*corev1.ConfigMap, error) {
+	domains, err := json.Marshal(instance.Spec.ManagedDomains)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal managed domains list into the configmap")
+	}
+
+	newConfigMapData := map[string]string{managedDomainsConfigMapKey: string(domains)}
+
+	currentConfigMap, err := r.getCurrentConfigMap(newConfigMapData, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	var mdConfigMap *corev1.ConfigMap
+	if currentConfigMap == nil {
+		log.Debug("need a new/updated configmap for managed domains")
+		mdConfigMap = &corev1.ConfigMap{}
+		mdConfigMap.Kind = "ConfigMap"
+		mdConfigMap.APIVersion = "v1"
+		mdConfigMap.GenerateName = managedDomainsConfigMapNamePrefix
+		mdConfigMap.Namespace = constants.HiveNamespace
+		mdConfigMap.Labels = map[string]string{configMapLabel: "true"}
+
+		mdConfigMap.Data = newConfigMapData
+
+		if err := r.Create(context.TODO(), mdConfigMap); err != nil {
+			return nil, errors.Wrap(err, "failed to save new managed domains configmap")
+		}
+		log.WithField("configmap", fmt.Sprintf("%s/%s", mdConfigMap.Namespace, mdConfigMap.Name)).
+			Debug("saved configmap for managed domains")
+
+	} else {
+		// If configmap data was equal keep using current configmap.
+		log.WithField("configmap", fmt.Sprintf("%s/%s", currentConfigMap.Namespace, currentConfigMap.Name)).
+			Info("using existing manage domains config map")
+		mdConfigMap = currentConfigMap
+	}
+
+	return mdConfigMap, nil
+}
+
+// getCurrentConfigMap will see if any existing configmap (for managed domains) already has the necessary
+// settings. It will also delete any configmaps (for managed domains) that have out-of-date contents
+// (so that the configmaps are not orphaned as config changes happen).
+func (r *ReconcileHiveConfig) getCurrentConfigMap(cmData map[string]string, logger log.FieldLogger) (*corev1.ConfigMap, error) {
+	configMapList := &corev1.ConfigMapList{}
+	labelSelector := map[string]string{configMapLabel: "true"}
+
+	err := r.List(context.TODO(), configMapList, client.MatchingLabels(labelSelector))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list config maps for managed domains")
+	}
+
+	currentConfigMap := &corev1.ConfigMap{}
+
+	// find any configmap that has current, correct managed domains data
+	for i, cm := range configMapList.Items {
+		if reflect.DeepEqual(cmData, cm.Data) {
+			currentConfigMap = &configMapList.Items[i]
+			break
+		}
+	}
+
+	// delete all the other configmaps (will delete all if no matches found in the step above)
+	for _, cm := range configMapList.Items {
+		if cm.Name != currentConfigMap.Name {
+			if err := r.Delete(context.TODO(), &cm); err != nil {
+				logger.WithError(err).Error("failed to delete out-of-date manged domains configmap")
+			}
+		}
+	}
+
+	if currentConfigMap.Name == "" {
+		return nil, nil
+	}
+
+	return currentConfigMap, nil
+}
+
+func addManagedDomainsVolume(podSpec *corev1.PodSpec, configMapName string) {
 	volume := corev1.Volume{}
-	volume.Name = "managed-domains"
+	volume.Name = constants.ManagedDomainsVolumeName
 	volume.ConfigMap = &corev1.ConfigMapVolumeSource{
 		LocalObjectReference: corev1.LocalObjectReference{
-			Name: managedDomainsConfigMapName,
+			Name: configMapName,
 		},
 	}
 	volumeMount := corev1.VolumeMount{
-		Name:      "managed-domains",
-		MountPath: "/data/config",
+		Name:      constants.ManagedDomainsVolumeName,
+		MountPath: configMapMountPath,
 	}
 	envVar := corev1.EnvVar{
 		Name:  constants.ManagedDomainsFileEnvVar,
-		Value: "/data/config/managed-domains",
+		Value: fmt.Sprintf("%s/%s", configMapMountPath, managedDomainsConfigMapKey),
 	}
 	podSpec.Volumes = append(podSpec.Volumes, volume)
 	podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, volumeMount)


### PR DESCRIPTION
The hive operator would not relaunch the hive-controllers deployment when the only change to the HiveConfig was adding/removing an existing managed domain entry (leaving at least one managed domain).

Update the logic to create a new configmap with a new name (so that the controllers cannot see the old configmap contents on controller restart), and detect when changes are needed so that the hive-controllers deployment is re-deployed as necessary.

A notable change is that a HiveConfig with no managed domain entries will now have a configmap with an empty list of managed domains used in the hive-controllers deployment (the dns controllers already handle the case of an empty list of managed domains). Previously the hive-operator would simply not create the configmap at all.