### PR TITLE
restart pods with injected certs when the certs rotate 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -171,6 +171,14 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:45c41cd27a8d986998680bfc86da0bbff5fa4f90d0f446c00636c8b099028ffe"
+  name = "github.com/blang/semver"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "ba2c2ddd89069b46a7011d4106f6868f17ee1705"
+  version = "v3.6.1"
+
+[[projects]]
   digest = "1:8f5acd4d4462b5136af644d25101f0968a7a94ee90fcb2059cec5b7cc42e0b20"
   name = "github.com/census-instrumentation/opencensus-proto"
   packages = [
@@ -887,11 +895,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:dc72947420fba63fc4131bf8474dfed1a837df3c4ba5c8a111d05039eed15c7a"
+  digest = "1:a2c104fe9eddc2d520e60593f73e26c307b5e91cbd5f8c51b7344d0e91646b9e"
   name = "github.com/openshift/library-go"
   packages = [
     "pkg/apiserver/apiserverconfig",
     "pkg/controller",
+    "pkg/controller/fileobserver",
     "pkg/operator/events",
     "pkg/operator/resource/resourcemerge",
     "pkg/operator/resource/resourceread",
@@ -1860,11 +1869,13 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:95008959442618ead2881a2ad2ff2f7278481aa43b786213f673557c86617220"
+  digest = "1:77465c0539a3ad3995a9f0ca0070da00cbe64e452e83660e88a94e4e1346f5ba"
   name = "k8s.io/component-base"
   packages = [
     "cli/flag",
     "logs",
+    "metrics",
+    "metrics/legacyregistry",
   ]
   pruneopts = "NUT"
   revision = "327675bd8ec35fe34a658207d9c3ecfdf0d6b462"
@@ -2180,6 +2191,7 @@
     "github.com/openshift/installer/pkg/types/gcp",
     "github.com/openshift/library-go/pkg/apiserver/apiserverconfig",
     "github.com/openshift/library-go/pkg/controller",
+    "github.com/openshift/library-go/pkg/controller/fileobserver",
     "github.com/openshift/library-go/pkg/operator/events",
     "github.com/openshift/library-go/pkg/operator/resource/resourcemerge",
     "github.com/openshift/library-go/pkg/operator/resource/resourceread",

--- a/cmd/hive-apiserver/main.go
+++ b/cmd/hive-apiserver/main.go
@@ -16,6 +16,7 @@ import (
 	utilflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 
+	"github.com/openshift/hive/pkg/certs"
 	"github.com/openshift/hive/pkg/cmd/hive-apiserver"
 )
 
@@ -35,6 +36,10 @@ func main() {
 	if len(os.Getenv("GOMAXPROCS")) == 0 {
 		runtime.GOMAXPROCS(runtime.NumCPU())
 	}
+
+	// TODO: Would be better to get this from the --tls-cert-file argument.
+	const certsDir = "/apiserver.local.config/certificates"
+	certs.TerminateOnCertChanges(certsDir)
 
 	command := NewHiveAPIServerCommand(stopCh)
 	if err := command.Execute(); err != nil {

--- a/cmd/hiveadmission/main.go
+++ b/cmd/hiveadmission/main.go
@@ -5,6 +5,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	hivevalidatingwebhooks "github.com/openshift/hive/pkg/apis/hive/v1/validating-webhooks"
+	"github.com/openshift/hive/pkg/certs"
 )
 
 func main() {
@@ -12,6 +13,11 @@ func main() {
 
 	// TODO: figure out a way to combine logrus and klog logging levels. The team has decided that hardcoding this is ok for now.
 	log.SetLevel(log.InfoLevel)
+
+	// TODO: Would be better to get this from the --tls-cert-file argument. The parsing of the argument is hidden in
+	// the internals of RunAdmissionServer.
+	const certsDir = "/var/serving-cert"
+	certs.TerminateOnCertChanges(certsDir)
 
 	admissionCmd.RunAdmissionServer(
 		&hivevalidatingwebhooks.DNSZoneValidatingAdmissionHook{},

--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -1,0 +1,48 @@
+package certs
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/openshift/library-go/pkg/controller/fileobserver"
+)
+
+var (
+	filenames = []string{"tls.crt", "tls.key"}
+)
+
+// TerminateOnCertChanges terminates the process when either tls.crt or tls.key in the specified certs directory change.
+func TerminateOnCertChanges(certsDir string) {
+	obs, err := fileobserver.NewObserver(10 * time.Second)
+	if err != nil {
+		log.WithError(err).Fatal("could not set up file observer to check for cert changes")
+	}
+	files := make(map[string][]byte, len(filenames))
+	fullFilenames := make([]string, len(filenames))
+	for i, fn := range filenames {
+		fullFilename := filepath.Join(certsDir, fn)
+		fullFilenames[i] = fullFilename
+		fileBytes, err := ioutil.ReadFile(fullFilename)
+		if err != nil {
+			log.WithError(err).WithField("filename", fullFilename).Fatal("Unable to read initial content of cert file")
+		}
+		files[fullFilename] = fileBytes
+	}
+	obs.AddReactor(func(filename string, action fileobserver.ActionType) error {
+		log.WithField("filename", filename).Info("exiting because cert changed")
+		// TODO: Exit more cleanly, allowing for cleanup by closing contexts.
+		os.Exit(0)
+		return nil
+	}, files, fullFilenames...)
+
+	stop := make(chan struct{})
+	go func() {
+		log.WithField("files", fullFilenames).Info("running file observer")
+		obs.Run(stop)
+		log.Fatal("file observer stopped")
+	}()
+}

--- a/vendor/github.com/blang/semver/LICENSE
+++ b/vendor/github.com/blang/semver/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2014 Benedikt Lang <github at benediktlang.de>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/vendor/github.com/blang/semver/json.go
+++ b/vendor/github.com/blang/semver/json.go
@@ -1,0 +1,23 @@
+package semver
+
+import (
+	"encoding/json"
+)
+
+// MarshalJSON implements the encoding/json.Marshaler interface.
+func (v Version) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.String())
+}
+
+// UnmarshalJSON implements the encoding/json.Unmarshaler interface.
+func (v *Version) UnmarshalJSON(data []byte) (err error) {
+	var versionString string
+
+	if err = json.Unmarshal(data, &versionString); err != nil {
+		return
+	}
+
+	*v, err = Parse(versionString)
+
+	return
+}

--- a/vendor/github.com/blang/semver/range.go
+++ b/vendor/github.com/blang/semver/range.go
@@ -1,0 +1,416 @@
+package semver
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type wildcardType int
+
+const (
+	noneWildcard  wildcardType = iota
+	majorWildcard wildcardType = 1
+	minorWildcard wildcardType = 2
+	patchWildcard wildcardType = 3
+)
+
+func wildcardTypefromInt(i int) wildcardType {
+	switch i {
+	case 1:
+		return majorWildcard
+	case 2:
+		return minorWildcard
+	case 3:
+		return patchWildcard
+	default:
+		return noneWildcard
+	}
+}
+
+type comparator func(Version, Version) bool
+
+var (
+	compEQ comparator = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == 0
+	}
+	compNE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) != 0
+	}
+	compGT = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == 1
+	}
+	compGE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) >= 0
+	}
+	compLT = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) == -1
+	}
+	compLE = func(v1 Version, v2 Version) bool {
+		return v1.Compare(v2) <= 0
+	}
+)
+
+type versionRange struct {
+	v Version
+	c comparator
+}
+
+// rangeFunc creates a Range from the given versionRange.
+func (vr *versionRange) rangeFunc() Range {
+	return Range(func(v Version) bool {
+		return vr.c(v, vr.v)
+	})
+}
+
+// Range represents a range of versions.
+// A Range can be used to check if a Version satisfies it:
+//
+//     range, err := semver.ParseRange(">1.0.0 <2.0.0")
+//     range(semver.MustParse("1.1.1") // returns true
+type Range func(Version) bool
+
+// OR combines the existing Range with another Range using logical OR.
+func (rf Range) OR(f Range) Range {
+	return Range(func(v Version) bool {
+		return rf(v) || f(v)
+	})
+}
+
+// AND combines the existing Range with another Range using logical AND.
+func (rf Range) AND(f Range) Range {
+	return Range(func(v Version) bool {
+		return rf(v) && f(v)
+	})
+}
+
+// ParseRange parses a range and returns a Range.
+// If the range could not be parsed an error is returned.
+//
+// Valid ranges are:
+//   - "<1.0.0"
+//   - "<=1.0.0"
+//   - ">1.0.0"
+//   - ">=1.0.0"
+//   - "1.0.0", "=1.0.0", "==1.0.0"
+//   - "!1.0.0", "!=1.0.0"
+//
+// A Range can consist of multiple ranges separated by space:
+// Ranges can be linked by logical AND:
+//   - ">1.0.0 <2.0.0" would match between both ranges, so "1.1.1" and "1.8.7" but not "1.0.0" or "2.0.0"
+//   - ">1.0.0 <3.0.0 !2.0.3-beta.2" would match every version between 1.0.0 and 3.0.0 except 2.0.3-beta.2
+//
+// Ranges can also be linked by logical OR:
+//   - "<2.0.0 || >=3.0.0" would match "1.x.x" and "3.x.x" but not "2.x.x"
+//
+// AND has a higher precedence than OR. It's not possible to use brackets.
+//
+// Ranges can be combined by both AND and OR
+//
+//  - `>1.0.0 <2.0.0 || >3.0.0 !4.2.1` would match `1.2.3`, `1.9.9`, `3.1.1`, but not `4.2.1`, `2.1.1`
+func ParseRange(s string) (Range, error) {
+	parts := splitAndTrim(s)
+	orParts, err := splitORParts(parts)
+	if err != nil {
+		return nil, err
+	}
+	expandedParts, err := expandWildcardVersion(orParts)
+	if err != nil {
+		return nil, err
+	}
+	var orFn Range
+	for _, p := range expandedParts {
+		var andFn Range
+		for _, ap := range p {
+			opStr, vStr, err := splitComparatorVersion(ap)
+			if err != nil {
+				return nil, err
+			}
+			vr, err := buildVersionRange(opStr, vStr)
+			if err != nil {
+				return nil, fmt.Errorf("Could not parse Range %q: %s", ap, err)
+			}
+			rf := vr.rangeFunc()
+
+			// Set function
+			if andFn == nil {
+				andFn = rf
+			} else { // Combine with existing function
+				andFn = andFn.AND(rf)
+			}
+		}
+		if orFn == nil {
+			orFn = andFn
+		} else {
+			orFn = orFn.OR(andFn)
+		}
+
+	}
+	return orFn, nil
+}
+
+// splitORParts splits the already cleaned parts by '||'.
+// Checks for invalid positions of the operator and returns an
+// error if found.
+func splitORParts(parts []string) ([][]string, error) {
+	var ORparts [][]string
+	last := 0
+	for i, p := range parts {
+		if p == "||" {
+			if i == 0 {
+				return nil, fmt.Errorf("First element in range is '||'")
+			}
+			ORparts = append(ORparts, parts[last:i])
+			last = i + 1
+		}
+	}
+	if last == len(parts) {
+		return nil, fmt.Errorf("Last element in range is '||'")
+	}
+	ORparts = append(ORparts, parts[last:])
+	return ORparts, nil
+}
+
+// buildVersionRange takes a slice of 2: operator and version
+// and builds a versionRange, otherwise an error.
+func buildVersionRange(opStr, vStr string) (*versionRange, error) {
+	c := parseComparator(opStr)
+	if c == nil {
+		return nil, fmt.Errorf("Could not parse comparator %q in %q", opStr, strings.Join([]string{opStr, vStr}, ""))
+	}
+	v, err := Parse(vStr)
+	if err != nil {
+		return nil, fmt.Errorf("Could not parse version %q in %q: %s", vStr, strings.Join([]string{opStr, vStr}, ""), err)
+	}
+
+	return &versionRange{
+		v: v,
+		c: c,
+	}, nil
+
+}
+
+// inArray checks if a byte is contained in an array of bytes
+func inArray(s byte, list []byte) bool {
+	for _, el := range list {
+		if el == s {
+			return true
+		}
+	}
+	return false
+}
+
+// splitAndTrim splits a range string by spaces and cleans whitespaces
+func splitAndTrim(s string) (result []string) {
+	last := 0
+	var lastChar byte
+	excludeFromSplit := []byte{'>', '<', '='}
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' && !inArray(lastChar, excludeFromSplit) {
+			if last < i-1 {
+				result = append(result, s[last:i])
+			}
+			last = i + 1
+		} else if s[i] != ' ' {
+			lastChar = s[i]
+		}
+	}
+	if last < len(s)-1 {
+		result = append(result, s[last:])
+	}
+
+	for i, v := range result {
+		result[i] = strings.Replace(v, " ", "", -1)
+	}
+
+	// parts := strings.Split(s, " ")
+	// for _, x := range parts {
+	// 	if s := strings.TrimSpace(x); len(s) != 0 {
+	// 		result = append(result, s)
+	// 	}
+	// }
+	return
+}
+
+// splitComparatorVersion splits the comparator from the version.
+// Input must be free of leading or trailing spaces.
+func splitComparatorVersion(s string) (string, string, error) {
+	i := strings.IndexFunc(s, unicode.IsDigit)
+	if i == -1 {
+		return "", "", fmt.Errorf("Could not get version from string: %q", s)
+	}
+	return strings.TrimSpace(s[0:i]), s[i:], nil
+}
+
+// getWildcardType will return the type of wildcard that the
+// passed version contains
+func getWildcardType(vStr string) wildcardType {
+	parts := strings.Split(vStr, ".")
+	nparts := len(parts)
+	wildcard := parts[nparts-1]
+
+	possibleWildcardType := wildcardTypefromInt(nparts)
+	if wildcard == "x" {
+		return possibleWildcardType
+	}
+
+	return noneWildcard
+}
+
+// createVersionFromWildcard will convert a wildcard version
+// into a regular version, replacing 'x's with '0's, handling
+// special cases like '1.x.x' and '1.x'
+func createVersionFromWildcard(vStr string) string {
+	// handle 1.x.x
+	vStr2 := strings.Replace(vStr, ".x.x", ".x", 1)
+	vStr2 = strings.Replace(vStr2, ".x", ".0", 1)
+	parts := strings.Split(vStr2, ".")
+
+	// handle 1.x
+	if len(parts) == 2 {
+		return vStr2 + ".0"
+	}
+
+	return vStr2
+}
+
+// incrementMajorVersion will increment the major version
+// of the passed version
+func incrementMajorVersion(vStr string) (string, error) {
+	parts := strings.Split(vStr, ".")
+	i, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return "", err
+	}
+	parts[0] = strconv.Itoa(i + 1)
+
+	return strings.Join(parts, "."), nil
+}
+
+// incrementMajorVersion will increment the minor version
+// of the passed version
+func incrementMinorVersion(vStr string) (string, error) {
+	parts := strings.Split(vStr, ".")
+	i, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", err
+	}
+	parts[1] = strconv.Itoa(i + 1)
+
+	return strings.Join(parts, "."), nil
+}
+
+// expandWildcardVersion will expand wildcards inside versions
+// following these rules:
+//
+// * when dealing with patch wildcards:
+// >= 1.2.x    will become    >= 1.2.0
+// <= 1.2.x    will become    <  1.3.0
+// >  1.2.x    will become    >= 1.3.0
+// <  1.2.x    will become    <  1.2.0
+// != 1.2.x    will become    <  1.2.0 >= 1.3.0
+//
+// * when dealing with minor wildcards:
+// >= 1.x      will become    >= 1.0.0
+// <= 1.x      will become    <  2.0.0
+// >  1.x      will become    >= 2.0.0
+// <  1.0      will become    <  1.0.0
+// != 1.x      will become    <  1.0.0 >= 2.0.0
+//
+// * when dealing with wildcards without
+// version operator:
+// 1.2.x       will become    >= 1.2.0 < 1.3.0
+// 1.x         will become    >= 1.0.0 < 2.0.0
+func expandWildcardVersion(parts [][]string) ([][]string, error) {
+	var expandedParts [][]string
+	for _, p := range parts {
+		var newParts []string
+		for _, ap := range p {
+			if strings.Contains(ap, "x") {
+				opStr, vStr, err := splitComparatorVersion(ap)
+				if err != nil {
+					return nil, err
+				}
+
+				versionWildcardType := getWildcardType(vStr)
+				flatVersion := createVersionFromWildcard(vStr)
+
+				var resultOperator string
+				var shouldIncrementVersion bool
+				switch opStr {
+				case ">":
+					resultOperator = ">="
+					shouldIncrementVersion = true
+				case ">=":
+					resultOperator = ">="
+				case "<":
+					resultOperator = "<"
+				case "<=":
+					resultOperator = "<"
+					shouldIncrementVersion = true
+				case "", "=", "==":
+					newParts = append(newParts, ">="+flatVersion)
+					resultOperator = "<"
+					shouldIncrementVersion = true
+				case "!=", "!":
+					newParts = append(newParts, "<"+flatVersion)
+					resultOperator = ">="
+					shouldIncrementVersion = true
+				}
+
+				var resultVersion string
+				if shouldIncrementVersion {
+					switch versionWildcardType {
+					case patchWildcard:
+						resultVersion, _ = incrementMinorVersion(flatVersion)
+					case minorWildcard:
+						resultVersion, _ = incrementMajorVersion(flatVersion)
+					}
+				} else {
+					resultVersion = flatVersion
+				}
+
+				ap = resultOperator + resultVersion
+			}
+			newParts = append(newParts, ap)
+		}
+		expandedParts = append(expandedParts, newParts)
+	}
+
+	return expandedParts, nil
+}
+
+func parseComparator(s string) comparator {
+	switch s {
+	case "==":
+		fallthrough
+	case "":
+		fallthrough
+	case "=":
+		return compEQ
+	case ">":
+		return compGT
+	case ">=":
+		return compGE
+	case "<":
+		return compLT
+	case "<=":
+		return compLE
+	case "!":
+		fallthrough
+	case "!=":
+		return compNE
+	}
+
+	return nil
+}
+
+// MustParseRange is like ParseRange but panics if the range cannot be parsed.
+func MustParseRange(s string) Range {
+	r, err := ParseRange(s)
+	if err != nil {
+		panic(`semver: ParseRange(` + s + `): ` + err.Error())
+	}
+	return r
+}

--- a/vendor/github.com/blang/semver/semver.go
+++ b/vendor/github.com/blang/semver/semver.go
@@ -1,0 +1,455 @@
+package semver
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	numbers  string = "0123456789"
+	alphas          = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-"
+	alphanum        = alphas + numbers
+)
+
+// SpecVersion is the latest fully supported spec version of semver
+var SpecVersion = Version{
+	Major: 2,
+	Minor: 0,
+	Patch: 0,
+}
+
+// Version represents a semver compatible version
+type Version struct {
+	Major uint64
+	Minor uint64
+	Patch uint64
+	Pre   []PRVersion
+	Build []string //No Precedence
+}
+
+// Version to string
+func (v Version) String() string {
+	b := make([]byte, 0, 5)
+	b = strconv.AppendUint(b, v.Major, 10)
+	b = append(b, '.')
+	b = strconv.AppendUint(b, v.Minor, 10)
+	b = append(b, '.')
+	b = strconv.AppendUint(b, v.Patch, 10)
+
+	if len(v.Pre) > 0 {
+		b = append(b, '-')
+		b = append(b, v.Pre[0].String()...)
+
+		for _, pre := range v.Pre[1:] {
+			b = append(b, '.')
+			b = append(b, pre.String()...)
+		}
+	}
+
+	if len(v.Build) > 0 {
+		b = append(b, '+')
+		b = append(b, v.Build[0]...)
+
+		for _, build := range v.Build[1:] {
+			b = append(b, '.')
+			b = append(b, build...)
+		}
+	}
+
+	return string(b)
+}
+
+// Equals checks if v is equal to o.
+func (v Version) Equals(o Version) bool {
+	return (v.Compare(o) == 0)
+}
+
+// EQ checks if v is equal to o.
+func (v Version) EQ(o Version) bool {
+	return (v.Compare(o) == 0)
+}
+
+// NE checks if v is not equal to o.
+func (v Version) NE(o Version) bool {
+	return (v.Compare(o) != 0)
+}
+
+// GT checks if v is greater than o.
+func (v Version) GT(o Version) bool {
+	return (v.Compare(o) == 1)
+}
+
+// GTE checks if v is greater than or equal to o.
+func (v Version) GTE(o Version) bool {
+	return (v.Compare(o) >= 0)
+}
+
+// GE checks if v is greater than or equal to o.
+func (v Version) GE(o Version) bool {
+	return (v.Compare(o) >= 0)
+}
+
+// LT checks if v is less than o.
+func (v Version) LT(o Version) bool {
+	return (v.Compare(o) == -1)
+}
+
+// LTE checks if v is less than or equal to o.
+func (v Version) LTE(o Version) bool {
+	return (v.Compare(o) <= 0)
+}
+
+// LE checks if v is less than or equal to o.
+func (v Version) LE(o Version) bool {
+	return (v.Compare(o) <= 0)
+}
+
+// Compare compares Versions v to o:
+// -1 == v is less than o
+// 0 == v is equal to o
+// 1 == v is greater than o
+func (v Version) Compare(o Version) int {
+	if v.Major != o.Major {
+		if v.Major > o.Major {
+			return 1
+		}
+		return -1
+	}
+	if v.Minor != o.Minor {
+		if v.Minor > o.Minor {
+			return 1
+		}
+		return -1
+	}
+	if v.Patch != o.Patch {
+		if v.Patch > o.Patch {
+			return 1
+		}
+		return -1
+	}
+
+	// Quick comparison if a version has no prerelease versions
+	if len(v.Pre) == 0 && len(o.Pre) == 0 {
+		return 0
+	} else if len(v.Pre) == 0 && len(o.Pre) > 0 {
+		return 1
+	} else if len(v.Pre) > 0 && len(o.Pre) == 0 {
+		return -1
+	}
+
+	i := 0
+	for ; i < len(v.Pre) && i < len(o.Pre); i++ {
+		if comp := v.Pre[i].Compare(o.Pre[i]); comp == 0 {
+			continue
+		} else if comp == 1 {
+			return 1
+		} else {
+			return -1
+		}
+	}
+
+	// If all pr versions are the equal but one has further prversion, this one greater
+	if i == len(v.Pre) && i == len(o.Pre) {
+		return 0
+	} else if i == len(v.Pre) && i < len(o.Pre) {
+		return -1
+	} else {
+		return 1
+	}
+
+}
+
+// IncrementPatch increments the patch version
+func (v *Version) IncrementPatch() error {
+	if v.Major == 0 {
+		return fmt.Errorf("Patch version can not be incremented for %q", v.String())
+	}
+	v.Patch += 1
+	return nil
+}
+
+// IncrementMinor increments the minor version
+func (v *Version) IncrementMinor() error {
+	if v.Major == 0 {
+		return fmt.Errorf("Minor version can not be incremented for %q", v.String())
+	}
+	v.Minor += 1
+	v.Patch = 0
+	return nil
+}
+
+// IncrementMajor increments the major version
+func (v *Version) IncrementMajor() error {
+	if v.Major == 0 {
+		return fmt.Errorf("Major version can not be incremented for %q", v.String())
+	}
+	v.Major += 1
+	v.Minor = 0
+	v.Patch = 0
+	return nil
+}
+
+// Validate validates v and returns error in case
+func (v Version) Validate() error {
+	// Major, Minor, Patch already validated using uint64
+
+	for _, pre := range v.Pre {
+		if !pre.IsNum { //Numeric prerelease versions already uint64
+			if len(pre.VersionStr) == 0 {
+				return fmt.Errorf("Prerelease can not be empty %q", pre.VersionStr)
+			}
+			if !containsOnly(pre.VersionStr, alphanum) {
+				return fmt.Errorf("Invalid character(s) found in prerelease %q", pre.VersionStr)
+			}
+		}
+	}
+
+	for _, build := range v.Build {
+		if len(build) == 0 {
+			return fmt.Errorf("Build meta data can not be empty %q", build)
+		}
+		if !containsOnly(build, alphanum) {
+			return fmt.Errorf("Invalid character(s) found in build meta data %q", build)
+		}
+	}
+
+	return nil
+}
+
+// New is an alias for Parse and returns a pointer, parses version string and returns a validated Version or error
+func New(s string) (vp *Version, err error) {
+	v, err := Parse(s)
+	vp = &v
+	return
+}
+
+// Make is an alias for Parse, parses version string and returns a validated Version or error
+func Make(s string) (Version, error) {
+	return Parse(s)
+}
+
+// ParseTolerant allows for certain version specifications that do not strictly adhere to semver
+// specs to be parsed by this library. It does so by normalizing versions before passing them to
+// Parse(). It currently trims spaces, removes a "v" prefix, adds a 0 patch number to versions
+// with only major and minor components specified, and removes leading 0s.
+func ParseTolerant(s string) (Version, error) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+
+	// Split into major.minor.(patch+pr+meta)
+	parts := strings.SplitN(s, ".", 3)
+	// Remove leading zeros.
+	for i, p := range parts {
+		if len(p) > 1 {
+			parts[i] = strings.TrimPrefix(p, "0")
+		}
+	}
+	// Fill up shortened versions.
+	if len(parts) < 3 {
+		if strings.ContainsAny(parts[len(parts)-1], "+-") {
+			return Version{}, errors.New("Short version cannot contain PreRelease/Build meta data")
+		}
+		for len(parts) < 3 {
+			parts = append(parts, "0")
+		}
+	}
+	s = strings.Join(parts, ".")
+
+	return Parse(s)
+}
+
+// Parse parses version string and returns a validated Version or error
+func Parse(s string) (Version, error) {
+	if len(s) == 0 {
+		return Version{}, errors.New("Version string empty")
+	}
+
+	// Split into major.minor.(patch+pr+meta)
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) != 3 {
+		return Version{}, errors.New("No Major.Minor.Patch elements found")
+	}
+
+	// Major
+	if !containsOnly(parts[0], numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in major number %q", parts[0])
+	}
+	if hasLeadingZeroes(parts[0]) {
+		return Version{}, fmt.Errorf("Major number must not contain leading zeroes %q", parts[0])
+	}
+	major, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	// Minor
+	if !containsOnly(parts[1], numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in minor number %q", parts[1])
+	}
+	if hasLeadingZeroes(parts[1]) {
+		return Version{}, fmt.Errorf("Minor number must not contain leading zeroes %q", parts[1])
+	}
+	minor, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	v := Version{}
+	v.Major = major
+	v.Minor = minor
+
+	var build, prerelease []string
+	patchStr := parts[2]
+
+	if buildIndex := strings.IndexRune(patchStr, '+'); buildIndex != -1 {
+		build = strings.Split(patchStr[buildIndex+1:], ".")
+		patchStr = patchStr[:buildIndex]
+	}
+
+	if preIndex := strings.IndexRune(patchStr, '-'); preIndex != -1 {
+		prerelease = strings.Split(patchStr[preIndex+1:], ".")
+		patchStr = patchStr[:preIndex]
+	}
+
+	if !containsOnly(patchStr, numbers) {
+		return Version{}, fmt.Errorf("Invalid character(s) found in patch number %q", patchStr)
+	}
+	if hasLeadingZeroes(patchStr) {
+		return Version{}, fmt.Errorf("Patch number must not contain leading zeroes %q", patchStr)
+	}
+	patch, err := strconv.ParseUint(patchStr, 10, 64)
+	if err != nil {
+		return Version{}, err
+	}
+
+	v.Patch = patch
+
+	// Prerelease
+	for _, prstr := range prerelease {
+		parsedPR, err := NewPRVersion(prstr)
+		if err != nil {
+			return Version{}, err
+		}
+		v.Pre = append(v.Pre, parsedPR)
+	}
+
+	// Build meta data
+	for _, str := range build {
+		if len(str) == 0 {
+			return Version{}, errors.New("Build meta data is empty")
+		}
+		if !containsOnly(str, alphanum) {
+			return Version{}, fmt.Errorf("Invalid character(s) found in build meta data %q", str)
+		}
+		v.Build = append(v.Build, str)
+	}
+
+	return v, nil
+}
+
+// MustParse is like Parse but panics if the version cannot be parsed.
+func MustParse(s string) Version {
+	v, err := Parse(s)
+	if err != nil {
+		panic(`semver: Parse(` + s + `): ` + err.Error())
+	}
+	return v
+}
+
+// PRVersion represents a PreRelease Version
+type PRVersion struct {
+	VersionStr string
+	VersionNum uint64
+	IsNum      bool
+}
+
+// NewPRVersion creates a new valid prerelease version
+func NewPRVersion(s string) (PRVersion, error) {
+	if len(s) == 0 {
+		return PRVersion{}, errors.New("Prerelease is empty")
+	}
+	v := PRVersion{}
+	if containsOnly(s, numbers) {
+		if hasLeadingZeroes(s) {
+			return PRVersion{}, fmt.Errorf("Numeric PreRelease version must not contain leading zeroes %q", s)
+		}
+		num, err := strconv.ParseUint(s, 10, 64)
+
+		// Might never be hit, but just in case
+		if err != nil {
+			return PRVersion{}, err
+		}
+		v.VersionNum = num
+		v.IsNum = true
+	} else if containsOnly(s, alphanum) {
+		v.VersionStr = s
+		v.IsNum = false
+	} else {
+		return PRVersion{}, fmt.Errorf("Invalid character(s) found in prerelease %q", s)
+	}
+	return v, nil
+}
+
+// IsNumeric checks if prerelease-version is numeric
+func (v PRVersion) IsNumeric() bool {
+	return v.IsNum
+}
+
+// Compare compares two PreRelease Versions v and o:
+// -1 == v is less than o
+// 0 == v is equal to o
+// 1 == v is greater than o
+func (v PRVersion) Compare(o PRVersion) int {
+	if v.IsNum && !o.IsNum {
+		return -1
+	} else if !v.IsNum && o.IsNum {
+		return 1
+	} else if v.IsNum && o.IsNum {
+		if v.VersionNum == o.VersionNum {
+			return 0
+		} else if v.VersionNum > o.VersionNum {
+			return 1
+		} else {
+			return -1
+		}
+	} else { // both are Alphas
+		if v.VersionStr == o.VersionStr {
+			return 0
+		} else if v.VersionStr > o.VersionStr {
+			return 1
+		} else {
+			return -1
+		}
+	}
+}
+
+// PreRelease version to string
+func (v PRVersion) String() string {
+	if v.IsNum {
+		return strconv.FormatUint(v.VersionNum, 10)
+	}
+	return v.VersionStr
+}
+
+func containsOnly(s string, set string) bool {
+	return strings.IndexFunc(s, func(r rune) bool {
+		return !strings.ContainsRune(set, r)
+	}) == -1
+}
+
+func hasLeadingZeroes(s string) bool {
+	return len(s) > 1 && s[0] == '0'
+}
+
+// NewBuildVersion creates a new valid build version
+func NewBuildVersion(s string) (string, error) {
+	if len(s) == 0 {
+		return "", errors.New("Buildversion is empty")
+	}
+	if !containsOnly(s, alphanum) {
+		return "", fmt.Errorf("Invalid character(s) found in build meta data %q", s)
+	}
+	return s, nil
+}

--- a/vendor/github.com/blang/semver/sort.go
+++ b/vendor/github.com/blang/semver/sort.go
@@ -1,0 +1,28 @@
+package semver
+
+import (
+	"sort"
+)
+
+// Versions represents multiple versions.
+type Versions []Version
+
+// Len returns length of version collection
+func (s Versions) Len() int {
+	return len(s)
+}
+
+// Swap swaps two versions inside the collection by its indices
+func (s Versions) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less checks if version at index i is less than version at index j
+func (s Versions) Less(i, j int) bool {
+	return s[i].LT(s[j])
+}
+
+// Sort sorts a slice of versions
+func Sort(versions []Version) {
+	sort.Sort(Versions(versions))
+}

--- a/vendor/github.com/blang/semver/sql.go
+++ b/vendor/github.com/blang/semver/sql.go
@@ -1,0 +1,30 @@
+package semver
+
+import (
+	"database/sql/driver"
+	"fmt"
+)
+
+// Scan implements the database/sql.Scanner interface.
+func (v *Version) Scan(src interface{}) (err error) {
+	var str string
+	switch src := src.(type) {
+	case string:
+		str = src
+	case []byte:
+		str = string(src)
+	default:
+		return fmt.Errorf("version.Scan: cannot convert %T to string", src)
+	}
+
+	if t, err := Parse(str); err == nil {
+		*v = t
+	}
+
+	return
+}
+
+// Value implements the database/sql/driver.Valuer interface.
+func (v Version) Value() (driver.Value, error) {
+	return v.String(), nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/controller/fileobserver/observer.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/fileobserver/observer.go
@@ -1,0 +1,79 @@
+package fileobserver
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"k8s.io/klog"
+)
+
+type Observer interface {
+	Run(stopChan <-chan struct{})
+	HasSynced() bool
+	AddReactor(reaction ReactorFn, startingFileContent map[string][]byte, files ...string) Observer
+}
+
+// ActionType define a type of action observed on the file
+type ActionType int
+
+const (
+	// FileModified means the file content was modified.
+	FileModified ActionType = iota
+
+	// FileCreated means the file was just created.
+	FileCreated
+
+	// FileDeleted means the file was deleted.
+	FileDeleted
+)
+
+func (t ActionType) name() string {
+	switch t {
+	case FileCreated:
+		return "create"
+	case FileDeleted:
+		return "delete"
+	case FileModified:
+		return "modified"
+	default:
+		return "unknown"
+	}
+}
+
+// String returns human readable form of action taken on a file.
+func (t ActionType) String(filename string) string {
+	switch t {
+	case FileCreated:
+		return fmt.Sprintf("file %s was created", filename)
+	case FileDeleted:
+		return fmt.Sprintf("file %s was deleted", filename)
+	case FileModified:
+		return fmt.Sprintf("file %s was modified", filename)
+	}
+	return ""
+}
+
+// ReactorFn define a reaction function called when an observed file is modified.
+type ReactorFn func(file string, action ActionType) error
+
+// ExitOnChangeReactor provides reactor function that causes the process to exit when the change is detected.
+// DEPRECATED: Using this function cause process to exit immediately without proper shutdown (context close/etc.)
+//             Use the TerminateOnChangeReactor() instead.
+var ExitOnChangeReactor = TerminateOnChangeReactor(func() { os.Exit(0) })
+
+func TerminateOnChangeReactor(terminateFn func()) ReactorFn {
+	return func(filename string, action ActionType) error {
+		klog.Infof("Triggering shutdown because %s", action.String(filename))
+		terminateFn()
+		return nil
+	}
+}
+
+func NewObserver(interval time.Duration) (Observer, error) {
+	return &pollingObserver{
+		interval: interval,
+		reactors: map[string][]ReactorFn{},
+		files:    map[string]fileHashAndState{},
+	}, nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/controller/fileobserver/observer_polling.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/fileobserver/observer_polling.go
@@ -1,0 +1,209 @@
+package fileobserver
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/klog"
+)
+
+type pollingObserver struct {
+	interval time.Duration
+	reactors map[string][]ReactorFn
+	files    map[string]fileHashAndState
+
+	reactorsMutex sync.RWMutex
+
+	syncedMutex sync.RWMutex
+	hasSynced   bool
+}
+
+// HasSynced indicates that the observer synced all observed files at least once.
+func (o *pollingObserver) HasSynced() bool {
+	o.syncedMutex.RLock()
+	defer o.syncedMutex.RUnlock()
+	return o.hasSynced
+}
+
+// AddReactor will add new reactor to this observer.
+func (o *pollingObserver) AddReactor(reaction ReactorFn, startingFileContent map[string][]byte, files ...string) Observer {
+	o.reactorsMutex.Lock()
+	defer o.reactorsMutex.Unlock()
+	for _, f := range files {
+		if len(f) == 0 {
+			panic(fmt.Sprintf("observed file name must not be empty (%#v)", files))
+		}
+		// Do not rehash existing files
+		if _, exists := o.files[f]; exists {
+			continue
+		}
+		var err error
+
+		if startingContent, ok := startingFileContent[f]; ok {
+			klog.V(3).Infof("Starting from specified content for file %q", f)
+			// if empty starting content is specified, do not hash the empty string but just return it the same
+			// way as calculateFileHash() does in that case.
+			// in case the file exists and is empty, we don't care about the initial content anyway, because we
+			// are only going to react when the file content change.
+			// in case the file does not exists but empty string is specified as initial content, without this
+			// the content will be hashed and reaction will trigger as if the content changed.
+			if len(startingContent) == 0 {
+				o.files[f] = fileHashAndState{exists: true}
+				o.reactors[f] = append(o.reactors[f], reaction)
+				continue
+			}
+			currentHash, emptyFile, err := calculateHash(bytes.NewBuffer(startingContent))
+			if err != nil {
+				panic(fmt.Sprintf("unexpected error while adding reactor for %#v: %v", files, err))
+			}
+			o.files[f] = fileHashAndState{exists: true, hash: currentHash, isEmpty: emptyFile}
+		} else {
+			klog.V(3).Infof("Adding reactor for file %q", f)
+			o.files[f], err = calculateFileHash(f)
+			if err != nil && !os.IsNotExist(err) {
+				panic(fmt.Sprintf("unexpected error while adding reactor for %#v: %v", files, err))
+			}
+		}
+		o.reactors[f] = append(o.reactors[f], reaction)
+	}
+	return o
+}
+
+func (o *pollingObserver) processReactors(stopCh <-chan struct{}) {
+	err := wait.PollImmediateInfinite(o.interval, func() (bool, error) {
+		select {
+		case <-stopCh:
+			return true, nil
+		default:
+		}
+		o.reactorsMutex.RLock()
+		defer o.reactorsMutex.RUnlock()
+		for filename, reactors := range o.reactors {
+			currentFileState, err := calculateFileHash(filename)
+			if err != nil && !os.IsNotExist(err) {
+				return false, err
+			}
+
+			lastKnownFileState := o.files[filename]
+			o.files[filename] = currentFileState
+
+			for i := range reactors {
+				var action ActionType
+				switch {
+				case !lastKnownFileState.exists && !currentFileState.exists:
+					// skip non-existing file
+					continue
+				case !lastKnownFileState.exists && currentFileState.exists && (len(currentFileState.hash) > 0 || currentFileState.isEmpty):
+					// if we see a new file created that has content or its empty, trigger FileCreate action
+					klog.Infof("Observed file %q has been created (hash=%q)", filename, currentFileState.hash)
+					action = FileCreated
+				case lastKnownFileState.exists && !currentFileState.exists:
+					klog.Infof("Observed file %q has been deleted", filename)
+					action = FileDeleted
+				case lastKnownFileState.hash == currentFileState.hash:
+					// skip if the hashes are the same
+					continue
+				case lastKnownFileState.hash != currentFileState.hash:
+					klog.Infof("Observed file %q has been modified (old=%q, new=%q)", filename, lastKnownFileState.hash, currentFileState.hash)
+					action = FileModified
+				}
+				// increment metrics counter for this file
+				observerActionsMetrics.WithLabelValues(filename, action.name()).Inc()
+				// execute the register reactor
+				if err := reactors[i](filename, action); err != nil {
+					klog.Errorf("Reactor for %q failed: %v", filename, err)
+				}
+			}
+		}
+		if !o.HasSynced() {
+			o.syncedMutex.Lock()
+			o.hasSynced = true
+			o.syncedMutex.Unlock()
+			klog.V(3).Info("File observer successfully synced")
+		}
+		return false, nil
+	})
+	if err != nil {
+		klog.Fatalf("file observer failed: %v", err)
+	}
+}
+
+var observerActionsMetrics = metrics.NewCounterVec(&metrics.CounterOpts{
+	Subsystem:      "fileobserver",
+	Name:           "action_count",
+	Help:           "Counter for every observed action for all monitored files",
+	StabilityLevel: metrics.ALPHA,
+}, []string{"name", "filename"})
+
+func init() {
+	(&sync.Once{}).Do(func() {
+		legacyregistry.MustRegister(observerActionsMetrics)
+	})
+}
+
+// Run will start a new observer.
+func (o *pollingObserver) Run(stopChan <-chan struct{}) {
+	klog.Info("Starting file observer")
+	defer klog.Infof("Shutting down file observer")
+	o.processReactors(stopChan)
+}
+
+type fileHashAndState struct {
+	hash    string
+	exists  bool
+	isEmpty bool
+}
+
+func calculateFileHash(path string) (fileHashAndState, error) {
+	result := fileHashAndState{}
+	stat, err := os.Stat(path)
+	if err != nil {
+		return result, err
+	}
+
+	// this is fatal
+	if stat.IsDir() {
+		return result, fmt.Errorf("you can watch only files, %s is a directory", path)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return result, err
+	}
+	defer f.Close()
+
+	// at this point we know for sure the file exists and we can read its content even if that content is empty
+	result.exists = true
+
+	hash, empty, err := calculateHash(f)
+	if err != nil {
+		return result, err
+	}
+
+	result.hash = hash
+	result.isEmpty = empty
+
+	return result, nil
+}
+
+func calculateHash(content io.Reader) (string, bool, error) {
+	hasher := sha256.New()
+	written, err := io.Copy(hasher, content)
+	if err != nil {
+		return "", false, err
+	}
+	// written == 0 means the content is empty
+	if written == 0 {
+		return "", true, nil
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), false, nil
+}

--- a/vendor/k8s.io/component-base/metrics/counter.go
+++ b/vendor/k8s.io/component-base/metrics/counter.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/blang/semver"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Counter is our internal representation for our wrapping struct around prometheus
+// counters. Counter implements both kubeCollector and CounterMetric.
+type Counter struct {
+	CounterMetric
+	*CounterOpts
+	lazyMetric
+	selfCollector
+}
+
+// NewCounter returns an object which satisfies the kubeCollector and CounterMetric interfaces.
+// However, the object returned will not measure anything unless the collector is first
+// registered, since the metric is lazily instantiated.
+func NewCounter(opts *CounterOpts) *Counter {
+	// todo: handle defaulting better
+	if opts.StabilityLevel == "" {
+		opts.StabilityLevel = ALPHA
+	}
+	kc := &Counter{
+		CounterOpts: opts,
+		lazyMetric:  lazyMetric{},
+	}
+	kc.setPrometheusCounter(noop)
+	kc.lazyInit(kc)
+	return kc
+}
+
+// setPrometheusCounter sets the underlying CounterMetric object, i.e. the thing that does the measurement.
+func (c *Counter) setPrometheusCounter(counter prometheus.Counter) {
+	c.CounterMetric = counter
+	c.initSelfCollection(counter)
+}
+
+// DeprecatedVersion returns a pointer to the Version or nil
+func (c *Counter) DeprecatedVersion() *semver.Version {
+	return c.CounterOpts.DeprecatedVersion
+}
+
+// initializeMetric invocation creates the actual underlying Counter. Until this method is called
+// the underlying counter is a no-op.
+func (c *Counter) initializeMetric() {
+	c.CounterOpts.annotateStabilityLevel()
+	// this actually creates the underlying prometheus counter.
+	c.setPrometheusCounter(prometheus.NewCounter(c.CounterOpts.toPromCounterOpts()))
+}
+
+// initializeDeprecatedMetric invocation creates the actual (but deprecated) Counter. Until this method
+// is called the underlying counter is a no-op.
+func (c *Counter) initializeDeprecatedMetric() {
+	c.CounterOpts.markDeprecated()
+	c.initializeMetric()
+}
+
+// CounterVec is the internal representation of our wrapping struct around prometheus
+// counterVecs. CounterVec implements both kubeCollector and CounterVecMetric.
+type CounterVec struct {
+	*prometheus.CounterVec
+	*CounterOpts
+	lazyMetric
+	originalLabels []string
+}
+
+// NewCounterVec returns an object which satisfies the kubeCollector and CounterVecMetric interfaces.
+// However, the object returned will not measure anything unless the collector is first
+// registered, since the metric is lazily instantiated.
+func NewCounterVec(opts *CounterOpts, labels []string) *CounterVec {
+	// todo: handle defaulting better
+	if opts.StabilityLevel == "" {
+		opts.StabilityLevel = ALPHA
+	}
+	cv := &CounterVec{
+		CounterVec:     noopCounterVec,
+		CounterOpts:    opts,
+		originalLabels: labels,
+		lazyMetric:     lazyMetric{},
+	}
+	cv.lazyInit(cv)
+	return cv
+}
+
+// DeprecatedVersion returns a pointer to the Version or nil
+func (v *CounterVec) DeprecatedVersion() *semver.Version {
+	return v.CounterOpts.DeprecatedVersion
+}
+
+// initializeMetric invocation creates the actual underlying CounterVec. Until this method is called
+// the underlying counterVec is a no-op.
+func (v *CounterVec) initializeMetric() {
+	v.CounterOpts.annotateStabilityLevel()
+	v.CounterVec = prometheus.NewCounterVec(v.CounterOpts.toPromCounterOpts(), v.originalLabels)
+}
+
+// initializeDeprecatedMetric invocation creates the actual (but deprecated) CounterVec. Until this method is called
+// the underlying counterVec is a no-op.
+func (v *CounterVec) initializeDeprecatedMetric() {
+	v.CounterOpts.markDeprecated()
+	v.initializeMetric()
+}
+
+// Default Prometheus behavior actually results in the creation of a new metric
+// if a metric with the unique label values is not found in the underlying stored metricMap.
+// This means  that if this function is called but the underlying metric is not registered
+// (which means it will never be exposed externally nor consumed), the metric will exist in memory
+// for perpetuity (i.e. throughout application lifecycle).
+//
+// For reference: https://github.com/prometheus/client_golang/blob/v0.9.2/prometheus/counter.go#L179-L197
+
+// WithLabelValues returns the Counter for the given slice of label
+// values (same order as the VariableLabels in Desc). If that combination of
+// label values is accessed for the first time, a new Counter is created IFF the counterVec
+// has been registered to a metrics registry.
+func (v *CounterVec) WithLabelValues(lvs ...string) CounterMetric {
+	if !v.IsCreated() {
+		return noop // return no-op counter
+	}
+	return v.CounterVec.WithLabelValues(lvs...)
+}
+
+// With returns the Counter for the given Labels map (the label names
+// must match those of the VariableLabels in Desc). If that label map is
+// accessed for the first time, a new Counter is created IFF the counterVec has
+// been registered to a metrics registry.
+func (v *CounterVec) With(labels prometheus.Labels) CounterMetric {
+	if !v.IsCreated() {
+		return noop // return no-op counter
+	}
+	return v.CounterVec.With(labels)
+}

--- a/vendor/k8s.io/component-base/metrics/gauge.go
+++ b/vendor/k8s.io/component-base/metrics/gauge.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/blang/semver"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Gauge is our internal representation for our wrapping struct around prometheus
+// gauges. kubeGauge implements both kubeCollector and KubeGauge.
+type Gauge struct {
+	GaugeMetric
+	*GaugeOpts
+	lazyMetric
+	selfCollector
+}
+
+// NewGauge returns an object which satisfies the kubeCollector and KubeGauge interfaces.
+// However, the object returned will not measure anything unless the collector is first
+// registered, since the metric is lazily instantiated.
+func NewGauge(opts *GaugeOpts) *Gauge {
+	// todo: handle defaulting better
+	if opts.StabilityLevel == "" {
+		opts.StabilityLevel = ALPHA
+	}
+	kc := &Gauge{
+		GaugeOpts:  opts,
+		lazyMetric: lazyMetric{},
+	}
+	kc.setPrometheusGauge(noop)
+	kc.lazyInit(kc)
+	return kc
+}
+
+// setPrometheusGauge sets the underlying KubeGauge object, i.e. the thing that does the measurement.
+func (g *Gauge) setPrometheusGauge(gauge prometheus.Gauge) {
+	g.GaugeMetric = gauge
+	g.initSelfCollection(gauge)
+}
+
+// DeprecatedVersion returns a pointer to the Version or nil
+func (g *Gauge) DeprecatedVersion() *semver.Version {
+	return g.GaugeOpts.DeprecatedVersion
+}
+
+// initializeMetric invocation creates the actual underlying Gauge. Until this method is called
+// the underlying gauge is a no-op.
+func (g *Gauge) initializeMetric() {
+	g.GaugeOpts.annotateStabilityLevel()
+	// this actually creates the underlying prometheus gauge.
+	g.setPrometheusGauge(prometheus.NewGauge(g.GaugeOpts.toPromGaugeOpts()))
+}
+
+// initializeDeprecatedMetric invocation creates the actual (but deprecated) Gauge. Until this method
+// is called the underlying gauge is a no-op.
+func (g *Gauge) initializeDeprecatedMetric() {
+	g.GaugeOpts.markDeprecated()
+	g.initializeMetric()
+}
+
+// GaugeVec is the internal representation of our wrapping struct around prometheus
+// gaugeVecs. kubeGaugeVec implements both kubeCollector and KubeGaugeVec.
+type GaugeVec struct {
+	*prometheus.GaugeVec
+	*GaugeOpts
+	lazyMetric
+	originalLabels []string
+}
+
+// NewGaugeVec returns an object which satisfies the kubeCollector and KubeGaugeVec interfaces.
+// However, the object returned will not measure anything unless the collector is first
+// registered, since the metric is lazily instantiated.
+func NewGaugeVec(opts *GaugeOpts, labels []string) *GaugeVec {
+	// todo: handle defaulting better
+	if opts.StabilityLevel == "" {
+		opts.StabilityLevel = ALPHA
+	}
+	cv := &GaugeVec{
+		GaugeVec:       noopGaugeVec,
+		GaugeOpts:      opts,
+		originalLabels: labels,
+		lazyMetric:     lazyMetric{},
+	}
+	cv.lazyInit(cv)
+	return cv
+}
+
+// DeprecatedVersion returns a pointer to the Version or nil
+func (v *GaugeVec) DeprecatedVersion() *semver.Version {
+	return v.GaugeOpts.DeprecatedVersion
+}
+
+// initializeMetric invocation creates the actual underlying GaugeVec. Until this method is called
+// the underlying gaugeVec is a no-op.
+func (v *GaugeVec) initializeMetric() {
+	v.GaugeOpts.annotateStabilityLevel()
+	v.GaugeVec = prometheus.NewGaugeVec(v.GaugeOpts.toPromGaugeOpts(), v.originalLabels)
+}
+
+// initializeDeprecatedMetric invocation creates the actual (but deprecated) GaugeVec. Until this method is called
+// the underlying gaugeVec is a no-op.
+func (v *GaugeVec) initializeDeprecatedMetric() {
+	v.GaugeOpts.markDeprecated()
+	v.initializeMetric()
+}
+
+// Default Prometheus behavior actually results in the creation of a new metric
+// if a metric with the unique label values is not found in the underlying stored metricMap.
+// This means  that if this function is called but the underlying metric is not registered
+// (which means it will never be exposed externally nor consumed), the metric will exist in memory
+// for perpetuity (i.e. throughout application lifecycle).
+//
+// For reference: https://github.com/prometheus/client_golang/blob/v0.9.2/prometheus/gauge.go#L190-L208
+
+// WithLabelValues returns the GaugeMetric for the given slice of label
+// values (same order as the VariableLabels in Desc). If that combination of
+// label values is accessed for the first time, a new GaugeMetric is created IFF the gaugeVec
+// has been registered to a metrics registry.
+func (v *GaugeVec) WithLabelValues(lvs ...string) GaugeMetric {
+	if !v.IsCreated() {
+		return noop // return no-op gauge
+	}
+	return v.GaugeVec.WithLabelValues(lvs...)
+}
+
+// With returns the GaugeMetric for the given Labels map (the label names
+// must match those of the VariableLabels in Desc). If that label map is
+// accessed for the first time, a new GaugeMetric is created IFF the gaugeVec has
+// been registered to a metrics registry.
+func (v *GaugeVec) With(labels prometheus.Labels) GaugeMetric {
+	if !v.IsCreated() {
+		return noop // return no-op gauge
+	}
+	return v.GaugeVec.With(labels)
+}

--- a/vendor/k8s.io/component-base/metrics/histogram.go
+++ b/vendor/k8s.io/component-base/metrics/histogram.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/blang/semver"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog"
+)
+
+// Histogram is our internal representation for our wrapping struct around prometheus
+// histograms. Summary implements both kubeCollector and ObserverMetric
+type Histogram struct {
+	ObserverMetric
+	*HistogramOpts
+	lazyMetric
+	selfCollector
+}
+
+// NewHistogram returns an object which is Histogram-like. However, nothing
+// will be measured until the histogram is registered somewhere.
+func NewHistogram(opts *HistogramOpts) *Histogram {
+	// todo: handle defaulting better
+	if opts.StabilityLevel == "" {
+		opts.StabilityLevel = ALPHA
+	}
+	h := &Histogram{
+		HistogramOpts: opts,
+		lazyMetric:    lazyMetric{},
+	}
+	h.setPrometheusHistogram(noopMetric{})
+	h.lazyInit(h)
+	return h
+}
+
+// setPrometheusHistogram sets the underlying KubeGauge object, i.e. the thing that does the measurement.
+func (h *Histogram) setPrometheusHistogram(histogram prometheus.Histogram) {
+	h.ObserverMetric = histogram
+	h.initSelfCollection(histogram)
+}
+
+// DeprecatedVersion returns a pointer to the Version or nil
+func (h *Histogram) DeprecatedVersion() *semver.Version {
+	return h.HistogramOpts.DeprecatedVersion
+}
+
+// initializeMetric invokes the actual prometheus.Histogram object instantiation
+// and stores a reference to it
+func (h *Histogram) initializeMetric() {
+	h.HistogramOpts.annotateStabilityLevel()
+	// this actually creates the underlying prometheus gauge.
+	h.setPrometheusHistogram(prometheus.NewHistogram(h.HistogramOpts.toPromHistogramOpts()))
+}
+
+// initializeDeprecatedMetric invokes the actual prometheus.Histogram object instantiation
+// but modifies the Help description prior to object instantiation.
+func (h *Histogram) initializeDeprecatedMetric() {
+	h.HistogramOpts.markDeprecated()
+	h.initializeMetric()
+}
+
+// HistogramVec is the internal representation of our wrapping struct around prometheus
+// histogramVecs.
+type HistogramVec struct {
+	*prometheus.HistogramVec
+	*HistogramOpts
+	lazyMetric
+	originalLabels []string
+}
+
+// NewHistogramVec returns an object which satisfies kubeCollector and wraps the
+// prometheus.HistogramVec object. However, the object returned will not measure
+// anything unless the collector is first registered, since the metric is lazily instantiated.
+func NewHistogramVec(opts *HistogramOpts, labels []string) *HistogramVec {
+	// todo: handle defaulting better
+	klog.Errorf("---%v---\n", opts)
+	if opts.StabilityLevel == "" {
+		opts.StabilityLevel = ALPHA
+	}
+	klog.Errorf("---%v---\n", opts)
+	v := &HistogramVec{
+		HistogramVec:   noopHistogramVec,
+		HistogramOpts:  opts,
+		originalLabels: labels,
+		lazyMetric:     lazyMetric{},
+	}
+	v.lazyInit(v)
+	return v
+}
+
+// DeprecatedVersion returns a pointer to the Version or nil
+func (v *HistogramVec) DeprecatedVersion() *semver.Version {
+	return v.HistogramOpts.DeprecatedVersion
+}
+
+func (v *HistogramVec) initializeMetric() {
+	v.HistogramOpts.annotateStabilityLevel()
+	v.HistogramVec = prometheus.NewHistogramVec(v.HistogramOpts.toPromHistogramOpts(), v.originalLabels)
+}
+
+func (v *HistogramVec) initializeDeprecatedMetric() {
+	v.HistogramOpts.markDeprecated()
+	v.initializeMetric()
+}
+
+// Default Prometheus behavior actually results in the creation of a new metric
+// if a metric with the unique label values is not found in the underlying stored metricMap.
+// This means  that if this function is called but the underlying metric is not registered
+// (which means it will never be exposed externally nor consumed), the metric will exist in memory
+// for perpetuity (i.e. throughout application lifecycle).
+//
+// For reference: https://github.com/prometheus/client_golang/blob/v0.9.2/prometheus/histogram.go#L460-L470
+
+// WithLabelValues returns the ObserverMetric for the given slice of label
+// values (same order as the VariableLabels in Desc). If that combination of
+// label values is accessed for the first time, a new ObserverMetric is created IFF the HistogramVec
+// has been registered to a metrics registry.
+func (v *HistogramVec) WithLabelValues(lvs ...string) ObserverMetric {
+	if !v.IsCreated() {
+		return noop
+	}
+	return v.HistogramVec.WithLabelValues(lvs...)
+}
+
+// With returns the ObserverMetric for the given Labels map (the label names
+// must match those of the VariableLabels in Desc). If that label map is
+// accessed for the first time, a new ObserverMetric is created IFF the HistogramVec has
+// been registered to a metrics registry.
+func (v *HistogramVec) With(labels prometheus.Labels) ObserverMetric {
+	if !v.IsCreated() {
+		return noop
+	}
+	return v.HistogramVec.With(labels)
+}

--- a/vendor/k8s.io/component-base/metrics/legacyregistry/registry.go
+++ b/vendor/k8s.io/component-base/metrics/legacyregistry/registry.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacyregistry
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	dto "github.com/prometheus/client_model/go"
+
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	"k8s.io/component-base/metrics"
+)
+
+var (
+	globalRegistryFactory = metricsRegistryFactory{
+		registerQueue:     make([]metrics.Registerable, 0),
+		mustRegisterQueue: make([]metrics.Registerable, 0),
+		globalRegistry:    noopRegistry{},
+	}
+)
+
+type noopRegistry struct{}
+
+func (noopRegistry) Register(metrics.Registerable) error  { return nil }
+func (noopRegistry) MustRegister(...metrics.Registerable) {}
+func (noopRegistry) Unregister(metrics.Registerable) bool { return true }
+func (noopRegistry) Gather() ([]*dto.MetricFamily, error) { return nil, nil }
+
+type metricsRegistryFactory struct {
+	globalRegistry    metrics.KubeRegistry
+	kubeVersion       *apimachineryversion.Info
+	registrationLock  sync.Mutex
+	registerQueue     []metrics.Registerable
+	mustRegisterQueue []metrics.Registerable
+}
+
+// HandlerForGlobalRegistry returns a http handler for the global registry. This
+// allows us to return a handler for the global registry without having to expose
+// the global registry itself directly.
+func HandlerForGlobalRegistry(opts promhttp.HandlerOpts) http.Handler {
+	return promhttp.HandlerFor(globalRegistryFactory.globalRegistry, opts)
+}
+
+// SetRegistryFactoryVersion sets the kubernetes version information for all
+// subsequent metrics registry initializations. Only the first call has an effect.
+// If a version is not set, then metrics registry creation will no-opt
+func SetRegistryFactoryVersion(ver apimachineryversion.Info) []error {
+	globalRegistryFactory.registrationLock.Lock()
+	defer globalRegistryFactory.registrationLock.Unlock()
+	if globalRegistryFactory.kubeVersion != nil {
+		if globalRegistryFactory.kubeVersion.String() != ver.String() {
+			panic(fmt.Sprintf("Cannot load a global registry more than once, had %s tried to load %s",
+				globalRegistryFactory.kubeVersion.String(),
+				ver.String()))
+		}
+		return nil
+	}
+	registrationErrs := make([]error, 0)
+	preloadedMetrics := []prometheus.Collector{
+		prometheus.NewGoCollector(),
+		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+	}
+	globalRegistryFactory.globalRegistry = metrics.NewPreloadedKubeRegistry(ver, preloadedMetrics...)
+	globalRegistryFactory.kubeVersion = &ver
+	for _, c := range globalRegistryFactory.registerQueue {
+		err := globalRegistryFactory.globalRegistry.Register(c)
+		if err != nil {
+			registrationErrs = append(registrationErrs, err)
+		}
+	}
+	for _, c := range globalRegistryFactory.mustRegisterQueue {
+		globalRegistryFactory.globalRegistry.MustRegister(c)
+	}
+	return registrationErrs
+}
+
+// Register registers a collectable metric, but it uses a global registry. Registration is deferred
+// until the global registry has a version to use.
+func Register(c metrics.Registerable) error {
+	globalRegistryFactory.registrationLock.Lock()
+	defer globalRegistryFactory.registrationLock.Unlock()
+
+	if reflect.DeepEqual(globalRegistryFactory.globalRegistry, noopRegistry{}) {
+		globalRegistryFactory.registerQueue = append(globalRegistryFactory.registerQueue, c)
+		return nil
+	}
+
+	return globalRegistryFactory.globalRegistry.Register(c)
+}
+
+// MustRegister works like Register but registers any number of
+// Collectors and panics upon the first registration that causes an
+// error. Registration is deferred  until the global registry has a version to use.
+func MustRegister(cs ...metrics.Registerable) {
+	globalRegistryFactory.registrationLock.Lock()
+	defer globalRegistryFactory.registrationLock.Unlock()
+
+	if reflect.DeepEqual(globalRegistryFactory.globalRegistry, noopRegistry{}) {
+		for _, c := range cs {
+			globalRegistryFactory.mustRegisterQueue = append(globalRegistryFactory.mustRegisterQueue, c)
+		}
+		return
+	}
+	globalRegistryFactory.globalRegistry.MustRegister(cs...)
+	return
+}

--- a/vendor/k8s.io/component-base/metrics/metric.go
+++ b/vendor/k8s.io/component-base/metrics/metric.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/blang/semver"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"k8s.io/klog"
+	"sync"
+)
+
+/*
+kubeCollector extends the prometheus.Collector interface to allow customization of the metric
+registration process. Defer metric initialization until Create() is called, which then
+delegates to the underlying metric's initializeMetric or initializeDeprecatedMetric
+method call depending on whether the metric is deprecated or not.
+*/
+type kubeCollector interface {
+	Collector
+	lazyKubeMetric
+	DeprecatedVersion() *semver.Version
+	// Each collector metric should provide an initialization function
+	// for both deprecated and non-deprecated variants of a metric. This
+	// is necessary since metric instantiation will be deferred
+	// until the metric is actually registered somewhere.
+	initializeMetric()
+	initializeDeprecatedMetric()
+}
+
+/*
+lazyKubeMetric defines our metric registration interface. lazyKubeMetric objects are expected
+to lazily instantiate metrics (i.e defer metric instantiation until when
+the Create() function is explicitly called).
+*/
+type lazyKubeMetric interface {
+	Create(*semver.Version) bool
+	IsCreated() bool
+	IsHidden() bool
+	IsDeprecated() bool
+}
+
+/*
+lazyMetric implements lazyKubeMetric. A lazy metric is lazy because it waits until metric
+registration time before instantiation. Add it as an anonymous field to a struct that
+implements kubeCollector to get deferred registration behavior. You must call lazyInit
+with the kubeCollector itself as an argument.
+*/
+type lazyMetric struct {
+	isDeprecated        bool
+	isHidden            bool
+	isCreated           bool
+	markDeprecationOnce sync.Once
+	createOnce          sync.Once
+	self                kubeCollector
+}
+
+func (r *lazyMetric) IsCreated() bool {
+	return r.isCreated
+}
+
+// lazyInit provides the lazyMetric with a reference to the kubeCollector it is supposed
+// to allow lazy initialization for. It should be invoked in the factory function which creates new
+// kubeCollector type objects.
+func (r *lazyMetric) lazyInit(self kubeCollector) {
+	r.self = self
+}
+
+// determineDeprecationStatus figures out whether the lazy metric should be deprecated or not.
+// This method takes a Version argument which should be the version of the binary in which
+// this code is currently being executed.
+func (r *lazyMetric) determineDeprecationStatus(version semver.Version) {
+	selfVersion := r.self.DeprecatedVersion()
+	if selfVersion == nil {
+		return
+	}
+	r.markDeprecationOnce.Do(func() {
+		if selfVersion.LTE(version) {
+			r.isDeprecated = true
+		}
+		if ShouldShowHidden() {
+			klog.Warningf("Hidden metrics have been manually overridden, showing this very deprecated metric.")
+			return
+		}
+		if selfVersion.LT(version) {
+			klog.Warningf("This metric has been deprecated for more than one release, hiding.")
+			r.isHidden = true
+		}
+	})
+}
+
+func (r *lazyMetric) IsHidden() bool {
+	return r.isHidden
+}
+
+func (r *lazyMetric) IsDeprecated() bool {
+	return r.isDeprecated
+}
+
+// Create forces the initialization of metric which has been deferred until
+// the point at which this method is invoked. This method will determine whether
+// the metric is deprecated or hidden, no-opting if the metric should be considered
+// hidden. Furthermore, this function no-opts and returns true if metric is already
+// created.
+func (r *lazyMetric) Create(version *semver.Version) bool {
+	if version != nil {
+		r.determineDeprecationStatus(*version)
+	}
+	// let's not create if this metric is slated to be hidden
+	if r.IsHidden() {
+		return false
+	}
+	r.createOnce.Do(func() {
+		r.isCreated = true
+		if r.IsDeprecated() {
+			r.self.initializeDeprecatedMetric()
+		} else {
+			r.self.initializeMetric()
+		}
+	})
+	return r.IsCreated()
+}
+
+/*
+This code is directly lifted from the prometheus codebase. It's a convenience struct which
+allows you satisfy the Collector interface automatically if you already satisfy the Metric interface.
+
+For reference: https://github.com/prometheus/client_golang/blob/v0.9.2/prometheus/collector.go#L98-L120
+*/
+type selfCollector struct {
+	metric prometheus.Metric
+}
+
+func (c *selfCollector) initSelfCollection(m prometheus.Metric) {
+	c.metric = m
+}
+
+func (c *selfCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.metric.Desc()
+}
+
+func (c *selfCollector) Collect(ch chan<- prometheus.Metric) {
+	ch <- c.metric
+}
+
+// no-op vecs for convenience
+var noopCounterVec = &prometheus.CounterVec{}
+var noopHistogramVec = &prometheus.HistogramVec{}
+var noopSummaryVec = &prometheus.SummaryVec{}
+var noopGaugeVec = &prometheus.GaugeVec{}
+var noopObserverVec = &noopObserverVector{}
+
+// just use a convenience struct for all the no-ops
+var noop = &noopMetric{}
+
+type noopMetric struct{}
+
+func (noopMetric) Inc()                             {}
+func (noopMetric) Add(float64)                      {}
+func (noopMetric) Dec()                             {}
+func (noopMetric) Set(float64)                      {}
+func (noopMetric) Sub(float64)                      {}
+func (noopMetric) Observe(float64)                  {}
+func (noopMetric) SetToCurrentTime()                {}
+func (noopMetric) Desc() *prometheus.Desc           { return nil }
+func (noopMetric) Write(*dto.Metric) error          { return nil }
+func (noopMetric) Describe(chan<- *prometheus.Desc) {}
+func (noopMetric) Collect(chan<- prometheus.Metric) {}
+
+type noopObserverVector struct{}
+
+func (noopObserverVector) GetMetricWith(prometheus.Labels) (prometheus.Observer, error) {
+	return noop, nil
+}
+func (noopObserverVector) GetMetricWithLabelValues(...string) (prometheus.Observer, error) {
+	return noop, nil
+}
+func (noopObserverVector) With(prometheus.Labels) prometheus.Observer    { return noop }
+func (noopObserverVector) WithLabelValues(...string) prometheus.Observer { return noop }
+func (noopObserverVector) CurryWith(prometheus.Labels) (prometheus.ObserverVec, error) {
+	return noopObserverVec, nil
+}
+func (noopObserverVector) MustCurryWith(prometheus.Labels) prometheus.ObserverVec {
+	return noopObserverVec
+}
+func (noopObserverVector) Describe(chan<- *prometheus.Desc) {}
+func (noopObserverVector) Collect(chan<- prometheus.Metric) {}

--- a/vendor/k8s.io/component-base/metrics/opts.go
+++ b/vendor/k8s.io/component-base/metrics/opts.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"github.com/blang/semver"
+	"github.com/prometheus/client_golang/prometheus"
+	"sync"
+	"time"
+)
+
+// KubeOpts is superset struct for prometheus.Opts. The prometheus Opts structure
+// is purposefully not embedded here because that would change struct initialization
+// in the manner which people are currently accustomed.
+//
+// Name must be set to a non-empty string. DeprecatedVersion is defined only
+// if the metric for which this options applies is, in fact, deprecated.
+type KubeOpts struct {
+	Namespace         string
+	Subsystem         string
+	Name              string
+	Help              string
+	ConstLabels       prometheus.Labels
+	DeprecatedVersion *semver.Version
+	deprecateOnce     sync.Once
+	annotateOnce      sync.Once
+	StabilityLevel    StabilityLevel
+}
+
+// StabilityLevel represents the API guarantees for a given defined metric.
+type StabilityLevel string
+
+const (
+	// ALPHA metrics have no stability guarantees, as such, labels may
+	// be arbitrarily added/removed and the metric may be deleted at any time.
+	ALPHA StabilityLevel = "ALPHA"
+	// STABLE metrics are guaranteed not be mutated and removal is governed by
+	// the deprecation policy outlined in by the control plane metrics stability KEP.
+	STABLE StabilityLevel = "STABLE"
+)
+
+// CounterOpts is an alias for Opts. See there for doc comments.
+type CounterOpts KubeOpts
+
+// Modify help description on the metric description.
+func (o *CounterOpts) markDeprecated() {
+	o.deprecateOnce.Do(func() {
+		o.Help = fmt.Sprintf("(Deprecated since %v) %v", o.DeprecatedVersion, o.Help)
+	})
+}
+
+// annotateStabilityLevel annotates help description on the metric description with the stability level
+// of the metric
+func (o *CounterOpts) annotateStabilityLevel() {
+	o.annotateOnce.Do(func() {
+		o.Help = fmt.Sprintf("[%v] %v", o.StabilityLevel, o.Help)
+	})
+}
+
+// convenience function to allow easy transformation to the prometheus
+// counterpart. This will do more once we have a proper label abstraction
+func (o *CounterOpts) toPromCounterOpts() prometheus.CounterOpts {
+	return prometheus.CounterOpts{
+		Namespace:   o.Namespace,
+		Subsystem:   o.Subsystem,
+		Name:        o.Name,
+		Help:        o.Help,
+		ConstLabels: o.ConstLabels,
+	}
+}
+
+// GaugeOpts is an alias for Opts. See there for doc comments.
+type GaugeOpts KubeOpts
+
+// Modify help description on the metric description.
+func (o *GaugeOpts) markDeprecated() {
+	o.deprecateOnce.Do(func() {
+		o.Help = fmt.Sprintf("(Deprecated since %v) %v", o.DeprecatedVersion, o.Help)
+	})
+}
+
+// annotateStabilityLevel annotates help description on the metric description with the stability level
+// of the metric
+func (o *GaugeOpts) annotateStabilityLevel() {
+	o.annotateOnce.Do(func() {
+		o.Help = fmt.Sprintf("[%v] %v", o.StabilityLevel, o.Help)
+	})
+}
+
+// convenience function to allow easy transformation to the prometheus
+// counterpart. This will do more once we have a proper label abstraction
+func (o GaugeOpts) toPromGaugeOpts() prometheus.GaugeOpts {
+	return prometheus.GaugeOpts{
+		Namespace:   o.Namespace,
+		Subsystem:   o.Subsystem,
+		Name:        o.Name,
+		Help:        o.Help,
+		ConstLabels: o.ConstLabels,
+	}
+}
+
+// HistogramOpts bundles the options for creating a Histogram metric. It is
+// mandatory to set Name to a non-empty string. All other fields are optional
+// and can safely be left at their zero value, although it is strongly
+// encouraged to set a Help string.
+type HistogramOpts struct {
+	Namespace         string
+	Subsystem         string
+	Name              string
+	Help              string
+	ConstLabels       prometheus.Labels
+	Buckets           []float64
+	DeprecatedVersion *semver.Version
+	deprecateOnce     sync.Once
+	annotateOnce      sync.Once
+	StabilityLevel    StabilityLevel
+}
+
+// Modify help description on the metric description.
+func (o *HistogramOpts) markDeprecated() {
+	o.deprecateOnce.Do(func() {
+		o.Help = fmt.Sprintf("(Deprecated since %v) %v", o.DeprecatedVersion, o.Help)
+	})
+}
+
+// annotateStabilityLevel annotates help description on the metric description with the stability level
+// of the metric
+func (o *HistogramOpts) annotateStabilityLevel() {
+	o.annotateOnce.Do(func() {
+		o.Help = fmt.Sprintf("[%v] %v", o.StabilityLevel, o.Help)
+	})
+}
+
+// convenience function to allow easy transformation to the prometheus
+// counterpart. This will do more once we have a proper label abstraction
+func (o HistogramOpts) toPromHistogramOpts() prometheus.HistogramOpts {
+	return prometheus.HistogramOpts{
+		Namespace:   o.Namespace,
+		Subsystem:   o.Subsystem,
+		Name:        o.Name,
+		Help:        o.Help,
+		ConstLabels: o.ConstLabels,
+		Buckets:     o.Buckets,
+	}
+}
+
+// SummaryOpts bundles the options for creating a Summary metric. It is
+// mandatory to set Name to a non-empty string. While all other fields are
+// optional and can safely be left at their zero value, it is recommended to set
+// a help string and to explicitly set the Objectives field to the desired value
+// as the default value will change in the upcoming v0.10 of the library.
+type SummaryOpts struct {
+	Namespace         string
+	Subsystem         string
+	Name              string
+	Help              string
+	ConstLabels       prometheus.Labels
+	Objectives        map[float64]float64
+	MaxAge            time.Duration
+	AgeBuckets        uint32
+	BufCap            uint32
+	DeprecatedVersion *semver.Version
+	deprecateOnce     sync.Once
+	annotateOnce      sync.Once
+	StabilityLevel    StabilityLevel
+}
+
+// Modify help description on the metric description.
+func (o *SummaryOpts) markDeprecated() {
+	o.deprecateOnce.Do(func() {
+		o.Help = fmt.Sprintf("(Deprecated since %v) %v", o.DeprecatedVersion, o.Help)
+	})
+}
+
+// annotateStabilityLevel annotates help description on the metric description with the stability level
+// of the metric
+func (o *SummaryOpts) annotateStabilityLevel() {
+	o.annotateOnce.Do(func() {
+		o.Help = fmt.Sprintf("[%v] %v", o.StabilityLevel, o.Help)
+	})
+}
+
+// convenience function to allow easy transformation to the prometheus
+// counterpart. This will do more once we have a proper label abstraction
+func (o SummaryOpts) toPromSummaryOpts() prometheus.SummaryOpts {
+	return prometheus.SummaryOpts{
+		Namespace:   o.Namespace,
+		Subsystem:   o.Subsystem,
+		Name:        o.Name,
+		Help:        o.Help,
+		ConstLabels: o.ConstLabels,
+		Objectives:  o.Objectives,
+		MaxAge:      o.MaxAge,
+		AgeBuckets:  o.AgeBuckets,
+		BufCap:      o.BufCap,
+	}
+}

--- a/vendor/k8s.io/component-base/metrics/processstarttime.go
+++ b/vendor/k8s.io/component-base/metrics/processstarttime.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/procfs"
+	"k8s.io/klog"
+	"os"
+	"time"
+)
+
+var processStartTime = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "process_start_time_seconds",
+		Help: "Start time of the process since unix epoch in seconds.",
+	},
+	[]string{},
+)
+
+// RegisterProcessStartTime registers the process_start_time_seconds to
+// a prometheus registry. This metric needs to be included to ensure counter
+// data fidelity.
+func RegisterProcessStartTime(registerer prometheus.Registerer) error {
+	start, err := getProcessStart()
+	if err != nil {
+		klog.Errorf("Could not get process start time, %v", err)
+		start = float64(time.Now().Unix())
+	}
+	processStartTime.WithLabelValues().Set(start)
+	return registerer.Register(processStartTime)
+}
+
+func getProcessStart() (float64, error) {
+	pid := os.Getpid()
+	p, err := procfs.NewProc(pid)
+	if err != nil {
+		return 0, err
+	}
+
+	if stat, err := p.NewStat(); err == nil {
+		return stat.StartTime()
+	}
+	return 0, err
+}

--- a/vendor/k8s.io/component-base/metrics/registry.go
+++ b/vendor/k8s.io/component-base/metrics/registry.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/blang/semver"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+)
+
+var (
+	showHiddenOnce sync.Once
+	showHidden     atomic.Value
+)
+
+// SetShowHidden will enable showing hidden metrics. This will no-opt
+// after the initial call
+func SetShowHidden() {
+	showHiddenOnce.Do(func() {
+		showHidden.Store(true)
+	})
+}
+
+// ShouldShowHidden returns whether showing hidden deprecated metrics
+// is enabled. While the primary usecase for this is internal (to determine
+// registration behavior) this can also be used to introspect
+func ShouldShowHidden() bool {
+	return showHidden.Load() != nil && showHidden.Load().(bool)
+}
+
+// Registerable is an interface for a collector metric which we
+// will register with KubeRegistry.
+type Registerable interface {
+	prometheus.Collector
+	Create(version *semver.Version) bool
+}
+
+// KubeRegistry is an interface which implements a subset of prometheus.Registerer and
+// prometheus.Gatherer interfaces
+type KubeRegistry interface {
+	Register(Registerable) error
+	MustRegister(...Registerable)
+	Unregister(Registerable) bool
+	Gather() ([]*dto.MetricFamily, error)
+}
+
+// kubeRegistry is a wrapper around a prometheus registry-type object. Upon initialization
+// the kubernetes binary version information is loaded into the registry object, so that
+// automatic behavior can be configured for metric versioning.
+type kubeRegistry struct {
+	PromRegistry
+	version semver.Version
+}
+
+// Register registers a new Collector to be included in metrics
+// collection. It returns an error if the descriptors provided by the
+// Collector are invalid or if they — in combination with descriptors of
+// already registered Collectors — do not fulfill the consistency and
+// uniqueness criteria described in the documentation of metric.Desc.
+func (kr *kubeRegistry) Register(c Registerable) error {
+	if c.Create(&kr.version) {
+		return kr.PromRegistry.Register(c)
+	}
+	return nil
+}
+
+// MustRegister works like Register but registers any number of
+// Collectors and panics upon the first registration that causes an
+// error.
+func (kr *kubeRegistry) MustRegister(cs ...Registerable) {
+	metrics := make([]prometheus.Collector, 0, len(cs))
+	for _, c := range cs {
+		if c.Create(&kr.version) {
+			metrics = append(metrics, c)
+		}
+	}
+	kr.PromRegistry.MustRegister(metrics...)
+}
+
+// Unregister unregisters the Collector that equals the Collector passed
+// in as an argument.  (Two Collectors are considered equal if their
+// Describe method yields the same set of descriptors.) The function
+// returns whether a Collector was unregistered. Note that an unchecked
+// Collector cannot be unregistered (as its Describe method does not
+// yield any descriptor).
+func (kr *kubeRegistry) Unregister(collector Registerable) bool {
+	return kr.PromRegistry.Unregister(collector)
+}
+
+// Gather calls the Collect method of the registered Collectors and then
+// gathers the collected metrics into a lexicographically sorted slice
+// of uniquely named MetricFamily protobufs. Gather ensures that the
+// returned slice is valid and self-consistent so that it can be used
+// for valid exposition. As an exception to the strict consistency
+// requirements described for metric.Desc, Gather will tolerate
+// different sets of label names for metrics of the same metric family.
+func (kr *kubeRegistry) Gather() ([]*dto.MetricFamily, error) {
+	return kr.PromRegistry.Gather()
+}
+
+// NewKubeRegistry creates a new vanilla Registry without any Collectors
+// pre-registered.
+func NewKubeRegistry(v apimachineryversion.Info) KubeRegistry {
+	return &kubeRegistry{
+		PromRegistry: prometheus.NewRegistry(),
+		version:      parseVersion(v),
+	}
+}
+
+// NewPreloadedKubeRegistry creates a new Registry with preloaded prometheus collectors
+// already registered. This is exposed specifically to maintain backwards
+// compatibility with the global prometheus registry.
+//
+// Deprecated
+func NewPreloadedKubeRegistry(v apimachineryversion.Info, cs ...prometheus.Collector) KubeRegistry {
+	registry := &kubeRegistry{
+		PromRegistry: prometheus.NewRegistry(),
+		version:      parseVersion(v),
+	}
+
+	registry.PromRegistry.MustRegister(cs...)
+	return registry
+}

--- a/vendor/k8s.io/component-base/metrics/summary.go
+++ b/vendor/k8s.io/component-base/metrics/summary.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/blang/semver"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Summary is our internal representation for our wrapping struct around prometheus
+// summaries. Summary implements both kubeCollector and ObserverMetric
+//
+// DEPRECATED: as per the metrics overhaul KEP
+type Summary struct {
+	ObserverMetric
+	*SummaryOpts
+	lazyMetric
+	selfCollector
+}
+
+// NewSummary returns an object which is Summary-like. However, nothing
+// will be measured until the summary is registered somewhere.
+//
+// DEPRECATED: as per the metrics overhaul KEP
+func NewSummary(opts *SummaryOpts) *Summary {
+	// todo: handle defaulting better
+	if opts.StabilityLevel == "" {
+		opts.StabilityLevel = ALPHA
+	}
+	s := &Summary{
+		SummaryOpts: opts,
+		lazyMetric:  lazyMetric{},
+	}
+	s.setPrometheusSummary(noopMetric{})
+	s.lazyInit(s)
+	return s
+}
+
+// setPrometheusSummary sets the underlying KubeGauge object, i.e. the thing that does the measurement.
+func (s *Summary) setPrometheusSummary(summary prometheus.Summary) {
+	s.ObserverMetric = summary
+	s.initSelfCollection(summary)
+}
+
+// DeprecatedVersion returns a pointer to the Version or nil
+func (s *Summary) DeprecatedVersion() *semver.Version {
+	return s.SummaryOpts.DeprecatedVersion
+}
+
+// initializeMetric invokes the actual prometheus.Summary object instantiation
+// and stores a reference to it
+func (s *Summary) initializeMetric() {
+	s.SummaryOpts.annotateStabilityLevel()
+	// this actually creates the underlying prometheus gauge.
+	s.setPrometheusSummary(prometheus.NewSummary(s.SummaryOpts.toPromSummaryOpts()))
+}
+
+// initializeDeprecatedMetric invokes the actual prometheus.Summary object instantiation
+// but modifies the Help description prior to object instantiation.
+func (s *Summary) initializeDeprecatedMetric() {
+	s.SummaryOpts.markDeprecated()
+	s.initializeMetric()
+}
+
+// SummaryVec is the internal representation of our wrapping struct around prometheus
+// summaryVecs.
+//
+// DEPRECATED: as per the metrics overhaul KEP
+type SummaryVec struct {
+	*prometheus.SummaryVec
+	*SummaryOpts
+	lazyMetric
+	originalLabels []string
+}
+
+// NewSummaryVec returns an object which satisfies kubeCollector and wraps the
+// prometheus.SummaryVec object. However, the object returned will not measure
+// anything unless the collector is first registered, since the metric is lazily instantiated.
+//
+// DEPRECATED: as per the metrics overhaul KEP
+func NewSummaryVec(opts *SummaryOpts, labels []string) *SummaryVec {
+	// todo: handle defaulting better
+	if opts.StabilityLevel == "" {
+		opts.StabilityLevel = ALPHA
+	}
+	v := &SummaryVec{
+		SummaryOpts:    opts,
+		originalLabels: labels,
+		lazyMetric:     lazyMetric{},
+	}
+	v.lazyInit(v)
+	return v
+}
+
+// DeprecatedVersion returns a pointer to the Version or nil
+func (v *SummaryVec) DeprecatedVersion() *semver.Version {
+	return v.SummaryOpts.DeprecatedVersion
+}
+
+func (v *SummaryVec) initializeMetric() {
+	v.SummaryOpts.annotateStabilityLevel()
+	v.SummaryVec = prometheus.NewSummaryVec(v.SummaryOpts.toPromSummaryOpts(), v.originalLabels)
+}
+
+func (v *SummaryVec) initializeDeprecatedMetric() {
+	v.SummaryOpts.markDeprecated()
+	v.initializeMetric()
+}
+
+// Default Prometheus behavior actually results in the creation of a new metric
+// if a metric with the unique label values is not found in the underlying stored metricMap.
+// This means  that if this function is called but the underlying metric is not registered
+// (which means it will never be exposed externally nor consumed), the metric will exist in memory
+// for perpetuity (i.e. throughout application lifecycle).
+//
+// For reference: https://github.com/prometheus/client_golang/blob/v0.9.2/prometheus/summary.go#L485-L495
+
+// WithLabelValues returns the ObserverMetric for the given slice of label
+// values (same order as the VariableLabels in Desc). If that combination of
+// label values is accessed for the first time, a new ObserverMetric is created IFF the summaryVec
+// has been registered to a metrics registry.
+func (v *SummaryVec) WithLabelValues(lvs ...string) ObserverMetric {
+	if !v.IsCreated() {
+		return noop
+	}
+	return v.SummaryVec.WithLabelValues(lvs...)
+}
+
+// With returns the ObserverMetric for the given Labels map (the label names
+// must match those of the VariableLabels in Desc). If that label map is
+// accessed for the first time, a new ObserverMetric is created IFF the summaryVec has
+// been registered to a metrics registry.
+func (v *SummaryVec) With(labels prometheus.Labels) ObserverMetric {
+	if !v.IsCreated() {
+		return noop
+	}
+	return v.SummaryVec.With(labels)
+}

--- a/vendor/k8s.io/component-base/metrics/version_parser.go
+++ b/vendor/k8s.io/component-base/metrics/version_parser.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"github.com/blang/semver"
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+	"regexp"
+)
+
+const (
+	versionRegexpString = `^v(\d+\.\d+\.\d+)`
+)
+
+var (
+	versionRe = regexp.MustCompile(versionRegexpString)
+)
+
+func parseVersion(ver apimachineryversion.Info) semver.Version {
+	matches := versionRe.FindAllStringSubmatch(ver.String(), -1)
+
+	if len(matches) != 1 {
+		panic(fmt.Sprintf("version string \"%v\" doesn't match expected regular expression: \"%v\"", ver.String(), versionRe.String()))
+	}
+	return semver.MustParse(matches[0][1])
+}

--- a/vendor/k8s.io/component-base/metrics/wrappers.go
+++ b/vendor/k8s.io/component-base/metrics/wrappers.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// This file contains a series of interfaces which we explicitly define for
+// integrating with prometheus. We redefine the interfaces explicitly here
+// so that we can prevent breakage if methods are ever added to prometheus
+// variants of them.
+
+// Collector defines a subset of prometheus.Collector interface methods
+type Collector interface {
+	Describe(chan<- *prometheus.Desc)
+	Collect(chan<- prometheus.Metric)
+}
+
+// Metric defines a subset of prometheus.Metric interface methods
+type Metric interface {
+	Desc() *prometheus.Desc
+	Write(*dto.Metric) error
+}
+
+// CounterMetric is a Metric that represents a single numerical value that only ever
+// goes up. That implies that it cannot be used to count items whose number can
+// also go down, e.g. the number of currently running goroutines. Those
+// "counters" are represented by Gauges.
+
+// CounterMetric is an interface which defines a subset of the interface provided by prometheus.Counter
+type CounterMetric interface {
+	Inc()
+	Add(float64)
+}
+
+// CounterVecMetric is an interface which prometheus.CounterVec satisfies.
+type CounterVecMetric interface {
+	WithLabelValues(...string) CounterMetric
+	With(prometheus.Labels) CounterMetric
+}
+
+// GaugeMetric is an interface which defines a subset of the interface provided by prometheus.Gauge
+type GaugeMetric interface {
+	Set(float64)
+	Inc()
+	Dec()
+}
+
+// ObserverMetric captures individual observations.
+type ObserverMetric interface {
+	Observe(float64)
+}
+
+// PromRegistry is an interface which implements a subset of prometheus.Registerer and
+// prometheus.Gatherer interfaces
+type PromRegistry interface {
+	Register(prometheus.Collector) error
+	MustRegister(...prometheus.Collector)
+	Unregister(prometheus.Collector) bool
+	Gather() ([]*dto.MetricFamily, error)
+}


### PR DESCRIPTION
The hiveadmission and hiveapi pods use certs that may change while the pods are running. When the certs change, the pods will no longer be able to do their work. The pods need to be restarted to pick up the new certs.