### PR TITLE
Fix hiveapi-cluster-role-binding.yaml

### DIFF
--- a/config/apiserver/hiveapi-cluster-role-binding.yaml
+++ b/config/apiserver/hiveapi-cluster-role-binding.yaml
@@ -3,10 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: hiveapi-extension-apiserver-authentication-reader
-  namespace: hive
+  namespace: kube-system
 roleRef:
   name: extension-apiserver-authentication-reader
-  namespace: kube-system
   kind: Role
   apiGroup: rbac.authorization.k8s.io
 subjects:


### PR DESCRIPTION
Hello,
Small fix for hiveapi-extension-apiserver-authentication-reader rolebinding otherwise rolebinding will fail getting applied. Wrong namespace selected and kube-system was defined under roleRef but not supported option.
Please review and merge.
Thx,
Bernd