### PR TITLE
admission: use kube decoder instead of go json unmarshal

### DIFF
--- a/cmd/hiveadmission/main.go
+++ b/cmd/hiveadmission/main.go
@@ -4,6 +4,10 @@ import (
 	admissionCmd "github.com/openshift/generic-admission-server/pkg/cmd"
 	log "github.com/sirupsen/logrus"
 
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	hivevalidatingwebhooks "github.com/openshift/hive/pkg/apis/hive/v1/validating-webhooks"
 	"github.com/openshift/hive/pkg/certs"
 )
@@ -19,13 +23,25 @@ func main() {
 	const certsDir = "/var/serving-cert"
 	certs.TerminateOnCertChanges(certsDir)
 
+	decoder := createDecoder()
+
 	admissionCmd.RunAdmissionServer(
-		&hivevalidatingwebhooks.DNSZoneValidatingAdmissionHook{},
-		hivevalidatingwebhooks.NewClusterDeploymentValidatingAdmissionHook(),
-		&hivevalidatingwebhooks.ClusterImageSetValidatingAdmissionHook{},
-		&hivevalidatingwebhooks.ClusterProvisionValidatingAdmissionHook{},
-		&hivevalidatingwebhooks.MachinePoolValidatingAdmissionHook{},
-		&hivevalidatingwebhooks.SyncSetValidatingAdmissionHook{},
-		&hivevalidatingwebhooks.SelectorSyncSetValidatingAdmissionHook{},
+		hivevalidatingwebhooks.NewDNSZoneValidatingAdmissionHook(decoder),
+		hivevalidatingwebhooks.NewClusterDeploymentValidatingAdmissionHook(decoder),
+		hivevalidatingwebhooks.NewClusterImageSetValidatingAdmissionHook(decoder),
+		hivevalidatingwebhooks.NewClusterProvisionValidatingAdmissionHook(decoder),
+		hivevalidatingwebhooks.NewMachinePoolValidatingAdmissionHook(decoder),
+		hivevalidatingwebhooks.NewSyncSetValidatingAdmissionHook(decoder),
+		hivevalidatingwebhooks.NewSelectorSyncSetValidatingAdmissionHook(decoder),
 	)
+}
+
+func createDecoder() *admission.Decoder {
+	scheme := runtime.NewScheme()
+	hivev1.AddToScheme(scheme)
+	decoder, err := admission.NewDecoder(scheme)
+	if err != nil {
+		log.WithError(err).Fatal("could not create a decoder")
+	}
+	return decoder
 }

--- a/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
@@ -106,7 +106,7 @@ func validClusterDeploymentDifferentMutableValue() *hivev1.ClusterDeployment {
 
 func TestClusterDeploymentValidatingResource(t *testing.T) {
 	// Arrange
-	data := ClusterDeploymentValidatingAdmissionHook{}
+	data := NewClusterDeploymentValidatingAdmissionHook(createDecoder(t))
 	expectedPlural := schema.GroupVersionResource{
 		Group:    "admission.hive.openshift.io",
 		Version:  "v1",
@@ -124,7 +124,7 @@ func TestClusterDeploymentValidatingResource(t *testing.T) {
 
 func TestClusterDeploymentInitialize(t *testing.T) {
 	// Arrange
-	data := ClusterDeploymentValidatingAdmissionHook{}
+	data := NewClusterDeploymentValidatingAdmissionHook(createDecoder(t))
 
 	// Act
 	err := data.Initialize(nil, nil)
@@ -648,6 +648,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Arrange
 			data := ClusterDeploymentValidatingAdmissionHook{
+				decoder:             createDecoder(t),
 				validManagedDomains: validTestManagedDomains,
 			}
 
@@ -732,6 +733,6 @@ func TestNewClusterDeploymentValidatingAdmissionHook(t *testing.T) {
 		t.Fatalf("unexpected: %v", err)
 	}
 	os.Setenv(constants.ManagedDomainsFileEnvVar, tempFile.Name())
-	webhook := NewClusterDeploymentValidatingAdmissionHook()
+	webhook := NewClusterDeploymentValidatingAdmissionHook(createDecoder(t))
 	assert.Equal(t, webhook.validManagedDomains, expectedDomains, "valid domains must match expected")
 }

--- a/pkg/apis/hive/v1/validating-webhooks/clusterimageset_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/clusterimageset_validating_admission_hook_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestClusterImageSetValidatingResource(t *testing.T) {
 	// Arrange
-	data := ClusterImageSetValidatingAdmissionHook{}
+	data := NewClusterImageSetValidatingAdmissionHook(createDecoder(t))
 	expectedPlural := schema.GroupVersionResource{
 		Group:    "admission.hive.openshift.io",
 		Version:  "v1",
@@ -32,7 +32,7 @@ func TestClusterImageSetValidatingResource(t *testing.T) {
 
 func TestClusterImageSetInitialize(t *testing.T) {
 	// Arrange
-	data := ClusterImageSetValidatingAdmissionHook{}
+	data := NewClusterImageSetValidatingAdmissionHook(createDecoder(t))
 
 	// Act
 	err := data.Initialize(nil, nil)
@@ -132,7 +132,7 @@ func TestClusterImageSetValidate(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Arrange
-			data := ClusterImageSetValidatingAdmissionHook{}
+			data := NewClusterImageSetValidatingAdmissionHook(createDecoder(t))
 			newObject := &hivev1.ClusterImageSet{
 				Spec: tc.newSpec,
 			}

--- a/pkg/apis/hive/v1/validating-webhooks/clusterprovision_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/clusterprovision_validating_admission_hook_test.go
@@ -54,7 +54,7 @@ func Test_ClusterProvisionAdmission_Validate_Kind(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cut := &ClusterProvisionValidatingAdmissionHook{}
+			cut := NewClusterProvisionValidatingAdmissionHook(createDecoder(t))
 			cut.Initialize(nil, nil)
 			request := &admissionv1beta1.AdmissionRequest{
 				Resource: metav1.GroupVersionResource{
@@ -92,7 +92,7 @@ func Test_ClusterProvisionAdmission_Validate_Operation(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cut := &ClusterProvisionValidatingAdmissionHook{}
+			cut := NewClusterProvisionValidatingAdmissionHook(createDecoder(t))
 			cut.Initialize(nil, nil)
 			request := &admissionv1beta1.AdmissionRequest{
 				Resource: metav1.GroupVersionResource{
@@ -248,7 +248,7 @@ func Test_ClusterProvisionAdmission_Validate_Create(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cut := &ClusterProvisionValidatingAdmissionHook{}
+			cut := NewClusterProvisionValidatingAdmissionHook(createDecoder(t))
 			cut.Initialize(nil, nil)
 			rawProvision, err := json.Marshal(tc.provision)
 			if !assert.NoError(t, err, "unexpected error marshalling provision") {
@@ -479,7 +479,7 @@ func Test_ClusterProvisionAdmission_Validate_Update(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cut := &ClusterProvisionValidatingAdmissionHook{}
+			cut := NewClusterProvisionValidatingAdmissionHook(createDecoder(t))
 			cut.Initialize(nil, nil)
 			oldAsJSON, err := json.Marshal(tc.old)
 			if !assert.NoError(t, err, "unexpected error marshalling old provision") {
@@ -532,7 +532,7 @@ func Test_ClusterProvisionAdmission_Validate_Update_StageTransition(t *testing.T
 			t.Run(
 				fmt.Sprintf("%s to %s", oldStage, newStage),
 				func(t *testing.T) {
-					cut := &ClusterProvisionValidatingAdmissionHook{}
+					cut := NewClusterProvisionValidatingAdmissionHook(createDecoder(t))
 					cut.Initialize(nil, nil)
 					oldProvision := testCompletedClusterProvision()
 					oldProvision.Spec.Stage = oldStage

--- a/pkg/apis/hive/v1/validating-webhooks/decoder_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/decoder_test.go
@@ -1,0 +1,20 @@
+package validatingwebhooks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+)
+
+func createDecoder(t *testing.T) *admission.Decoder {
+	scheme := runtime.NewScheme()
+	hivev1.AddToScheme(scheme)
+	decoder, err := admission.NewDecoder(scheme)
+	require.NoError(t, err, "unexpected error creating decoder")
+	return decoder
+}

--- a/pkg/apis/hive/v1/validating-webhooks/dnszone_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/dnszone_validating_admission_hook_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestDNSZoneValidatingResource(t *testing.T) {
 	// Arrange
-	data := DNSZoneValidatingAdmissionHook{}
+	data := NewDNSZoneValidatingAdmissionHook(createDecoder(t))
 	expectedPlural := schema.GroupVersionResource{
 		Group:    "admission.hive.openshift.io",
 		Version:  "v1",
@@ -32,7 +32,7 @@ func TestDNSZoneValidatingResource(t *testing.T) {
 
 func TestDNSZoneInitialize(t *testing.T) {
 	// Arrange
-	data := DNSZoneValidatingAdmissionHook{}
+	data := NewDNSZoneValidatingAdmissionHook(createDecoder(t))
 
 	// Act
 	err := data.Initialize(nil, nil)
@@ -141,7 +141,7 @@ func TestDNSZoneValidate(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Arrange
-			data := DNSZoneValidatingAdmissionHook{}
+			data := NewDNSZoneValidatingAdmissionHook(createDecoder(t))
 			newObject := &hivev1.DNSZone{
 				Spec: hivev1.DNSZoneSpec{
 					Zone: tc.newZoneStr,

--- a/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook_test.go
@@ -57,7 +57,7 @@ func Test_MachinePoolAdmission_Validate_Kind(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cut := &MachinePoolValidatingAdmissionHook{}
+			cut := NewMachinePoolValidatingAdmissionHook(createDecoder(t))
 			cut.Initialize(nil, nil)
 			request := &admissionv1beta1.AdmissionRequest{
 				Resource: metav1.GroupVersionResource{
@@ -95,7 +95,7 @@ func Test_MachinePoolAdmission_Validate_Operation(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cut := &MachinePoolValidatingAdmissionHook{}
+			cut := NewMachinePoolValidatingAdmissionHook(createDecoder(t))
 			cut.Initialize(nil, nil)
 			request := &admissionv1beta1.AdmissionRequest{
 				Resource: metav1.GroupVersionResource{
@@ -440,7 +440,7 @@ func Test_MachinePoolAdmission_Validate_Create(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cut := &MachinePoolValidatingAdmissionHook{}
+			cut := NewMachinePoolValidatingAdmissionHook(createDecoder(t))
 			cut.Initialize(nil, nil)
 			rawProvision, err := json.Marshal(tc.provision)
 			if !assert.NoError(t, err, "unexpected error marshalling provision") {
@@ -531,7 +531,7 @@ func Test_MachinePoolAdmission_Validate_Update(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			cut := &MachinePoolValidatingAdmissionHook{}
+			cut := NewMachinePoolValidatingAdmissionHook(createDecoder(t))
 			cut.Initialize(nil, nil)
 			oldAsJSON, err := json.Marshal(tc.old)
 			if !assert.NoError(t, err, "unexpected error marshalling old provision") {

--- a/pkg/apis/hive/v1/validating-webhooks/selector_syncset_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/selector_syncset_validating_admission_hook_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestSelectorSyncSetValidatingResource(t *testing.T) {
 	// Arrange
-	data := SelectorSyncSetValidatingAdmissionHook{}
+	data := NewSelectorSyncSetValidatingAdmissionHook(createDecoder(t))
 	expectedPlural := schema.GroupVersionResource{
 		Group:    "admission.hive.openshift.io",
 		Version:  "v1",
@@ -32,7 +32,7 @@ func TestSelectorSyncSetValidatingResource(t *testing.T) {
 
 func TestSelectorSyncSetInitialize(t *testing.T) {
 	// Arrange
-	data := SelectorSyncSetValidatingAdmissionHook{}
+	data := NewSelectorSyncSetValidatingAdmissionHook(createDecoder(t))
 
 	// Act
 	err := data.Initialize(nil, nil)
@@ -280,7 +280,7 @@ func TestSelectorSyncSetValidate(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Arrange
-			data := SelectorSyncSetValidatingAdmissionHook{}
+			data := NewSelectorSyncSetValidatingAdmissionHook(createDecoder(t))
 
 			objectRaw, _ := json.Marshal(tc.selectorSyncSet)
 

--- a/pkg/apis/hive/v1/validating-webhooks/syncset_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/syncset_validating_admission_hook_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestSyncSetValidatingResource(t *testing.T) {
 	// Arrange
-	data := SyncSetValidatingAdmissionHook{}
+	data := NewSyncSetValidatingAdmissionHook(createDecoder(t))
 	expectedPlural := schema.GroupVersionResource{
 		Group:    "admission.hive.openshift.io",
 		Version:  "v1",
@@ -32,7 +32,7 @@ func TestSyncSetValidatingResource(t *testing.T) {
 
 func TestSyncSetInitialize(t *testing.T) {
 	// Arrange
-	data := SyncSetValidatingAdmissionHook{}
+	data := NewSyncSetValidatingAdmissionHook(createDecoder(t))
 
 	// Act
 	err := data.Initialize(nil, nil)
@@ -268,7 +268,7 @@ func TestSyncSetValidate(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Arrange
-			data := SyncSetValidatingAdmissionHook{}
+			data := NewSyncSetValidatingAdmissionHook(createDecoder(t))
 
 			objectRaw, _ := json.Marshal(tc.syncSet)
 


### PR DESCRIPTION
The basic GO JSON unmarshal is case-insensitive for field names. Kube is case-sensitive for field names. Since the admission webhooks were using JSON unmarshal, resources that used the incorrect case for fields were being incorrectly accepted. For example, if a user attempted to create a bare-metal ClusterDeployment but used .spec.platform.baremetal instead of .spec.platform.bareMetal, then the ClusterDeployment would be accepted by the validating webhook even though it should be rejected for not having a platform specified.

https://issues.redhat.com/browse/CO-846