### PR TITLE
Update ResourceApplyMode for remoteingress

### DIFF
--- a/config/crds/hive_v1_syncsetinstance.yaml
+++ b/config/crds/hive_v1_syncsetinstance.yaml
@@ -38,8 +38,8 @@ spec:
               type: object
             resourceApplyMode:
               description: ResourceApplyMode indicates if the resource apply mode
-                is "upsert" (default) or "sync". ApplyMode "upsert" indicates create
-                and update. ApplyMode "sync" indicates create, update and delete.
+                is "Upsert" (default) or "Sync". ApplyMode "Upsert" indicates create
+                and update. ApplyMode "Sync" indicates create, update and delete.
               type: string
             selectorSyncSetRef:
               description: SelectorSyncSetRef is a reference to the selectorsyncset

--- a/pkg/apis/hive/v1/syncsetinstance_types.go
+++ b/pkg/apis/hive/v1/syncsetinstance_types.go
@@ -46,9 +46,9 @@ type SyncSetInstanceSpec struct {
 	// +optional
 	SelectorSyncSetRef *SelectorSyncSetReference `json:"selectorSyncSetRef,omitempty"`
 
-	// ResourceApplyMode indicates if the resource apply mode is "upsert" (default) or "sync".
-	// ApplyMode "upsert" indicates create and update.
-	// ApplyMode "sync" indicates create, update and delete.
+	// ResourceApplyMode indicates if the resource apply mode is "Upsert" (default) or "Sync".
+	// ApplyMode "Upsert" indicates create and update.
+	// ApplyMode "Sync" indicates create, update and delete.
 	// +optional
 	ResourceApplyMode SyncSetResourceApplyMode `json:"resourceApplyMode,omitempty"`
 

--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -245,7 +245,7 @@ func newSyncSetSpec(cd *hivev1.ClusterDeployment, rawExtensions []runtime.RawExt
 		SyncSetCommonSpec: hivev1.SyncSetCommonSpec{
 			Resources:         rawExtensions,
 			Secrets:           secretMappings,
-			ResourceApplyMode: "sync",
+			ResourceApplyMode: hivev1.SyncResourceApplyMode,
 		},
 		ClusterDeploymentRefs: []corev1.LocalObjectReference{
 			{

--- a/pkg/hive/apis/hive/syncset_types.go
+++ b/pkg/hive/apis/hive/syncset_types.go
@@ -121,9 +121,9 @@ type SyncSetObjectStatus struct {
 	// +optional
 	Resources []SyncStatus `json:"resources,omitempty"`
 
-	// ResourceApplyMode indicates if the Resource apply mode is "upsert" (default) or "sync".
-	// ApplyMode "upsert" indicates create and update.
-	// ApplyMode "sync" indicates create, update and delete.
+	// ResourceApplyMode indicates if the Resource apply mode is "Upsert" (default) or "Sync".
+	// ApplyMode "Upsert" indicates create and update.
+	// ApplyMode "Sync" indicates create, update and delete.
 	// +optional
 	ResourceApplyMode SyncSetResourceApplyMode `json:"resourceApplyMode,omitempty"`
 

--- a/pkg/hive/apis/hive/syncsetinstance_types.go
+++ b/pkg/hive/apis/hive/syncsetinstance_types.go
@@ -46,9 +46,9 @@ type SyncSetInstanceSpec struct {
 	// +optional
 	SelectorSyncSet *SelectorSyncSetReference `json:"selectorSyncSet,omitempty"`
 
-	// ResourceApplyMode indicates if the resource apply mode is "upsert" (default) or "sync".
-	// ApplyMode "upsert" indicates create and update.
-	// ApplyMode "sync" indicates create, update and delete.
+	// ResourceApplyMode indicates if the resource apply mode is "Upsert" (default) or "Sync".
+	// ApplyMode "Upsert" indicates create and update.
+	// ApplyMode "Sync" indicates create, update and delete.
 	// +optional
 	ResourceApplyMode SyncSetResourceApplyMode `json:"resourceApplyMode,omitempty"`
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -4922,8 +4922,8 @@ spec:
               type: object
             resourceApplyMode:
               description: ResourceApplyMode indicates if the resource apply mode
-                is "upsert" (default) or "sync". ApplyMode "upsert" indicates create
-                and update. ApplyMode "sync" indicates create, update and delete.
+                is "Upsert" (default) or "Sync". ApplyMode "Upsert" indicates create
+                and update. ApplyMode "Sync" indicates create, update and delete.
               type: string
             selectorSyncSetRef:
               description: SelectorSyncSetRef is a reference to the selectorsyncset


### PR DESCRIPTION
This does the following:
- Fix a hard coded reference of `sync` to the proper `hivev1.SyncResourceApplyMode`
- Update some API comments that were incorrect