### PR TITLE
migration: add certificaterequests to owner refs to save

### DIFF
--- a/contrib/pkg/v1migration/saveownerrefs.go
+++ b/contrib/pkg/v1migration/saveownerrefs.go
@@ -39,6 +39,11 @@ var defaultResources = []schema.GroupVersionResource{
 	corev1.SchemeGroupVersion.WithResource("secrets"),
 	corev1.SchemeGroupVersion.WithResource("persistentvolumeclaims"),
 	batchv1.SchemeGroupVersion.WithResource("jobs"),
+	{
+		Group:    "certman.managed.openshift.io",
+		Version:  "v1alpha1",
+		Resource: "certificaterequests",
+	},
 }
 
 // SaveOwnerRefsOptions is the set of options for the saving owner references.


### PR DESCRIPTION
On the hive-int cluster, there are certificaterequests with owner references to ClusterDeployments. We need to save and restore those owner references during migration.