### PR TITLE
chore: label SyncSetInstances with (Selector)SyncSetRef

### DIFF
--- a/pkg/apis/hive/v1/syncsetinstance_types.go
+++ b/pkg/apis/hive/v1/syncsetinstance_types.go
@@ -31,6 +31,12 @@ const (
 	// FinalizerSyncSetInstance is used on SyncSetInstances to ensure we remove
 	// resources corresponnding to Sync mode syncset resources.
 	FinalizerSyncSetInstance string = "hive.openshift.io/syncsetinstance"
+
+	// SyncSetNameLabel is the label used to identify the SyncSet of a particular SyncSetInstance
+	SyncSetNameLabel = "hive.openshift.io/sync-set-name"
+
+	// SelectorSyncSetNameLabel is the label used to identify the SyncSet of a particular SelectorSyncSetInstance
+	SelectorSyncSetNameLabel = "hive.openshift.io/selector-sync-set-name"
 )
 
 // SyncSetInstanceSpec defines the desired state of SyncSetInstance

--- a/pkg/controller/syncset/syncset_controller.go
+++ b/pkg/controller/syncset/syncset_controller.go
@@ -396,6 +396,9 @@ func (r *ReconcileSyncSet) syncSetInstanceForSyncSet(cd *hivev1.ClusterDeploymen
 			Name:            syncSetInstanceNameForSyncSet(cd, syncSet),
 			Namespace:       cd.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*cdRef},
+			Labels: map[string]string{
+				"SyncSetName": syncSet.Name,
+			},
 		},
 		Spec: hivev1.SyncSetInstanceSpec{
 			ClusterDeploymentRef: corev1.LocalObjectReference{
@@ -421,6 +424,9 @@ func (r *ReconcileSyncSet) syncSetInstanceForSelectorSyncSet(cd *hivev1.ClusterD
 			Name:            syncSetInstanceNameForSelectorSyncSet(cd, selectorSyncSet),
 			Namespace:       cd.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*cdRef},
+			Labels: map[string]string{
+				"SelectorSyncSetName": selectorSyncSet.Name,
+			},
 		},
 		Spec: hivev1.SyncSetInstanceSpec{
 			ClusterDeploymentRef: corev1.LocalObjectReference{

--- a/pkg/controller/syncset/syncset_controller.go
+++ b/pkg/controller/syncset/syncset_controller.go
@@ -397,7 +397,7 @@ func (r *ReconcileSyncSet) syncSetInstanceForSyncSet(cd *hivev1.ClusterDeploymen
 			Namespace:       cd.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*cdRef},
 			Labels: map[string]string{
-				"SyncSetName": syncSet.Name,
+				hivev1.SyncSetNameLabel: syncSet.Name,
 			},
 		},
 		Spec: hivev1.SyncSetInstanceSpec{
@@ -425,7 +425,7 @@ func (r *ReconcileSyncSet) syncSetInstanceForSelectorSyncSet(cd *hivev1.ClusterD
 			Namespace:       cd.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*cdRef},
 			Labels: map[string]string{
-				"SelectorSyncSetName": selectorSyncSet.Name,
+				hivev1.SelectorSyncSetNameLabel: selectorSyncSet.Name,
 			},
 		},
 		Spec: hivev1.SyncSetInstanceSpec{


### PR DESCRIPTION
Add a label to SyncSetInstances with the SelectorSyncSet or SyncSet they
are associated with. This makes it possible, knowing the (Selector)SyncSet, to find SyncSetInstances that were created.