### PR TITLE
Validate SyncSet ResourceApplyMode

### DIFF
--- a/config/crds/hive_v1_selectorsyncset.yaml
+++ b/config/crds/hive_v1_selectorsyncset.yaml
@@ -63,8 +63,8 @@ spec:
               type: array
             resourceApplyMode:
               description: ResourceApplyMode indicates if the Resource apply mode
-                is "upsert" (default) or "sync". ApplyMode "upsert" indicates create
-                and update. ApplyMode "sync" indicates create, update and delete.
+                is "Upsert" (default) or "Sync". ApplyMode "Upsert" indicates create
+                and update. ApplyMode "Sync" indicates create, update and delete.
               type: string
             resources:
               description: Resources is the list of objects to sync from RawExtension

--- a/config/crds/hive_v1_syncset.yaml
+++ b/config/crds/hive_v1_syncset.yaml
@@ -66,8 +66,8 @@ spec:
               type: array
             resourceApplyMode:
               description: ResourceApplyMode indicates if the Resource apply mode
-                is "upsert" (default) or "sync". ApplyMode "upsert" indicates create
-                and update. ApplyMode "sync" indicates create, update and delete.
+                is "Upsert" (default) or "Sync". ApplyMode "Upsert" indicates create
+                and update. ApplyMode "Sync" indicates create, update and delete.
               type: string
             resources:
               description: Resources is the list of objects to sync from RawExtension

--- a/pkg/apis/hive/v1/syncset_types.go
+++ b/pkg/apis/hive/v1/syncset_types.go
@@ -130,9 +130,9 @@ type SyncSetObjectStatus struct {
 	// +optional
 	Resources []SyncStatus `json:"resources,omitempty"`
 
-	// ResourceApplyMode indicates if the Resource apply mode is "upsert" (default) or "sync".
-	// ApplyMode "upsert" indicates create and update.
-	// ApplyMode "sync" indicates create, update and delete.
+	// ResourceApplyMode indicates if the Resource apply mode is "Upsert" (default) or "Sync".
+	// ApplyMode "Upsert" indicates create and update.
+	// ApplyMode "Sync" indicates create, update and delete.
 	// +optional
 	ResourceApplyMode SyncSetResourceApplyMode `json:"resourceApplyMode,omitempty"`
 
@@ -185,9 +185,9 @@ type SyncSetCommonSpec struct {
 	// +optional
 	Resources []runtime.RawExtension `json:"resources,omitempty"`
 
-	// ResourceApplyMode indicates if the Resource apply mode is "upsert" (default) or "sync".
-	// ApplyMode "upsert" indicates create and update.
-	// ApplyMode "sync" indicates create, update and delete.
+	// ResourceApplyMode indicates if the Resource apply mode is "Upsert" (default) or "Sync".
+	// ApplyMode "Upsert" indicates create and update.
+	// ApplyMode "Sync" indicates create, update and delete.
 	// +optional
 	ResourceApplyMode SyncSetResourceApplyMode `json:"resourceApplyMode,omitempty"`
 

--- a/pkg/apis/hive/v1/validating-webhooks/selector_syncset_validating_admission_hook.go
+++ b/pkg/apis/hive/v1/validating-webhooks/selector_syncset_validating_admission_hook.go
@@ -153,6 +153,7 @@ func (a *SelectorSyncSetValidatingAdmissionHook) validateCreate(admissionSpec *a
 	allErrs = append(allErrs, validateResources(newObject.Spec.Resources, field.NewPath("spec").Child("resources"))...)
 	allErrs = append(allErrs, validatePatches(newObject.Spec.Patches, field.NewPath("spec").Child("patches"))...)
 	allErrs = append(allErrs, validateSecrets(newObject.Spec.Secrets, field.NewPath("spec").Child("secretMappings"))...)
+	allErrs = append(allErrs, validateResourceApplyMode(newObject.Spec.ResourceApplyMode, field.NewPath("spec", "resourceApplyMode"))...)
 
 	if len(allErrs) > 0 {
 		statusError := errors.NewInvalid(newObject.GroupVersionKind().GroupKind(), newObject.Name, allErrs).Status()
@@ -200,6 +201,7 @@ func (a *SelectorSyncSetValidatingAdmissionHook) validateUpdate(admissionSpec *a
 	allErrs = append(allErrs, validateResources(newObject.Spec.Resources, field.NewPath("spec", "resources"))...)
 	allErrs = append(allErrs, validatePatches(newObject.Spec.Patches, field.NewPath("spec", "patches"))...)
 	allErrs = append(allErrs, validateSecrets(newObject.Spec.Secrets, field.NewPath("spec", "secretReferences"))...)
+	allErrs = append(allErrs, validateResourceApplyMode(newObject.Spec.ResourceApplyMode, field.NewPath("spec", "resourceApplyMode"))...)
 
 	if len(allErrs) > 0 {
 		statusError := errors.NewInvalid(newObject.GroupVersionKind().GroupKind(), newObject.Name, allErrs).Status()

--- a/pkg/apis/hive/v1/validating-webhooks/selector_syncset_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/selector_syncset_validating_admission_hook_test.go
@@ -149,6 +149,86 @@ func TestSelectorSyncSetValidate(t *testing.T) {
 			expectedAllowed: false,
 		},
 		{
+			name:      "Test valid empty string resourceApplyMode create",
+			operation: admissionv1beta1.Create,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSelectorSyncSet()
+				ss.Spec.ResourceApplyMode = ""
+				return ss
+			}(),
+			expectedAllowed: true,
+		},
+		{
+			name:      "Test valid empty string resourceApplyMode update",
+			operation: admissionv1beta1.Update,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSelectorSyncSet()
+				ss.Spec.ResourceApplyMode = ""
+				return ss
+			}(),
+			expectedAllowed: true,
+		},
+		{
+			name:      "Test valid Upsert resourceApplyMode create",
+			operation: admissionv1beta1.Create,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSelectorSyncSet()
+				ss.Spec.ResourceApplyMode = "Upsert"
+				return ss
+			}(),
+			expectedAllowed: true,
+		},
+		{
+			name:      "Test valid Upsert resourceApplyMode update",
+			operation: admissionv1beta1.Update,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSelectorSyncSet()
+				ss.Spec.ResourceApplyMode = "Upsert"
+				return ss
+			}(),
+			expectedAllowed: true,
+		},
+		{
+			name:      "Test valid Sync resourceApplyMode create",
+			operation: admissionv1beta1.Create,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSelectorSyncSet()
+				ss.Spec.ResourceApplyMode = "Sync"
+				return ss
+			}(),
+			expectedAllowed: true,
+		},
+		{
+			name:      "Test valid Sync resourceApplyMode update",
+			operation: admissionv1beta1.Update,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSelectorSyncSet()
+				ss.Spec.ResourceApplyMode = "Sync"
+				return ss
+			}(),
+			expectedAllowed: true,
+		},
+		{
+			name:      "Test invalid resourceApplyMode create",
+			operation: admissionv1beta1.Create,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSelectorSyncSet()
+				ss.Spec.ResourceApplyMode = "sync"
+				return ss
+			}(),
+			expectedAllowed: false,
+		},
+		{
+			name:      "Test invalid resourceApplyMode update",
+			operation: admissionv1beta1.Update,
+			selectorSyncSet: func() *hivev1.SelectorSyncSet {
+				ss := testSelectorSyncSet()
+				ss.Spec.ResourceApplyMode = "sync"
+				return ss
+			}(),
+			expectedAllowed: false,
+		},
+		{
 			name:            "Test invalid unmarshalable TypeMeta Resource create",
 			operation:       admissionv1beta1.Create,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": 798786}`),

--- a/pkg/apis/hive/v1/validating-webhooks/syncset_validating_admission_hook.go
+++ b/pkg/apis/hive/v1/validating-webhooks/syncset_validating_admission_hook.go
@@ -42,6 +42,21 @@ var validPatchTypes = map[string]bool{
 
 var validPatchTypeSlice = []string{"json", "merge", "strategic"}
 
+var (
+	validResourceApplyModes = map[hivev1.SyncSetResourceApplyMode]bool{
+		hivev1.UpsertResourceApplyMode: true,
+		hivev1.SyncResourceApplyMode:   true,
+	}
+
+	validResourceApplyModeSlice = func() []string {
+		v := make([]string, 0, len(validResourceApplyModes))
+		for m := range validResourceApplyModes {
+			v = append(v, string(m))
+		}
+		return v
+	}()
+)
+
 // SyncSetValidatingAdmissionHook is a struct that is used to reference what code should be run by the generic-admission-server.
 type SyncSetValidatingAdmissionHook struct{}
 
@@ -172,6 +187,7 @@ func (a *SyncSetValidatingAdmissionHook) validateCreate(admissionSpec *admission
 	allErrs = append(allErrs, validateResources(newObject.Spec.Resources, field.NewPath("spec").Child("resources"))...)
 	allErrs = append(allErrs, validatePatches(newObject.Spec.Patches, field.NewPath("spec").Child("patches"))...)
 	allErrs = append(allErrs, validateSecrets(newObject.Spec.Secrets, field.NewPath("spec").Child("secretMappings"))...)
+	allErrs = append(allErrs, validateResourceApplyMode(newObject.Spec.ResourceApplyMode, field.NewPath("spec", "resourceApplyMode"))...)
 
 	if len(allErrs) > 0 {
 		statusError := errors.NewInvalid(newObject.GroupVersionKind().GroupKind(), newObject.Name, allErrs).Status()
@@ -219,6 +235,7 @@ func (a *SyncSetValidatingAdmissionHook) validateUpdate(admissionSpec *admission
 	allErrs = append(allErrs, validateResources(newObject.Spec.Resources, field.NewPath("spec", "resources"))...)
 	allErrs = append(allErrs, validatePatches(newObject.Spec.Patches, field.NewPath("spec", "patches"))...)
 	allErrs = append(allErrs, validateSecrets(newObject.Spec.Secrets, field.NewPath("spec", "secretMappings"))...)
+	allErrs = append(allErrs, validateResourceApplyMode(newObject.Spec.ResourceApplyMode, field.NewPath("spec", "resourceApplyMode"))...)
 
 	if len(allErrs) > 0 {
 		statusError := errors.NewInvalid(newObject.GroupVersionKind().GroupKind(), newObject.Name, allErrs).Status()
@@ -243,6 +260,14 @@ func validatePatches(patches []hivev1.SyncObjectPatch, fldPath *field.Path) fiel
 		if !validPatchTypes[patch.PatchType] {
 			allErrs = append(allErrs, field.NotSupported(fldPath.Index(i).Child("PatchType"), patch.PatchType, validPatchTypeSlice))
 		}
+	}
+	return allErrs
+}
+
+func validateResourceApplyMode(resourceApplyMode hivev1.SyncSetResourceApplyMode, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if resourceApplyMode != "" && !validResourceApplyModes[resourceApplyMode] {
+		allErrs = append(allErrs, field.NotSupported(fldPath, resourceApplyMode, validResourceApplyModeSlice))
 	}
 	return allErrs
 }

--- a/pkg/apis/hive/v1/validating-webhooks/syncset_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/syncset_validating_admission_hook_test.go
@@ -137,6 +137,86 @@ func TestSyncSetValidate(t *testing.T) {
 			expectedAllowed: false,
 		},
 		{
+			name:      "Test valid empty string resourceApplyMode create",
+			operation: admissionv1beta1.Create,
+			syncSet: func() *hivev1.SyncSet {
+				ss := testSyncSet()
+				ss.Spec.ResourceApplyMode = ""
+				return ss
+			}(),
+			expectedAllowed: true,
+		},
+		{
+			name:      "Test valid empty string resourceApplyMode update",
+			operation: admissionv1beta1.Update,
+			syncSet: func() *hivev1.SyncSet {
+				ss := testSyncSet()
+				ss.Spec.ResourceApplyMode = ""
+				return ss
+			}(),
+			expectedAllowed: true,
+		},
+		{
+			name:      "Test valid Upsert resourceApplyMode create",
+			operation: admissionv1beta1.Create,
+			syncSet: func() *hivev1.SyncSet {
+				ss := testSyncSet()
+				ss.Spec.ResourceApplyMode = "Upsert"
+				return ss
+			}(),
+			expectedAllowed: true,
+		},
+		{
+			name:      "Test valid Upsert resourceApplyMode update",
+			operation: admissionv1beta1.Update,
+			syncSet: func() *hivev1.SyncSet {
+				ss := testSyncSet()
+				ss.Spec.ResourceApplyMode = "Upsert"
+				return ss
+			}(),
+			expectedAllowed: true,
+		},
+		{
+			name:      "Test valid Sync resourceApplyMode create",
+			operation: admissionv1beta1.Create,
+			syncSet: func() *hivev1.SyncSet {
+				ss := testSyncSet()
+				ss.Spec.ResourceApplyMode = "Sync"
+				return ss
+			}(),
+			expectedAllowed: true,
+		},
+		{
+			name:      "Test valid Sync resourceApplyMode update",
+			operation: admissionv1beta1.Update,
+			syncSet: func() *hivev1.SyncSet {
+				ss := testSyncSet()
+				ss.Spec.ResourceApplyMode = "Sync"
+				return ss
+			}(),
+			expectedAllowed: true,
+		},
+		{
+			name:      "Test invalid resourceApplyMode create",
+			operation: admissionv1beta1.Create,
+			syncSet: func() *hivev1.SyncSet {
+				ss := testSyncSet()
+				ss.Spec.ResourceApplyMode = "sync"
+				return ss
+			}(),
+			expectedAllowed: false,
+		},
+		{
+			name:      "Test invalid resourceApplyMode update",
+			operation: admissionv1beta1.Update,
+			syncSet: func() *hivev1.SyncSet {
+				ss := testSyncSet()
+				ss.Spec.ResourceApplyMode = "sync"
+				return ss
+			}(),
+			expectedAllowed: false,
+		},
+		{
 			name:            "Test invalid unmarshalable TypeMeta Resource create",
 			operation:       admissionv1beta1.Create,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": 798786}`),

--- a/pkg/controller/syncsetinstance/syncsetinstance_controller.go
+++ b/pkg/controller/syncsetinstance/syncsetinstance_controller.go
@@ -619,7 +619,7 @@ func (r *ReconcileSyncSetInstance) applySyncSetResources(ssi *hivev1.SyncSetInst
 func (r *ReconcileSyncSetInstance) reconcileDeleted(deleteTerm string, applyMode hivev1.SyncSetResourceApplyMode, dynamicClient dynamic.Interface, existingStatusList, newStatusList []hivev1.SyncStatus, err error, ssiLog log.FieldLogger) []hivev1.SyncStatus {
 	ssiLog.Debugf("reconciling syncset %ss, existing: %d, actual: %d", deleteTerm, len(existingStatusList), len(newStatusList))
 	if applyMode == "" || applyMode == hivev1.UpsertResourceApplyMode {
-		ssiLog.Debugf("apply mode is upsert, remote %ss will not be deleted", deleteTerm)
+		ssiLog.Debugf("resourceApplyMode is Upsert, remote %ss will not be deleted", deleteTerm)
 		return newStatusList
 	}
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -4104,8 +4104,8 @@ spec:
               type: array
             resourceApplyMode:
               description: ResourceApplyMode indicates if the Resource apply mode
-                is "upsert" (default) or "sync". ApplyMode "upsert" indicates create
-                and update. ApplyMode "sync" indicates create, update and delete.
+                is "Upsert" (default) or "Sync". ApplyMode "Upsert" indicates create
+                and update. ApplyMode "Sync" indicates create, update and delete.
               type: string
             resources:
               description: Resources is the list of objects to sync from RawExtension
@@ -4807,8 +4807,8 @@ spec:
               type: array
             resourceApplyMode:
               description: ResourceApplyMode indicates if the Resource apply mode
-                is "upsert" (default) or "sync". ApplyMode "upsert" indicates create
-                and update. ApplyMode "sync" indicates create, update and delete.
+                is "Upsert" (default) or "Sync". ApplyMode "Upsert" indicates create
+                and update. ApplyMode "Sync" indicates create, update and delete.
               type: string
             resources:
               description: Resources is the list of objects to sync from RawExtension


### PR DESCRIPTION
https://issues.redhat.com/browse/CO-830

SyncSet [resourceApplyMode](https://github.com/openshift/hive/blob/master/docs/syncset.md#syncset-object-definition) is case sensitive and we only support `""`, `"Upsert"` (default) and `"Sync"` modes so we should validate them in the API.

Ex.
```
➜  oc create -f ~/syncsets/sss.yaml
The SelectorSyncSet "mygroup" is invalid: spec.ResourceApplyMode: Unsupported value: "sync": supported values: "Upsert", "Sync"
```