### PR TITLE
Formalize addition of ssh known hosts in install manager.

### DIFF
--- a/config/crds/hive_v1_clusterdeployment.yaml
+++ b/config/crds/hive_v1_clusterdeployment.yaml
@@ -287,6 +287,15 @@ spec:
                     way to specify what specific version of OpenShift you wish to
                     install.
                   type: string
+                sshKnownHosts:
+                  description: SSHKnownHosts are known hosts to be configured in the
+                    hive install manager pod to avoid ssh prompts. Use of ssh in the
+                    install pod is somewhat limited today (failure log gathering from
+                    cluster, some bare metal provisioning scenarios), so this setting
+                    is often not needed.
+                  items:
+                    type: string
+                  type: array
                 sshPrivateKeySecretRef:
                   description: SSHPrivateKeySecretRef is the reference to the secret
                     that contains the private SSH key to use for access to compute

--- a/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -119,6 +119,11 @@ type Provisioning struct {
 	// +optional
 	SSHPrivateKeySecretRef *corev1.LocalObjectReference `json:"sshPrivateKeySecretRef,omitempty"`
 
+	// SSHKnownHosts are known hosts to be configured in the hive install manager pod to avoid ssh prompts.
+	// Use of ssh in the install pod is somewhat limited today (failure log gathering from cluster, some bare metal
+	// provisioning scenarios), so this setting is often not needed.
+	SSHKnownHosts []string `json:"sshKnownHosts,omitempty"`
+
 	// InstallerEnv are extra environment variables to pass through to the installer. This may be used to enable
 	// additional features of the installer.
 	// +optional

--- a/pkg/apis/hive/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/hive/v1/zz_generated.deepcopy.go
@@ -1765,6 +1765,11 @@ func (in *Provisioning) DeepCopyInto(out *Provisioning) {
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
+	if in.SSHKnownHosts != nil {
+		in, out := &in.SSHKnownHosts, &out.SSHKnownHosts
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.InstallerEnv != nil {
 		in, out := &in.InstallerEnv, &out.InstallerEnv
 		*out = make([]corev1.EnvVar, len(*in))

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -75,7 +75,7 @@ const (
 	defaultInstallConfigMountPath       = "/installconfig/install-config.yaml"
 	defaultPullSecretMountPath          = "/pullsecret/" + corev1.DockerConfigJsonKey
 	defaultManifestsMountPath           = "/manifests"
-	hiveSSHKnownHostsAnnotation         = "hive.openshift.io/ssh-known-host"
+	defaultHomeDir                      = "/home/hive" // Used if no HOME env var set.
 )
 
 var (
@@ -267,8 +267,13 @@ func (m *InstallManager) Run() error {
 	}
 	m.log.Infof("copied %s to %s", m.InstallConfigMountPath, destInstallConfigPath)
 
-	if knownHost, ok := cd.Annotations[hiveSSHKnownHostsAnnotation]; ok {
-		err = m.setupSSHKnownHost(knownHost)
+	if cd.Spec.Provisioning != nil && len(cd.Spec.Provisioning.SSHKnownHosts) > 0 {
+		err = m.setupSSHUser()
+		if err != nil {
+			m.log.WithError(err).Error("error setting up SSH known_hosts")
+			return err
+		}
+		err = m.writeSSHKnownHosts(getHomeDir(), cd.Spec.Provisioning.SSHKnownHosts)
 		if err != nil {
 			m.log.WithError(err).Error("error setting up SSH known_hosts")
 			return err
@@ -1169,11 +1174,10 @@ func waitForProvisioningStage(provision *hivev1.ClusterProvision, m *InstallMana
 	return errors.Wrap(err, "ClusterProvision did not transition to provisioning stage")
 }
 
-func (m *InstallManager) setupSSHKnownHost(knownHost string) error {
+func (m *InstallManager) setupSSHUser() error {
 
 	// Add our potentially random UID to /etc/passwd so ssh works. Need to shell out here as
 	// the go libraries for user info appear to rely on /etc/passwd, which our user is not in.
-	// TODO: temporary work so we can use libvirt over ssh, this whole function can go once we're no longer doing that.
 	out, err := exec.Command("id", "-u").Output()
 	if err != nil {
 		m.log.WithError(err).Error("error running id -u")
@@ -1188,23 +1192,27 @@ func (m *InstallManager) setupSSHKnownHost(knownHost string) error {
 		return err
 	}
 	defer f.Close()
-	passwdLine := fmt.Sprintf("default:x:%s:0:default user:/home/hive:/sbin/nologin\n", uid)
+	passwdLine := fmt.Sprintf("default:x:%s:0:default user:%s:/sbin/nologin\n", uid, getHomeDir())
 	m.log.Infof("Wrote passwd line: %s", passwdLine)
 	if _, err := f.WriteString(passwdLine); err != nil {
 		m.log.WithError(err).Error("error writing to /etc/passwd")
 		return err
 	}
+	return nil
+}
 
-	sshDir := "/home/hive/.ssh"
+func (m *InstallManager) writeSSHKnownHosts(homeDir string, knownHosts []string) error {
+	sshDir := filepath.Join(homeDir, ".ssh")
 	if err := os.MkdirAll(sshDir, 0700); err != nil {
 		m.log.WithError(err).Errorf("error creating %s directory", sshDir)
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(sshDir, "known_hosts"), []byte(knownHost), 0644); err != nil {
+	allKnownHosts := strings.Join(knownHosts, "\n")
+	if err := ioutil.WriteFile(filepath.Join(sshDir, "known_hosts"), []byte(allKnownHosts), 0644); err != nil {
 		m.log.WithError(err).Error("error writing ssh known_hosts")
 		return err
 	}
-	m.log.Infof("Wrote known host to %s/known_hosts: %s", sshDir, knownHost)
+	m.log.WithField("knownHosts", knownHosts).Infof("Wrote known hosts to %s/known_hosts", sshDir)
 	return nil
 }
 
@@ -1265,4 +1273,12 @@ func pasteInPullSecret(icData []byte, pullSecretFile string) ([]byte, error) {
 	}
 	icRaw["pullSecret"] = string(pullSecretData)
 	return yaml.Marshal(icRaw)
+}
+
+func getHomeDir() string {
+	home := os.Getenv("HOME")
+	if home != "" {
+		return home
+	}
+	return defaultHomeDir
 }

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -2055,6 +2055,15 @@ spec:
                     way to specify what specific version of OpenShift you wish to
                     install.
                   type: string
+                sshKnownHosts:
+                  description: SSHKnownHosts are known hosts to be configured in the
+                    hive install manager pod to avoid ssh prompts. Use of ssh in the
+                    install pod is somewhat limited today (failure log gathering from
+                    cluster, some bare metal provisioning scenarios), so this setting
+                    is often not needed.
+                  items:
+                    type: string
+                  type: array
                 sshPrivateKeySecretRef:
                   description: SSHPrivateKeySecretRef is the reference to the secret
                     that contains the private SSH key to use for access to compute


### PR DESCRIPTION
Originally done as part of a PoC for bare metal provisioning with a
dedicated libvirt hypervisor host, we now wish to make this a more long
term hive feature.

As a first step in this, this change removes the ssh known host
annotation and makes it a formal part of the Hive API. The hosts are now
represented in in spec.Provisioning.SSHKnownHosts. This is generic and
not tied to bare metal provisioning as we're not sure the extent we may
need ssh in installs in the future. We already use ssh to gather logs on
failures and while this does not currently require known hosts entries,
it seems best to keep the door open.