### PR TITLE
scripts for creating Hive v1 images for use on hive-test

### DIFF
--- a/hack/v1migration/app_sre_build_deploy.sh
+++ b/hack/v1migration/app_sre_build_deploy.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# AppSRE team CD
+
+set -exv
+
+CURRENT_DIR=$(dirname $0)
+
+BASE_IMG="hive"
+QUAY_IMAGE="${QUAY_IMAGE:-quay.io/staebler/${BASE_IMG}}"
+IMG="${BASE_IMG}:latest"
+
+GIT_HASH=`git rev-parse --short=7 HEAD`
+
+# build the image
+BUILD_CMD="docker build" IMG="$IMG" make docker-build
+
+# push the image
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${IMG}" \
+    "docker://${QUAY_IMAGE}:latest"
+
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${IMG}" \
+    "docker://${QUAY_IMAGE}:${GIT_HASH}"
+
+# create and push staging image catalog
+$CURRENT_DIR/app_sre_create_image_catalog.sh staging "$QUAY_IMAGE"
+
+# create and push production image catalog
+##REMOVE_UNDEPLOYED=true $CURRENT_DIR/app_sre_create_image_catalog.sh production "$QUAY_IMAGE"

--- a/hack/v1migration/app_sre_create_image_catalog.sh
+++ b/hack/v1migration/app_sre_create_image_catalog.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -exv
+
+BRANCH_CHANNEL="$1"
+QUAY_IMAGE="$2"
+
+GIT_HASH=`git rev-parse --short=7 HEAD`
+GIT_COMMIT_COUNT=`git rev-list 9c56c62c6d0180c27e1cc9cf195f4bbfd7a617dd..HEAD --count`
+
+# clone bundle repo
+SAAS_OPERATOR_DIR="saas-hive-operator-bundle"
+BUNDLE_DIR="$SAAS_OPERATOR_DIR/hive/"
+
+rm -rf "$SAAS_OPERATOR_DIR"
+
+git clone \
+    --branch $BRANCH_CHANNEL \
+    https://gitlab.cee.redhat.com/service/saas-hive-operator-bundle.git \
+    $SAAS_OPERATOR_DIR
+
+# remove any versions more recent than deployed hash
+REMOVED_VERSIONS=""
+if [[ "$REMOVE_UNDEPLOYED" == true ]]; then
+    DEPLOYED_HASH=$(
+        curl -s 'https://gitlab.cee.redhat.com/service/saas-hive/raw/master/hive-services/hive.yaml' | \
+            docker run --rm -i evns/yq -r '.services[]|select(.name="hive").hash'
+    )
+
+    delete=false
+    for version in `ls $BUNDLE_DIR | sort -t . -k 3 -g`; do
+        # skip if not directory
+        [ -d "$BUNDLE_DIR/$version" ] || continue
+
+        if [[ "$delete" == false ]]; then
+            short_hash=$(echo $version | cut -d- -f2)
+            short_hash=${short_hash##sha}
+
+            if [[ "$DEPLOYED_HASH" == "${short_hash}"* ]]; then
+                delete=true
+            fi
+        else
+            rm -rf "$BUNDLE_DIR/$version"
+            REMOVED_VERSIONS="$version $REMOVED_VERSIONS"
+        fi
+    done
+fi
+
+# generate bundle
+PREV_VERSION=$(ls $BUNDLE_DIR | sort -t . -k 3 -g | tail -n 1)
+
+./hack/generate-operator-bundle.py \
+    $BUNDLE_DIR \
+    $PREV_VERSION \
+    $GIT_COMMIT_COUNT \
+    $GIT_HASH \
+    $QUAY_IMAGE:$GIT_HASH
+
+NEW_VERSION=$(ls $BUNDLE_DIR | sort -t . -k 3 -g | tail -n 1)
+
+if [ "$NEW_VERSION" = "$PREV_VERSION" ]; then
+    # stopping script as that version was already built, so no need to rebuild it
+    exit 0
+fi
+
+# create package yaml
+cat <<EOF > $BUNDLE_DIR/hive.package.yaml
+packageName: hive-operator
+channels:
+- name: $BRANCH_CHANNEL
+  currentCSV: hive-operator.v${NEW_VERSION}
+EOF
+
+# build the registry image
+REGISTRY_IMG="${REGISTRY_IMG:-quay.io/staebler/hive-registry}"
+DOCKERFILE_REGISTRY="Dockerfile.olm-registry"
+
+cat <<EOF > $DOCKERFILE_REGISTRY
+FROM quay.io/openshift/origin-operator-registry:latest
+
+COPY $SAAS_OPERATOR_DIR manifests
+RUN initializer
+
+CMD ["registry-server", "-t", "/tmp/terminate.log"]
+EOF
+
+docker build -f $DOCKERFILE_REGISTRY --tag "${REGISTRY_IMG}:${BRANCH_CHANNEL}-latest" .
+
+# push image
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${REGISTRY_IMG}:${BRANCH_CHANNEL}-latest" \
+    "docker://${REGISTRY_IMG}:${BRANCH_CHANNEL}-latest"
+
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${REGISTRY_IMG}:${BRANCH_CHANNEL}-latest" \
+    "docker://${REGISTRY_IMG}:${BRANCH_CHANNEL}-${GIT_HASH}"
+


### PR DESCRIPTION
*** THIS SHOULD NOT BE MERGED ***

/hold

Scripts for creating a Hive image and a Hive registry image to run Hive v1 on the hive-test cluster.

```sh
export QUAY_USER=<your quay user>
export QUAY_TOKEN=<your quay password>
export QUAY_IMAGE=<your Hive image on quay>
export REGISTRY_IMG=<your Hive registry image on quay>

./hack/v1migration/app_sre_build_deploy.sh

oc process --local --output yaml -f hack/olm-registry/olm-artifacts-template.yaml IMAGE_TAG=<your-hive-image-tag> EXTERNAL_DNS_MANAGED_DOMAIN=s1.devshift.org REGISTRY_IMG=<your-hive-registry-image> ADDITIONAL_CERTIFICATE_AUTHORITY=letsencrypt-ca CHANNEL=staging > hive-stage.yaml

oc project hive
oc apply -f hive-stage.yaml
```