### PR TITLE
Set region label on Clusterdeployment CR

### DIFF
--- a/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -36,6 +36,12 @@ const (
 	// searching and filtering clusters, as well as in SelectorSyncSets to only
 	// target specific cloud platforms.
 	HiveClusterPlatformLabel = "hive.openshift.io/cluster-platform"
+
+	// HiveClusterRegionLabel is a label that is applied to ClusterDeployments
+	// to denote which region the cluster was created in. This can be used in
+	// searching and filtering clusters, as well as in SelectorSyncSets to only
+	// target specific regions of the cluster-platform.
+	HiveClusterRegionLabel = "hive.openshift.io/cluster-region"
 )
 
 // ClusterDeploymentSpec defines the desired state of ClusterDeployment

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -66,7 +66,7 @@ const (
 
 	platformAWS       = "aws"
 	platformAzure     = "azure"
-	platformGCP       = "hcp"
+	platformGCP       = "gcp"
 	platformBaremetal = "baremetal"
 	platformUnknown   = "unknown"
 	regionUnknown     = "unknown"

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -63,6 +63,13 @@ const (
 
 	deleteAfterAnnotation    = "hive.openshift.io/delete-after" // contains a duration after which the cluster should be cleaned up.
 	tryInstallOnceAnnotation = "hive.openshift.io/try-install-once"
+
+	platformAWS       = "aws"
+	platformAzure     = "azure"
+	platformGCP       = "GCP"
+	platformBaremetal = "baremetal"
+	platformUnknown   = "unknown platform"
+	regionUnknown     = "unknown region"
 )
 
 var (
@@ -340,6 +347,23 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 			cdLog.WithError(err).Log(controllerutils.LogLevel(err), "failed to set cluster platform label")
 		}
 		return reconcile.Result{}, err
+	}
+
+	// Set region label on the ClusterDeployment
+	if region := getClusterRegion(cd); cd.Spec.Platform.BareMetal == nil && cd.Labels[hivev1.HiveClusterRegionLabel] != region {
+		if cd.Labels == nil {
+			cd.Labels = make(map[string]string)
+		}
+		if cd.Labels[hivev1.HiveClusterRegionLabel] != "" {
+			cdLog.Warnf("changing the value of %s from %s to %s", hivev1.HiveClusterRegionLabel,
+				cd.Labels[hivev1.HiveClusterRegionLabel], region)
+		}
+		cd.Labels[hivev1.HiveClusterRegionLabel] = region
+		err := r.Update(context.TODO(), cd)
+		if err != nil {
+			cdLog.WithError(err).Log(controllerutils.LogLevel(err), "failed to set cluster region label")
+		}
+		return reconcile.Result{}, nil
 	}
 
 	if cd.DeletionTimestamp != nil {
@@ -1818,13 +1842,26 @@ func (r *ReconcileClusterDeployment) setSyncSetFailedCondition(cd *hivev1.Cluste
 func getClusterPlatform(cd *hivev1.ClusterDeployment) string {
 	switch {
 	case cd.Spec.Platform.AWS != nil:
-		return "aws"
+		return platformAWS
 	case cd.Spec.Platform.Azure != nil:
-		return "azure"
+		return platformAzure
 	case cd.Spec.Platform.GCP != nil:
-		return "gcp"
+		return platformGCP
 	case cd.Spec.Platform.BareMetal != nil:
-		return "baremetal"
+		return platformBaremetal
 	}
-	return "unknown"
+	return platformUnknown
+}
+
+// getClusterRegion returns the region of a given ClusterDeployment
+func getClusterRegion(cd *hivev1.ClusterDeployment) string {
+	switch {
+	case cd.Spec.Platform.AWS != nil:
+		return cd.Spec.Platform.AWS.Region
+	case cd.Spec.Platform.Azure != nil:
+		return cd.Spec.Platform.Azure.Region
+	case cd.Spec.Platform.GCP != nil:
+		return cd.Spec.Platform.GCP.Region
+	}
+	return regionUnknown
 }

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -66,10 +66,10 @@ const (
 
 	platformAWS       = "aws"
 	platformAzure     = "azure"
-	platformGCP       = "GCP"
+	platformGCP       = "hcp"
 	platformBaremetal = "baremetal"
-	platformUnknown   = "unknown platform"
-	regionUnknown     = "unknown region"
+	platformUnknown   = "unknown"
+	regionUnknown     = "unknown"
 )
 
 var (
@@ -363,7 +363,7 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 		if err != nil {
 			cdLog.WithError(err).Log(controllerutils.LogLevel(err), "failed to set cluster region label")
 		}
-		return reconcile.Result{}, nil
+		return reconcile.Result{}, err
 	}
 
 	if cd.DeletionTimestamp != nil {

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -1060,7 +1060,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 			validate: func(c client.Client, t *testing.T) {
 				cd := getCD(c)
 				if assert.NotNil(t, cd, "missing clusterdeployment") {
-					//					assert.Equal(t, getClusterRegion(cd), cd.Labels[hivev1.HiveClusterRegionLabel], "incorrect cluster region label")
+					assert.Equal(t, getClusterRegion(cd), cd.Labels[hivev1.HiveClusterRegionLabel], "incorrect cluster region label")
 					assert.Equal(t, getClusterRegion(cd), "us-east-1", "incorrect cluster region label")
 				}
 			},

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -1060,7 +1060,8 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 			validate: func(c client.Client, t *testing.T) {
 				cd := getCD(c)
 				if assert.NotNil(t, cd, "missing clusterdeployment") {
-					assert.Equal(t, getClusterRegion(cd), cd.Labels[hivev1.HiveClusterRegionLabel], "incorrect cluster region label")
+					//					assert.Equal(t, getClusterRegion(cd), cd.Labels[hivev1.HiveClusterRegionLabel], "incorrect cluster region label")
+					assert.Equal(t, getClusterRegion(cd), "us-east-1", "incorrect cluster region label")
 				}
 			},
 		},

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -1053,6 +1053,18 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "Add cluster region label",
+			existing: []runtime.Object{
+				testClusterDeploymentWithoutRegionLabel(),
+			},
+			validate: func(c client.Client, t *testing.T) {
+				cd := getCD(c)
+				if assert.NotNil(t, cd, "missing clusterdeployment") {
+					assert.Equal(t, getClusterRegion(cd), cd.Labels[hivev1.HiveClusterRegionLabel], "incorrect cluster region label")
+				}
+			},
+		},
+		{
 			name: "Ensure cluster metadata set from provision",
 			existing: []runtime.Object{
 				func() runtime.Object {
@@ -1386,6 +1398,7 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 	}
 
 	cd.Labels[hivev1.HiveClusterPlatformLabel] = "aws"
+	cd.Labels[hivev1.HiveClusterRegionLabel] = "us-east-1"
 
 	cd.Status = hivev1.ClusterDeploymentStatus{
 		InstallerImage: pointer.StringPtr("installer-image:latest"),
@@ -1413,6 +1426,12 @@ func testClusterDeploymentWithoutFinalizer() *hivev1.ClusterDeployment {
 func testClusterDeploymentWithoutPlatformLabel() *hivev1.ClusterDeployment {
 	cd := testClusterDeployment()
 	delete(cd.Labels, hivev1.HiveClusterPlatformLabel)
+	return cd
+}
+
+func testClusterDeploymentWithoutRegionLabel() *hivev1.ClusterDeployment {
+	cd := testClusterDeployment()
+	delete(cd.Labels, hivev1.HiveClusterRegionLabel)
 	return cd
 }
 


### PR DESCRIPTION
This PR mimics the logic behind setting the platformLabel in the
Clusterdeployment CR. Previously present strings were also moved to
const's in the same package.