### PR TITLE
controller: use requeue as backoff for unreachable controller

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -455,14 +455,7 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 			}
 
 			if cd.Status.WebConsoleURL == "" || cd.Status.APIURL == "" {
-				if err := r.setClusterStatusURLs(cd, cdLog); err != nil {
-					cdLog.WithError(err).Error("failed to set admin kubeconfig status")
-					return reconcile.Result{}, err
-				}
-				if err := r.Status().Update(context.TODO(), cd); err != nil {
-					cdLog.WithError(err).Log(controllerutils.LogLevel(err), "could not set installed status")
-					return reconcile.Result{}, err
-				}
+				return r.setClusterStatusURLs(cd, cdLog)
 			}
 
 		}
@@ -750,22 +743,6 @@ func (r *ReconcileClusterDeployment) reconcileCompletedProvision(cd *hivev1.Clus
 	if changed {
 		statusChange = true
 		cd.Status.Conditions = conds
-	}
-	if cd.Spec.ClusterMetadata != nil &&
-		cd.Spec.ClusterMetadata.AdminKubeconfigSecretRef.Name != "" {
-
-		if err := r.addAdditionalKubeconfigCAs(cd, cdLog); err != nil {
-			return reconcile.Result{}, err
-		}
-
-		if cd.Status.WebConsoleURL == "" || cd.Status.APIURL == "" {
-			statusChange = true
-			if err := r.setClusterStatusURLs(cd, cdLog); err != nil {
-				cdLog.WithError(err).Error("failed to set cluster status URLs")
-				return reconcile.Result{}, err
-			}
-		}
-
 	}
 	if statusChange {
 		if err := r.Status().Update(context.TODO(), cd); err != nil {
@@ -1058,30 +1035,43 @@ func (r *ReconcileClusterDeployment) setImageSetNotFoundCondition(cd *hivev1.Clu
 // setClusterStatusURLs fetches the openshift console route from the remote cluster and uses it to determine
 // the correct APIURL and WebConsoleURL, and then set them in the Status. Typically only called if these Status fields
 // are unset.
-func (r *ReconcileClusterDeployment) setClusterStatusURLs(cd *hivev1.ClusterDeployment, cdLog log.FieldLogger) error {
-	remoteClientBuilder := r.remoteClusterAPIClientBuilder(cd)
-	server, err := remoteClientBuilder.APIURL()
+func (r *ReconcileClusterDeployment) setClusterStatusURLs(cd *hivev1.ClusterDeployment, cdLog log.FieldLogger) (reconcile.Result, error) {
+	server, err := remoteclient.InitialURL(r.Client, cd)
 	if err != nil {
-		return err
+		cdLog.WithError(err).Error("could not get API URL from kubeconfig")
+		return reconcile.Result{}, err
 	}
 	cdLog.Debugf("found cluster API URL in kubeconfig: %s", server)
 	cd.Status.APIURL = server
-	remoteClient, err := remoteClientBuilder.Build()
-	if err != nil {
-		return err
+
+	remoteClient, unreachable, requeue := remoteclient.ConnectToRemoteCluster(
+		cd,
+		r.remoteClusterAPIClientBuilder(cd),
+		r.Client,
+		cdLog,
+	)
+	if unreachable {
+		return reconcile.Result{Requeue: requeue}, nil
 	}
+
 	routeObject := &routev1.Route{}
 	if err := remoteClient.Get(
 		context.Background(),
 		client.ObjectKey{Namespace: "openshift-console", Name: "console"},
 		routeObject,
 	); err != nil {
-		cdLog.WithError(err).Error("error fetching remote route object")
-		return err
+		cdLog.WithError(err).Info("error fetching remote route object")
+		return reconcile.Result{Requeue: true}, nil
 	}
 	cdLog.Debugf("read remote route object: %s", routeObject)
 	cd.Status.WebConsoleURL = "https://" + routeObject.Spec.Host
-	return nil
+
+	if err := r.Status().Update(context.TODO(), cd); err != nil {
+		cdLog.WithError(err).Log(controllerutils.LogLevel(err), "could not set cluster status URLs")
+		return reconcile.Result{Requeue: true}, nil
+	}
+
+	return reconcile.Result{}, nil
 }
 
 // ensureManagedDNSZoneDeleted is a safety check to ensure that the child managed DNSZone

--- a/pkg/controller/clusterstate/clusterstate_controller_test.go
+++ b/pkg/controller/clusterstate/clusterstate_controller_test.go
@@ -163,7 +163,6 @@ func TestClusterStateReconcile(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 			mockRemoteClientBuilder := remoteclientmock.NewMockBuilder(mockCtrl)
-			mockRemoteClientBuilder.EXPECT().Unreachable().Return(false)
 			if !test.noRemoteCall {
 				mockRemoteClientBuilder.EXPECT().Build().Return(fake.NewFakeClient(test.remote...), nil)
 			}
@@ -233,6 +232,12 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 				},
 			},
 			Installed: true,
+		},
+		Status: hivev1.ClusterDeploymentStatus{
+			Conditions: []hivev1.ClusterDeploymentCondition{{
+				Type:   hivev1.UnreachableCondition,
+				Status: corev1.ConditionFalse,
+			}},
 		},
 	}
 }

--- a/pkg/controller/clusterversion/clusterversion_controller_test.go
+++ b/pkg/controller/clusterversion/clusterversion_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	configv1 "github.com/openshift/api/config/v1"
+
 	"github.com/openshift/hive/pkg/apis"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	hivev1aws "github.com/openshift/hive/pkg/apis/hive/v1/aws"
@@ -86,7 +87,6 @@ func TestClusterVersionReconcile(t *testing.T) {
 			defer mockCtrl.Finish()
 			mockRemoteClientBuilder := remoteclientmock.NewMockBuilder(mockCtrl)
 			if !test.noRemoteCall {
-				mockRemoteClientBuilder.EXPECT().Unreachable().Return(false)
 				mockRemoteClientBuilder.EXPECT().Build().Return(testRemoteClusterAPIClient(), nil)
 			}
 			rcd := &ReconcileClusterVersion{
@@ -150,6 +150,12 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 				},
 			},
 			Installed: true,
+		},
+		Status: hivev1.ClusterDeploymentStatus{
+			Conditions: []hivev1.ClusterDeploymentCondition{{
+				Type:   hivev1.UnreachableCondition,
+				Status: corev1.ConditionFalse,
+			}},
 		},
 	}
 	return cd

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
@@ -23,30 +23,36 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	openshiftapiv1 "github.com/openshift/api/config/v1"
+
 	"github.com/openshift/hive/pkg/apis"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
-	"github.com/openshift/hive/pkg/remoteclient"
-	mockremoteclient "github.com/openshift/hive/pkg/remoteclient/mock"
 	"github.com/openshift/hive/pkg/resource"
+	testsecret "github.com/openshift/hive/pkg/test/secret"
 )
 
 const (
-	fakeName         = "fake-cluster"
-	fakeNamespace    = "fake-namespace"
-	fakeDomain       = "example.com"
-	fakeAPIURL       = "https://test-api-url:6443"
-	fakeAPIURLDomain = "test-api-url"
+	fakeName             = "fake-cluster"
+	fakeNamespace        = "fake-namespace"
+	fakeDomain           = "example.com"
+	fakeAPIURL           = "https://test-api-url:6443"
+	fakeAPIURLDomain     = "test-api-url"
+	kubeconfigSecretName = "test-kubeconfig"
+	adminKubeconfig      = `clusters:
+- cluster:
+    server: https://test-api-url:6443
+  name: bar
+contexts:
+- context:
+    cluster: bar
+  name: admin
+current-context: admin
+`
 )
 
 func init() {
 	log.SetLevel(log.DebugLevel)
-}
-
-type fakeRemoteClientResponse struct {
-	apiURL string
-	err    error
 }
 
 func TestReconcileControlPlaneCerts(t *testing.T) {
@@ -54,10 +60,9 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 	openshiftapiv1.Install(scheme.Scheme)
 
 	tests := []struct {
-		name                 string
-		existing             []runtime.Object
-		remoteClientResponse *fakeRemoteClientResponse
-		validate             func(*testing.T, client.Client, []runtime.Object)
+		name     string
+		existing []runtime.Object
+		validate func(*testing.T, client.Client, []runtime.Object)
 	}{
 		{
 			name: "no control plane certs",
@@ -67,7 +72,7 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 			validate: func(t *testing.T, c client.Client, applied []runtime.Object) {
 				cd := getFakeClusterDeployment(t, c)
 				assert.Empty(t, applied, "no syncset should be applied")
-				assert.Empty(t, cd.Status.Conditions, "no conditions should be set")
+				assert.Len(t, cd.Status.Conditions, 1, "no conditions should be added")
 			},
 		},
 		{
@@ -76,12 +81,9 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 				fakeClusterDeployment().defaultCert("default-cert", "default-secret").obj(),
 				fakeCertSecret("default-secret"),
 			},
-			remoteClientResponse: &fakeRemoteClientResponse{
-				apiURL: fakeAPIURL,
-			},
 			validate: func(t *testing.T, c client.Client, applied []runtime.Object) {
 				cd := getFakeClusterDeployment(t, c)
-				assert.Empty(t, cd.Status.Conditions, "no conditions should be set")
+				assert.Len(t, cd.Status.Conditions, 1, "no conditions should be added")
 
 				validateAppliedSyncSet(t, applied, "", additionalCert(fakeAPIURLDomain, "default-secret"))
 
@@ -103,7 +105,7 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 			},
 			validate: func(t *testing.T, c client.Client, applied []runtime.Object) {
 				cd := getFakeClusterDeployment(t, c)
-				assert.Empty(t, cd.Status.Conditions, "no conditions should be set")
+				assert.Len(t, cd.Status.Conditions, 1, "no conditions should be added")
 				validateAppliedSyncSet(t, applied, "", additionalCert("foo.com", "secret1"), additionalCert("bar.com", "secret2"))
 			},
 		},
@@ -119,12 +121,9 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 				fakeCertSecret("secret1"),
 				fakeCertSecret("secret2"),
 			},
-			remoteClientResponse: &fakeRemoteClientResponse{
-				apiURL: fakeAPIURL,
-			},
 			validate: func(t *testing.T, c client.Client, applied []runtime.Object) {
 				cd := getFakeClusterDeployment(t, c)
-				assert.Empty(t, cd.Status.Conditions, "no conditions should be set")
+				assert.Len(t, cd.Status.Conditions, 1, "no conditions should be added")
 
 				validateAppliedSyncSet(t, applied, "", additionalCert(fakeAPIURLDomain, "secret0"), additionalCert("foo.com", "secret1"), additionalCert("bar.com", "secret2"))
 			},
@@ -142,10 +141,10 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 			validate: func(t *testing.T, c client.Client, applied []runtime.Object) {
 				assert.Empty(t, applied)
 				cd := getFakeClusterDeployment(t, c)
-				assert.Equal(t, 1, len(cd.Status.Conditions))
+				assert.Equal(t, 2, len(cd.Status.Conditions), "unexpected number of conditions")
 				notFoundCondition := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ControlPlaneCertificateNotFoundCondition)
-				assert.NotNil(t, notFoundCondition)
-				assert.Equal(t, notFoundCondition.Status, corev1.ConditionTrue)
+				assert.NotNil(t, notFoundCondition, "expected a NotFound condition")
+				assert.Equal(t, notFoundCondition.Status, corev1.ConditionTrue, "expected NotFound condition to be True")
 			},
 		},
 		{
@@ -166,38 +165,33 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 			},
 			validate: func(t *testing.T, c client.Client, applied []runtime.Object) {
 				cd := getFakeClusterDeployment(t, c)
-				assert.Equal(t, 1, len(cd.Status.Conditions))
+				assert.Equal(t, 2, len(cd.Status.Conditions), "unexpected number of conditions")
 				notFoundCondition := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ControlPlaneCertificateNotFoundCondition)
-				assert.NotNil(t, notFoundCondition)
-				assert.Equal(t, string(corev1.ConditionFalse), string(notFoundCondition.Status))
+				assert.NotNil(t, notFoundCondition, "expected a NotFound condition")
+				assert.Equal(t, string(corev1.ConditionFalse), string(notFoundCondition.Status), "unexpected NotFound status")
 			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			test.existing = append(test.existing,
+				testsecret.Build(
+					testsecret.WithName(kubeconfigSecretName),
+					testsecret.WithNamespace(fakeNamespace),
+					testsecret.WithDataKeyValue(constants.KubeconfigSecretKey, []byte(adminKubeconfig)),
+				),
+			)
 			fakeClient := fake.NewFakeClient(test.existing...)
 
 			mockController := gomock.NewController(t)
 			defer mockController.Finish()
-
-			mockRemoteClientBuilder := mockremoteclient.NewMockBuilder(mockController)
-			if test.remoteClientResponse != nil {
-				mockRemoteClientBuilder.EXPECT().UseSecondaryAPIURL().Return(mockRemoteClientBuilder)
-				mockRemoteClientBuilder.EXPECT().APIURL().Return(
-					test.remoteClientResponse.apiURL,
-					test.remoteClientResponse.err,
-				)
-			}
 
 			applier := &fakeApplier{}
 			r := &ReconcileControlPlaneCerts{
 				Client:  fakeClient,
 				scheme:  scheme.Scheme,
 				applier: applier,
-				remoteClientBuilder: func(*hivev1.ClusterDeployment) remoteclient.Builder {
-					return mockRemoteClientBuilder
-				},
 			}
 
 			_, err := r.Reconcile(reconcile.Request{
@@ -323,9 +317,16 @@ func fakeClusterDeployment() *fakeClusterDeploymentWrapper {
 			ClusterName: fakeName,
 			BaseDomain:  fakeDomain,
 			Installed:   true,
+			ClusterMetadata: &hivev1.ClusterMetadata{
+				AdminKubeconfigSecretRef: corev1.LocalObjectReference{Name: kubeconfigSecretName},
+			},
 		},
 		Status: hivev1.ClusterDeploymentStatus{
 			APIURL: fakeAPIURL,
+			Conditions: []hivev1.ClusterDeploymentCondition{{
+				Type:   hivev1.UnreachableCondition,
+				Status: corev1.ConditionFalse,
+			}},
 		},
 	}
 	return &fakeClusterDeploymentWrapper{cd: cd}

--- a/pkg/controller/syncsetinstance/syncsetinstance_controller_test.go
+++ b/pkg/controller/syncsetinstance/syncsetinstance_controller_test.go
@@ -628,7 +628,6 @@ func TestSyncSetReconcile(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 			mockRemoteClientBuilder := remoteclientmock.NewMockBuilder(mockCtrl)
-			mockRemoteClientBuilder.EXPECT().Unreachable().Return(false).AnyTimes()
 			mockRemoteClientBuilder.EXPECT().RESTConfig().Return(nil, nil).AnyTimes()
 			mockRemoteClientBuilder.EXPECT().BuildDynamic().Return(dynamicClient, nil).AnyTimes()
 
@@ -721,6 +720,12 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 				AdminKubeconfigSecretRef: corev1.LocalObjectReference{Name: adminKubeconfigSecret},
 			},
 			Installed: true,
+		},
+		Status: hivev1.ClusterDeploymentStatus{
+			Conditions: []hivev1.ClusterDeploymentCondition{{
+				Type:   hivev1.UnreachableCondition,
+				Status: corev1.ConditionFalse,
+			}},
 		},
 	}
 

--- a/pkg/controller/unreachable/unreachable_controller_test.go
+++ b/pkg/controller/unreachable/unreachable_controller_test.go
@@ -24,31 +24,25 @@ import (
 	"github.com/golang/mock/gomock"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/pointer"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/hive/pkg/apis"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
-	hivev1aws "github.com/openshift/hive/pkg/apis/hive/v1/aws"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/remoteclient"
 	remoteclientmock "github.com/openshift/hive/pkg/remoteclient/mock"
+	testcd "github.com/openshift/hive/pkg/test/clusterdeployment"
 )
 
 const (
-	testName         = "foo-unreachable"
-	testClusterName  = "bar"
-	testClusterID    = "testFooClusterUUID"
-	testNamespace    = "default"
-	pullSecretSecret = "pull-secret"
+	testName      = "test-cluster-deployment"
+	testNamespace = "test-namespace"
 )
 
 func init() {
@@ -56,130 +50,168 @@ func init() {
 }
 
 func TestReconcile(t *testing.T) {
-	apis.AddToScheme(scheme.Scheme)
-	configv1.Install(scheme.Scheme)
-
 	tests := []struct {
 		name                          string
-		existing                      []runtime.Object
-		errorConnecting               bool
+		cd                            *hivev1.ClusterDeployment
+		errorConnecting               *bool
 		errorConnectingSecondary      *bool
-		expectError                   bool
-		expectNoCondition             bool
 		expectedStatus                corev1.ConditionStatus
 		expectActiveOverrideCondition bool
 		expectedActiveOverrideStatus  corev1.ConditionStatus
+		expectRequeue                 bool
+		expectRequeueAfter            bool
 	}{
 		{
-			name: "unreachable condition should be added",
-			existing: []runtime.Object{
-				getClusterDeployment(),
-			},
-			errorConnecting: true,
+			name:               "recent reachable condition",
+			cd:                 buildClusterDeployment(withUnreachableCondition(corev1.ConditionFalse, time.Now())),
+			expectedStatus:     corev1.ConditionFalse,
+			expectRequeueAfter: true,
+		},
+		{
+			name:            "unreachable with no condition",
+			cd:              buildClusterDeployment(),
+			errorConnecting: pointer.BoolPtr(true),
 			expectedStatus:  corev1.ConditionTrue,
+			expectRequeue:   true,
 		},
 		{
-			name: "unreachable condition should change from false to true",
-			existing: []runtime.Object{
-				getCDWithUnreachableConditionFalse(),
-			},
-			errorConnecting: true,
+			name:            "unreachable with old reachable condition",
+			cd:              buildClusterDeployment(withUnreachableCondition(corev1.ConditionFalse, time.Now().Add(-maxUnreachableDuration))),
+			errorConnecting: pointer.BoolPtr(true),
 			expectedStatus:  corev1.ConditionTrue,
+			expectRequeue:   true,
 		},
 		{
-			name: "lastProbeTime>2hr lastTransitionTime-12hour condition false to true",
-			existing: []runtime.Object{
-				func() *hivev1.ClusterDeployment {
-					lastProbeTime := metav1.NewTime(time.Now().Add(-(time.Minute * 121)))
-					lastTransitionTime := metav1.NewTime(time.Now().Add(-(time.Hour * 12)))
-					return getCDWithProbeAndTransitionTime(lastProbeTime, lastTransitionTime, corev1.ConditionFalse)
-				}(),
-			},
-			errorConnecting: true,
+			name:            "unreachable with unreachable condition",
+			cd:              buildClusterDeployment(withUnreachableCondition(corev1.ConditionTrue, time.Now())),
+			errorConnecting: pointer.BoolPtr(true),
 			expectedStatus:  corev1.ConditionTrue,
+			expectRequeue:   true,
 		},
 		{
-			name: "unreachable condition should not be added",
-			existing: []runtime.Object{
-				getClusterDeployment(),
-			},
-			expectNoCondition: true,
+			name:               "reachable with no condition",
+			cd:                 buildClusterDeployment(),
+			errorConnecting:    pointer.BoolPtr(false),
+			expectedStatus:     corev1.ConditionFalse,
+			expectRequeueAfter: true,
 		},
 		{
-			name: "unreachable condition should change from true to false",
-			existing: []runtime.Object{
-				getCDWithUnreachableConditionTrue(),
-			},
-			expectedStatus: corev1.ConditionFalse,
+			name:               "reachable with old reachable condition",
+			cd:                 buildClusterDeployment(withUnreachableCondition(corev1.ConditionFalse, time.Now().Add(-maxUnreachableDuration))),
+			errorConnecting:    pointer.BoolPtr(false),
+			expectedStatus:     corev1.ConditionFalse,
+			expectRequeueAfter: true,
 		},
 		{
-			name: "lastProbeTime lastTransitionTime 1hour ago unreachable condition true to false",
-			existing: []runtime.Object{
-				func() *hivev1.ClusterDeployment {
-					lastProbeTime := metav1.NewTime(time.Now().Add(-(time.Hour * 1)))
-					lastTransitionTime := lastProbeTime
-					return getCDWithProbeAndTransitionTime(lastProbeTime, lastTransitionTime, corev1.ConditionTrue)
-				}(),
-			},
-			expectedStatus: corev1.ConditionFalse,
+			name:               "reachable with unreachable condition",
+			cd:                 buildClusterDeployment(withUnreachableCondition(corev1.ConditionTrue, time.Now())),
+			errorConnecting:    pointer.BoolPtr(false),
+			expectedStatus:     corev1.ConditionFalse,
+			expectRequeueAfter: true,
 		},
 		{
-			name: "primary reachable",
-			existing: []runtime.Object{
-				func() *hivev1.ClusterDeployment {
-					cd := getCDWithUnreachableConditionTrue()
-					cd.Spec.ControlPlaneConfig.APIURLOverride = "test override URL"
-					return cd
-				}(),
-			},
+			name:                          "reachable to primary with no conditions",
+			cd:                            buildClusterDeployment(withAPIURLOverride()),
+			errorConnecting:               pointer.BoolPtr(false),
 			expectedStatus:                corev1.ConditionFalse,
 			expectActiveOverrideCondition: true,
 			expectedActiveOverrideStatus:  corev1.ConditionTrue,
+			expectRequeueAfter:            true,
 		},
 		{
-			name: "secondary reachable",
-			existing: []runtime.Object{
-				func() *hivev1.ClusterDeployment {
-					cd := getCDWithUnreachableConditionTrue()
-					cd.Spec.ControlPlaneConfig.APIURLOverride = "test override URL"
-					return cd
-				}(),
-			},
-			errorConnecting:               true,
+			name: "reachable to primary with recent reachable condition",
+			cd: buildClusterDeployment(
+				withAPIURLOverride(),
+				withUnreachableCondition(corev1.ConditionFalse, time.Now()),
+			),
+			errorConnecting:               pointer.BoolPtr(false),
+			expectedStatus:                corev1.ConditionFalse,
+			expectActiveOverrideCondition: true,
+			expectedActiveOverrideStatus:  corev1.ConditionTrue,
+			expectRequeueAfter:            true,
+		},
+		{
+			name:                          "reachable to secondary with no conditions",
+			cd:                            buildClusterDeployment(withAPIURLOverride()),
+			errorConnecting:               pointer.BoolPtr(true),
 			errorConnectingSecondary:      pointer.BoolPtr(false),
 			expectedStatus:                corev1.ConditionFalse,
 			expectActiveOverrideCondition: true,
 			expectedActiveOverrideStatus:  corev1.ConditionFalse,
+			expectRequeue:                 true,
 		},
 		{
-			name: "primary and secondary unreachable",
-			existing: []runtime.Object{
-				func() *hivev1.ClusterDeployment {
-					cd := getClusterDeployment()
-					cd.Spec.ControlPlaneConfig.APIURLOverride = "test override URL"
-					return cd
-				}(),
-			},
-			errorConnecting:               true,
-			errorConnectingSecondary:      pointer.BoolPtr(true),
-			expectedStatus:                corev1.ConditionTrue,
+			name: "reachable to secondary with recent reachable to secondary",
+			cd: buildClusterDeployment(
+				withAPIURLOverride(),
+				withUnreachableCondition(corev1.ConditionFalse, time.Now()),
+				withActiveAPIURLOverrideCondition(corev1.ConditionFalse),
+			),
+			errorConnecting:               pointer.BoolPtr(true),
+			expectedStatus:                corev1.ConditionFalse,
 			expectActiveOverrideCondition: true,
 			expectedActiveOverrideStatus:  corev1.ConditionFalse,
+			expectRequeue:                 true,
+		},
+		{
+			name: "reachable to secondary with old reachable to secondary",
+			cd: buildClusterDeployment(
+				withAPIURLOverride(),
+				withUnreachableCondition(corev1.ConditionFalse, time.Now().Add(-maxUnreachableDuration)),
+				withActiveAPIURLOverrideCondition(corev1.ConditionFalse),
+			),
+			errorConnecting:               pointer.BoolPtr(true),
+			errorConnectingSecondary:      pointer.BoolPtr(false),
+			expectedStatus:                corev1.ConditionFalse,
+			expectActiveOverrideCondition: true,
+			expectedActiveOverrideStatus:  corev1.ConditionFalse,
+			expectRequeue:                 true,
+		},
+		{
+			name: "reachable to primary with reachable to secondary condition",
+			cd: buildClusterDeployment(
+				withAPIURLOverride(),
+				withUnreachableCondition(corev1.ConditionFalse, time.Now()),
+				withActiveAPIURLOverrideCondition(corev1.ConditionFalse),
+			),
+			errorConnecting:               pointer.BoolPtr(false),
+			expectedStatus:                corev1.ConditionFalse,
+			expectActiveOverrideCondition: true,
+			expectedActiveOverrideStatus:  corev1.ConditionTrue,
+			expectRequeueAfter:            true,
+		},
+		{
+			name: "reachable to secondary with old reachable to primary condition",
+			cd: buildClusterDeployment(
+				withAPIURLOverride(),
+				withUnreachableCondition(corev1.ConditionFalse, time.Now().Add(-maxUnreachableDuration)),
+				withActiveAPIURLOverrideCondition(corev1.ConditionTrue),
+			),
+			errorConnecting:               pointer.BoolPtr(true),
+			errorConnectingSecondary:      pointer.BoolPtr(false),
+			expectedStatus:                corev1.ConditionFalse,
+			expectActiveOverrideCondition: true,
+			expectedActiveOverrideStatus:  corev1.ConditionFalse,
+			expectRequeue:                 true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fakeClient := fake.NewFakeClient(test.existing...)
+			scheme := runtime.NewScheme()
+			hivev1.AddToScheme(scheme)
+			fakeClient := fake.NewFakeClientWithScheme(scheme, test.cd)
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 			mockRemoteClientBuilder := remoteclientmock.NewMockBuilder(mockCtrl)
-			mockRemoteClientBuilder.EXPECT().UsePrimaryAPIURL().Return(mockRemoteClientBuilder)
-			var buildError error
-			if test.errorConnecting {
-				buildError = errors.New("cluster not reachable")
+			if test.errorConnecting != nil {
+				mockRemoteClientBuilder.EXPECT().UsePrimaryAPIURL().Return(mockRemoteClientBuilder)
+				var buildError error
+				if *test.errorConnecting {
+					buildError = errors.New("cluster not reachable")
+				}
+				mockRemoteClientBuilder.EXPECT().Build().Return(nil, buildError)
 			}
-			mockRemoteClientBuilder.EXPECT().Build().Return(nil, buildError)
 			if test.errorConnectingSecondary != nil {
 				mockRemoteClientBuilder.EXPECT().UseSecondaryAPIURL().Return(mockRemoteClientBuilder)
 				var buildError error
@@ -190,7 +222,7 @@ func TestReconcile(t *testing.T) {
 			}
 			rcd := &ReconcileRemoteMachineSet{
 				Client:                        fakeClient,
-				scheme:                        scheme.Scheme,
+				scheme:                        scheme,
 				logger:                        log.WithField("controller", "unreachable"),
 				remoteClusterAPIClientBuilder: func(*hivev1.ClusterDeployment) remoteclient.Builder { return mockRemoteClientBuilder },
 			}
@@ -200,23 +232,14 @@ func TestReconcile(t *testing.T) {
 				Namespace: testNamespace,
 			}
 
-			_, err := rcd.Reconcile(reconcile.Request{NamespacedName: namespacedName})
-
-			if test.expectError {
-				assert.Error(t, err, "expected error during reconcile")
-				return
-			}
-
+			result, err := rcd.Reconcile(reconcile.Request{NamespacedName: namespacedName})
 			assert.NoError(t, err, "unexpected error during reconcile")
+
 			cd := &hivev1.ClusterDeployment{}
 			if err := fakeClient.Get(context.TODO(), namespacedName, cd); assert.NoError(t, err, "missing clusterdeployment") {
 				cond := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.UnreachableCondition)
-				if test.expectNoCondition {
-					assert.Nil(t, cond, "expected no unreachable condition")
-				} else {
-					if assert.NotNil(t, cond, "missing unreachable condition") {
-						assert.Equal(t, string(test.expectedStatus), string(cond.Status), "unexpected status on unreachable condition")
-					}
+				if assert.NotNil(t, cond, "missing unreachable condition") {
+					assert.Equal(t, string(test.expectedStatus), string(cond.Status), "unexpected status on unreachable condition")
 				}
 				cond = controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ActiveAPIURLOverrideCondition)
 				if !test.expectActiveOverrideCondition {
@@ -227,163 +250,53 @@ func TestReconcile(t *testing.T) {
 					}
 				}
 			}
-		})
-	}
-}
 
-func TestIsTimeForConnectivityCheck(t *testing.T) {
-	tests := []struct {
-		name     string
-		cd       *hivev1.ClusterDeployment
-		expected bool
-	}{
-		{
-			name: "lastProbeTime, lastTransitionTime is same",
-			cd: func() *hivev1.ClusterDeployment {
-				lastProbeTime := metav1.NewTime(time.Now().Add(-(time.Hour * 1)))
-				lastTransitionTime := lastProbeTime
-				return getCDWithProbeAndTransitionTime(lastProbeTime, lastTransitionTime, corev1.ConditionFalse)
-			}(),
-			expected: true,
-		},
-		{
-			name: "lastProbeTime 20Mins ago and lastTransitionTime 100Mins ago",
-			cd: func() *hivev1.ClusterDeployment {
-				lastProbeTime := metav1.NewTime(time.Now().Add(-(time.Minute * 20)))
-				lastTransitionTime := metav1.NewTime(time.Now().Add(-(time.Minute * 100)))
-				return getCDWithProbeAndTransitionTime(lastProbeTime, lastTransitionTime, corev1.ConditionFalse)
-			}(),
-			expected: false,
-		},
-		{
-			name: "lastProbeTime 1hour ago lastTransitionTime 5hour ago",
-			cd: func() *hivev1.ClusterDeployment {
-				lastProbeTime := metav1.NewTime(time.Now().Add(-(time.Hour * 1)))
-				lastTransitionTime := metav1.NewTime(time.Now().Add(-(time.Hour * 5)))
-				return getCDWithProbeAndTransitionTime(lastProbeTime, lastTransitionTime, corev1.ConditionFalse)
-			}(),
-			expected: false,
-		},
-		{
-			name: "lastProbeTime more than 2hour ago lastTransitionTime 12hour ago",
-			cd: func() *hivev1.ClusterDeployment {
-				lastProbeTime := metav1.NewTime(time.Now().Add(-(time.Minute * 121)))
-				lastTransitionTime := metav1.NewTime(time.Now().Add(-(time.Hour * 12)))
-				return getCDWithProbeAndTransitionTime(lastProbeTime, lastTransitionTime, corev1.ConditionFalse)
-			}(),
-			expected: true,
-		},
-		{
-			name: "lastProbeTime 60min ago lastTransitionTime 160min ago",
-			cd: func() *hivev1.ClusterDeployment {
-				lastProbeTime := metav1.NewTime(time.Now().Add(-(time.Minute * 60)))
-				lastTransitionTime := metav1.NewTime(time.Now().Add(-(time.Minute * 160)))
-				return getCDWithProbeAndTransitionTime(lastProbeTime, lastTransitionTime, corev1.ConditionFalse)
-			}(),
-			expected: true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			cond := controllerutils.FindClusterDeploymentCondition(test.cd.Status.Conditions, hivev1.UnreachableCondition)
-			actual := isTimeForConnectivityCheck(cond)
-			if test.expected != actual {
-				t.Errorf("expected: %t actual: %t", test.expected, actual)
+			assert.Equal(t, test.expectRequeue, result.Requeue, "unexpected requeue")
+			if test.expectRequeueAfter {
+				assert.NotZero(t, result.RequeueAfter, "expected non-zero requeue after")
+			} else {
+				assert.Zero(t, result.RequeueAfter, "expected zero requeue after")
 			}
 		})
 	}
 }
 
-func getClusterDeployment() *hivev1.ClusterDeployment {
-	cd := &hivev1.ClusterDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       testName,
-			Namespace:  testNamespace,
-			Finalizers: []string{hivev1.FinalizerDeprovision},
-			UID:        types.UID("1234"),
+func buildClusterDeployment(options ...testcd.Option) *hivev1.ClusterDeployment {
+	options = append(
+		[]testcd.Option{
+			func(cd *hivev1.ClusterDeployment) {
+				cd.Name = testName
+				cd.Namespace = testNamespace
+				cd.Spec.Installed = true
+				cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{}
+			},
 		},
-		Spec: hivev1.ClusterDeploymentSpec{
-			ClusterName: testClusterName,
-			PullSecretRef: &corev1.LocalObjectReference{
-				Name: pullSecretSecret,
-			},
-			Platform: hivev1.Platform{
-				AWS: &hivev1aws.Platform{
-					CredentialsSecretRef: corev1.LocalObjectReference{
-						Name: "aws-credentials",
-					},
-					Region: "us-east-1",
-				},
-			},
-			ClusterMetadata: &hivev1.ClusterMetadata{
-				ClusterID: testClusterID,
-				AdminKubeconfigSecretRef: corev1.LocalObjectReference{
-					Name: "kubeconfig-secret",
-				},
-			},
-			Installed: true,
+		options...,
+	)
+	return testcd.Build(options...)
+}
+
+func withUnreachableCondition(status corev1.ConditionStatus, probeTime time.Time) testcd.Option {
+	return testcd.WithCondition(
+		hivev1.ClusterDeploymentCondition{
+			Type:          hivev1.UnreachableCondition,
+			Status:        status,
+			LastProbeTime: metav1.NewTime(probeTime),
 		},
+	)
+}
+
+func withActiveAPIURLOverrideCondition(status corev1.ConditionStatus) testcd.Option {
+	return testcd.WithCondition(
+		hivev1.ClusterDeploymentCondition{
+			Type:   hivev1.ActiveAPIURLOverrideCondition,
+			Status: status,
+		},
+	)
+}
+
+func withAPIURLOverride() testcd.Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Spec.ControlPlaneConfig.APIURLOverride = "some-api-url"
 	}
-	return cd
-}
-
-func getCDWithUnreachableConditionFalse() *hivev1.ClusterDeployment {
-	cd := getClusterDeployment()
-	probeTime := time.Now().Add(-(time.Hour * 1))
-	lastProbeTime := metav1.NewTime(probeTime)
-
-	// Explicitly set the condition hivev1.UnreachableCondition as false
-	var conditions []hivev1.ClusterDeploymentCondition
-	cd.Status.Conditions = append(
-		conditions,
-		hivev1.ClusterDeploymentCondition{
-			Type:               hivev1.UnreachableCondition,
-			Status:             corev1.ConditionFalse,
-			Reason:             "ClusterReachable",
-			Message:            "Setting the condition when cluster is reachable",
-			LastTransitionTime: lastProbeTime,
-			LastProbeTime:      lastProbeTime,
-		},
-	)
-	return cd
-}
-
-func getCDWithUnreachableConditionTrue() *hivev1.ClusterDeployment {
-	cd := getClusterDeployment()
-	probeTime := time.Now().Add(-(time.Hour * 1))
-	lastProbeTime := metav1.NewTime(probeTime)
-
-	// Explicitly set the condition hivev1.UnreachableCondition as false
-	var conditions []hivev1.ClusterDeploymentCondition
-	cd.Status.Conditions = append(
-		conditions,
-		hivev1.ClusterDeploymentCondition{
-			Type:               hivev1.UnreachableCondition,
-			Status:             corev1.ConditionTrue,
-			Reason:             "ClusterReachable",
-			Message:            "Setting the condition when cluster is reachable",
-			LastTransitionTime: lastProbeTime,
-			LastProbeTime:      lastProbeTime,
-		},
-	)
-	return cd
-}
-
-func getCDWithProbeAndTransitionTime(lastProbeTime, lastTransitionTime metav1.Time, status corev1.ConditionStatus) *hivev1.ClusterDeployment {
-	cd := getClusterDeployment()
-	var conditions []hivev1.ClusterDeploymentCondition
-
-	cd.Status.Conditions = append(
-		conditions,
-		hivev1.ClusterDeploymentCondition{
-			Type:               hivev1.UnreachableCondition,
-			Status:             status,
-			Reason:             "test reason",
-			Message:            "test message",
-			LastTransitionTime: lastTransitionTime,
-			LastProbeTime:      lastProbeTime,
-		},
-	)
-	return cd
 }

--- a/pkg/remoteclient/mock/remoteclient_generated.go
+++ b/pkg/remoteclient/mock/remoteclient_generated.go
@@ -66,35 +66,6 @@ func (mr *MockBuilderMockRecorder) BuildDynamic() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildDynamic", reflect.TypeOf((*MockBuilder)(nil).BuildDynamic))
 }
 
-// Unreachable mocks base method
-func (m *MockBuilder) Unreachable() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Unreachable")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// Unreachable indicates an expected call of Unreachable
-func (mr *MockBuilderMockRecorder) Unreachable() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unreachable", reflect.TypeOf((*MockBuilder)(nil).Unreachable))
-}
-
-// APIURL mocks base method
-func (m *MockBuilder) APIURL() (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIURL")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// APIURL indicates an expected call of APIURL
-func (mr *MockBuilderMockRecorder) APIURL() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIURL", reflect.TypeOf((*MockBuilder)(nil).APIURL))
-}
-
 // RESTConfig mocks base method
 func (m *MockBuilder) RESTConfig() (*rest.Config, error) {
 	m.ctrl.T.Helper()

--- a/pkg/remoteclient/remoteclient.go
+++ b/pkg/remoteclient/remoteclient.go
@@ -4,8 +4,10 @@ package remoteclient
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
@@ -20,10 +22,9 @@ import (
 	autoscalingv1beta1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1beta1"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/controller/utils"
 )
-
-const adminKubeconfigKey = "kubeconfig"
 
 // Builder is used to build API clients to the remote cluster
 type Builder interface {
@@ -32,14 +33,6 @@ type Builder interface {
 
 	// BuildDynamic will return a dynamic kubeclient for the remote cluster.
 	BuildDynamic() (dynamic.Interface, error)
-
-	// Unreachable returns true if Hive has not been able to reach the remote cluster.
-	// Note that this function will not attempt to reach the remote cluster. It only checks the current conditions on
-	// the ClusterDeployment to determine if the remote cluster is reachable.
-	Unreachable() bool
-
-	// APIURL returns the API URL used to connect to the remote cluster.
-	APIURL() (string, error)
 
 	// RESTConfig returns the config for a REST client that connects to the remote cluster.
 	RESTConfig() (*rest.Config, error)
@@ -65,6 +58,137 @@ func NewBuilder(c client.Client, cd *hivev1.ClusterDeployment, controllerName st
 	}
 }
 
+// ConnectToRemoteCluster connects to a remote cluster using the specified builder.
+// If the ClusterDeployment is marked as unreachable, then no connection will be made.
+// If there are problems connecting, then the specified clusterdeployment will be marked as unreachable.
+func ConnectToRemoteCluster(
+	cd *hivev1.ClusterDeployment,
+	remoteClientBuilder Builder,
+	localClient client.Client,
+	logger log.FieldLogger,
+) (remoteClient client.Client, unreachable, requeue bool) {
+	var rawRemoteClient interface{}
+	rawRemoteClient, unreachable, requeue = connectToRemoteCluster(
+		cd,
+		remoteClientBuilder,
+		localClient,
+		logger,
+		func(builder Builder) (interface{}, error) { return builder.Build() },
+	)
+	if unreachable {
+		return
+	}
+	remoteClient = rawRemoteClient.(client.Client)
+	return
+}
+
+// ConnectToRemoteClusterWithDynamicClient connects to a remote cluster using the specified builder and builds a dynamic client.
+// If the ClusterDeployment is marked as unreachable, then no connection will be made.
+// If there are problems connecting, then the specified clusterdeployment will be marked as unreachable.
+func ConnectToRemoteClusterWithDynamicClient(
+	cd *hivev1.ClusterDeployment,
+	remoteClientBuilder Builder,
+	localClient client.Client,
+	logger log.FieldLogger,
+) (remoteClient dynamic.Interface, unreachable, requeue bool) {
+	var rawRemoteClient interface{}
+	rawRemoteClient, unreachable, requeue = connectToRemoteCluster(
+		cd,
+		remoteClientBuilder,
+		localClient,
+		logger,
+		func(builder Builder) (interface{}, error) { return builder.BuildDynamic() },
+	)
+	if unreachable {
+		return
+	}
+	remoteClient = rawRemoteClient.(dynamic.Interface)
+	return
+}
+
+func connectToRemoteCluster(
+	cd *hivev1.ClusterDeployment,
+	remoteClientBuilder Builder,
+	localClient client.Client,
+	logger log.FieldLogger,
+	buildFunc func(builder Builder) (interface{}, error),
+) (remoteClient interface{}, unreachable, requeue bool) {
+	if u, _ := Unreachable(cd); u {
+		logger.Debug("skipping cluster with unreachable condition")
+		unreachable = true
+		return
+	}
+	var err error
+	remoteClient, err = buildFunc(remoteClientBuilder)
+	if err == nil {
+		return
+	}
+	unreachable = true
+	logger.WithError(err).Info("remote cluster is unreachable")
+	SetUnreachableCondition(cd, err)
+	if err := localClient.Update(context.Background(), cd); err != nil {
+		logger.WithError(err).Log(utils.LogLevel(err), "could not update clusterdeployment with unreachable condition")
+		requeue = true
+	}
+	return
+}
+
+// InitialURL returns the initial API URL for the ClusterDeployment.
+func InitialURL(c client.Client, cd *hivev1.ClusterDeployment) (string, error) {
+	cfg, err := restConfig(c, cd)
+	if err != nil {
+		return "", err
+	}
+	return cfg.Host, nil
+}
+
+// Unreachable returns true if Hive has not been able to reach the remote cluster.
+// Note that this function will not attempt to reach the remote cluster. It only checks the current conditions on
+// the ClusterDeployment to determine if the remote cluster is reachable.
+func Unreachable(cd *hivev1.ClusterDeployment) (unreachable bool, lastCheck time.Time) {
+	cond := utils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.UnreachableCondition)
+	if cond == nil {
+		unreachable = true
+		return
+	}
+	return cond.Status == corev1.ConditionTrue, cond.LastProbeTime.Time
+}
+
+// IsPrimaryURLActive returns true if the remote cluster is reachable via the primary API URL.
+func IsPrimaryURLActive(cd *hivev1.ClusterDeployment) bool {
+	if cd.Spec.ControlPlaneConfig.APIURLOverride == "" {
+		return true
+	}
+	cond := utils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ActiveAPIURLOverrideCondition)
+	return cond != nil && cond.Status == corev1.ConditionTrue
+}
+
+// SetUnreachableCondition sets the Unreachable condition on the ClusterDeployment based on the specified error
+// encountered when attempting to connect to the remote cluster.
+func SetUnreachableCondition(cd *hivev1.ClusterDeployment, connectionError error) (changed bool) {
+	status := corev1.ConditionFalse
+	reason := "ClusterReachable"
+	message := "cluster is reachable"
+	// This needs to always update so that the probe time is updated. The probe time is used to determine when to
+	// perform the next connectivity check.
+	updateCheck := utils.UpdateConditionAlways
+	if connectionError != nil {
+		status = corev1.ConditionTrue
+		reason = "ErrorConnectingToCluster"
+		message = connectionError.Error()
+		updateCheck = utils.UpdateConditionIfReasonOrMessageChange
+	}
+	cd.Status.Conditions, changed = utils.SetClusterDeploymentConditionWithChangeCheck(
+		cd.Status.Conditions,
+		hivev1.UnreachableCondition,
+		status,
+		reason,
+		message,
+		updateCheck,
+	)
+	return
+}
+
 type builder struct {
 	c              client.Client
 	cd             *hivev1.ClusterDeployment
@@ -77,11 +201,6 @@ const (
 	primaryURL
 	secondaryURL
 )
-
-func (b *builder) Unreachable() bool {
-	cond := utils.FindClusterDeploymentCondition(b.cd.Status.Conditions, hivev1.UnreachableCondition)
-	return cond != nil && cond.Status == corev1.ConditionTrue
-}
 
 func (b *builder) Build() (client.Client, error) {
 	cfg, err := b.RESTConfig()
@@ -143,9 +262,9 @@ func (b *builder) RESTConfig() (*rest.Config, error) {
 	); err != nil {
 		return nil, errors.Wrap(err, "could not get admin kubeconfig secret")
 	}
-	kubeconfigData, ok := kubeconfigSecret.Data[adminKubeconfigKey]
+	kubeconfigData, ok := kubeconfigSecret.Data[constants.KubeconfigSecretKey]
 	if !ok {
-		return nil, errors.Errorf("admin kubeconfig secret does not contain %q data", adminKubeconfigKey)
+		return nil, errors.Errorf("admin kubeconfig secret does not contain %q data", constants.KubeconfigSecretKey)
 	}
 
 	config, err := clientcmd.Load(kubeconfigData)
@@ -161,30 +280,33 @@ func (b *builder) RESTConfig() (*rest.Config, error) {
 	utils.AddControllerMetricsTransportWrapper(cfg, b.controllerName, true)
 
 	if override := b.cd.Spec.ControlPlaneConfig.APIURLOverride; override != "" {
-		useOverrideURL := false
-		switch b.urlToUse {
-		case activeURL:
-			useOverrideURL = b.apiURLOverrideActive()
-		case primaryURL:
-			useOverrideURL = true
-		}
-		if useOverrideURL {
-			cfg.Host = b.cd.Spec.ControlPlaneConfig.APIURLOverride
+		if b.urlToUse == primaryURL ||
+			(b.urlToUse == activeURL && IsPrimaryURLActive(b.cd)) {
+			cfg.Host = override
 		}
 	}
 
 	return cfg, nil
 }
 
-func (b *builder) APIURL() (string, error) {
-	cfg, err := b.RESTConfig()
-	if err != nil {
-		return "", err
+func restConfig(c client.Client, cd *hivev1.ClusterDeployment) (*rest.Config, error) {
+	kubeconfigSecret := &corev1.Secret{}
+	if err := c.Get(
+		context.Background(),
+		client.ObjectKey{Namespace: cd.Namespace, Name: cd.Spec.ClusterMetadata.AdminKubeconfigSecretRef.Name},
+		kubeconfigSecret,
+	); err != nil {
+		return nil, errors.Wrap(err, "could not get admin kubeconfig secret")
 	}
-	return cfg.Host, nil
-}
+	kubeconfigData, ok := kubeconfigSecret.Data[constants.KubeconfigSecretKey]
+	if !ok {
+		return nil, errors.Errorf("admin kubeconfig secret does not contain %q data", constants.KubeconfigSecretKey)
+	}
 
-func (b *builder) apiURLOverrideActive() bool {
-	cond := utils.FindClusterDeploymentCondition(b.cd.Status.Conditions, hivev1.ActiveAPIURLOverrideCondition)
-	return cond != nil && cond.Status == corev1.ConditionTrue
+	config, err := clientcmd.Load(kubeconfigData)
+	if err != nil {
+		return nil, err
+	}
+	kubeConfig := clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{})
+	return kubeConfig.ClientConfig()
 }

--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -24,3 +24,16 @@ func Generic(opt generic.Option) Option {
 		opt(clusterDeployment)
 	}
 }
+
+// WithCondition adds the specified condition to the ClusterDeployment
+func WithCondition(cond hivev1.ClusterDeploymentCondition) Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		for i, c := range clusterDeployment.Status.Conditions {
+			if c.Type == cond.Type {
+				clusterDeployment.Status.Conditions[i] = cond
+				return
+			}
+		}
+		clusterDeployment.Status.Conditions = append(clusterDeployment.Status.Conditions, cond)
+	}
+}

--- a/pkg/test/secret/secret.go
+++ b/pkg/test/secret/secret.go
@@ -1,8 +1,9 @@
 package secret
 
 import (
-	"github.com/openshift/hive/pkg/test/generic"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift/hive/pkg/test/generic"
 )
 
 // Option defines a function signature for any function that wants to be passed into Build
@@ -23,6 +24,16 @@ func Generic(opt generic.Option) Option {
 	return func(obj *corev1.Secret) {
 		opt(obj)
 	}
+}
+
+// WithName sets the object.Name field when building an object with Build.
+func WithName(name string) Option {
+	return Generic(generic.WithName(name))
+}
+
+// WithNamespace sets the object.Namespace field when building an object with Build.
+func WithNamespace(namespace string) Option {
+	return Generic(generic.WithNamespace(namespace))
 }
 
 // WithDataKeyValue adds the key and value to the secret's data section.


### PR DESCRIPTION
Use the unreachable controller work queue backoff as the means of backing off from attempting to connect to an unreachable remote cluster.

If an API URL override is set, continue attempting to connect to the cluster using the work queue backoff rather than falling back to the 2-hour check used when the cluster is reachable.

When a reachable ClusterDeployment is synced in the unreachable controller, requeue the ClusterDeployment so that it is re-synced for the 2-hour check.

In other controllers that connect to the remote cluster, set the unreachable condition if there is a failure to connect to the remote cluster. This will give a bit faster feedback when a cluster becomes unreachable, and will allow the controllers to fall back to the initial API URL more quickly.

https://issues.redhat.com/browse/CO-847