### PR TITLE
support aws china for managed dns

### DIFF
--- a/config/crds/hive_v1_dnszone.yaml
+++ b/config/crds/hive_v1_dnszone.yaml
@@ -52,6 +52,10 @@ spec:
                   description: CredentialsSecretRef contains a reference to a secret
                     that contains AWS credentials for CRUD operations
                   type: object
+                region:
+                  description: Region is the AWS region to use for route53 operations.
+                    This defaults to us-east-1. For AWS China, use cn-northwest-1.
+                  type: string
               type: object
             gcp:
               description: GCP specifies GCP-specific cloud configuration

--- a/config/crds/hive_v1_hiveconfig.yaml
+++ b/config/crds/hive_v1_hiveconfig.yaml
@@ -115,6 +115,10 @@ spec:
                           parent ManageDNSConfig object. Secret should have AWS keys
                           named 'aws_access_key_id' and 'aws_secret_access_key'.
                         type: object
+                      region:
+                        description: Region is the AWS region to use for route53 operations.
+                          This defaults to us-east-1. For AWS China, use cn-northwest-1.
+                        type: string
                     type: object
                   domains:
                     description: Domains is the list of domains that hive will be

--- a/pkg/apis/hive/v1/dnszone_types.go
+++ b/pkg/apis/hive/v1/dnszone_types.go
@@ -45,6 +45,12 @@ type AWSDNSZoneSpec struct {
 	// to these tags,the DNS Zone controller will set a hive.openhsift.io/hostedzone tag
 	// identifying the HostedZone record that it belongs to.
 	AdditionalTags []AWSResourceTag `json:"additionalTags,omitempty"`
+
+	// Region is the AWS region to use for route53 operations.
+	// This defaults to us-east-1.
+	// For AWS China, use cn-northwest-1.
+	// +optional
+	Region string `json:"region,omitempty"`
 }
 
 // AWSResourceTag represents a tag that is applied to an AWS cloud resource

--- a/pkg/apis/hive/v1/hiveconfig_types.go
+++ b/pkg/apis/hive/v1/hiveconfig_types.go
@@ -129,6 +129,12 @@ type ManageDNSAWSConfig struct {
 	// Secret should have AWS keys named 'aws_access_key_id' and 'aws_secret_access_key'.
 	// +optional
 	CredentialsSecretRef corev1.LocalObjectReference `json:"credentialsSecretRef,omitempty"`
+
+	// Region is the AWS region to use for route53 operations.
+	// This defaults to us-east-1.
+	// For AWS China, use cn-northwest-1.
+	// +optional
+	Region string `json:"region,omitempty"`
 }
 
 // ManageDNSGCPConfig contains GCP-specific info to manage a given domain.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -140,6 +140,15 @@ const (
 
 	// PasswordSecretKey is a key used to store a password inside of a secret containing username / password credentials
 	PasswordSecretKey = "password"
+
+	// AWSRoute53Region is the region to use for route53 operations.
+	AWSRoute53Region = "us-east-1"
+
+	// AWSChinaRoute53Region is the region to use for AWS China route53 operations.
+	AWSChinaRoute53Region = "cn-northwest-1"
+
+	// AWSChinaRegionPrefix is the prefix for regions in AWS China.
+	AWSChinaRegionPrefix = "cn-"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -1359,9 +1360,14 @@ func (r *ReconcileClusterDeployment) createManagedDNSZone(cd *hivev1.ClusterDepl
 		for k, v := range cd.Spec.Platform.AWS.UserTags {
 			additionalTags = append(additionalTags, hivev1.AWSResourceTag{Key: k, Value: v})
 		}
+		region := ""
+		if strings.HasPrefix(cd.Spec.Platform.AWS.Region, constants.AWSChinaRegionPrefix) {
+			region = constants.AWSChinaRoute53Region
+		}
 		dnsZone.Spec.AWS = &hivev1.AWSDNSZoneSpec{
 			CredentialsSecretRef: cd.Spec.Platform.AWS.CredentialsSecretRef,
 			AdditionalTags:       additionalTags,
+			Region:               region,
 		}
 	case cd.Spec.Platform.GCP != nil:
 		dnsZone.Spec.GCP = &hivev1.GCPDNSZoneSpec{

--- a/pkg/controller/dnsendpoint/dnsendpoint_controller.go
+++ b/pkg/controller/dnsendpoint/dnsendpoint_controller.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/controller/dnsendpoint/nameserver"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
@@ -277,7 +278,11 @@ func createNameServerQuery(c client.Client, logger log.FieldLogger, managedDomai
 	if managedDomain.AWS != nil {
 		secretName := managedDomain.AWS.CredentialsSecretRef.Name
 		logger.Infof("using aws creds for managed domains stored in %q secret", secretName)
-		return nameserver.NewAWSQuery(c, secretName)
+		region := managedDomain.AWS.Region
+		if region == "" {
+			region = constants.AWSRoute53Region
+		}
+		return nameserver.NewAWSQuery(c, secretName, region)
 	}
 	if managedDomain.GCP != nil {
 		secretName := managedDomain.GCP.CredentialsSecretRef.Name

--- a/pkg/controller/dnsendpoint/nameserver/aws.go
+++ b/pkg/controller/dnsendpoint/nameserver/aws.go
@@ -17,10 +17,10 @@ import (
 )
 
 // NewAWSQuery creates a new name server query for AWS.
-func NewAWSQuery(c client.Client, credsSecretName string) Query {
+func NewAWSQuery(c client.Client, credsSecretName string, region string) Query {
 	return &awsQuery{
 		getAWSClient: func() (awsclient.Client, error) {
-			awsClient, err := awsclient.NewClient(c, credsSecretName, constants.HiveNamespace, "us-east-1")
+			awsClient, err := awsclient.NewClient(c, credsSecretName, constants.HiveNamespace, region)
 			return awsClient, errors.Wrap(err, "error creating AWS client")
 		},
 	}

--- a/pkg/controller/dnszone/awsactuator.go
+++ b/pkg/controller/dnszone/awsactuator.go
@@ -17,11 +17,11 @@ import (
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	awsclient "github.com/openshift/hive/pkg/awsclient"
+	"github.com/openshift/hive/pkg/constants"
 )
 
 const (
-	hiveDNSZoneAWSTag     = "hive.openshift.io/dnszone"
-	defaultRegionEndpoint = "us-east-1"
+	hiveDNSZoneAWSTag = "hive.openshift.io/dnszone"
 )
 
 // Ensure AWSActuator implements the Actuator interface. This will fail at compile time when false.
@@ -54,9 +54,11 @@ func NewAWSActuator(
 	dnsZone *hivev1.DNSZone,
 	awsClientBuilder awsClientBuilderType,
 ) (*AWSActuator, error) {
-	// Route53 is a regionless service, we specify a default region just for the purpose of creating
-	// our client configuration.
-	awsClient, err := awsClientBuilder(secret, defaultRegionEndpoint)
+	region := dnsZone.Spec.AWS.Region
+	if region == "" {
+		region = constants.AWSRoute53Region
+	}
+	awsClient, err := awsClientBuilder(secret, region)
 	if err != nil {
 		logger.WithError(err).Error("Error creating AWSClient")
 		return nil, err

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -2853,6 +2853,10 @@ spec:
                   description: CredentialsSecretRef contains a reference to a secret
                     that contains AWS credentials for CRUD operations
                   type: object
+                region:
+                  description: Region is the AWS region to use for route53 operations.
+                    This defaults to us-east-1. For AWS China, use cn-northwest-1.
+                  type: string
               type: object
             gcp:
               description: GCP specifies GCP-specific cloud configuration
@@ -3077,6 +3081,10 @@ spec:
                           parent ManageDNSConfig object. Secret should have AWS keys
                           named 'aws_access_key_id' and 'aws_secret_access_key'.
                         type: object
+                      region:
+                        description: Region is the AWS region to use for route53 operations.
+                          This defaults to us-east-1. For AWS China, use cn-northwest-1.
+                        type: string
                     type: object
                   domains:
                     description: Domains is the list of domains that hive will be


### PR DESCRIPTION
Use a custom endpoint for route53 when the region is a "cn-" region.

A region field has been added to .spec.managedDomains[].aws in HiveConfig. When the managed domain is handled by AWS China, the region field should be set to "cn-northwest-1" so that the route53 requests are sent to AWS China instead of regular AWS.

https://issues.redhat.com/browse/CO-769