### PR TITLE
sync stable order with master when using cherry-pick

### DIFF
--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -24,8 +24,15 @@ skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
     "docker-daemon:${IMG}" \
     "docker://${QUAY_IMAGE}:${GIT_HASH}"
 
+# IMPORTANT: DO NOT MERGE THIS CHANGE BACK TO MASTER
+# we need the count to be synced with deploments from master branch.
+# since this branch is used temporarily for deploying hotfixes, and we
+# use the number of commits from a past commit for deployment ordering -
+# set this variable to the merge commit into master to help with ordering
+GIT_COMMIT_CHERRY_PICK="ed7dfcb60d719846815e1f7be88a8060cc76949c"
+
 # create and push staging image catalog
-$CURRENT_DIR/app_sre_create_image_catalog.sh staging "$QUAY_IMAGE"
+$CURRENT_DIR/app_sre_create_image_catalog.sh staging "$QUAY_IMAGE" "$GIT_COMMIT_CHERRY_PICK"
 
 # create and push production image catalog
-REMOVE_UNDEPLOYED=true $CURRENT_DIR/app_sre_create_image_catalog.sh production "$QUAY_IMAGE"
+REMOVE_UNDEPLOYED=true $CURRENT_DIR/app_sre_create_image_catalog.sh production "$QUAY_IMAGE" "$GIT_COMMIT_CHERRY_PICK"

--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -25,7 +25,7 @@ skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
     "docker://${QUAY_IMAGE}:${GIT_HASH}"
 
 # IMPORTANT: DO NOT MERGE THIS CHANGE BACK TO MASTER
-# we need the count to be synced with deploments from master branch.
+# we need the count to be synced with deployments from master branch.
 # since this branch is used temporarily for deploying hotfixes, and we
 # use the number of commits from a past commit for deployment ordering -
 # set this variable to the merge commit into master to help with ordering

--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -32,14 +32,10 @@ skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
 GIT_COMMIT_CHERRY_PICK="ed7dfcb60d719846815e1f7be88a8060cc76949c"
 
 # create and push staging image catalog
-$CURRENT_DIR/app_sre_create_image_catalog.sh \
-    staging "$QUAY_IMAGE" \
-    "$GIT_COMMIT_CHERRY_PICK"
+$CURRENT_DIR/app_sre_create_image_catalog.sh staging "$QUAY_IMAGE" "$GIT_COMMIT_CHERRY_PICK"
 
 # create and push production image catalog
-REMOVE_UNDEPLOYED=true $CURRENT_DIR/app_sre_create_image_catalog.sh \
-    production "$QUAY_IMAGE" \
-    "$GIT_COMMIT_CHERRY_PICK"
+REMOVE_UNDEPLOYED=true $CURRENT_DIR/app_sre_create_image_catalog.sh production "$QUAY_IMAGE" "$GIT_COMMIT_CHERRY_PICK"
 
 exit 0
 # IMPORTANT: DO NOT MERGE THE ABOVE CHANGES BACK TO MASTER

--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -24,7 +24,7 @@ skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
     "docker-daemon:${IMG}" \
     "docker://${QUAY_IMAGE}:${GIT_HASH}"
 
-# IMPORTANT: DO NOT MERGE THIS CHANGE BACK TO MASTER
+# IMPORTANT: DO NOT MERGE THE BELOW CHANGES BACK TO MASTER
 # we need the count to be synced with deployments from master branch.
 # since this branch is used temporarily for deploying hotfixes, and we
 # use the number of commits from a past commit for deployment ordering -
@@ -32,7 +32,20 @@ skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
 GIT_COMMIT_CHERRY_PICK="ed7dfcb60d719846815e1f7be88a8060cc76949c"
 
 # create and push staging image catalog
-$CURRENT_DIR/app_sre_create_image_catalog.sh staging "$QUAY_IMAGE" "$GIT_COMMIT_CHERRY_PICK"
+$CURRENT_DIR/app_sre_create_image_catalog.sh \
+    staging "$QUAY_IMAGE" \
+    "$GIT_COMMIT_CHERRY_PICK"
 
 # create and push production image catalog
-REMOVE_UNDEPLOYED=true $CURRENT_DIR/app_sre_create_image_catalog.sh production "$QUAY_IMAGE" "$GIT_COMMIT_CHERRY_PICK"
+REMOVE_UNDEPLOYED=true $CURRENT_DIR/app_sre_create_image_catalog.sh \
+    production "$QUAY_IMAGE" \
+    "$GIT_COMMIT_CHERRY_PICK"
+
+exit 0
+# IMPORTANT: DO NOT MERGE THE ABOVE CHANGES BACK TO MASTER
+
+# create and push staging image catalog
+$CURRENT_DIR/app_sre_create_image_catalog.sh staging "$QUAY_IMAGE"
+
+# create and push production image catalog
+REMOVE_UNDEPLOYED=true $CURRENT_DIR/app_sre_create_image_catalog.sh production "$QUAY_IMAGE"

--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -8,7 +8,7 @@ QUAY_IMAGE="$2"
 GIT_HASH=`git rev-parse --short=7 HEAD`
 GIT_COMMIT_COUNT=`git rev-list 9c56c62c6d0180c27e1cc9cf195f4bbfd7a617dd..HEAD --count`
 
-# IMPORTANT: DO NOT MERGE THIS CHANGE BACK TO MASTER
+# IMPORTANT: DO NOT MERGE THE BELOW CHANGES BACK TO MASTER
 # we need the count to be synced with deployments from master branch.
 # since this branch is used temporarily for deploying hotfixes, and we
 # use the number of commits from a past commit for deployment ordering -
@@ -16,6 +16,7 @@ GIT_COMMIT_COUNT=`git rev-list 9c56c62c6d0180c27e1cc9cf195f4bbfd7a617dd..HEAD --
 GIT_COMMIT_CHERRY_PICK="$3"
 GIT_COMMIT_COUNT=`git rev-list 9c56c62c6d0180c27e1cc9cf195f4bbfd7a617dd..$GIT_COMMIT_CHERRY_PICK --count`
 GIT_COMMIT_COUNT=$((GIT_COMMIT_COUNT+1))
+# IMPORTANT: DO NOT MERGE THE ABOVE CHANGES BACK TO MASTER
 
 # clone bundle repo
 SAAS_OPERATOR_DIR="saas-hive-operator-bundle"

--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -8,6 +8,15 @@ QUAY_IMAGE="$2"
 GIT_HASH=`git rev-parse --short=7 HEAD`
 GIT_COMMIT_COUNT=`git rev-list 9c56c62c6d0180c27e1cc9cf195f4bbfd7a617dd..HEAD --count`
 
+# IMPORTANT: DO NOT MERGE THIS CHANGE BACK TO MASTER
+# we need the count to be synced with deploments from master branch.
+# since this branch is used temporarily for deploying hotfixes, and we
+# use the number of commits from a past commit for deployment ordering -
+# set this variable to the merge commit into master to help with ordering
+GIT_COMMIT_CHERRY_PICK="$3"
+GIT_COMMIT_COUNT=`git rev-list 9c56c62c6d0180c27e1cc9cf195f4bbfd7a617dd..$GIT_COMMIT_CHERRY_PICK --count`
+GIT_COMMIT_COUNT=$((GIT_COMMIT_COUNT+1))
+
 # clone bundle repo
 SAAS_OPERATOR_DIR="saas-hive-operator-bundle"
 BUNDLE_DIR="$SAAS_OPERATOR_DIR/hive/"

--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -9,7 +9,7 @@ GIT_HASH=`git rev-parse --short=7 HEAD`
 GIT_COMMIT_COUNT=`git rev-list 9c56c62c6d0180c27e1cc9cf195f4bbfd7a617dd..HEAD --count`
 
 # IMPORTANT: DO NOT MERGE THIS CHANGE BACK TO MASTER
-# we need the count to be synced with deploments from master branch.
+# we need the count to be synced with deployments from master branch.
 # since this branch is used temporarily for deploying hotfixes, and we
 # use the number of commits from a past commit for deployment ordering -
 # set this variable to the merge commit into master to help with ordering


### PR DESCRIPTION
Since we are using the `stable` branch to deploy fixes to stage and production, and since each deployment is ordered (number of commits from a past commit are used to count), we need the `stable` branch's count to be aligned with the `master` branch count.

To do this, we specify the commit we are cherry picking from `master`. That commit will be used for the count, and to guarantee that it takes precedence over the commit in `master`, we add 1.

This should fix the problem of staging images not created in https://ci-int-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/hive/job/openshift-hive-gh-build-stable/3.

IMPORTANT:
1. this change assumes that `stable` will never be merged into `master`.
2. this change assumes that every change to `stable` is cherry-picked from `master`.
3. the GIT_COMMIT_CHERRY_PICK variable should be updated on every change to `stable`.
4. the GIT_COMMIT_CHERRY_PICK variable should point to a merge commit. 