### PR TITLE
Add HiveConfig.Spec.DeprovisionsDisabled.

### DIFF
--- a/config/crds/hive_v1_hiveconfig.yaml
+++ b/config/crds/hive_v1_hiveconfig.yaml
@@ -62,6 +62,10 @@ spec:
                       type: boolean
                   type: object
               type: object
+            deprovisionsDisabled:
+              description: DeprovisionsDisabled can be set to true to block deprovision
+                jobs from running.
+              type: boolean
             failedProvisionConfig:
               description: FailedProvisionConfig is used to configure settings related
                 to handling provision failures.

--- a/pkg/apis/hive/v1/hiveconfig_types.go
+++ b/pkg/apis/hive/v1/hiveconfig_types.go
@@ -54,6 +54,9 @@ type HiveConfigSpec struct {
 	// nothing is running that will add or act upon finalizers on Hive types. This should rarely be needed.
 	// Sets replicas to 0 for the hive-controllers deployment to accomplish this.
 	MaintenanceMode *bool `json:"maintenanceMode,omitempty"`
+
+	// DeprovisionsDisabled can be set to true to block deprovision jobs from running.
+	DeprovisionsDisabled *bool `json:"deprovisionsDisabled,omitempty"`
 }
 
 // HiveConfigStatus defines the observed state of Hive

--- a/pkg/apis/hive/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/hive/v1/zz_generated.deepcopy.go
@@ -1388,6 +1388,11 @@ func (in *HiveConfigSpec) DeepCopyInto(out *HiveConfigSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DeprovisionsDisabled != nil {
+		in, out := &in.DeprovisionsDisabled, &out.DeprovisionsDisabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -11,6 +11,10 @@ const (
 	// VeleroBackupEnvVar is the name of the environment variable used to tell the controller manager to enable velero backup integration.
 	VeleroBackupEnvVar = "HIVE_VELERO_BACKUP"
 
+	// DeprovisionsDisabledEnvVar is the name of the environment variable used to tell the controller manager to skip
+	// processing of any ClusterDeprovisions.
+	DeprovisionsDisabledEnvVar = "DEPROVISIONS_DISABLED"
+
 	// MinBackupPeriodSecondsEnvVar is the name of the environment variable used to tell the controller manager the minimum period of time between backups.
 	MinBackupPeriodSecondsEnvVar = "HIVE_MIN_BACKUP_PERIOD_SECONDS"
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -3034,6 +3034,10 @@ spec:
                       type: boolean
                   type: object
               type: object
+            deprovisionsDisabled:
+              description: DeprovisionsDisabled can be set to true to block deprovision
+                jobs from running.
+              type: boolean
             failedProvisionConfig:
               description: FailedProvisionConfig is used to configure settings related
                 to handling provision failures.

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -112,6 +112,15 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helpe
 		hiveContainer.Env = append(hiveContainer.Env, tmpEnvVar)
 	}
 
+	if instance.Spec.DeprovisionsDisabled != nil && *instance.Spec.DeprovisionsDisabled {
+		hLog.Info("deprovisions disabled in hiveconfig")
+		tmpEnvVar := corev1.EnvVar{
+			Name:  hiveconstants.DeprovisionsDisabledEnvVar,
+			Value: "true",
+		}
+		hiveContainer.Env = append(hiveContainer.Env, tmpEnvVar)
+	}
+
 	if instance.Spec.Backup.MinBackupPeriodSeconds != nil {
 		hLog.Infof("MinBackupPeriodSeconds specified.")
 		tmpEnvVar := corev1.EnvVar{


### PR DESCRIPTION
Adding for safety net in scenarios where you'd like to make sure no
deprovision jobs can accidentally trigger.