### PR TITLE
apiserver: omit empty serviceNetwork and machineNetwork from installconfig

### DIFF
--- a/pkg/hive/apiserver/registry/util/convert.go
+++ b/pkg/hive/apiserver/registry/util/convert.go
@@ -54,11 +54,19 @@ func ClusterDeploymentToHiveV1(in *hiveapi.ClusterDeployment, sshKey string, out
 		installConfig.Networking = &installtypes.Networking{}
 	}
 	installConfig.Networking.NetworkType = string(in.Spec.Networking.Type)
-	installConfig.Networking.ServiceNetwork = []ipnet.IPNet{*parseCIDR(in.Spec.Networking.ServiceCIDR)}
-	installConfig.Networking.MachineNetwork = []installtypes.MachineNetworkEntry{
-		{
-			CIDR: *parseCIDR(in.Spec.Networking.MachineCIDR),
-		},
+	if in.Spec.Networking.ServiceCIDR != "" && in.Spec.Networking.ServiceCIDR != "<nil>" {
+		installConfig.Networking.ServiceNetwork = []ipnet.IPNet{*parseCIDR(in.Spec.Networking.ServiceCIDR)}
+	} else {
+		installConfig.Networking.ServiceNetwork = nil
+	}
+	if in.Spec.Networking.MachineCIDR != "" && in.Spec.Networking.MachineCIDR != "<nil>" {
+		installConfig.Networking.MachineNetwork = []installtypes.MachineNetworkEntry{
+			{
+				CIDR: *parseCIDR(in.Spec.Networking.MachineCIDR),
+			},
+		}
+	} else {
+		installConfig.Networking.MachineNetwork = nil
 	}
 	// installConfig.PullSecret = <filled in by the Hive installmanager>
 	if installConfig.ControlPlane == nil {


### PR DESCRIPTION
The aggregated API server was assuming that the serviceCIDR and machineCIDR were
required fields in the v1alpha1 ClusterDeployment. However, they can be omitted
to use defaults. When they were omitted in the v1alpha1 ClusterDeployment,
the aggregated API server was creating a bad element in the serviceNetwork
and machineNetwork fields in the installconfig.

These changes
 (1) keep the bad element from being created and
 (2) treat a bad element (with the text "<nil>") as non-existent to correct the
     problem for existing clusters.