### PR TITLE
add config setting for cli image

### DIFF
--- a/config/crds/hive_v1_hiveconfig.yaml
+++ b/config/crds/hive_v1_hiveconfig.yaml
@@ -89,6 +89,10 @@ spec:
               description: HiveAPIEnabled is a boolean controlling whether or not
                 the Hive operator will start up the v1alpha1 aggregated API server.
               type: boolean
+            imageExtractionCLIImage:
+              description: ImageExtractionCLIImage can be set to override the location
+                of the image with the oc command line tool.
+              type: string
             logLevel:
               description: LogLevel is the level of logging to use for the Hive controllers.
                 Acceptable levels, from coarsest to finest, are panic, fatal, error,

--- a/pkg/apis/hive/v1/hiveconfig_types.go
+++ b/pkg/apis/hive/v1/hiveconfig_types.go
@@ -57,6 +57,10 @@ type HiveConfigSpec struct {
 
 	// DeprovisionsDisabled can be set to true to block deprovision jobs from running.
 	DeprovisionsDisabled *bool `json:"deprovisionsDisabled,omitempty"`
+
+	// ImageExtractionCLIImage can be set to override the location of
+	// the image with the oc command line tool.
+	ImageExtractionCLIImage string `json:"imageExtractionCLIImage,omitempty"`
 }
 
 // HiveConfigStatus defines the observed state of Hive

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -3065,6 +3065,10 @@ spec:
               description: HiveAPIEnabled is a boolean controlling whether or not
                 the Hive operator will start up the v1alpha1 aggregated API server.
               type: boolean
+            imageExtractionCLIImage:
+              description: ImageExtractionCLIImage can be set to override the location
+                of the image with the oc command line tool.
+              type: string
             logLevel:
               description: LogLevel is the level of logging to use for the Hive controllers.
                 Acceptable levels, from coarsest to finest, are panic, fatal, error,

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -46,6 +46,15 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helpe
 	hiveDeployment := resourceread.ReadDeploymentV1OrDie(asset)
 	hiveContainer := &hiveDeployment.Spec.Template.Spec.Containers[0]
 
+	cliImage := images.DefaultCLIImage
+	if instance.Spec.ImageExtractionCLIImage != "" {
+		cliImage = instance.Spec.ImageExtractionCLIImage
+	}
+	hiveContainer.Env = append(hiveContainer.Env, corev1.EnvVar{
+		Name:  images.CLIImageEnvVar,
+		Value: cliImage,
+	})
+
 	if r.hiveImage != "" {
 		hiveContainer.Image = r.hiveImage
 		hiveImageEnvVar := corev1.EnvVar{


### PR DESCRIPTION
When using hive in a disconnected bare metal environment the user
needs to be able to specify the location of the CLI image. Add a field
to the config spec and use it to set the existing environment variable
via the deployment for the controller.