### PR TITLE
OLM artifacts: use empty array for MANAGED_DOMAINS default

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -15,12 +15,7 @@ parameters:
 - name: GLOBAL_PULL_SECRET
   value: ""
 - name: MANAGED_DOMAINS
-  value:
-  - aws:
-      credentialsSecretRef:
-        name: my-dns-creds
-    domains:
-    - openshift.example.com
+  value: "[]"
 
 objects:
 - apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
OLM artifacts: use empty array for MANAGED_DOMAINS default

The previous attempt to populate the array with dummy data
was invalid oc template syntax. Use an empty array.