### PR TITLE
Add an install log scan regex for AWS NAT gateway limit exceeded errors.

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: hive
 data:
   regexes: |
+    # AWS Specific:
+    - name: AWSNATGatewayLimitExceeded
+      searchRegexStrings:
+      - "NatGatewayLimitExceeded"
+      installFailingReason: AWSNATGatewayLimitExceeded
+      installFailingMessage: AWS NAT gateway limit exceeded
     - name: DNSAlreadyExists
       searchRegexStrings:
       - "aws_route53_record.*Error building changeset:.*Tried to create resource record set.*but it already exists"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -4938,6 +4938,12 @@ metadata:
   namespace: hive
 data:
   regexes: |
+    # AWS Specific:
+    - name: AWSNATGatewayLimitExceeded
+      searchRegexStrings:
+      - "NatGatewayLimitExceeded"
+      installFailingReason: AWSNATGatewayLimitExceeded
+      installFailingMessage: AWS NAT gateway limit exceeded
     - name: DNSAlreadyExists
       searchRegexStrings:
       - "aws_route53_record.*Error building changeset:.*Tried to create resource record set.*but it already exists"


### PR DESCRIPTION
Surfaces as: "Error: Error creating NAT Gateway:
NatGatewayLimitExceeded: Performing this operation would exceed the limit
of 5 NAT gateways"

Scanning just for the AWS error string seems easiest and safe.