### PR TITLE
Add install failure debugging annotations.

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -102,6 +102,16 @@ const (
 	// SyncsetPauseAnnotation is a annotation used by clusterDeployment, if it's true, then we will disable syncing to a specific cluster
 	SyncsetPauseAnnotation = "hive.openshift.io/syncset-pause"
 
+	// DisableInstallLogPasswordRedactionAnnotation is an annotation used on ClusterDeployments to disable the installmanager
+	// functionality which refuses to print output if it appears to contain a password or sensitive info. This can be
+	// useful in scenarios where debugging is needed and important info is being redacted. Set to "true".
+	DisableInstallLogPasswordRedactionAnnotation = "hive.openshift.io/disable-install-log-password-redaction"
+
+	// PauseOnInstallFailureAnnotation is an annotation used on ClusterDeployments to trigger a sleep after an install
+	// failure for the specified duration. This will keep the install pod running and allow a user to rsh in for debug
+	// purposes. Examples: "1h", "20m".
+	PauseOnInstallFailureAnnotation = "hive.openshift.io/pause-on-install-failure"
+
 	// ManagedDomainsFileEnvVar if present, points to a simple text
 	// file that includes a valid managed domain per line. Cluster deployments
 	// requesting that their domains be managed must have a base domain

--- a/pkg/installmanager/installmanager_test.go
+++ b/pkg/installmanager/installmanager_test.go
@@ -215,7 +215,7 @@ func TestInstallManager(t *testing.T) {
 			}
 
 			if test.failedInstallerLogRead {
-				im.readInstallerLog = func(*hivev1.ClusterProvision, *InstallManager) (string, error) {
+				im.readInstallerLog = func(*hivev1.ClusterProvision, *InstallManager, bool) (string, error) {
 					return "", fmt.Errorf("faiiled to save install log")
 				}
 			}


### PR DESCRIPTION
One to sleep on install failures for a configurable duration, allowing
developers to rsh into the install pod and poke around.

One to disable log scrubbing of passwords as in some scenarios this can
redact important info.

cc @dhellmann 