### PR TITLE
Add maintenanceMode support in HiveConfig.

### DIFF
--- a/config/crds/hive_v1alpha1_hiveconfig.yaml
+++ b/config/crds/hive_v1alpha1_hiveconfig.yaml
@@ -109,6 +109,13 @@ spec:
                 with precedence given to the contents of the pull secret for the cluster
                 deployment.
               type: object
+            maintenanceMode:
+              description: MaintenanceMode can be set to true to disable the hive
+                controllers in situations where we need to ensure nothing is running
+                that will add or act upon finalizers on Hive types. This should rarely
+                be needed. Sets replicas to 0 for the hive-controllers deployment
+                to accomplish this.
+              type: boolean
             managedDomains:
               description: 'ManagedDomains is the list of DNS domains that are allowed
                 to be used by the ''managedDNS'' feature. When specifying ''managedDNS:

--- a/pkg/apis/hive/v1alpha1/hiveconfig_types.go
+++ b/pkg/apis/hive/v1alpha1/hiveconfig_types.go
@@ -39,6 +39,11 @@ type HiveConfigSpec struct {
 
 	// FailedProvisionConfig is used to configure settings related to handling provision failures.
 	FailedProvisionConfig FailedProvisionConfig `json:"failedProvisionConfig"`
+
+	// MaintenanceMode can be set to true to disable the hive controllers in situations where we need to ensure
+	// nothing is running that will add or act upon finalizers on Hive types. This should rarely be needed.
+	// Sets replicas to 0 for the hive-controllers deployment to accomplish this.
+	MaintenanceMode *bool `json:"maintenanceMode,omitempty"`
 }
 
 // HiveConfigStatus defines the observed state of Hive

--- a/pkg/apis/hive/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/hive/v1alpha1/zz_generated.deepcopy.go
@@ -1575,6 +1575,11 @@ func (in *HiveConfigSpec) DeepCopyInto(out *HiveConfigSpec) {
 	}
 	in.Backup.DeepCopyInto(&out.Backup)
 	out.FailedProvisionConfig = in.FailedProvisionConfig
+	if in.MaintenanceMode != nil {
+		in, out := &in.MaintenanceMode, &out.MaintenanceMode
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -3199,6 +3199,13 @@ spec:
                 with precedence given to the contents of the pull secret for the cluster
                 deployment.
               type: object
+            maintenanceMode:
+              description: MaintenanceMode can be set to true to disable the hive
+                controllers in situations where we need to ensure nothing is running
+                that will add or act upon finalizers on Hive types. This should rarely
+                be needed. Sets replicas to 0 for the hive-controllers deployment
+                to accomplish this.
+              type: boolean
             managedDomains:
               description: 'ManagedDomains is the list of DNS domains that are allowed
                 to be used by the ''managedDNS'' feature. When specifying ''managedDNS:

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -130,6 +130,12 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helpe
 
 	r.includeGlobalPullSecret(hLog, h, instance, hiveDeployment)
 
+	if instance.Spec.MaintenanceMode != nil && *instance.Spec.MaintenanceMode {
+		hLog.Warn("maintenanceMode enabled in HiveConfig, setting hive-controllers replicas to 0")
+		replicas := int32(0)
+		hiveDeployment.Spec.Replicas = &replicas
+	}
+
 	result, err := h.ApplyRuntimeObject(hiveDeployment, scheme.Scheme)
 	if err != nil {
 		hLog.WithError(err).Error("error applying deployment")


### PR DESCRIPTION
If set to true, will scale down hive-controllers to 0 replicas. Only
useful in extreme situations where we need to ensure the controllers are
not manipulating data, as in our upcoming v1 migration.