### PR TITLE
Refactor hiveutil create-cluster code into a package.

### DIFF
--- a/config/templates/cluster-deployment-customimageset.yaml
+++ b/config/templates/cluster-deployment-customimageset.yaml
@@ -82,7 +82,6 @@ objects:
     annotations:
       hive.openshift.io/delete-after: "8h"
       hive.openshift.io/try-install-once: "${TRY_INSTALL_ONCE}"
-      hive.openshift.io/try-uninstall-once: "${TRY_UNINSTALL_ONCE}"
       hive.openshift.io/cluster-type: "unmanaged"
     name: ${CLUSTER_NAME}
   spec:

--- a/config/templates/cluster-deployment.yaml
+++ b/config/templates/cluster-deployment.yaml
@@ -86,7 +86,6 @@ objects:
     annotations:
       hive.openshift.io/delete-after: "8h"
       hive.openshift.io/try-install-once: "${TRY_INSTALL_ONCE}"
-      hive.openshift.io/try-uninstall-once: "${TRY_UNINSTALL_ONCE}"
     name: ${CLUSTER_NAME}
   spec:
     platformSecrets:

--- a/pkg/clusterresource/azure.go
+++ b/pkg/clusterresource/azure.go
@@ -1,13 +1,7 @@
-package createcluster
+package clusterresource
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-
-	log "github.com/sirupsen/logrus"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -24,25 +18,18 @@ const (
 	azureInstanceType = "Standard_D2s_v3"
 )
 
-var _ cloudProvider = (*azureCloudProvider)(nil)
+var _ CloudBuilder = (*AzureCloudBuilder)(nil)
 
-type azureCloudProvider struct {
+// AzureCloudBuilder encapsulates cluster artifact generation logic specific to Azure.
+type AzureCloudBuilder struct {
+	// ServicePrincipal is the bytes from a service principal file, typically ~/.azure/osServicePrincipal.json.
+	ServicePrincipal []byte
+
+	// BaseDomainResourceGroupName is the resource group where the base domain for this cluster is configured.
+	BaseDomainResourceGroupName string
 }
 
-func (p *azureCloudProvider) generateCredentialsSecret(o *Options) (*corev1.Secret, error) {
-	credsFilePath := filepath.Join(os.Getenv("HOME"), ".azure", azureCredFile)
-	if l := os.Getenv("AZURE_AUTH_LOCATION"); l != "" {
-		credsFilePath = l
-	}
-	if o.CredsFile != "" {
-		credsFilePath = o.CredsFile
-	}
-	log.Infof("Loading Azure service principal from: %s", credsFilePath)
-	spFileContents, err := ioutil.ReadFile(credsFilePath)
-	if err != nil {
-		return nil, err
-	}
-
+func (p *AzureCloudBuilder) generateCredentialsSecret(o *Builder) *corev1.Secret {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
@@ -54,50 +41,48 @@ func (p *azureCloudProvider) generateCredentialsSecret(o *Options) (*corev1.Secr
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
-			azureCredFile: spFileContents,
+			azureCredFile: p.ServicePrincipal,
 		},
-	}, nil
+	}
 }
 
-func (p *azureCloudProvider) addPlatformDetails(
-	o *Options,
-	cd *hivev1.ClusterDeployment,
-	machinePool *hivev1.MachinePool,
-	installConfig *installertypes.InstallConfig,
-) error {
+func (p *AzureCloudBuilder) addClusterDeploymentPlatform(o *Builder, cd *hivev1.ClusterDeployment) {
 	cd.Spec.Platform = hivev1.Platform{
 		Azure: &hivev1azure.Platform{
 			CredentialsSecretRef: corev1.LocalObjectReference{
 				Name: p.credsSecretName(o),
 			},
 			Region:                      azureRegion,
-			BaseDomainResourceGroupName: o.AzureBaseDomainResourceGroupName,
+			BaseDomainResourceGroupName: p.BaseDomainResourceGroupName,
 		},
 	}
+}
 
-	machinePool.Spec.Platform.Azure = &hivev1azure.MachinePool{
+func (p *AzureCloudBuilder) addMachinePoolPlatform(o *Builder, mp *hivev1.MachinePool) {
+	mp.Spec.Platform.Azure = &hivev1azure.MachinePool{
 		InstanceType: azureInstanceType,
 		OSDisk: hivev1azure.OSDisk{
 			DiskSizeGB: 128,
 		},
 	}
 
+}
+
+func (p *AzureCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installertypes.InstallConfig) {
 	// Inject platform details into InstallConfig:
-	installConfig.Platform = installertypes.Platform{
+	ic.Platform = installertypes.Platform{
 		Azure: &azureinstallertypes.Platform{
 			Region:                      azureRegion,
-			BaseDomainResourceGroupName: o.AzureBaseDomainResourceGroupName,
+			BaseDomainResourceGroupName: p.BaseDomainResourceGroupName,
 		},
 	}
 
 	// Used for both control plane and workers.
 	mpp := &azureinstallertypes.MachinePool{}
-	installConfig.ControlPlane.Platform.Azure = mpp
-	installConfig.Compute[0].Platform.Azure = mpp
-
-	return nil
+	ic.ControlPlane.Platform.Azure = mpp
+	ic.Compute[0].Platform.Azure = mpp
 }
 
-func (p *azureCloudProvider) credsSecretName(o *Options) string {
+func (p *AzureCloudBuilder) credsSecretName(o *Builder) string {
 	return fmt.Sprintf("%s-azure-creds", o.Name)
 }

--- a/pkg/clusterresource/builder.go
+++ b/pkg/clusterresource/builder.go
@@ -1,0 +1,493 @@
+package clusterresource
+
+import (
+	"fmt"
+	"github.com/ghodss/yaml"
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
+	"github.com/openshift/installer/pkg/ipnet"
+	installertypes "github.com/openshift/installer/pkg/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	deleteAfterAnnotation    = "hive.openshift.io/delete-after"
+	tryInstallOnceAnnotation = "hive.openshift.io/try-install-once"
+)
+
+// Builder can be used to build all artifacts required for to create a ClusterDeployment.
+type Builder struct {
+	// Name is the name of your Cluster. Will be used for both the ClusterDeployment.Name and the
+	// ClusterDeployment.Spec.ClusterName, which encompasses the subdomain and cloud provider resource
+	// tagging.
+	Name string
+
+	// Namespace where the ClusterDeployment and all associated artifacts will be created.
+	Namespace string
+
+	// Labels are labels to be added to the ClusterDeployment.
+	Labels map[string]string
+
+	// CloudBuilder encapsulates logic for building the objects for a specific cloud.
+	CloudBuilder CloudBuilder
+
+	// PullSecret is the secret to use when pulling images.
+	PullSecret string
+
+	// SSHPrivateKey is an optional SSH key to configure on hosts in the cluster. This would
+	// typically be read from ~/.ssh/id_rsa.
+	SSHPrivateKey string
+
+	// SSHPublicKey is an optional public SSH key to configure on hosts in the cluster. This would
+	// typically be read from ~/.ssh/id_rsa.pub. Must match the SSHPrivateKey.
+	SSHPublicKey string
+
+	// InstallOnce indicates that the provision job should not be retried on failure.
+	InstallOnce bool
+
+	// BaseDomain is the DNS base domain to be used for the cluster.
+	BaseDomain string
+
+	// WorkerNodesCount is the number of worker nodes to create in the cluster initially.
+	WorkerNodesCount int64
+
+	// ManageDNS can be set to true to enable Hive's automatic DNS zone creation and forwarding. (assuming
+	// this is properly configured in HiveConfig)
+	ManageDNS bool
+
+	// DeleteAfter is the duration after which the cluster should be automatically destroyed, relative to
+	// creationTimestamp. Stored as an annotation on the ClusterDeployment.
+	DeleteAfter string
+
+	// ServingCert is the contents of a serving certificate to be used for the cluster.
+	ServingCert string
+
+	// ServingCertKey is the contents of a key for the ServingCert.
+	ServingCertKey string
+
+	// Adopt is a flag indicating we're adopting a pre-existing cluster.
+	Adopt bool
+
+	// AdoptAdminKubeconfig is a cluster administrator admin kubeconfig typically obtained
+	// from openshift-install. Required when adopting pre-existing clusters.
+	AdoptAdminKubeconfig []byte
+
+	// AdoptClusterID is the unique generated ID for a cluster being adopted.
+	// Required when adopting pre-existing clusters.
+	AdoptClusterID string
+
+	// AdoptInfraID is the unique generated infrastructure ID for a cluster being adopted.
+	// Required when adopting pre-existing clusters.
+	AdoptInfraID string
+
+	// AdoptAdminUsername is the admin username for an adopted cluster, typically written to disk
+	// after openshift-install create-cluster. This field is optional when adopting.
+	AdoptAdminUsername string
+
+	// AdoptAdminPassword is the admin password for an adopted cluster, typically written to disk
+	// after openshift-install create-cluster. This field is optional when adopting.
+	AdoptAdminPassword string
+
+	// InstallerManifests is a map of filename strings to bytes for files to inject into the installers
+	// manifests dir before launching create-cluster.
+	InstallerManifests map[string][]byte
+
+	// ImageSet is the ClusterImageSet to use for this cluster.
+	ImageSet string
+
+	// ReleaseImage is a specific OpenShift release image to install this cluster with. Will override
+	// ImageSet.
+	ReleaseImage string
+}
+
+// Validate ensures that the builder's fields are logically configured and usable to generate the cluster resources.
+func (o *Builder) Validate() error {
+	if len(o.Name) == 0 {
+		return fmt.Errorf("name is required")
+	}
+	if len(o.BaseDomain) == 0 {
+		return fmt.Errorf("BaseDomain is required")
+	}
+	if o.CloudBuilder == nil {
+		return fmt.Errorf("no CloudBuilder configured for this Builder")
+	}
+	if len(o.ImageSet) > 0 && len(o.ReleaseImage) > 0 {
+		return fmt.Errorf("cannot set both ImageSet and ReleaseImage")
+	}
+	if len(o.ImageSet) == 0 && len(o.ReleaseImage) == 0 {
+		return fmt.Errorf("must set either image set or release image")
+	}
+
+	if len(o.ServingCert) > 0 && len(o.ServingCertKey) == 0 {
+		return fmt.Errorf("must set serving cert key to use with serving cert")
+	}
+
+	if o.Adopt {
+		if len(o.AdoptAdminKubeconfig) == 0 || o.AdoptInfraID == "" || o.AdoptClusterID == "" {
+			return fmt.Errorf("must specify the following fields to adopt a cluster: AdoptAdminKubeConfig AdoptInfraID AdoptClusterID")
+		}
+
+		if (o.AdoptAdminUsername != "" || o.AdoptAdminPassword != "") && !(o.AdoptAdminUsername != "" && o.AdoptAdminPassword != "") {
+			return fmt.Errorf("either both AdoptAdminPassword and AdoptAdminUsername must be set, or neither")
+		}
+	} else {
+		if len(o.AdoptAdminKubeconfig) > 0 || o.AdoptInfraID != "" || o.AdoptClusterID != "" || o.AdoptAdminUsername != "" || o.AdoptAdminPassword != "" {
+			return fmt.Errorf("cannot set adoption fields if Adopt is false")
+		}
+	}
+
+	return nil
+}
+
+// Build generates all resources using the fields configured.
+func (o *Builder) Build() ([]runtime.Object, error) {
+
+	if err := o.Validate(); err != nil {
+		return nil, err
+	}
+
+	var allObjects []runtime.Object
+	allObjects = append(allObjects, o.generateClusterDeployment())
+	allObjects = append(allObjects, o.generateMachinePool())
+	installConfigSecret, err := o.generateInstallConfigSecret()
+	if err != nil {
+		return nil, err
+	}
+	allObjects = append(allObjects, installConfigSecret)
+
+	// TODO: maintain "include secrets" flag functionality? possible this should just be removed
+	if len(o.PullSecret) != 0 {
+		allObjects = append(allObjects, o.generatePullSecretSecret())
+	}
+	if o.SSHPrivateKey != "" {
+		allObjects = append(allObjects, o.generateSSHPrivateKeySecret())
+	}
+	if o.ServingCertKey != "" && o.ServingCert != "" {
+		allObjects = append(allObjects, o.generateServingCertSecret())
+	}
+	cloudCredsSecret := o.CloudBuilder.generateCredentialsSecret(o)
+	if cloudCredsSecret != nil {
+		allObjects = append(allObjects, cloudCredsSecret)
+	}
+
+	if o.InstallerManifests != nil {
+		allObjects = append(allObjects, o.generateInstallerManifestsConfigMap())
+	}
+
+	if o.Adopt {
+		allObjects = append(allObjects, o.generateAdminKubeconfigSecret())
+		if o.AdoptAdminUsername != "" {
+			allObjects = append(allObjects, o.generateAdoptedAdminPasswordSecret())
+		}
+	}
+
+	return allObjects, nil
+}
+
+func (o *Builder) generateClusterDeployment() *hivev1.ClusterDeployment {
+	cd := &hivev1.ClusterDeployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterDeployment",
+			APIVersion: hivev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        o.Name,
+			Namespace:   o.Namespace,
+			Annotations: map[string]string{},
+			Labels:      o.Labels,
+		},
+		Spec: hivev1.ClusterDeploymentSpec{
+			ClusterName:  o.Name,
+			BaseDomain:   o.BaseDomain,
+			ManageDNS:    o.ManageDNS,
+			Provisioning: &hivev1.Provisioning{},
+		},
+	}
+
+	if o.SSHPrivateKey != "" {
+		cd.Spec.Provisioning.SSHPrivateKeySecretRef = &corev1.LocalObjectReference{Name: o.getSSHPrivateKeySecretName()}
+	}
+
+	if o.InstallOnce {
+		cd.Annotations[tryInstallOnceAnnotation] = "true"
+	}
+
+	if o.PullSecret != "" {
+		cd.Spec.PullSecretRef = &corev1.LocalObjectReference{Name: o.getPullSecretSecretName()}
+	}
+
+	if len(o.ServingCert) > 0 {
+		cd.Spec.CertificateBundles = []hivev1.CertificateBundleSpec{
+			{
+				Name: "serving-cert",
+				CertificateSecretRef: corev1.LocalObjectReference{
+					Name: fmt.Sprintf("%s-serving-cert", o.Name),
+				},
+			},
+		}
+		cd.Spec.ControlPlaneConfig.ServingCertificates.Default = "serving-cert"
+		cd.Spec.Ingress = []hivev1.ClusterIngress{
+			{
+				Name:               "default",
+				Domain:             fmt.Sprintf("apps.%s.%s", o.Name, o.BaseDomain),
+				ServingCertificate: "serving-cert",
+			},
+		}
+	}
+
+	if o.DeleteAfter != "" {
+		cd.ObjectMeta.Annotations[deleteAfterAnnotation] = o.DeleteAfter
+	}
+
+	if o.Adopt {
+		cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
+			ClusterID:                o.AdoptClusterID,
+			InfraID:                  o.AdoptInfraID,
+			AdminKubeconfigSecretRef: corev1.LocalObjectReference{Name: o.getAdoptAdminKubeconfigSecretName()},
+		}
+		cd.Spec.Installed = true
+		if o.AdoptAdminUsername != "" {
+			cd.Spec.ClusterMetadata.AdminPasswordSecretRef = corev1.LocalObjectReference{
+				Name: o.getAdoptAdminPasswordSecretName(),
+			}
+		}
+	}
+
+	if o.InstallerManifests != nil {
+		cd.Spec.Provisioning.ManifestsConfigMapRef = &corev1.LocalObjectReference{
+			Name: o.getManifestsConfigMapName(),
+		}
+	}
+
+	if o.ReleaseImage != "" {
+		cd.Spec.Provisioning.ReleaseImage = o.ReleaseImage
+	} else if o.ImageSet != "" {
+		cd.Spec.Provisioning.ImageSetRef = &hivev1.ClusterImageSetReference{Name: o.ImageSet}
+	}
+
+	cd.Spec.Provisioning.InstallConfigSecretRef = corev1.LocalObjectReference{Name: o.getInstallConfigSecretName()}
+	o.CloudBuilder.addClusterDeploymentPlatform(o, cd)
+
+	return cd
+}
+
+func (o *Builder) generateInstallConfigSecret() (*corev1.Secret, error) {
+	installConfig := &installertypes.InstallConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: o.Name,
+		},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: installertypes.InstallConfigVersion,
+		},
+		SSHKey:     o.SSHPublicKey,
+		BaseDomain: o.BaseDomain,
+		Networking: &installertypes.Networking{
+			NetworkType:    "OpenShiftSDN",
+			ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
+			ClusterNetwork: []installertypes.ClusterNetworkEntry{
+				{
+					CIDR:       *ipnet.MustParseCIDR("10.128.0.0/14"),
+					HostPrefix: 23,
+				},
+			},
+			MachineNetwork: []installertypes.MachineNetworkEntry{
+				{
+					CIDR: *ipnet.MustParseCIDR("10.0.0.0/16"),
+				},
+			},
+		},
+		ControlPlane: &installertypes.MachinePool{
+			Name:     "master",
+			Replicas: pointer.Int64Ptr(3),
+		},
+		Compute: []installertypes.MachinePool{
+			{
+				Name:     "worker",
+				Replicas: &o.WorkerNodesCount,
+			},
+		},
+	}
+
+	o.CloudBuilder.addInstallConfigPlatform(o, installConfig)
+
+	d, err := yaml.Marshal(installConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      o.getInstallConfigSecretName(),
+			Namespace: o.Namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"install-config.yaml": d,
+		},
+	}, nil
+}
+
+func (o *Builder) generateMachinePool() *hivev1.MachinePool {
+	mp := &hivev1.MachinePool{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "MachinePool",
+			APIVersion: hivev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-worker", o.Name),
+			Namespace: o.Namespace,
+		},
+		Spec: hivev1.MachinePoolSpec{
+			ClusterDeploymentRef: corev1.LocalObjectReference{
+				Name: o.Name,
+			},
+			Name:     "worker",
+			Replicas: pointer.Int64Ptr(o.WorkerNodesCount),
+		},
+	}
+	o.CloudBuilder.addMachinePoolPlatform(o, mp)
+	return mp
+}
+
+func (o *Builder) getInstallConfigSecretName() string {
+	return fmt.Sprintf("%s-install-config", o.Name)
+}
+
+// generatePullSecretSecret returns a Kubernetes Secret containing the pull secret to be
+// used for pulling images.
+func (o *Builder) generatePullSecretSecret() *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      o.getPullSecretSecretName(),
+			Namespace: o.Namespace,
+		},
+		Type: corev1.SecretTypeDockerConfigJson,
+		StringData: map[string]string{
+			corev1.DockerConfigJsonKey: o.PullSecret,
+		},
+	}
+}
+
+// generateSSHPrivateKeySecret returns a Kubernetes Secret containing the SSH private
+// key to be used.
+func (o *Builder) generateSSHPrivateKeySecret() *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      o.getSSHPrivateKeySecretName(),
+			Namespace: o.Namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		StringData: map[string]string{
+			constants.SSHPrivateKeySecretKey: o.SSHPrivateKey,
+		},
+	}
+}
+
+func (o *Builder) generateServingCertSecret() *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      o.getServingCertSecretName(),
+			Namespace: o.Namespace,
+		},
+		Type: corev1.SecretTypeTLS,
+		StringData: map[string]string{
+			constants.TLSCrtSecretKey: o.ServingCert,
+			constants.TLSKeySecretKey: o.ServingCertKey,
+		},
+	}
+}
+
+func (o *Builder) generateAdminKubeconfigSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      o.getAdoptAdminKubeconfigSecretName(),
+			Namespace: o.Namespace,
+		},
+		Data: map[string][]byte{
+			constants.KubeconfigSecretKey:    o.AdoptAdminKubeconfig,
+			constants.RawKubeconfigSecretKey: o.AdoptAdminKubeconfig,
+		},
+	}
+}
+
+func (o *Builder) generateInstallerManifestsConfigMap() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      o.getManifestsConfigMapName(),
+			Namespace: o.Namespace,
+		},
+		BinaryData: o.InstallerManifests,
+	}
+}
+
+func (o *Builder) generateAdoptedAdminPasswordSecret() *corev1.Secret {
+	if o.AdoptAdminUsername == "" {
+		return nil
+	}
+	adminPasswordSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      o.getAdoptAdminPasswordSecretName(),
+			Namespace: o.Namespace,
+		},
+		StringData: map[string]string{
+			"username": o.AdoptAdminUsername,
+			"password": o.AdoptAdminPassword,
+		},
+	}
+	return adminPasswordSecret
+}
+
+func (o *Builder) getManifestsConfigMapName() string {
+	return fmt.Sprintf("%s-manifests", o.Name)
+}
+func (o *Builder) getAdoptAdminPasswordSecretName() string {
+	return fmt.Sprintf("%s-adopted-admin-password", o.Name)
+}
+
+func (o *Builder) getServingCertSecretName() string {
+	return fmt.Sprintf("%s-serving-cert", o.Name)
+}
+
+func (o *Builder) getAdoptAdminKubeconfigSecretName() string {
+	return fmt.Sprintf("%s-adopted-admin-kubeconfig", o.Name)
+}
+
+// TODO: handle long cluster names.
+func (o *Builder) getSSHPrivateKeySecretName() string {
+	return fmt.Sprintf("%s-ssh-private-key", o.Name)
+}
+
+// TODO: handle long cluster names.
+func (o *Builder) getPullSecretSecretName() string {
+	return fmt.Sprintf("%s-pull-secret", o.Name)
+}
+
+// CloudBuilder interface exposes the functions we will use to set cloud specific portions of the cluster's resources.
+type CloudBuilder interface {
+	addClusterDeploymentPlatform(o *Builder, cd *hivev1.ClusterDeployment)
+	addMachinePoolPlatform(o *Builder, mp *hivev1.MachinePool)
+	addInstallConfigPlatform(o *Builder, ic *installertypes.InstallConfig)
+	generateCredentialsSecret(o *Builder) *corev1.Secret
+}

--- a/pkg/clusterresource/builder_test.go
+++ b/pkg/clusterresource/builder_test.go
@@ -1,0 +1,254 @@
+package clusterresource
+
+import (
+	"fmt"
+	"github.com/openshift/hive/pkg/apis"
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"testing"
+)
+
+const (
+	clusterName                      = "mycluster"
+	baseDomain                       = "example.com"
+	namespace                        = "mynamespace"
+	workerNodeCount                  = 3
+	pullSecret                       = "fakepullsecret"
+	deleteAfter                      = "8h"
+	imageSetName                     = "fake-image-set"
+	sshPrivateKey                    = "fakeprivatekey"
+	sshPublicKey                     = "fakepublickey"
+	fakeManifestFile                 = "my.yaml"
+	fakeManifestFileContents         = "fakemanifest"
+	fakeAWSAccessKeyID               = "fakeaccesskeyid"
+	fakeAWSSecretAccessKey           = "fakesecretAccessKey"
+	fakeAzureServicePrincipal        = "fakeSP"
+	fakeAzureBaseDomainResourceGroup = "azure-resource-group"
+	fakeGCPServiceAccount            = "fakeSA"
+	fakeGCPProjectID                 = "gcp-project-id"
+	adoptAdminKubeconfig             = "adopted-admin-kubeconfig"
+	adoptClusterID                   = "adopted-cluster-id"
+	adoptInfraID                     = "adopted-infra-id"
+)
+
+func createTestBuilder() *Builder {
+	b := &Builder{
+		Name:             clusterName,
+		Namespace:        namespace,
+		WorkerNodesCount: workerNodeCount,
+		PullSecret:       pullSecret,
+		SSHPrivateKey:    sshPrivateKey,
+		SSHPublicKey:     sshPublicKey,
+		BaseDomain:       baseDomain,
+		Labels: map[string]string{
+			"foo": "bar",
+		},
+		InstallerManifests: map[string][]byte{
+			fakeManifestFile: []byte(fakeManifestFileContents),
+		},
+		DeleteAfter: deleteAfter,
+		ImageSet:    imageSetName,
+	}
+	return b
+}
+
+func createAWSClusterBuilder() *Builder {
+	b := createTestBuilder()
+	b.CloudBuilder = &AWSCloudBuilder{
+		AccessKeyID:     fakeAWSAccessKeyID,
+		SecretAccessKey: fakeAWSSecretAccessKey,
+	}
+	return b
+}
+
+func createAzureClusterBuilder() *Builder {
+	b := createTestBuilder()
+	b.CloudBuilder = &AzureCloudBuilder{
+		ServicePrincipal:            []byte(fakeAzureServicePrincipal),
+		BaseDomainResourceGroupName: fakeAzureBaseDomainResourceGroup,
+	}
+	return b
+}
+
+func createGCPClusterBuilder() *Builder {
+	b := createTestBuilder()
+	b.CloudBuilder = &GCPCloudBuilder{
+		ServiceAccount: []byte(fakeGCPServiceAccount),
+		ProjectID:      fakeGCPProjectID,
+	}
+	return b
+}
+
+func TestBuildClusterResources(t *testing.T) {
+	tests := []struct {
+		name     string
+		builder  *Builder
+		validate func(t *testing.T, allObjects []runtime.Object)
+	}{
+		{
+			name:    "AWS cluster",
+			builder: createAWSClusterBuilder(),
+			validate: func(t *testing.T, allObjects []runtime.Object) {
+				cd := findClusterDeployment(allObjects, clusterName)
+				workerPool := findMachinePool(allObjects, fmt.Sprintf("%s-%s", clusterName, "worker"))
+
+				credsSecretName := fmt.Sprintf("%s-aws-creds", clusterName)
+				credsSecret := findSecret(allObjects, credsSecretName)
+				require.NotNil(t, credsSecret)
+				assert.Equal(t, credsSecret.Name, cd.Spec.Platform.AWS.CredentialsSecretRef.Name)
+
+				assert.Equal(t, awsInstanceType, workerPool.Spec.Platform.AWS.InstanceType)
+			},
+		},
+		{
+			name: "adopt AWS cluster",
+			builder: func() *Builder {
+				awsBuilder := createAWSClusterBuilder()
+				awsBuilder.Adopt = true
+				awsBuilder.AdoptInfraID = adoptInfraID
+				awsBuilder.AdoptClusterID = adoptClusterID
+				awsBuilder.AdoptAdminKubeconfig = []byte(adoptAdminKubeconfig)
+				return awsBuilder
+			}(),
+			validate: func(t *testing.T, allObjects []runtime.Object) {
+				cd := findClusterDeployment(allObjects, clusterName)
+
+				assert.Equal(t, true, cd.Spec.Installed)
+				assert.Equal(t, adoptInfraID, cd.Spec.ClusterMetadata.InfraID)
+				assert.Equal(t, adoptClusterID, cd.Spec.ClusterMetadata.ClusterID)
+
+				adminKubeconfig := findSecret(allObjects, fmt.Sprintf("%s-adopted-admin-kubeconfig", clusterName))
+				require.NotNil(t, adminKubeconfig)
+				assert.Equal(t, adminKubeconfig.Name, cd.Spec.ClusterMetadata.AdminKubeconfigSecretRef.Name)
+			},
+		},
+		{
+			name:    "Azure cluster",
+			builder: createAzureClusterBuilder(),
+			validate: func(t *testing.T, allObjects []runtime.Object) {
+				cd := findClusterDeployment(allObjects, clusterName)
+				workerPool := findMachinePool(allObjects, fmt.Sprintf("%s-%s", clusterName, "worker"))
+
+				credsSecretName := fmt.Sprintf("%s-azure-creds", clusterName)
+				credsSecret := findSecret(allObjects, credsSecretName)
+				require.NotNil(t, credsSecret)
+				assert.Equal(t, credsSecret.Name, cd.Spec.Platform.Azure.CredentialsSecretRef.Name)
+
+				assert.Equal(t, azureInstanceType, workerPool.Spec.Platform.Azure.InstanceType)
+			},
+		},
+		{
+			name:    "GCP cluster",
+			builder: createGCPClusterBuilder(),
+			validate: func(t *testing.T, allObjects []runtime.Object) {
+				cd := findClusterDeployment(allObjects, clusterName)
+				workerPool := findMachinePool(allObjects, fmt.Sprintf("%s-%s", clusterName, "worker"))
+
+				credsSecretName := fmt.Sprintf("%s-gcp-creds", clusterName)
+				credsSecret := findSecret(allObjects, credsSecretName)
+				require.NotNil(t, credsSecret)
+				assert.Equal(t, credsSecret.Name, cd.Spec.Platform.GCP.CredentialsSecretRef.Name)
+
+				assert.Equal(t, gcpInstanceType, workerPool.Spec.Platform.GCP.InstanceType)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		apis.AddToScheme(scheme.Scheme)
+		t.Run(test.name, func(t *testing.T) {
+			require.NoError(t, test.builder.Validate())
+			allObjects, err := test.builder.Build()
+			assert.NoError(t, err)
+
+			cd := findClusterDeployment(allObjects, clusterName)
+			require.NotNil(t, cd)
+
+			assert.Equal(t, clusterName, cd.Name)
+			assert.Equal(t, "bar", cd.Labels["foo"])
+			assert.Equal(t, baseDomain, cd.Spec.BaseDomain)
+			assert.Equal(t, deleteAfter, cd.Annotations[deleteAfterAnnotation])
+			assert.Equal(t, imageSetName, cd.Spec.Provisioning.ImageSetRef.Name)
+
+			installConfigSecret := findSecret(allObjects, fmt.Sprintf("%s-install-config", clusterName))
+			require.NotNil(t, installConfigSecret)
+			assert.Equal(t, installConfigSecret.Name, cd.Spec.Provisioning.InstallConfigSecretRef.Name)
+
+			pullSecretSecret := findSecret(allObjects, fmt.Sprintf("%s-pull-secret", clusterName))
+			require.NotNil(t, pullSecretSecret)
+			assert.Equal(t, pullSecretSecret.Name, cd.Spec.PullSecretRef.Name)
+
+			sshKeySecret := findSecret(allObjects, fmt.Sprintf("%s-ssh-private-key", clusterName))
+			require.NotNil(t, sshKeySecret)
+			assert.Equal(t, sshKeySecret.Name, cd.Spec.Provisioning.SSHPrivateKeySecretRef.Name)
+
+			workerPool := findMachinePool(allObjects, fmt.Sprintf("%s-%s", clusterName, "worker"))
+			require.NotNil(t, workerPool)
+			nc := int64(workerNodeCount)
+			assert.Equal(t, &nc, workerPool.Spec.Replicas)
+
+			manifestsConfigMap := findConfigMap(allObjects, fmt.Sprintf("%s-%s", clusterName, "manifests"))
+			require.NotNil(t, manifestsConfigMap)
+			assert.Equal(t, manifestsConfigMap.Name, cd.Spec.Provisioning.ManifestsConfigMapRef.Name)
+
+			test.validate(t, allObjects)
+		})
+	}
+
+}
+
+func findSecret(allObjects []runtime.Object, name string) *corev1.Secret {
+	for _, ro := range allObjects {
+		obj, ok := ro.(*corev1.Secret)
+		if !ok {
+			continue
+		}
+		if obj.Name == name {
+			return obj
+		}
+	}
+	return nil
+}
+
+func findClusterDeployment(allObjects []runtime.Object, name string) *hivev1.ClusterDeployment {
+	for _, ro := range allObjects {
+		obj, ok := ro.(*hivev1.ClusterDeployment)
+		if !ok {
+			continue
+		}
+		if obj.Name == name {
+			return obj
+		}
+	}
+	return nil
+}
+
+func findMachinePool(allObjects []runtime.Object, name string) *hivev1.MachinePool {
+	for _, ro := range allObjects {
+		obj, ok := ro.(*hivev1.MachinePool)
+		if !ok {
+			continue
+		}
+		if obj.Name == name {
+			return obj
+		}
+	}
+	return nil
+}
+
+func findConfigMap(allObjects []runtime.Object, name string) *corev1.ConfigMap {
+	for _, ro := range allObjects {
+		obj, ok := ro.(*corev1.ConfigMap)
+		if !ok {
+			continue
+		}
+		if obj.Name == name {
+			return obj
+		}
+	}
+	return nil
+}

--- a/pkg/clusterresource/gcp.go
+++ b/pkg/clusterresource/gcp.go
@@ -1,19 +1,16 @@
-package createcluster
+package clusterresource
 
 import (
 	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	installertypes "github.com/openshift/installer/pkg/types"
 	installergcp "github.com/openshift/installer/pkg/types/gcp"
 
-	gcputils "github.com/openshift/hive/contrib/pkg/utils/gcp"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	hivev1gcp "github.com/openshift/hive/pkg/apis/hive/v1/gcp"
 	"github.com/openshift/hive/pkg/constants"
-	"github.com/openshift/hive/pkg/gcpclient"
 )
 
 const (
@@ -21,16 +18,18 @@ const (
 	gcpInstanceType = "n1-standard-4"
 )
 
-var _ cloudProvider = (*gcpCloudProvider)(nil)
+var _ CloudBuilder = (*GCPCloudBuilder)(nil)
 
-type gcpCloudProvider struct {
+// GCPCloudBuilder encapsulates cluster artifact generation logic specific to GCP.
+type GCPCloudBuilder struct {
+	// ServicePrincipal is the bytes from a service account file, typically ~/.gcp/osServiceAccount.json.
+	ServiceAccount []byte
+
+	// ProjectID is the GCP project to use.
+	ProjectID string
 }
 
-func (p *gcpCloudProvider) generateCredentialsSecret(o *Options) (*corev1.Secret, error) {
-	saFileContents, err := gcputils.GetCreds(o.CredsFile)
-	if err != nil {
-		return nil, err
-	}
+func (p *GCPCloudBuilder) generateCredentialsSecret(o *Builder) *corev1.Secret {
 	return &corev1.Secret{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Secret",
@@ -42,26 +41,12 @@ func (p *gcpCloudProvider) generateCredentialsSecret(o *Options) (*corev1.Secret
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
-			constants.GCPCredentialsName: saFileContents,
+			constants.GCPCredentialsName: p.ServiceAccount,
 		},
-	}, nil
+	}
 }
 
-func (p *gcpCloudProvider) addPlatformDetails(
-	o *Options,
-	cd *hivev1.ClusterDeployment,
-	machinePool *hivev1.MachinePool,
-	installConfig *installertypes.InstallConfig,
-) error {
-	creds, err := gcputils.GetCreds(o.CredsFile)
-	if err != nil {
-		return err
-	}
-	projectID, err := gcpclient.ProjectID(creds)
-	if err != nil {
-		return err
-	}
-
+func (p *GCPCloudBuilder) addClusterDeploymentPlatform(o *Builder, cd *hivev1.ClusterDeployment) {
 	cd.Spec.Platform = hivev1.Platform{
 		GCP: &hivev1gcp.Platform{
 			CredentialsSecretRef: corev1.LocalObjectReference{
@@ -70,14 +55,19 @@ func (p *gcpCloudProvider) addPlatformDetails(
 			Region: gcpRegion,
 		},
 	}
+}
 
-	machinePool.Spec.Platform.GCP = &hivev1gcp.MachinePool{
+func (p *GCPCloudBuilder) addMachinePoolPlatform(o *Builder, mp *hivev1.MachinePool) {
+	mp.Spec.Platform.GCP = &hivev1gcp.MachinePool{
 		InstanceType: gcpInstanceType,
 	}
 
-	installConfig.Platform = installertypes.Platform{
+}
+
+func (p *GCPCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installertypes.InstallConfig) {
+	ic.Platform = installertypes.Platform{
 		GCP: &installergcp.Platform{
-			ProjectID: projectID,
+			ProjectID: p.ProjectID,
 			Region:    gcpRegion,
 		},
 	}
@@ -86,12 +76,10 @@ func (p *gcpCloudProvider) addPlatformDetails(
 	mpp := &installergcp.MachinePool{
 		InstanceType: gcpInstanceType,
 	}
-	installConfig.ControlPlane.Platform.GCP = mpp
-	installConfig.Compute[0].Platform.GCP = mpp
-
-	return nil
+	ic.ControlPlane.Platform.GCP = mpp
+	ic.Compute[0].Platform.GCP = mpp
 }
 
-func (p *gcpCloudProvider) credsSecretName(o *Options) string {
+func (p *GCPCloudBuilder) credsSecretName(o *Builder) string {
 	return fmt.Sprintf("%s-gcp-creds", o.Name)
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -169,6 +169,19 @@ const (
 
 	// AWSChinaRegionPrefix is the prefix for regions in AWS China.
 	AWSChinaRegionPrefix = "cn-"
+
+	// SSHPrivateKeySecretKey is the key we use in a Kubernetes Secret containing an SSH private key.
+	SSHPrivateKeySecretKey = "ssh-privatekey"
+
+	// RawKubeconfigSecretKey is the key we use in a Kubernetes Secret containing the raw (unmodified) form of
+	// an admin kubeconfig. (before Hive injects things such as additional CAs)
+	RawKubeconfigSecretKey = "raw-kubeconfig"
+
+	// TLSCrtSecretKey is the key we use in a Kubernetes Secret containing a TLS certificate.
+	TLSCrtSecretKey = "tls.crt"
+
+	// TLSKeySecretKey is the key we use in a Kubernetes Secret containing a TLS certificate key.
+	TLSKeySecretKey = "tls.key"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -52,8 +52,6 @@ const (
 	defaultRequeueTime = 10 * time.Second
 	maxProvisions      = 3
 
-	rawAdminKubeconfigKey = "raw-kubeconfig"
-
 	clusterImageSetNotFoundReason = "ClusterImageSetNotFound"
 	clusterImageSetFoundReason    = "ClusterImageSetFound"
 
@@ -303,9 +301,9 @@ func (r *ReconcileClusterDeployment) addAdditionalKubeconfigCAs(cd *hivev1.Clust
 
 	originalSecret := adminKubeconfigSecret.DeepCopy()
 
-	rawData, hasRawData := adminKubeconfigSecret.Data[rawAdminKubeconfigKey]
+	rawData, hasRawData := adminKubeconfigSecret.Data[constants.RawKubeconfigSecretKey]
 	if !hasRawData {
-		adminKubeconfigSecret.Data[rawAdminKubeconfigKey] = adminKubeconfigSecret.Data[constants.KubeconfigSecretKey]
+		adminKubeconfigSecret.Data[constants.RawKubeconfigSecretKey] = adminKubeconfigSecret.Data[constants.KubeconfigSecretKey]
 		rawData = adminKubeconfigSecret.Data[constants.KubeconfigSecretKey]
 	}
 

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -263,7 +263,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 					akcSecret)
 				require.NoError(t, err)
 				require.NotNil(t, akcSecret)
-				assert.Contains(t, akcSecret.Data, rawAdminKubeconfigKey)
+				assert.Contains(t, akcSecret.Data, constants.RawKubeconfigSecretKey)
 			},
 		},
 		{
@@ -294,7 +294,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 					akcSecret)
 				require.NoError(t, err)
 				require.NotNil(t, akcSecret)
-				assert.Contains(t, akcSecret.Data, rawAdminKubeconfigKey)
+				assert.Contains(t, akcSecret.Data, constants.RawKubeconfigSecretKey)
 			},
 		},
 		{

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
@@ -377,8 +377,8 @@ func fakeCertSecret(name string) *corev1.Secret {
 	s.Name = name
 	s.Namespace = fakeNamespace
 	s.Data = map[string][]byte{
-		"tls.key": []byte("blah"),
-		"tls.crt": []byte("blah"),
+		constants.TLSKeySecretKey: []byte("blah"),
+		constants.TLSCrtSecretKey: []byte("blah"),
 	}
 	s.Type = corev1.SecretTypeTLS
 	return s

--- a/pkg/controller/remoteingress/remoteingress_controller_test.go
+++ b/pkg/controller/remoteingress/remoteingress_controller_test.go
@@ -554,8 +554,8 @@ func testSecretForCertificateBundle(cb hivev1.CertificateBundleSpec) corev1.Secr
 			Kind: "Secret",
 		},
 		Data: map[string][]byte{
-			"tls.crt": []byte("SOME_FAKE_CERTIFICATE_DATA"),
-			"tls.key": []byte("SOME_FAKE_CERTIFICATE_KEY_DATA"),
+			constants.TLSCrtSecretKey: []byte("SOME_FAKE_CERTIFICATE_DATA"),
+			constants.TLSKeySecretKey: []byte("SOME_FAKE_CERTIFICATE_KEY_DATA"),
 		},
 	}
 	return secret

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -22,28 +22,24 @@ const (
 	// image is specified through a ClusterImageSet reference or on the ClusterDeployment itself.
 	DefaultInstallerImage = "registry.svc.ci.openshift.org/openshift/origin-v4.0:installer"
 
-	tryUninstallOnceAnnotation = "hive.openshift.io/try-uninstall-once"
-	azureAuthDir               = "/.azure"
-	azureAuthFile              = azureAuthDir + "/osServicePrincipal.json"
-	gcpAuthDir                 = "/.gcp"
-	gcpAuthFile                = gcpAuthDir + "/" + constants.GCPCredentialsName
+	azureAuthDir  = "/.azure"
+	azureAuthFile = azureAuthDir + "/osServicePrincipal.json"
+	gcpAuthDir    = "/.gcp"
+	gcpAuthFile   = gcpAuthDir + "/" + constants.GCPCredentialsName
 
 	// SSHPrivateKeyDir is the directory where the generated Job will mount the ssh secret to
 	SSHPrivateKeyDir = "/sshkeys"
 
 	// LibvirtSSHPrivateKeyDir is the directory where the generated Job will mount the libvirt ssh secret to
 	LibvirtSSHPrivateKeyDir = "/libvirtsshkeys"
-
-	// SSHSecretPrivateKeyName is the key name holding the private key in the SSH secret
-	SSHSecretPrivateKeyName = "ssh-privatekey"
 )
 
 var (
 	// SSHPrivateKeyFilePath is the path to the private key contents (from the SSH secret)
-	SSHPrivateKeyFilePath = fmt.Sprintf("%s/%s", SSHPrivateKeyDir, SSHSecretPrivateKeyName)
+	SSHPrivateKeyFilePath = fmt.Sprintf("%s/%s", SSHPrivateKeyDir, constants.SSHPrivateKeySecretKey)
 
 	// LibvirtSSHPrivateKeyFilePath is the path to the private key contents (from the libvirt SSH secret)
-	LibvirtSSHPrivateKeyFilePath = fmt.Sprintf("%s/%s", LibvirtSSHPrivateKeyDir, SSHSecretPrivateKeyName)
+	LibvirtSSHPrivateKeyFilePath = fmt.Sprintf("%s/%s", LibvirtSSHPrivateKeyDir, constants.SSHPrivateKeySecretKey)
 )
 
 // InstallerPodSpec generates a spec for an installer pod.
@@ -378,16 +374,7 @@ func GetUninstallJobName(name string) string {
 func GenerateUninstallerJobForDeprovision(
 	req *hivev1.ClusterDeprovision) (*batchv1.Job, error) {
 
-	tryOnce := false
-	if req.Annotations != nil {
-		value, exists := req.Annotations[tryUninstallOnceAnnotation]
-		tryOnce = exists && value == "true"
-	}
-
 	restartPolicy := corev1.RestartPolicyOnFailure
-	if tryOnce {
-		restartPolicy = corev1.RestartPolicyNever
-	}
 
 	podSpec := corev1.PodSpec{
 		DNSPolicy:     corev1.DNSClusterFirst,


### PR DESCRIPTION
In preparation for cluster pools, we will want a way to generate a ClusterDeployment and all related objects in the core hive code. We however do not want this code reading from the filesystem or environment variables, or assuming the use of apply.

Move parts of hiveutil's create-cluster command which generates the runtime.Objects into a new package. A Generator object can be created and configured incrementally prior to generating all the required objects. Callers likely don't care what the objects are, they just configure the generator, get the list of objects, and then create or apply them.

In the midst of this there is a new option for re-using a credentials secret that already exists.

Still needs validation and unit tests.