### PR TITLE
Fix crash when using more than 35 GCP MachinePools.

### DIFF
--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -318,6 +318,8 @@ gcp:
   type: n1-standard-4
 ```
 
+WARNING: Due to some naming restrictions on various components in GCP, Hive will restrict you to a max of 35 MachinePools (including the original worker pool created by default). We are left with only a single character to differentiate the machines and nodes from a pool, and 'm' is already reserved for the master hosts, leaving us with a-z (minus m) and 0-9 for a total of 35. Hive will automatically create a MachinePoolNameLease for GCP MachinePools to grab one of the available characters until none are left, at which point your MachinePool will not be provisioned.
+
 #### Create Cluster on Bare Metal
 
 Hive supports bare metal provisioning as provided by [openshift-install](https://github.com/openshift/installer/blob/master/docs/user/metal/install_ipi.md)

--- a/pkg/apis/hive/v1/machinepool_types.go
+++ b/pkg/apis/hive/v1/machinepool_types.go
@@ -120,6 +120,10 @@ const (
 	// NotEnoughReplicasMachinePoolCondition is true when the minReplicas field
 	// is set too low for the number of machinesets for the machine pool.
 	NotEnoughReplicasMachinePoolCondition MachinePoolConditionType = "NotEnoughReplicas"
+
+	// NoMachinePoolNameLeasesAvailable is true when the cloud provider requires a name lease for the in-cluster MachineSet, but no
+	// leases are available.
+	NoMachinePoolNameLeasesAvailable MachinePoolConditionType = "NoMachinePoolNameLeasesAvailable"
 )
 
 // +genclient


### PR DESCRIPTION
Code did not properly handle the case when no lease characters are
available.

Added a short docs blurb, and a condition to be set when this situation
arises.

cc @lwan-wanglin 