### PR TITLE
update cleanupLogOutput to handle malformed data from libvirt and ssh

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -36,3 +36,17 @@ data:
       - "failed to initialize the cluster: Cluster operator monitoring is still updating"
       installFailingReason: MonitoringOperatorStillUpdating
       installFailingMessage: Timeout waiting for the monitoring operator to become ready
+    # Bare Metal
+    - name: LibvirtSSHKeyPermissionDenied
+      searchRegexStrings:
+      - "platform.baremetal.libvirtURI: Internal error: could not connect to libvirt: virError.Code=38, Domain=7, Message=.Cannot recv data: Permission denied"
+      installFailingReason: LibvirtSSHKeyPermissionDenied
+      installFailingMessage: "Permission denied connecting to libvirt host, check SSH key configuration and pass phrase"
+    # Processing stops at the first match, so this more generic
+    # message about the connection failure must always come after the
+    # more specific message for LibvirtSSHKeyPermissionDenied.
+    - name: LibvirtConnectionFailed
+      searchRegexStrings:
+      - "could not connect to libvirt"
+      installFailingReason: LibvirtConnectionFailed
+      installFailingMessage: "Could not connect to libvirt host"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -5224,6 +5224,20 @@ data:
       - "failed to initialize the cluster: Cluster operator monitoring is still updating"
       installFailingReason: MonitoringOperatorStillUpdating
       installFailingMessage: Timeout waiting for the monitoring operator to become ready
+    # Bare Metal
+    - name: LibvirtSSHKeyPermissionDenied
+      searchRegexStrings:
+      - "platform.baremetal.libvirtURI: Internal error: could not connect to libvirt: virError.Code=38, Domain=7, Message=.Cannot recv data: Permission denied"
+      installFailingReason: LibvirtSSHKeyPermissionDenied
+      installFailingMessage: "Permission denied connecting to libvirt host, check SSH key configuration and pass phrase"
+    # Processing stops at the first match, so this more generic
+    # message about the connection failure must always come after the
+    # more specific message for LibvirtSSHKeyPermissionDenied.
+    - name: LibvirtConnectionFailed
+      searchRegexStrings:
+      - "could not connect to libvirt"
+      installFailingReason: LibvirtConnectionFailed
+      installFailingMessage: "Could not connect to libvirt host"
 `)
 
 func configConfigmapsInstallLogRegexesConfigmapYamlBytes() ([]byte, error) {


### PR DESCRIPTION
When the baremetal installer fails to connect via ssh to a remote libvirt 
host, the error message included embedded and *escaped* carriage returns 
and newlines. This change unescapes them so that any redaction of the error
message contents is minimized. The change is in cleanupLogOutput instead of
the function that reads the log because there are no tests for the reading
function and there are for the cleaning function.

Addresses #878