### PR TITLE
Add cd name to sample syncsets.

### DIFF
--- a/contrib/pkg/createcluster/create.go
+++ b/contrib/pkg/createcluster/create.go
@@ -656,7 +656,7 @@ func (o *Options) configureImages(cd *hivev1.ClusterDeployment) (*hivev1.Cluster
 func (o *Options) generateSampleSyncSets() []runtime.Object {
 	syncsets := []runtime.Object{}
 	for i := range [10]int{} {
-		syncsets = append(syncsets, sampleSyncSet(fmt.Sprintf("sample-syncset%d", i), o.Namespace, o.Name))
+		syncsets = append(syncsets, sampleSyncSet(fmt.Sprintf("%s-sample-syncset%d", o.Name, i), o.Namespace, o.Name))
 		syncsets = append(syncsets, sampleSelectorSyncSet(fmt.Sprintf("sample-selector-syncset%d", i), o.Name))
 	}
 	return syncsets


### PR DESCRIPTION
To keep syncsets created in the same namespace from colliding.

selectorsyncsets are applied to the same label so they don't need a prefix.