### PR TITLE
migration: changes to support hive-int

### DIFF
--- a/contrib/pkg/v1migration/deleteobjects.go
+++ b/contrib/pkg/v1migration/deleteobjects.go
@@ -134,6 +134,13 @@ func (o *DeleteObjectsOptions) deleteObject(client dynamic.Interface, objFromFil
 	objFromFile.SetOwnerReferences(objFromKube.GetOwnerReferences())
 	objFromFile.SetResourceVersion(objFromKube.GetResourceVersion())
 
+	// For cluster-scoped resources, set the namespace to the empty string so that the deep equal check does not pick
+	// up a difference in the namespace. Setting to an empty string will delete the .metadata.namespace entry from the
+	// unstructured data.
+	if namespace == "" {
+		objFromFile.SetNamespace("")
+	}
+
 	if !reflect.DeepEqual(objFromFile, objFromKube) {
 		logger.Warn("object in JSON file differs from object in the cluster")
 		fmt.Printf("Diff in %s/%s (%s)\n%s\n", kind, name, namespace, diff.ObjectReflectDiff(objFromFile, objFromKube))

--- a/contrib/pkg/v1migration/saveownerrefs.go
+++ b/contrib/pkg/v1migration/saveownerrefs.go
@@ -75,7 +75,7 @@ func (o *SaveOwnerRefsOptions) Run() error {
 	}
 	resources, err := discoveryClient.ServerPreferredResources()
 	if err != nil {
-		return errors.Wrap(err, "could discovery the server resources")
+		return errors.Wrap(err, "could not discover the server resources")
 	}
 	client, err := dynamic.NewForConfig(clientConfig)
 	if err != nil {

--- a/hack/v1migration/README.md
+++ b/hack/v1migration/README.md
@@ -2,13 +2,17 @@
 
   1. Deploy master (v1alpha1) to a cluster.
   1. Create a cluster deployment and wait for completion.
-  1. Run `./hack/v1migration/scaledown.sh` to scale down Hive deployments.
+  1. Run `oc patch hiveconfig hive --type='merge' -p $'spec:\n maintenanceMode: true'`
+  1. Run `./hack/v1migration/scaledown.sh hive-operator` to scale down Hive operator.
+  1. Run `./hack/v1migration/remove_hiveadmission.sh` to remove the Hive validation webhooks.
   1. Run `./hack/v1migration/delete.sh [workdir]` to backup all data to disk and remove Hive resources (CRs, CRDs, and admission webhooks).
   1. Deploy Hive v1.
   1. If running on a cluster that does not support cert injection, run `./hack/hiveapi-dev-certs.sh` to create the certs for the Hive aggregated API server.
   1. Run `./hack/v1migration/deploy_apiserver.sh` to enabled the Hive aggregated API server.
   1. Run `./hack/v1migration/restore_hiveconfig.sh [workdir]` to restore HiveConfig from v1alpha1.
   1. Wait for any changes from HiveConfig for hiveadmission to propagate.
-  1. Run `./hack/v1migration/scaledown.sh` to scale down Hive deployments.
+  1. Run `oc patch hiveconfig hive --type='merge' -p $'spec:\n maintenanceMode: true'`
+  1. Run `./hack/v1migration/scaledown.sh hive-operator` to scale down Hive operator.
   1. Run `./hack/v1migration/restore.sh [workdir]` to restore all data from disk.
-  1. Run `./hack/v1migration/scaleup.sh` to scale up Hive deployments.
+  1. Run `./hack/v1migration/scaleup.sh hive-operator` to scale up Hive operator.
+  1. Run `oc patch hiveconfig hive --type='merge' -p $'spec:\n maintenanceMode: false'`

--- a/hack/v1migration/remove_hiveadmission.sh
+++ b/hack/v1migration/remove_hiveadmission.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+echo "Deleting webhooks"
+oc get validatingwebhookconfiguration -oname | \
+  grep -E -e "\.hive\.openshift\.io$" | \
+  xargs -i oc delete {}
+
+echo "Deleting admission api service"
+oc delete apiservice v1alpha1.admission.hive.openshift.io
+
+echo "Deleting hiveadmission deployment"
+oc delete -n hive deployment/hiveadmission

--- a/hack/v1migration/scaledown.sh
+++ b/hack/v1migration/scaledown.sh
@@ -5,12 +5,8 @@ set -e
 # shellcheck source=verify_scaledown.sh
 source "$(dirname "$0")/verify_scaledown.sh"
 
-scaledown() {
-  local deployment_name=${1:?must specify a deployment name}
-  echo "Scaling down $deployment_name"
-  oc scale -n hive "deployment.v1.apps/$deployment_name" --replicas=0
-  verify_scaledown "$deployment_name"
-}
+DEPLOYMENT_NAME=${1:?must specify a deployment name}
 
-scaledown "hive-operator"
-scaledown "hive-controllers"
+echo "Scaling down $DEPLOYMENT_NAME"
+oc scale -n hive "deployment.v1.apps/$DEPLOYMENT_NAME" --replicas=0
+verify_scaledown "$DEPLOYMENT_NAME"

--- a/hack/v1migration/scaleup.sh
+++ b/hack/v1migration/scaleup.sh
@@ -2,16 +2,12 @@
 
 set -e
 
-scaleup() {
-  local deployment_name=${1:?must specify a deployment name}
-  echo "Scaling up $deployment_name"
-  oc scale -n hive "deployment.v1.apps/$deployment_name" --replicas=1
-  oc rollout status -n hive "deployment.v1.apps/$deployment_name" -w
-  if [[ "$(oc get -n hive "deployment.v1.apps/$deployment_name" -o jsonpath='{.spec.replicas}')" != "1" ]]
-  then
-    echo "$deployment_name has not been scaled down to 0"
-  fi
-}
+DEPLOYMENT_NAME=${1:?must specify a deployment name}
 
-scaleup "hive-operator"
-scaleup "hive-controllers"
+echo "Scaling up $DEPLOYMENT_NAME"
+oc scale -n hive "deployment.v1.apps/$DEPLOYMENT_NAME" --replicas=1
+oc rollout status -n hive "deployment.v1.apps/$DEPLOYMENT_NAME" -w
+if [[ "$(oc get -n hive "deployment.v1.apps/$DEPLOYMENT_NAME" -o jsonpath='{.spec.replicas}')" != "1" ]]
+then
+  echo "$DEPLOYMENT_NAME has not been scaled down to 0"
+fi

--- a/hack/v1migration/verify_scaledown.sh
+++ b/hack/v1migration/verify_scaledown.sh
@@ -1,11 +1,16 @@
 verify_scaledown() {
   local deployment_name=${1:?must specify a deployment name}
   echo "Verifying that $deployment_name has been scaled down"
-  oc rollout status -n hive "deployment.v1.apps/$deployment_name" -w
-  if [[ "$(oc get -n hive "deployment.v1.apps/$deployment_name" -o jsonpath='{.spec.replicas}')" != "0" ]]
+  if [[ "$(oc get -n hive "deployment.v1.apps/$deployment_name" -o name --ignore-not-found)" != "" ]]
   then
-    echo "$deployment_name has not been scaled down to 0"
-    exit 1
+    oc rollout status -n hive "deployment.v1.apps/$deployment_name" -w
+    if [[ "$(oc get -n hive "deployment.v1.apps/$deployment_name" -o jsonpath='{.spec.replicas}')" != "0" ]]
+    then
+      echo "Deployment $deployment_name has not been scaled down to 0"
+      exit 1
+    fi
+  else
+    echo "Deployment $deployment_name does not exist"
   fi
 }
 


### PR DESCRIPTION
* Fix differences seen in namespace when comparing cluster-scoped resources.
* Ignore not-found errors when trying to restore owner references on DNSEndpoints and install-log PVCs.
* Fix delete_jobs script function.
* Do not do a dry-run delete of jobs as that is not supported with oc 3.11.
* Make a separate step for removing the validating webhooks. The hiveadmission will not work once the Hive CSV is deleted. So the validating webhooks need to be deleted prior to run the delete.sh script.
* Make the scaling scripts more granular. Deleting the Hive CSV will delete the hive-operator deployment.
* Accept a missing dpeloyment as an acceptably scaled-down deployment.