### PR TITLE
add type info for syncsets and selectorsyncsets

### DIFF
--- a/contrib/pkg/createcluster/create.go
+++ b/contrib/pkg/createcluster/create.go
@@ -664,6 +664,10 @@ func (o *Options) generateSampleSyncSets() []runtime.Object {
 
 func sampleSyncSet(name, namespace, cdName string) *hivev1.SyncSet {
 	return &hivev1.SyncSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SyncSet",
+			APIVersion: hivev1.SchemeGroupVersion.String(),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
@@ -688,6 +692,10 @@ func sampleSyncSet(name, namespace, cdName string) *hivev1.SyncSet {
 
 func sampleSelectorSyncSet(name, cdName string) *hivev1.SelectorSyncSet {
 	return &hivev1.SelectorSyncSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SelectorSyncSet",
+			APIVersion: hivev1.SchemeGroupVersion.String(),
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},


### PR DESCRIPTION
Trying to

``` 'create-cluster -o yaml' | sed 'change from us-east-1 to us-east-2' | oc create -f - ```

and it applies the secrets and cluster deployment, but you get error messages for the syncset-related items.

```
unable to get type info from the object "*unstructured.Unstructured": Object 'Kind' is missing in 'object has no kind field '
```

Add type info for these objects.
