### PR TITLE
apiserver: fix rbac and port used

### DIFF
--- a/config/apiserver/deployment.yaml
+++ b/config/apiserver/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         args:
           - "start"
           - "--v=2"
-          - "--secure-port=10433"
+          - "--secure-port=10443"
           - "--logtostderr"
           - "--tls-cert-file=/apiserver.local.config/certificates/tls.crt"
           - "--tls-private-key-file=/apiserver.local.config/certificates/tls.key"

--- a/config/apiserver/hiveapi-cluster-role-binding.yaml
+++ b/config/apiserver/hiveapi-cluster-role-binding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: hiveapi
+  name: hiveapi-extension-apiserver-authentication-reader
   namespace: hive
 roleRef:
   name: extension-apiserver-authentication-reader
@@ -13,16 +13,31 @@ subjects:
 - kind: ServiceAccount
   name: hiveapi-sa
   namespace: hive
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: hiveapi-cluster-admin
+  name: hiveapi-auth-delegator
+roleRef:
+  name: system:auth-delegator
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: hiveapi-sa
+    namespace: hive
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hiveapi-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  namespace: hive
   name: hiveapi-sa
+  namespace: hive

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -159,7 +159,7 @@ spec:
         args:
           - "start"
           - "--v=2"
-          - "--secure-port=10433"
+          - "--secure-port=10443"
           - "--logtostderr"
           - "--tls-cert-file=/apiserver.local.config/certificates/tls.crt"
           - "--tls-private-key-file=/apiserver.local.config/certificates/tls.key"
@@ -193,7 +193,7 @@ var _configApiserverHiveapiClusterRoleBindingYaml = []byte(`---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: hiveapi
+  name: hiveapi-extension-apiserver-authentication-reader
   namespace: hive
 roleRef:
   name: extension-apiserver-authentication-reader
@@ -204,19 +204,34 @@ subjects:
 - kind: ServiceAccount
   name: hiveapi-sa
   namespace: hive
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: hiveapi-cluster-admin
+  name: hiveapi-auth-delegator
+roleRef:
+  name: system:auth-delegator
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: hiveapi-sa
+    namespace: hive
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hiveapi-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  namespace: hive
   name: hiveapi-sa
+  namespace: hive
 `)
 
 func configApiserverHiveapiClusterRoleBindingYamlBytes() ([]byte, error) {

--- a/pkg/operator/hive/hiveapi.go
+++ b/pkg/operator/hive/hiveapi.go
@@ -28,18 +28,11 @@ func (r *ReconcileHiveConfig) deployHiveAPI(hLog log.FieldLogger, h *resource.He
 		return r.tearDownHiveAPI(hLog)
 	}
 
-	err := util.ApplyAsset(h, "config/apiserver/hiveapi-cluster-role-binding.yaml", hLog)
-	if err != nil {
+	if err := util.ApplyAsset(h, "config/apiserver/service.yaml", hLog); err != nil {
 		return err
 	}
 
-	err = util.ApplyAsset(h, "config/apiserver/service.yaml", hLog)
-	if err != nil {
-		return err
-	}
-
-	err = util.ApplyAsset(h, "config/apiserver/service-account.yaml", hLog)
-	if err != nil {
+	if err := util.ApplyAsset(h, "config/apiserver/service-account.yaml", hLog); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Change the port that the apiserver is listening on to 10443 to match the target port set for the service.

Add a ClusterRoleBinding for the apiserver service account to system:auth-delegator.

Remove the code in hive-operator that was trying to set up for RBAC for the apiserver service account. This will always fail because the operator does not have the necessary permissions to pass to the apiserver. The RBAC needs to be set up for the apiserver in the same way that it is set up for the hiveadmission.