### PR TITLE
migration: make speed improvements

### DIFF
--- a/contrib/pkg/v1migration/deleteobjects.go
+++ b/contrib/pkg/v1migration/deleteobjects.go
@@ -3,10 +3,10 @@ package v1migration
 import (
 	"bufio"
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
-	"reflect"
+	"runtime"
+	"sync"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -14,7 +14,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/utils/pointer"
 
@@ -25,7 +24,6 @@ import (
 // DeleteObjectsOptions is the set of options for the deleting Hive objects.
 type DeleteObjectsOptions struct {
 	fileName string
-	dryRun   bool
 }
 
 // NewDeleteObjectsCommand creates a command that executes the migration utility to delete Hive objects stored in a file.
@@ -50,8 +48,6 @@ func NewDeleteObjectsCommand() *cobra.Command {
 			}
 		},
 	}
-	flags := cmd.Flags()
-	flags.BoolVar(&opt.dryRun, "dry-run", false, "Whether this is a dry run")
 	return cmd
 }
 
@@ -81,6 +77,13 @@ func (o *DeleteObjectsOptions) Run() error {
 		errors.Wrap(err, "could not open the JSON file")
 	}
 	defer file.Close()
+	logger := log.StandardLogger()
+	objChan := make(chan *unstructured.Unstructured)
+	var deleteWG sync.WaitGroup
+	for i := 0; i < runtime.NumCPU(); i++ {
+		deleteWG.Add(1)
+		go deleteObjects(client, objChan, &deleteWG, logger)
+	}
 	decoder := json.NewDecoder(bufio.NewReader(file))
 	for {
 		var objFromFile unstructured.Unstructured
@@ -90,68 +93,55 @@ func (o *DeleteObjectsOptions) Run() error {
 			}
 			return errors.Wrap(err, "could not decode JSON from file")
 		}
-		o.deleteObject(client, &objFromFile)
+		objChan <- &objFromFile
 	}
+	close(objChan)
+	deleteWG.Wait()
 	return nil
 }
 
-func (o *DeleteObjectsOptions) deleteObject(client dynamic.Interface, objFromFile *unstructured.Unstructured) {
-	apiVersion := objFromFile.GetAPIVersion()
-	kind := objFromFile.GetKind()
-	namespace := objFromFile.GetNamespace()
-	name := objFromFile.GetName()
-	logger := log.WithFields(log.Fields{
-		"apiVersion": apiVersion,
-		"kind":       kind,
-		"name":       name,
-	})
-	if namespace != "" {
-		logger = logger.WithField("namespace", namespace)
-	}
-	if apiVersion != hivev1alpha1.SchemeGroupVersion.String() {
-		logger.Warn("object in JSON file is not a Hive v1alpha1 resource")
-		return
-	}
-	gvr := hivev1alpha1.SchemeGroupVersion.WithResource(resourceForHiveKind(kind))
-	var resourceClient dynamic.ResourceInterface
-	if namespace != "" {
-		resourceClient = client.Resource(gvr).Namespace(namespace)
-	} else {
-		resourceClient = client.Resource(gvr)
-	}
-	objFromKube, err := resourceClient.Get(name, metav1.GetOptions{})
-	switch {
-	case apierrors.IsNotFound(err):
-		logger.Warn("object not found")
-		return
-	case err != nil:
-		logger.WithError(err).Error("failed to get object")
-		return
-	}
+func deleteObjects(client dynamic.Interface, objChan chan *unstructured.Unstructured, wg *sync.WaitGroup, logger log.FieldLogger) {
+	defer wg.Done()
+	for objFromFile := range objChan {
+		apiVersion := objFromFile.GetAPIVersion()
+		kind := objFromFile.GetKind()
+		namespace := objFromFile.GetNamespace()
+		name := objFromFile.GetName()
+		logger := logger.WithFields(log.Fields{
+			"apiVersion": apiVersion,
+			"kind":       kind,
+			"name":       name,
+		})
+		if namespace != "" {
+			logger = logger.WithField("namespace", namespace)
+		}
+		if apiVersion != hivev1alpha1.SchemeGroupVersion.String() {
+			logger.Warn("object in JSON file is not a Hive v1alpha1 resource")
+			continue
+		}
+		gvr := hivev1alpha1.SchemeGroupVersion.WithResource(resourceForHiveKind(kind))
+		var resourceClient dynamic.ResourceInterface
+		if namespace != "" {
+			resourceClient = client.Resource(gvr).Namespace(namespace)
+		} else {
+			resourceClient = client.Resource(gvr)
+		}
+		objFromKube, err := resourceClient.Get(name, metav1.GetOptions{})
+		switch {
+		case apierrors.IsNotFound(err):
+			logger.Warn("object not found")
+			continue
+		case err != nil:
+			logger.WithError(err).Error("failed to get object")
+			continue
+		}
 
-	// Ignore owner refs and resource version when looking for diffs as some Hive objects may have been orphaned.
-	// TODO: Check changes to owner refs to ensure that the only changes are removals of references to Hive objects.
-	objFromFile.SetOwnerReferences(objFromKube.GetOwnerReferences())
-	objFromFile.SetResourceVersion(objFromKube.GetResourceVersion())
-
-	// For cluster-scoped resources, set the namespace to the empty string so that the deep equal check does not pick
-	// up a difference in the namespace. Setting to an empty string will delete the .metadata.namespace entry from the
-	// unstructured data.
-	if namespace == "" {
-		objFromFile.SetNamespace("")
-	}
-
-	if !reflect.DeepEqual(objFromFile, objFromKube) {
-		logger.Warn("object in JSON file differs from object in the cluster")
-		fmt.Printf("Diff in %s/%s (%s)\n%s\n", kind, name, namespace, diff.ObjectReflectDiff(objFromFile, objFromKube))
-	}
-	if !o.dryRun {
 		if finalizersFromKube := objFromKube.GetFinalizers(); len(finalizersFromKube) > 0 {
 			objFromKube.SetFinalizers(nil)
 			objFromKube, err = resourceClient.Update(objFromKube, metav1.UpdateOptions{})
 			if err != nil {
 				logger.WithError(err).Error("could not remove finalizers")
-				return
+				continue
 			}
 		}
 		uid := objFromKube.GetUID()
@@ -165,7 +155,7 @@ func (o *DeleteObjectsOptions) deleteObject(client dynamic.Interface, objFromFil
 		}
 		if err := resourceClient.Delete(name, deleteOptions); err != nil {
 			logger.WithError(err).Error("could not delete object")
-			return
+			continue
 		}
 		logger.Info("deleted object")
 	}

--- a/contrib/pkg/v1migration/discoverowned.go
+++ b/contrib/pkg/v1migration/discoverowned.go
@@ -1,0 +1,104 @@
+package v1migration
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+
+	contributils "github.com/openshift/hive/contrib/pkg/utils"
+	hivev1alpha1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
+)
+
+// DiscoverOwnedOptions is the set of options for discovering resources with owner references to Hive resources.
+type DiscoverOwnedOptions struct {
+}
+
+// NewDiscoverOwnedCommand creates a command that executes the migration utility to discover resources with owner
+// references to Hive resources.
+func NewDiscoverOwnedCommand() *cobra.Command {
+	opt := &DiscoverOwnedOptions{}
+	cmd := &cobra.Command{
+		Use:   "discover-owned",
+		Short: "discover the resource with owner references to Hive resources",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := opt.Run(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+		},
+	}
+	return cmd
+}
+
+// Run executes the command
+func (o *DiscoverOwnedOptions) Run() error {
+	clientConfig, err := contributils.GetClientConfig()
+	if err != nil {
+		return errors.Wrap(err, "could not get the client config")
+	}
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(clientConfig)
+	if err != nil {
+		return errors.Wrap(err, "could not create a discovery client")
+	}
+	resources, err := discoveryClient.ServerPreferredResources()
+	if err != nil {
+		return errors.Wrap(err, "could not discover the server resources")
+	}
+	client, err := dynamic.NewForConfig(clientConfig)
+	if err != nil {
+		return errors.Wrap(err, "could not create kube client")
+	}
+	var errs []error
+	for _, resourceList := range resources {
+		for _, r := range resourceList.APIResources {
+			if !canList(r) {
+				continue
+			}
+			gv, err := schema.ParseGroupVersion(resourceList.GroupVersion)
+			if err != nil {
+				errs = append(errs, errors.Wrapf(err, "could not parse group version %q\n", resourceList.GroupVersion))
+				continue
+			}
+			gvr := gv.WithResource(r.Name)
+			objs, err := client.Resource(gvr).List(metav1.ListOptions{})
+			if err != nil {
+				errs = append(errs, errors.Wrapf(err, "could not list resources %q\n", resourceList.GroupVersion))
+				continue
+			}
+			for _, obj := range objs.Items {
+				if isOwnedByHiveResource(&obj) {
+					fmt.Println(gvr)
+					break
+				}
+			}
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+func isOwnedByHiveResource(obj *unstructured.Unstructured) bool {
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.APIVersion == hivev1alpha1.SchemeGroupVersion.String() {
+			return true
+		}
+	}
+	return false
+}
+
+func canList(r metav1.APIResource) bool {
+	for _, v := range r.Verbs {
+		if v == "list" {
+			return true
+		}
+	}
+	return false
+}

--- a/contrib/pkg/v1migration/ref.go
+++ b/contrib/pkg/v1migration/ref.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	ownerRefsFilename = "owner-refs.yaml"
+	ownerRefsFilename = "owner-refs.json"
 )
 
 type ownerRef struct {

--- a/contrib/pkg/v1migration/restoreownerrefs.go
+++ b/contrib/pkg/v1migration/restoreownerrefs.go
@@ -1,7 +1,10 @@
 package v1migration
 
 import (
-	"io/ioutil"
+	"bufio"
+	"encoding/json"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -13,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-	"sigs.k8s.io/yaml"
 
 	contributils "github.com/openshift/hive/contrib/pkg/utils"
 	hivev1alpha1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
@@ -71,15 +73,20 @@ func (o *RestoreOwnerRefsOptions) Run() error {
 	if err != nil {
 		return errors.Wrap(err, "could not create kube client")
 	}
-	ownerRefsData, err := ioutil.ReadFile(filepath.Join(o.workDir, ownerRefsFilename))
+	file, err := os.Open(filepath.Join(o.workDir, ownerRefsFilename))
 	if err != nil {
-		return errors.Wrap(err, "could not read owner refs file")
+		return errors.Wrap(err, "could not open owner refs file")
 	}
-	var refs []ownerRef
-	if err := yaml.Unmarshal(ownerRefsData, &refs); err != nil {
-		return errors.Wrap(err, "could not unmarshal owner refs")
-	}
-	for _, ref := range refs {
+	defer file.Close()
+	decoder := json.NewDecoder(bufio.NewReader(file))
+	for {
+		var ref ownerRef
+		if err := decoder.Decode(&ref); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return errors.Wrap(err, "could not decode JSON from file")
+		}
 		logger := log.WithField("resource", ref.Resource).WithField("name", ref.Name)
 		if ref.Namespace != "" {
 			logger = logger.WithField("namespace", ref.Namespace)

--- a/contrib/pkg/v1migration/saveownerrefs.go
+++ b/contrib/pkg/v1migration/saveownerrefs.go
@@ -1,19 +1,24 @@
 package v1migration
 
 import (
-	"io/ioutil"
+	"bufio"
+	"encoding/json"
+	"os"
 	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
-	"sigs.k8s.io/yaml"
 
 	contributils "github.com/openshift/hive/contrib/pkg/utils"
 	hivev1alpha1 "github.com/openshift/hive/pkg/apis/hive/v1alpha1"
@@ -21,9 +26,25 @@ import (
 	"github.com/openshift/hive/pkg/imageset"
 )
 
+// fill this out with the resources discovered using the following command:
+//    hiveutil v1migration discover-owned
+var defaultResources = []schema.GroupVersionResource{
+	hivev1alpha1.SchemeGroupVersion.WithResource("clusterdeprovisionrequests"),
+	hivev1alpha1.SchemeGroupVersion.WithResource("clusterprovisions"),
+	hivev1alpha1.SchemeGroupVersion.WithResource("clusterstates"),
+	hivev1alpha1.SchemeGroupVersion.WithResource("dnszones"),
+	hivev1alpha1.SchemeGroupVersion.WithResource("syncidentityproviders"),
+	hivev1alpha1.SchemeGroupVersion.WithResource("syncsetinstances"),
+	hivev1alpha1.SchemeGroupVersion.WithResource("syncsets"),
+	corev1.SchemeGroupVersion.WithResource("secrets"),
+	corev1.SchemeGroupVersion.WithResource("persistentvolumeclaims"),
+	batchv1.SchemeGroupVersion.WithResource("jobs"),
+}
+
 // SaveOwnerRefsOptions is the set of options for the saving owner references.
 type SaveOwnerRefsOptions struct {
-	workDir string
+	workDir       string
+	resourcesFile string
 }
 
 // NewSaveOwnerRefsCommand creates a command that executes the migration utility to save owner references to Hive resources.
@@ -50,6 +71,7 @@ func NewSaveOwnerRefsCommand() *cobra.Command {
 	}
 	flags := cmd.Flags()
 	flags.StringVar(&opt.workDir, "work-dir", ".", "Directory in which store owner references file")
+	flags.StringVar(&opt.resourcesFile, "resources", "", "File containing the resources to look at for owner references")
 	return cmd
 }
 
@@ -65,142 +87,139 @@ func (o *SaveOwnerRefsOptions) Validate(cmd *cobra.Command) error {
 
 // Run executes the command
 func (o *SaveOwnerRefsOptions) Run() error {
+	resources, err := resourcesToSearch(o.resourcesFile)
+	if err != nil {
+		return errors.Wrap(err, "could not determine the resources to search")
+	}
 	clientConfig, err := contributils.GetClientConfig()
 	if err != nil {
 		return errors.Wrap(err, "could not get the client config")
-	}
-	discoveryClient, err := discovery.NewDiscoveryClientForConfig(clientConfig)
-	if err != nil {
-		return errors.Wrap(err, "could create a discovery client")
-	}
-	resources, err := discoveryClient.ServerPreferredResources()
-	if err != nil {
-		return errors.Wrap(err, "could not discover the server resources")
 	}
 	client, err := dynamic.NewForConfig(clientConfig)
 	if err != nil {
 		return errors.Wrap(err, "could not create kube client")
 	}
-	namespacesWithHiveResources, err := findNamespacesWithHiveResources(discoveryClient, client)
-	if err != nil {
-		return err
+	logger := log.StandardLogger()
+	objChan := make(chan objToProcess)
+	ownerRefChan := make(chan ownerRef)
+	var processWG sync.WaitGroup
+	for i := 0; i < runtime.NumCPU(); i++ {
+		processWG.Add(1)
+		go processObjects(objChan, ownerRefChan, &processWG, logger)
 	}
-	var refs []ownerRef
-	for _, resourceList := range resources {
-		for _, r := range resourceList.APIResources {
-			logger := log.WithField("resource", r.Name)
-			if !canList(r) {
-				logger.Debug("skipping resource since it cannot be listed")
-				continue
-			}
-			logger.Debugf("checking resource")
-			gv, err := schema.ParseGroupVersion(resourceList.GroupVersion)
-			if err != nil {
-				return errors.Wrapf(err, "could not parse group version %q\n", resourceList.GroupVersion)
-			}
-			gvr := gv.WithResource(r.Name)
-			if r.Namespaced {
-				for _, ns := range namespacesWithHiveResources.List() {
-					refs = addReferencesFromResource(refs, client.Resource(gvr).Namespace(ns), gvr, logger.WithField("namespace", ns))
-				}
-			} else {
-				refs = addReferencesFromResource(refs, client.Resource(gvr), gvr, logger)
+	var writeWG sync.WaitGroup
+	writeWG.Add(1)
+	go writeOwnerRefsToFile(filepath.Join(o.workDir, ownerRefsFilename), ownerRefChan, &writeWG, logger)
+	for _, r := range resources {
+		objs, err := client.Resource(r).List(metav1.ListOptions{})
+		if err != nil {
+			logger.WithError(err).WithField("resource", r).Fatal("could not list resource")
+		}
+		for i := range objs.Items {
+			objChan <- objToProcess{
+				gvr: r,
+				obj: &objs.Items[i],
 			}
 		}
 	}
-	refsData, err := yaml.Marshal(refs)
-	if err != nil {
-		return errors.Wrap(err, "could not marshal the owner references")
-	}
-	if err := ioutil.WriteFile(filepath.Join(o.workDir, ownerRefsFilename), refsData, 0666); err != nil {
-		return errors.Wrap(err, "could not write owner references file")
-	}
+	close(objChan)
+	processWG.Wait()
+	close(ownerRefChan)
+	writeWG.Wait()
 	return nil
 }
 
-func findNamespacesWithHiveResources(discoveryClient *discovery.DiscoveryClient, client dynamic.Interface) (sets.String, error) {
-	hiveResources, err := discoveryClient.ServerResourcesForGroupVersion(hivev1alpha1.SchemeGroupVersion.String())
-	if err != nil {
-		return nil, errors.Wrap(err, "could not discovery the Hive resources")
-	}
-	namespacesWithHiveResources := sets.NewString()
-	for _, r := range hiveResources.APIResources {
-		if !r.Namespaced {
-			continue
-		}
-		if !canList(r) {
-			continue
-		}
-		objs, err := client.Resource(hivev1alpha1.SchemeGroupVersion.WithResource(r.Name)).List(metav1.ListOptions{})
-		if err != nil {
-			return nil, errors.Wrapf(err, "could not list %s", r.Name)
-		}
-		for _, o := range objs.Items {
-			namespacesWithHiveResources.Insert(o.GetNamespace())
-		}
-	}
-	log.Info("Namespaces with Hive resources")
-	for _, n := range namespacesWithHiveResources.List() {
-		log.Infof("  %s", n)
-	}
-	return namespacesWithHiveResources, nil
+type objToProcess struct {
+	gvr schema.GroupVersionResource
+	obj *unstructured.Unstructured
 }
 
-func addReferencesFromResource(refs []ownerRef, resourceClient dynamic.ResourceInterface, gvr schema.GroupVersionResource, logger log.FieldLogger) []ownerRef {
-	objs, err := resourceClient.List(metav1.ListOptions{})
-	if err != nil {
-		logger.WithError(err).Warn("could not list resource")
-		return refs
-	}
-	for _, obj := range objs.Items {
-		refs = addReferencesFromObject(refs, gvr, obj, logger)
-	}
-	return refs
-}
-
-func addReferencesFromObject(refs []ownerRef, gvr schema.GroupVersionResource, obj unstructured.Unstructured, logger log.FieldLogger) []ownerRef {
-	if isInstallOrImagesetJob(gvr, obj) {
-		logger.Debug("ignoring install or imageset job")
-		return refs
-	}
-	for _, ref := range obj.GetOwnerReferences() {
-		if ref.APIVersion != hivev1alpha1.SchemeGroupVersion.String() {
+func processObjects(objChan chan objToProcess, ownerRefChan chan ownerRef, wg *sync.WaitGroup, logger log.FieldLogger) {
+	defer wg.Done()
+	for obj := range objChan {
+		if isInstallOrImagesetJob(&obj) {
+			logger.Debug("ignoring install or imageset job")
 			continue
 		}
-		logger = logger.WithField("name", obj.GetName()).
-			WithField("referencedKind", ref.Kind).
-			WithField("referencedName", ref.Name)
-		if ns := obj.GetNamespace(); ns == "" {
-			logger = logger.WithField("namespace", ns)
-		}
-		logger.Info("found reference to Hive resource")
-		refs = append(refs,
-			ownerRef{
-				Group:     gvr.Group,
-				Version:   gvr.Version,
-				Resource:  gvr.Resource,
-				Namespace: obj.GetNamespace(),
-				Name:      obj.GetName(),
+		for _, ref := range obj.obj.GetOwnerReferences() {
+			if ref.APIVersion != hivev1alpha1.SchemeGroupVersion.String() {
+				continue
+			}
+			logger = logger.WithField("resource", obj.gvr.Resource).
+				WithField("name", obj.obj.GetName()).
+				WithField("ownerKind", ref.Kind).
+				WithField("ownerName", ref.Name)
+			if ns := obj.obj.GetNamespace(); ns != "" {
+				logger = logger.WithField("namespace", ns)
+			}
+			logger.Info("found reference to Hive resource")
+			ownerRefChan <- ownerRef{
+				Group:     obj.gvr.Group,
+				Version:   obj.gvr.Version,
+				Resource:  obj.gvr.Resource,
+				Namespace: obj.obj.GetNamespace(),
+				Name:      obj.obj.GetName(),
 				Ref:       ref,
-			})
-	}
-	return refs
-}
-
-func canList(r metav1.APIResource) bool {
-	for _, v := range r.Verbs {
-		if v == "list" {
-			return true
+			}
 		}
 	}
-	return false
 }
 
-func isInstallOrImagesetJob(gvr schema.GroupVersionResource, obj unstructured.Unstructured) bool {
-	if gvr.Group != "batch" || gvr.Version != "v1" || gvr.Resource != "jobs" {
+func writeOwnerRefsToFile(filename string, ownerRefChan chan ownerRef, wg *sync.WaitGroup, logger log.FieldLogger) {
+	defer wg.Done()
+	file, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE, 0666)
+	if err != nil {
+		logger.WithError(err).WithField("filename", filename).Fatal("could not create file")
+	}
+	defer file.Close()
+	writer := bufio.NewWriter(file)
+	defer writer.Flush()
+	encoder := json.NewEncoder(writer)
+	encoder.SetIndent("", "  ")
+	for ownerRef := range ownerRefChan {
+		if err := encoder.Encode(ownerRef); err != nil {
+			logger.WithError(err).Fatal("could not marshal owner ref")
+		}
+	}
+}
+
+func isInstallOrImagesetJob(obj *objToProcess) bool {
+	if obj.gvr.Group != batchv1.GroupName || obj.gvr.Resource != "jobs" {
 		return false
 	}
-	labels := obj.GetLabels()
+	labels := obj.obj.GetLabels()
 	return labels[constants.InstallJobLabel] == "true" ||
 		labels[imageset.ImagesetJobLabel] == "true"
+}
+
+func resourcesToSearch(filename string) ([]schema.GroupVersionResource, error) {
+	if filename == "" {
+		return defaultResources, nil
+	}
+	var resources []schema.GroupVersionResource
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not read the resources file")
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	lineNumber := 1
+	lineExp := regexp.MustCompile("^\\s*([^\\/]*)\\/([^\\/]*),\\s*Resource=([^\\s]*)$")
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		submatches := lineExp.FindStringSubmatch(line)
+		if submatches == nil {
+			return nil, errors.Errorf("bad line (%d) in resources file: %s", lineNumber, line)
+		}
+		resources = append(resources, schema.GroupVersionResource{
+			Group:    submatches[1],
+			Version:  submatches[2],
+			Resource: submatches[3],
+		})
+		lineNumber++
+	}
+	return resources, nil
 }

--- a/contrib/pkg/v1migration/v1migration.go
+++ b/contrib/pkg/v1migration/v1migration.go
@@ -20,6 +20,7 @@ func NewV1MigrationCommand() *cobra.Command {
 	cmd.AddCommand(NewRestoreOwnerRefsCommand())
 	cmd.AddCommand(NewDeleteObjectsCommand())
 	cmd.AddCommand(NewRecreateObjectsCommand())
+	cmd.AddCommand(NewDiscoverOwnedCommand())
 	return cmd
 }
 

--- a/hack/v1migration/README.md
+++ b/hack/v1migration/README.md
@@ -4,8 +4,10 @@
   1. Create a cluster deployment and wait for completion.
   1. Run `oc patch hiveconfig hive --type='merge' -p $'spec:\n maintenanceMode: true'`
   1. Run `./hack/v1migration/scaledown.sh hive-operator` to scale down Hive operator.
+  1. Run `./hack/v1migration/delete_hive_jobs.sh` to delete any outstanding Hive jobs (imageset, install, uninstall).
+  1. Run `./hack/v1migration/save.sh [workdir]` to backup all data to disk.
   1. Run `./hack/v1migration/remove_hiveadmission.sh` to remove the Hive validation webhooks.
-  1. Run `./hack/v1migration/delete.sh [workdir]` to backup all data to disk and remove Hive resources (CRs, CRDs, and admission webhooks).
+  1. Run `./hack/v1migration/delete.sh [workdir]` to remove Hive resources (CRs and CRDs).
   1. Deploy Hive v1.
   1. If running on a cluster that does not support cert injection, run `./hack/hiveapi-dev-certs.sh` to create the certs for the Hive aggregated API server.
   1. Run `./hack/v1migration/deploy_apiserver.sh` to enabled the Hive aggregated API server.

--- a/hack/v1migration/delete.sh
+++ b/hack/v1migration/delete.sh
@@ -1,62 +1,20 @@
 #!/bin/bash
 
+set -e
+
 WORKDIR=${1:?must specify working directory}
 echo "Using workdir: $WORKDIR"
 
-case "${2}" in
-"--dry-run" )
-  dry_run="--dry-run"
-  ;;
-"" )
-  # When doing a dry run, allow the script to continue after errors. Operations such as deleting a CRD are likely
-  # to fail since the CRs are not being deleted in a dry run.
-  set -e
-  ;;
-* )
-  echo "Only valid flag is \"--dry-run\""
+# shellcheck source=verify_scaledown.sh
+source "$(dirname "$0")/verify_scaledown.sh"
+verify_all_scaled_down
+
+echo "WARNING: this script will delete all Hive custom resources and their definitions"
+echo "It should only be used during migrations to the v1 API."
+read -r -p "Do you wish to proceed? [y/N] " response
+if [[ ! "$response" =~ ^([yY]([eE][sS])?)$ ]]
+then
   exit 1
-esac
-
-if [[ -z $dry_run ]]
-then
-  # shellcheck source=verify_scaledown.sh
-  source "$(dirname "$0")/verify_scaledown.sh"
-  verify_all_scaled_down
-fi
-
-mkdir -p "$WORKDIR"
-
-if [[ -z $dry_run && \
-      "$(ls "$WORKDIR" 2>/dev/null)" ]]
-then
-  echo "WARNING: workdir ($WORKDIR) is not empty."
-  echo "Files in workdir may be overwritten."
-  read -r -p "Do you wish to proceed? [y/N] " response
-  if [[ ! "$response" =~ ^([yY]([eE][sS])?)$ ]]
-  then
-    exit 1
-  fi
-fi
-
-HIVE_TYPES=( checkpoints clusterdeployments clusterdeprovisionrequests clusterimagesets clusterprovisions clusterstates dnsendpoints dnszones hiveconfigs selectorsyncidentityproviders selectorsyncsets syncidentityproviders syncsetinstances syncsets )
-
-for t in "${HIVE_TYPES[@]}"
-do
-	echo "Storing all ${t} in ${WORKDIR}/${t}.json"
-	oc get "${t}.hive.openshift.io" --all-namespaces -o json | jq .items[] > "${WORKDIR}/${t}.json"
-done
-
-bin/hiveutil v1migration save-owner-refs --work-dir "${WORKDIR}"
-
-if [[ -z $dry_run ]]
-then
-  echo "WARNING: this script will delete all Hive custom resources and their definitions"
-  echo "It should only be used during migrations to the v1 API."
-  read -r -p "Do you wish to proceed? [y/N] " response
-  if [[ ! "$response" =~ ^([yY]([eE][sS])?)$ ]]
-  then
-    exit 1
-  fi
 fi
 
 delete_jobs() {
@@ -68,40 +26,31 @@ delete_jobs() {
 }
 
 echo "Deleting install jobs"
-if [[ -z $dry_run ]]
-then
-  delete_jobs "hive.openshift.io/install=true"
-fi
+delete_jobs "hive.openshift.io/install=true"
 
 echo "Deleting imageset jobs"
-if [[ -z $dry_run ]]
-then
-  delete_jobs "hive.openshift.io/imageset=true"
-fi
+delete_jobs "hive.openshift.io/imageset=true"
+
+# shellcheck source=hivetypes.sh
+source "$(dirname "$0")/hivetypes.sh"
 
 for t in "${HIVE_TYPES[@]}"
 do
   echo "Deleting ${t} objects"
-  bin/hiveutil v1migration delete-objects "${WORKDIR}/${t}.json" $dry_run
+  bin/hiveutil v1migration delete-objects "${WORKDIR}/${t}.json"
 
-  if [[ -z $dry_run ]]
-  then
-    for i in 1 2 3 4 5
-    do
-      if [[ "$(oc get "${t}.hive.openshift.io" --all-namespaces -o name | wc -l)" -eq 0 ]]; then break; fi
-      if (( i == 5 ))
-      then
-        echo "There are still remaining ${t}"
-        exit 1
-      fi
-      echo "Waiting for delete of ${t} to complete..."
-      sleep 1
-    done
-  fi
+  for i in 1 2 3 4 5
+  do
+    if [[ "$(oc get "${t}.hive.openshift.io" --all-namespaces -o name | wc -l)" -eq 0 ]]; then break; fi
+    if (( i == 5 ))
+    then
+      echo "There are still remaining ${t}"
+      exit 1
+    fi
+    echo "Waiting for delete of ${t} to complete..."
+    sleep 1
+  done
 
 	echo "Deleting ${t}.hive.openshift.io CRD"
-	if [[ -z $dry_run ]]
-	then
-	  oc delete "customresourcedefinition.apiextensions.k8s.io/${t}.hive.openshift.io" $dry_run
-	fi
+  oc delete "customresourcedefinition.apiextensions.k8s.io/${t}.hive.openshift.io"
 done

--- a/hack/v1migration/delete_hive_jobs.sh
+++ b/hack/v1migration/delete_hive_jobs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+# shellcheck source=verify_scaledown.sh
+source "$(dirname "$0")/verify_scaledown.sh"
+verify_all_scaled_down
+
+delete_jobs() {
+  local labels=${1:?must specify a label for the jobs to delete}
+  oc get jobs -l "${labels}" --all-namespaces -o json | \
+    jq -r '.items[]?.metadata.namespace' | \
+    sort -u | \
+    xargs -i oc delete jobs -n {} -l "${labels}"
+}
+
+echo "Deleting install jobs"
+delete_jobs "hive.openshift.io/install=true"
+
+echo "Deleting imageset jobs"
+delete_jobs "hive.openshift.io/imageset=true"
+
+echo "Deleting uninstall jobs"
+delete_jobs "hive.openshift.io/uninstall=true"

--- a/hack/v1migration/hivetypes.sh
+++ b/hack/v1migration/hivetypes.sh
@@ -1,0 +1,1 @@
+HIVE_TYPES=( checkpoints clusterdeployments clusterdeprovisionrequests clusterimagesets clusterprovisions clusterstates dnsendpoints dnszones hiveconfigs selectorsyncidentityproviders selectorsyncsets syncidentityproviders syncsetinstances syncsets )

--- a/hack/v1migration/restore.sh
+++ b/hack/v1migration/restore.sh
@@ -24,6 +24,7 @@ find "${WORKDIR}" -maxdepth 1 -type f \
   -name "*.json" \
   -not -name "hiveconfigs.json" \
   -not -name "dnsendpoints.json" \
+  -not -name "owner-refs.json" \
   -not -empty \
   -exec bin/hiveutil v1migration recreate-objects {} \;
 

--- a/hack/v1migration/save.sh
+++ b/hack/v1migration/save.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+
+WORKDIR=${1:?must specify working directory}
+echo "Using workdir: $WORKDIR"
+
+if [[ -z $NO_SCALEDOWN_VERIFY ]]
+then
+  # shellcheck source=verify_scaledown.sh
+  source "$(dirname "$0")/verify_scaledown.sh"
+  verify_all_scaled_down
+fi
+
+mkdir -p "$WORKDIR"
+
+if [[ "$(ls "$WORKDIR" 2>/dev/null)" ]]
+then
+  echo "WARNING: workdir ($WORKDIR) is not empty."
+  echo "Files in workdir may be overwritten."
+  read -r -p "Do you wish to proceed? [y/N] " response
+  if [[ ! "$response" =~ ^([yY]([eE][sS])?)$ ]]
+  then
+    exit 1
+  fi
+fi
+
+# shellcheck source=hivetypes.sh
+source "$(dirname "$0")/hivetypes.sh"
+
+for t in "${HIVE_TYPES[@]}"
+do
+	echo "Storing all ${t} in ${WORKDIR}/${t}.json"
+	oc get "${t}.hive.openshift.io" --all-namespaces -o json | jq .items[] > "${WORKDIR}/${t}.json"
+done
+
+bin/hiveutil v1migration save-owner-refs --work-dir "${WORKDIR}"


### PR DESCRIPTION
This PR covers the 3 areas that we discussed changing to improve the speed of migration.

1) When saving owner references, we should only look at resource types that are known to have owner references to Hive resources. The `hiveutil v1migration save-owner-refs` command now has a hard-coded list of resource types that will be searched for owner references. This list can be overriden by passing in a file containing the list of resource types. Additionally, there is a `hiveutil v1migration discover-owned` command that can be run to collect the resource types owned by Hive resources. This command can be run on the int, stage, and prod clusters to ascertain prior to migration day which resource types should be included.
2) We should make use of parallelization for long tasks. The processes of saving owner references, restoring owner references, deleting Hive resources, and recreating Hive resources have all been modified to use concurrent goroutines.
3) We cannot afford to spend time verifying that the resources that were saved to disk match the resources that are currently in the cluster. This check has been removed from the process of deleting Hive resources.