### PR TITLE
migration: remove initial fetch from delete process

### DIFF
--- a/hack/v1migration/delete.sh
+++ b/hack/v1migration/delete.sh
@@ -17,20 +17,6 @@ then
   exit 1
 fi
 
-delete_jobs() {
-  local labels=${1:?must specify a label for the jobs to delete}
-  oc get jobs -l "${labels}" --all-namespaces -o json | \
-    jq -r '.items[]?.metadata.namespace' | \
-    sort -u | \
-    xargs -i oc delete jobs -n {} -l "${labels}"
-}
-
-echo "Deleting install jobs"
-delete_jobs "hive.openshift.io/install=true"
-
-echo "Deleting imageset jobs"
-delete_jobs "hive.openshift.io/imageset=true"
-
 # shellcheck source=hivetypes.sh
 source "$(dirname "$0")/hivetypes.sh"
 


### PR DESCRIPTION
* Use a Patch instead of an Update to remove finalizers. This eliminates the need to do the initial Get of the resource from the cluster.
* Eliminate the pre-conditions check on the Delete, in case it takes some extra time to validate the pre-conditions.
* Remove the deleting of jobs from the delete.sh script as that has been moved to the delete_hive_jobs.sh script, run separately.