### PR TITLE
validation: reject changes to MachinePool platform fields

### DIFF
--- a/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook.go
+++ b/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook.go
@@ -222,6 +222,7 @@ func validateMachinePoolUpdate(old, new *hivev1.MachinePool) field.ErrorList {
 	allErrs = append(allErrs, validation.ValidateImmutableField(new.Spec.Name, old.Spec.Name, specPath.Child("name"))...)
 	allErrs = append(allErrs, validation.ValidateImmutableField(new.Spec.Labels, old.Spec.Labels, specPath.Child("labels"))...)
 	allErrs = append(allErrs, validation.ValidateImmutableField(new.Spec.Taints, old.Spec.Taints, specPath.Child("taints"))...)
+	allErrs = append(allErrs, validation.ValidateImmutableField(new.Spec.Platform, old.Spec.Platform, specPath.Child("platform"))...)
 	return allErrs
 }
 

--- a/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook_test.go
@@ -514,6 +514,20 @@ func Test_MachinePoolAdmission_Validate_Update(t *testing.T) {
 				return pool
 			}(),
 		},
+		{
+			name: "platform changed",
+			old:  testMachinePool(),
+			new:  testGCPMachinePool(),
+		},
+		{
+			name: "instance type changed",
+			old:  testMachinePool(),
+			new: func() *hivev1.MachinePool {
+				pool := testMachinePool()
+				pool.Spec.Platform.AWS.InstanceType = "other-instance-type"
+				return pool
+			}(),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
The MCO does not support updating existing machines when platform details are changed in a machineset. Consequently, Hive should not support making such changes.

https://issues.redhat.com/browse/CO-798