### PR TITLE
modify openshift detection logic

### DIFF
--- a/pkg/operator/hive/hive_controller.go
+++ b/pkg/operator/hive/hive_controller.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -79,6 +80,11 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	r.(*ReconcileHiveConfig).apiextClient, err = apiextclientv1beta1.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return err
+	}
+
+	r.(*ReconcileHiveConfig).discoveryClient, err = discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
 	if err != nil {
 		return err
 	}
@@ -208,6 +214,7 @@ type ReconcileHiveConfig struct {
 	kubeClient            kubernetes.Interface
 	apiextClient          *apiextclientv1beta1.ApiextensionsV1beta1Client
 	apiregClient          *apiregclientv1.ApiregistrationV1Client
+	discoveryClient       discovery.DiscoveryInterface
 	dynamicClient         dynamic.Interface
 	restConfig            *rest.Config
 	hiveImage             string

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -118,7 +118,11 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h *resou
 	// the cluster CA and inject into the webhooks.
 	// NOTE: If this is vanilla kube, you will also need to manually create a certificate
 	// secret, see hack/hiveadmission-dev-cert.sh.
-	if !r.runningOnOpenShift(hLog) || is311 {
+	isOpenShift, err := r.runningOnOpenShift(hLog)
+	if err != nil {
+		return err
+	}
+	if !isOpenShift || is311 {
 		hLog.Debug("non-OpenShift 4.x cluster detected, modifying hiveadmission webhooks for CA certs")
 		err = r.injectCerts(apiService, validatingWebhooks, nil, hLog)
 		if err != nil {

--- a/pkg/operator/hive/hiveapi.go
+++ b/pkg/operator/hive/hiveapi.go
@@ -63,7 +63,12 @@ func (r *ReconcileHiveConfig) createAPIServerAPIService(hLog log.FieldLogger, h 
 	// the cluster CA and inject into the APIServer.
 	// NOTE: If this is vanilla kube, you will also need to manually create a certificate
 	// secret, see hack/hiveapi-dev-cert.sh.
-	if !r.runningOnOpenShift(hLog) || is311 {
+	isOpenShift, err := r.runningOnOpenShift(hLog)
+	if err != nil {
+		return err
+	}
+
+	if !isOpenShift || is311 {
 		hLog.Debug("non-OpenShift 4.x cluster detected, modifying apiservice")
 		serviceCA, _, err := r.getCACerts(hLog)
 		if err != nil {


### PR DESCRIPTION
Rather than list DeploymentConfig objects to detect whetther or not hive is running on openshift, query the available resources for the DeploymentConfig group/version to determine OpenShift vs non-OpenShift.

This should silence some of the log output from the operator that looks like:

`E0303 16:28:56.009055 1 reflector.go:329] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:204: expected type *v1beta1.CustomResourceDefinition, but watch event object had type *unstructured.Unstructured`

by having the controller-runtime not open a watch on the DeploymentConfigs.