### PR TITLE
Update to secretMappings in syncset doc.

### DIFF
--- a/docs/syncset.md
+++ b/docs/syncset.md
@@ -43,11 +43,11 @@ spec:
       { "data": { "foo": "new-bar" } }
     patchType: merge
     
-  secretReferences:
-  - source:
+  secretMappings:
+  - sourceRef:
       name: ad-bind-password
       namespace: default
-    target:
+    targetRef:
       name: ad-bind-password
       namespace: openshift-config
 ```
@@ -58,7 +58,7 @@ spec:
 | `resourceApplyMode` | Defaults to `"Upsert"`, which indicates that objects will be created and updated to match the `SyncSet`. Existing `SyncSet` resources that are not listed in the `SyncSet` are not deleted. Specify `"Sync"` to allow deleting existing objects that were previously in the resources list. |
 | `resources` | A list of resource object definitions. Resources will be created in the referenced clusters. |
 | `patches` | A list of patches to apply to existing resources in the referenced clusters. You can include any valid cluster object type in the list. By default, the `patch` `applyMode` value is `"AlwaysApply"`, which applies the patch every 2 hours. |
-| `secretReferences` | A list of secret references. The secrets will be copied from the existing sources to the target resources in the referenced clusters |
+| `secretMappings` | A list of secret mappings. The secrets will be copied from the existing sources to the target resources in the referenced clusters |
 
 ### Example of SyncSet use
 

--- a/pkg/apis/hive/v1/validating-webhooks/selector_syncset_validating_admission_hook.go
+++ b/pkg/apis/hive/v1/validating-webhooks/selector_syncset_validating_admission_hook.go
@@ -204,7 +204,7 @@ func (a *SelectorSyncSetValidatingAdmissionHook) validateUpdate(admissionSpec *a
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validateResources(newObject.Spec.Resources, field.NewPath("spec", "resources"))...)
 	allErrs = append(allErrs, validatePatches(newObject.Spec.Patches, field.NewPath("spec", "patches"))...)
-	allErrs = append(allErrs, validateSecrets(newObject.Spec.Secrets, field.NewPath("spec", "secretReferences"))...)
+	allErrs = append(allErrs, validateSecrets(newObject.Spec.Secrets, field.NewPath("spec", "secretMappings"))...)
 	allErrs = append(allErrs, validateResourceApplyMode(newObject.Spec.ResourceApplyMode, field.NewPath("spec", "resourceApplyMode"))...)
 
 	if len(allErrs) > 0 {

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller.go
@@ -270,7 +270,7 @@ func (r *ReconcileControlPlaneCerts) generateControlPlaneCertsSyncSet(cd *hivev1
 	// Using SecretMapping to sync secrets
 	secretMappings := []hivev1.SecretMapping{}
 	for _, secret := range secrets {
-		cdLog.WithField("secret", secret.Name).Debug("adding secret to secretReferences list")
+		cdLog.WithField("secret", secret.Name).Debug("adding secret to secretMappings list")
 		secretMapping := hivev1.SecretMapping{
 			SourceRef: hivev1.SecretReference{
 				Namespace: secret.Namespace,


### PR DESCRIPTION
Update our syncset docs to reflect the name change from `secretReferences` to `secretMappings` introduced in https://github.com/openshift/hive/pull/783.

/cc @csrwng 