### PR TITLE
controllers: add doc.go

### DIFF
--- a/pkg/controller/doc.go
+++ b/pkg/controller/doc.go
@@ -1,0 +1,2 @@
+// Package controller contains controllers that run as part of hive-controllers deployment.
+package controller


### PR DESCRIPTION
This is a dummy PR to ensure that the pipelines to hive-stage and hive-int are disabled.