### PR TITLE
updated externalDNS example in respect to V1 CD crd

### DIFF
--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -237,11 +237,10 @@ To use this feature:
          name: hive
        spec:
          managedDomains:
-         - hive.example.com
-         externalDNS:
-           aws:
-             credentialsSecretRef:
-               name: route53-aws-creds
+         - credentialsSecretRef:
+           name: route53-aws-creds
+         - domains:
+           - hive.example.com
        ```
      - GCP
        ```yaml


### PR DESCRIPTION
As per:

```
            managedDomains:
              description: 'ManagedDomains is the list of DNS domains that are managed
                by the Hive cluster When specifying ''managedDNS: true'' in a ClusterDeployment,
                the ClusterDeployment''s baseDomain should be a direct child of one
                of these domains, otherwise the ClusterDeployment creation will result
                in a validation error.'
              items:
                properties:
                  aws:
                    description: AWS contains AWS-specific settings for external DNS
                    properties:
                      credentialsSecretRef:
                        description: CredentialsSecretRef references a secret that
                          will be used to authenticate with AWS Route53. It will need
                          permission to manage entries for the domain listed in the
                          parent ManageDNSConfig object. Secret should have AWS keys
                          named 'aws_access_key_id' and 'aws_secret_access_key'.
                        type: object
                    type: object
                  domains:
                    description: Domains is the list of domains that hive will be
                      managing entries for with the provided credentials.
                    items:
                      type: string
                    type: array
                  gcp:
                    description: GCP contains GCP-specific settings for external DNS
                    properties:
                      credentialsSecretRef:
                        description: CredentialsSecretRef references a secret that
                          will be used to authenticate with GCP DNS. It will need
                          permission to manage entries in each of the managed domains
                          for this cluster. listed in the parent ManageDNSConfig object.
                          Secret should have a key named 'osServiceAccount.json'.
                          The credentials must specify the project to use.
                        type: object
                    type: object
                type: object
              type: array
```