### PR TITLE
WIP: new lambda for building running instance reports

### DIFF
--- a/hack/lambda/periodic_lambda_function.py
+++ b/hack/lambda/periodic_lambda_function.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+import boto3
+import json
+import io
+
+def lambda_handler(event, context):
+
+    print(event)
+    running_instances = {}
+
+    for region in event["regions"]:
+        ec2client = boto3.client('ec2', region)
+
+        response = ec2client.describe_instances()
+        
+        running_instances[region] = []
+
+        for resp in response["Reservations"]:
+            for instance in resp["Instances"]:
+                if instance["State"]["Name"] == "running":
+                    for tag in instance["Tags"]:
+                        if tag["Key"] == "Name":
+                            running_instances[region].append(tag["Value"])
+
+        running_instances[region].sort()
+
+    instances_formatted = build_instance_email_text(running_instances)
+
+    send_email(event["recipients"], event["fromemail"], instances_formatted, event["emailregion"])
+
+    return {
+        'statusCode': 200,
+        'body': json.dumps('Lambda complete!')
+    }
+
+def build_instance_email_text(instances):
+    buf = io.StringIO()
+
+    for region in instances.keys():
+        buf.write("Region: {}\n".format(region))
+        for instance in instances[region]:
+            buf.write("{}\n".format(instance))
+
+        buf.write("\n")
+        
+    return buf.getvalue()
+
+def send_email(recipients, fromemail, email_body, region):
+    sesclient = boto3.client('ses', region)
+
+    response = sesclient.send_email(
+        Source=fromemail,
+        Destination={
+            'ToAddresses': recipients,
+        },
+        Message={
+            'Subject': {'Data': 'Hive running instance report'},
+            'Body': {'Text': {'Data': email_body}},
+        },
+    )
+
+    print("Email response: {}".format(response))
+
+def main():
+    event = {"regions": ["us-east-1", "us-east-2"],
+            "recipients": ["someone@example.com"],
+            "fromemail": "return@example.com",
+            "emailregion": "us-east-1",
+            }
+    result = lambda_handler(event, "")
+    print(result)
+
+if __name__ == "__main__":
+    main()

--- a/hack/lambda/rolepolicy.json
+++ b/hack/lambda/rolepolicy.json
@@ -1,0 +1,28 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "logs:CreateLogGroup",
+            "Resource": "arn:aws:logs:us-east-1:125931421481:*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],
+            "Resource": [
+                "arn:aws:logs:us-east-1:125931421481:log-group:/aws/lambda/periodicHiveLambdaFunction:*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                    "ec2:DescribeInstances",
+                    "ses:SendEmail"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/hack/lambda/trustpolicy.json
+++ b/hack/lambda/trustpolicy.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/hack/upload-lambda.yaml
+++ b/hack/upload-lambda.yaml
@@ -1,0 +1,107 @@
+#!/usr/bin/env -S ansible-playbook
+#
+# Provide a JSON-formated list of recipients and what email to use in the From field (for bounce-back emails).
+# --extra-vars '{"recipeints": ["email@example.com", "email2@example.com"], "fromemail": "reply@example.com"}'
+#
+---
+- hosts: localhost
+  vars:
+    iam_role_name: periodicHiveLambdaRole
+    lambda_function_name: periodicHiveLambdaFunction
+    default_region: us-east-1
+    cloudwatch_rule_name: PeriodicHiveLambdaSchedule
+    cloudwatch_rule_target_event_id: PeriodicHiveID
+  tasks:
+  - name: ensure recipients provided
+    fail:
+      msg: "need to provided json formatted list of email recipients in variable named 'recipients'"
+    when: recipients is undefined
+
+  - name: ensure source email provided
+    fail:
+      msg: "need to provide the source/From email address in variable named 'fromemail'"
+    when: fromemail is undefined
+
+  - name: create lambda role
+    iam_role:
+      name: "{{ iam_role_name }}"
+      assume_role_policy_document: "{{ lookup('file', 'lambda/trustpolicy.json') }}"
+      description: "Periodic Hive Lambda Role"
+    register: iam_role
+
+  - debug:
+      var: iam_role
+      verbosity: 1
+
+  - name: attach permissions to role
+    iam_policy:
+      iam_type: role
+      iam_name: "{{ iam_role_name }}"
+      policy_name: periodicHiveLambdaRolePolicy
+      state: present
+      policy_document: "lambda/rolepolicy.json"
+
+
+  - name: zip up lambda function
+    archive:
+      path: lambda/periodic_lambda_function.py
+      dest: lambda.zip
+      format: zip
+      force_archive: yes
+
+  - name: upload lambda function
+    lambda:
+      name: "{{ lambda_function_name }}"
+      state: present
+      zip_file: lambda.zip
+      runtime: python3.8
+      role: "{{ iam_role.iam_role.role_name }}"
+      handler: periodic_lambda_function.lambda_handler
+      region: "{{ default_region }}"
+      timeout: 15
+    register: lambda_func
+
+  - debug:
+      var: lambda_func
+      verbosity: 1
+
+  - name: cleanup zip file
+    file:
+      state: absent
+      path: lambda.zip
+
+  - name: set event schedule
+    cloudwatchevent_rule:
+      name: "{{ cloudwatch_rule_name }}"
+      state: present
+      #state: disabled
+      region: "{{ default_region }}"
+      description: Run Hive Lambda Function on weekdays
+      schedule_expression: "cron(0 22 ? * MON-FRI *)"
+      #schedule_expression: "cron(0/10 * * * ? *)"
+      targets:
+        - id: "{{ cloudwatch_rule_target_event_id }}"
+          arn: "{{ lambda_func.configuration.function_arn }}"
+          input: ' {"regions": ["us-east-1", "us-east-2"], "emailregion": "{{ default_region }}", "recipients": {{ recipients | to_json }} , "fromemail": "{{ fromemail}}" } '
+    register: event_info
+
+  - debug:
+      var: event_info
+      verbosity: 1
+
+  - name: allow event to call lambda function
+    lambda_policy:
+      state: present
+      statement_id: lambda-cloudwatch-event-rule
+      region: "{{ default_region }}"
+      function_name: "{{ lambda_func.configuration.function_name }}"
+      action: lambda:InvokeFunction
+      principal: events.amazonaws.com
+      source_arn: "{{ event_info.rule.arn }}"
+
+  - name: apply settings to cloudwatch logs
+    cloudwatchlogs_log_group:
+      log_group_name: "/aws/lambda/{{ lambda_function_name }}"
+      state: present
+      retention: 14
+      region: "{{ default_region }}"


### PR DESCRIPTION
* A new AWS Lambda function written in Python that can be used to get a list of running instances from a list of regions, and email a report out.
* A CloudWatch event to periodically (once a day) run the Lambda, and provide the Lambda with the values it needs to perform its function (ie recipients, regions to search through, etc).
* Static AWS policies that grant the necessary permissions to the Lambda.
* An Ansible playbook to create all these objects in AWS and stitch them together.

The create/update flow is to run the playbook while providing the list of recipients who will recieve the report and the email to use as the from address (for bounce back emails).

`./upload-lambda.yaml --extra-vars '{"recipients": ["one@example.com", "two@example.com"], "fromemail": "reply@example.com"}'`