### PR TITLE
Stop treating syncset applyErrs as controller errors.

### DIFF
--- a/pkg/resource/apply.go
+++ b/pkg/resource/apply.go
@@ -57,7 +57,7 @@ func (r *Helper) Apply(obj []byte) (ApplyResult, error) {
 	if err != nil {
 		r.logger.WithError(err).
 			WithField("stdout", ioStreams.Out.(*bytes.Buffer).String()).
-			WithField("stderr", ioStreams.ErrOut.(*bytes.Buffer).String()).Error("running the apply command failed")
+			WithField("stderr", ioStreams.ErrOut.(*bytes.Buffer).String()).Warn("running the apply command failed")
 		return "", err
 	}
 	return changeTracker.GetResult(), nil
@@ -67,7 +67,7 @@ func (r *Helper) Apply(obj []byte) (ApplyResult, error) {
 func (r *Helper) ApplyRuntimeObject(obj runtime.Object, scheme *runtime.Scheme) (ApplyResult, error) {
 	data, err := r.Serialize(obj, scheme)
 	if err != nil {
-		r.logger.WithError(err).Error("cannot serialize runtime object")
+		r.logger.WithError(err).Warn("cannot serialize runtime object")
 		return "", err
 	}
 	return r.Apply(data)

--- a/pkg/resource/patch.go
+++ b/pkg/resource/patch.go
@@ -40,7 +40,7 @@ func (r *Helper) Patch(name types.NamespacedName, kind, apiVersion string, patch
 	if err != nil {
 		r.logger.WithError(err).
 			WithField("stdout", ioStreams.Out.(*bytes.Buffer).String()).
-			WithField("stderr", ioStreams.ErrOut.(*bytes.Buffer).String()).Error("running the patch command failed")
+			WithField("stderr", ioStreams.ErrOut.(*bytes.Buffer).String()).Warn("running the patch command failed")
 		return err
 	}
 	return nil

--- a/pkg/resource/serializer.go
+++ b/pkg/resource/serializer.go
@@ -44,12 +44,12 @@ func (e *metaTimeExtension) Encode(ptr unsafe.Pointer, stream *json.Stream) {
 	metaTime := reflect2.TypeOf(metav1.Time{}).UnsafeIndirect(ptr).(metav1.Time)
 	data, err := metaTime.MarshalJSON()
 	if err != nil {
-		log.Errorf("cannot marshal %#v as meta time: %v", ptr, err)
+		log.Warnf("cannot marshal %#v as meta time: %v", ptr, err)
 		return
 	}
 	_, err = stream.Write(data)
 	if err != nil {
-		log.Errorf("cannot write serialized time (%s): %v", string(data), err)
+		log.Warnf("cannot write serialized time (%s): %v", string(data), err)
 	}
 }
 
@@ -77,7 +77,7 @@ func (r *Helper) Serialize(obj runtime.Object, scheme *runtime.Scheme) ([]byte, 
 	printer := printers.NewTypeSetter(scheme).ToPrinter(&jsonPrinter{})
 	buf := &bytes.Buffer{}
 	if err := printer.PrintObj(obj, buf); err != nil {
-		r.logger.WithError(err).Errorf("cannot serialize runtime object of type %T", obj)
+		r.logger.WithError(err).Warnf("cannot serialize runtime object of type %T", obj)
 		return nil, err
 	}
 	return buf.Bytes(), nil


### PR DESCRIPTION
https://issues.redhat.com/browse/CO-793

Return `reconcile.Result{Requeue: true}` when an error is encountered applying a syncset instead of returning the error. This will backoff as if we had returned the error but will no longer result in a controller error for metrics. An `applyErr`can occur if we can't apply the resource/patch or if we can't read a local secret wrt `secretMappings`.

An `applyErr` is still logged as an error in several places. I can change this if we'd rather treat as debug logs.

