### PR TITLE
migration: process for fixing bad restores mid-migration

### DIFF
--- a/contrib/pkg/v1migration/saveownerrefs.go
+++ b/contrib/pkg/v1migration/saveownerrefs.go
@@ -49,9 +49,9 @@ var defaultResources = []schema.GroupVersionResource{
 
 // SaveOwnerRefsOptions is the set of options for the saving owner references.
 type SaveOwnerRefsOptions struct {
-	workDir       string
-	resourcesFile string
-	listLimit     int64
+	workDir         string
+	resourcesFile   string
+	listLimit       int64
 	outputResources bool
 }
 

--- a/hack/v1migration/README.md
+++ b/hack/v1migration/README.md
@@ -16,6 +16,7 @@
   1. Run `oc patch hiveconfig hive --type='merge' -p $'spec:\n maintenanceMode: true'`
   1. Run `./hack/v1migration/scaledown.sh hive-operator` to scale down Hive operator.
   1. Run `./hack/v1migration/restore.sh [workdir]` to restore all data from disk.
+  1. Run `./hack/v1migration/validate.sh [workdir]` to validate that everything was restored and is not deleted.
   1. Run `./hack/v1migration/scaleup.sh hive-operator` to scale up Hive operator.
   1. Run `oc patch hiveconfig hive --type='merge' -p $'spec:\n maintenanceMode: false'`
 

--- a/hack/v1migration/README.md
+++ b/hack/v1migration/README.md
@@ -18,3 +18,15 @@
   1. Run `./hack/v1migration/restore.sh [workdir]` to restore all data from disk.
   1. Run `./hack/v1migration/scaleup.sh hive-operator` to scale up Hive operator.
   1. Run `oc patch hiveconfig hive --type='merge' -p $'spec:\n maintenanceMode: false'`
+
+
+# Resolving Problems during Restore
+
+If there was a problem during restore, then we should delete the resources in that namesapce
+that were restored, fix the data being restored, and run the restore again for just that namespace.
+
+  1. `./hack/v1migration/hive_resources_in_namespace.sh [workdir] [namespace] > [namespace_workdir]/resources.json`
+  1. `./hack/v1migration/hive_owner_refs_in_namespace.sh [workdir] [namespace] > [namespace_workdir]/owner-ref.json`
+  1. `./hack/v1migration/delete_in_namespace.sh [namespace]`
+  1. Make whatever changes are needed to resources saved in `[namespace_workdir]`.
+  1. `./hack/v1migration/restore.sh [namespace_workdir]`

--- a/hack/v1migration/delete_in_namespace.sh
+++ b/hack/v1migration/delete_in_namespace.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-NAMESPACE=${1:?must specificy namespace}
+NAMESPACE=${1:?must specify namespace}
 echo "Using namespace: $NAMESPACE"
 
 # shellcheck source=hivetypes.sh

--- a/hack/v1migration/delete_in_namespace.sh
+++ b/hack/v1migration/delete_in_namespace.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+NAMESPACE=${1:?must specificy namespace}
+echo "Using namespace: $NAMESPACE"
+
+# shellcheck source=hivetypes.sh
+source "$(dirname "$0")/hivetypes.sh"
+
+echo "Deleting machinepools"
+oc delete machinepools -n "${NAMESPACE}" --all --cascade=false
+
+echo "Deleting installconfig secrets"
+oc get clusterdeployments -n "${NAMESPACE}" -ojson | \
+  jq -r '.items[].spec.provisioning.installConfigSecretRef.name' | \
+  xargs -i oc delete secret {} -n "${NAMESPACE}"
+
+for t in "${NAMESPACE_SCOPED_HIVE_TYPES[@]}"
+do
+  if [[ "$t" == "dnsendpoints" ]]; then continue; fi
+  echo "Deleting $t"
+  oc get "$t".v1alpha1.hive.openshift.io -n "${NAMESPACE}" -oname | \
+    xargs -i oc patch {} -n "${NAMESPACE}" --type='merge' -p $'metadata:\n finalizers: []'
+  oc delete "$t".v1alpha1.hive.openshift.io -n "${NAMESPACE}" --all --cascade=false
+done

--- a/hack/v1migration/hive_owner_refs_in_namespace.sh
+++ b/hack/v1migration/hive_owner_refs_in_namespace.sh
@@ -3,7 +3,7 @@
 set -e
 
 WORKDIR=${1:?must specify working directory}
-NAMESPACE=${2:?must specificy namespace}
+NAMESPACE=${2:?must specify namespace}
 
 if [[ ! -d "$WORKDIR" ]]
 then

--- a/hack/v1migration/hive_owner_refs_in_namespace.sh
+++ b/hack/v1migration/hive_owner_refs_in_namespace.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+WORKDIR=${1:?must specify working directory}
+NAMESPACE=${2:?must specificy namespace}
+
+if [[ ! -d "$WORKDIR" ]]
+then
+  echo "Directory $WORKDIR does not exist."
+  exit 1
+fi
+
+<"${WORKDIR}/owner-refs.json" jq --arg NAMESPACE "${NAMESPACE}" 'select(.namespace==$NAMESPACE)'

--- a/hack/v1migration/hive_resources_in_namespace.sh
+++ b/hack/v1migration/hive_resources_in_namespace.sh
@@ -3,7 +3,7 @@
 set -e
 
 WORKDIR=${1:?must specify working directory}
-NAMESPACE=${2:?must specificy namespace}
+NAMESPACE=${2:?must specify namespace}
 
 if [[ ! -d "$WORKDIR" ]]
 then

--- a/hack/v1migration/hive_resources_in_namespace.sh
+++ b/hack/v1migration/hive_resources_in_namespace.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+WORKDIR=${1:?must specify working directory}
+NAMESPACE=${2:?must specificy namespace}
+
+if [[ ! -d "$WORKDIR" ]]
+then
+  echo "Directory $WORKDIR does not exist."
+  exit 1
+fi
+
+for f in "${WORKDIR}"/*.json
+do
+  if [[ "$f" =~ (hiveconfigs)|(dnsendpoints)|(owner-refs).json ]]; then continue; fi
+  <"$f" jq --arg NAMESPACE "$NAMESPACE" 'select(.metadata.namespace==$NAMESPACE)'
+done

--- a/hack/v1migration/hivetypes.sh
+++ b/hack/v1migration/hivetypes.sh
@@ -1,1 +1,5 @@
-HIVE_TYPES=( checkpoints clusterdeployments clusterdeprovisionrequests clusterimagesets clusterprovisions clusterstates dnsendpoints dnszones hiveconfigs selectorsyncidentityproviders selectorsyncsets syncidentityproviders syncsetinstances syncsets )
+NAMESPACE_SCOPED_HIVE_TYPES=( checkpoints clusterdeployments clusterdeprovisionrequests clusterprovisions clusterstates dnsendpoints dnszones syncidentityproviders syncsetinstances syncsets )
+
+CLUSTER_SCOPED_HIVE_TYPES=( clusterimagesets hiveconfigs selectorsyncidentityproviders selectorsyncsets )
+
+HIVE_TYPES=( "${NAMESPACE_SCOPED_HIVE_TYPES[@]}" "${CLUSTER_SCOPED_HIVE_TYPES[@]}" )

--- a/hack/v1migration/save.sh
+++ b/hack/v1migration/save.sh
@@ -5,7 +5,12 @@ set -e
 WORKDIR=${1:?must specify working directory}
 echo "Using workdir: $WORKDIR"
 
-if [[ -z $NO_SCALEDOWN_VERIFY ]]
+if [[ -n "$OWNED_RESOURCES" ]]
+then
+  RESOURCES_ARG="--resources $OWNED_RESOURCES"
+fi
+
+if [[ -z "$NO_SCALEDOWN_VERIFY" ]]
 then
   # shellcheck source=verify_scaledown.sh
   source "$(dirname "$0")/verify_scaledown.sh"
@@ -34,4 +39,4 @@ do
 	oc get "${t}.hive.openshift.io" --all-namespaces -o json | jq .items[] > "${WORKDIR}/${t}.json"
 done
 
-bin/hiveutil v1migration save-owner-refs --work-dir "${WORKDIR}"
+bin/hiveutil v1migration save-owner-refs --work-dir "${WORKDIR}" $RESOURCES_ARG

--- a/hack/v1migration/validate.sh
+++ b/hack/v1migration/validate.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+WORKDIR=${1:?must specify working directory}
+echo "Using workdir: $WORKDIR"
+
+if [[ ! -d "$WORKDIR" ]]
+then
+  echo "Directory $WORKDIR does not exist."
+  exit 1
+fi
+
+# shellcheck source=hivetypes.sh
+source "$(dirname "$0")/hivetypes.sh"
+
+TEMPDIR="$(mktemp -d)"
+
+for t in "${HIVE_TYPES[@]}"
+do
+  if [[ "$t" == "dnsendpoints" ]]; then continue; fi
+
+  echo "Validating ${t}"
+
+  <"${WORKDIR}/$t.json" jq '.metadata.namespace + "/" + .metadata.name' | sort > "${TEMPDIR}/$t.orig"
+  oc get "$t.v1alpha1.hive.openshift.io" --all-namespaces -o json | jq '.items[] | .metadata.namespace + "/" + .metadata.name' | sort > "${TEMPDIR}/$t.restored"
+
+  echo "Diff in resources"
+  diff "${TEMPDIR}/$t.orig" "${TEMPDIR}/$t.restored"
+
+  echo "Deleted resources"
+  oc get "$t.v1alpha1.hive.openshift.io" --all-namespaces -o json | jq '.items[] | select(.metadata.deletionTimestamp) | .metadata.namespace + "/" + .metadata.name'
+done
+
+echo "Validating machinepools"
+
+<"${WORKDIR}/clusterdeployments.json" jq '.metadata.namespace + "/" + .metadata.name + "-" + .spec.compute[]?.name' | sort > "${TEMPDIR}/machinepools.orig"
+oc get machinepools --all-namespaces -o json | jq '.items[] | .metadata.namespace + "/" + .metadata.name' | sort > "${TEMPDIR}/machinepools.restored"
+
+echo "Diff in resources"
+diff "${TEMPDIR}/machinepools.orig" "${TEMPDIR}/machinepools.restored"
+
+echo "Deleted resources"
+oc get machinepools --all-namespaces -o json | jq '.items[] | select(.metadata.deletionTimestamp) | .metadata.namespace + "/" + .metadata.name'

--- a/pkg/hive/apiserver/registry/clusterdeployment/proxy.go
+++ b/pkg/hive/apiserver/registry/clusterdeployment/proxy.go
@@ -229,6 +229,7 @@ func (s *REST) Create(ctx context.Context, obj runtime.Object, _ rest.ValidateOb
 	if err != nil {
 		return nil, err
 	}
+	sortMachinePools(machinePools)
 
 	clusterDeployment := &hiveapi.ClusterDeployment{}
 	if err := util.ClusterDeploymentFromHiveV1(ret, installConfig, machinePools, installConfigSecret.ResourceVersion, clusterDeployment); err != nil {
@@ -450,10 +451,14 @@ func getMachinePools(cdName string, machinePoolClient hivev1client.MachinePoolIn
 		}
 		pools = append(pools, &poolsList.Items[i])
 	}
-	sort.Slice(pools, func(i, j int) bool {
-		return pools[i].Name < pools[j].Name
-	})
+	sortMachinePools(pools)
 	return pools, nil
+}
+
+func sortMachinePools(machinePools []*hivev1.MachinePool) {
+	sort.Slice(machinePools, func(i, j int) bool {
+		return machinePools[i].Name < machinePools[j].Name
+	})
 }
 
 func reconcileMachinePools(


### PR DESCRIPTION
Provide tooling for fixing resources that did not restore properly during a migration.

The process is the following.
1. Create restore data for only the namespace with problems so that fixes can be made in isolation to the resources in that namespace.
1. Clear out Hive resources from the problem namespace.
1. Restore the isolated data for that namespace with whatever changes needed to be made.