### PR TITLE
build: include mockgen in build image

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -25,3 +25,5 @@ RUN mkdir -p /go && chgrp -R root /go && chmod -R g+rwX /go
 RUN export GOLANGCI_LINT_VERSION=v1.17.1 &&\
     curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s $(GOLANGCI_LINT_VERSION) && \
     mv ./bin/golangci-lint /usr/local/bin/golangci-lint
+
+RUN go get -u github.com/golang/mock/mockgen


### PR DESCRIPTION
This is the first step to removing the mockgen installation from the makefile.