### PR TITLE
Fix case on bare metal platform to match openshift-install.

### DIFF
--- a/config/crds/hive_v1_clusterdeployment.yaml
+++ b/config/crds/hive_v1_clusterdeployment.yaml
@@ -226,7 +226,7 @@ spec:
                         will be created.
                       type: string
                   type: object
-                bareMetal:
+                baremetal:
                   description: BareMetal is the configuration used when installing
                     on bare metal.
                   properties:

--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -396,7 +396,7 @@ spec:
   controlPlaneConfig:
     servingCertificates: {}
   platform:
-    bareMetal:
+    baremetal:
       libvirtSSHPrivateKeySecretRef:
         name: provisioning-host-ssh-private-key
   provisioning:

--- a/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -320,7 +320,7 @@ type Platform struct {
 	GCP *gcp.Platform `json:"gcp,omitempty"`
 
 	// BareMetal is the configuration used when installing on bare metal.
-	BareMetal *baremetal.Platform `json:"bareMetal,omitempty"`
+	BareMetal *baremetal.Platform `json:"baremetal,omitempty"`
 }
 
 // ClusterIngress contains the configurable pieces for any ClusterIngress objects

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -2007,7 +2007,7 @@ spec:
                         will be created.
                       type: string
                   type: object
-                bareMetal:
+                baremetal:
                   description: BareMetal is the configuration used when installing
                     on bare metal.
                   properties:


### PR DESCRIPTION
This is regretably a breaking API change, but we believe this is driven
by the only user of the bare metal provisioning API.