### PR TITLE
add version information to log output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ SRC_DIRS = pkg contrib
 GOFILES = $(shell find $(SRC_DIRS) -name '*.go' | grep -v bindata | grep -v generated)
 VERIFY_IMPORTS_CONFIG = build/verify-imports/import-rules.yaml
 
+# See pkg/version/version.go for details
+GIT_COMMIT=$(shell git rev-parse --verify 'HEAD^{commit}')
+LDFLAGS=-ldflags "-X github.com/openshift/hive/pkg/version.Raw=$(shell git describe --always --abbrev=40 --dirty) -X github.com/openshift/hive/pkg/version.Commit=${GIT_COMMIT}"
+
 # To use docker build, specify BUILD_CMD="docker build"
 BUILD_CMD ?= imagebuilder
 
@@ -68,26 +72,26 @@ build: manager hiveutil hiveadmission operator hive-apiserver
 # Build manager binary
 .PHONY: manager
 manager: generate
-	go build -o bin/manager github.com/openshift/hive/cmd/manager
+	go build -o bin/manager $(LDFLAGS) github.com/openshift/hive/cmd/manager
 
 .PHONY: operator
 operator: generate
-	go build -o bin/hive-operator github.com/openshift/hive/cmd/operator
+	go build -o bin/hive-operator $(LDFLAGS) github.com/openshift/hive/cmd/operator
 
 # Build hiveutil binary
 .PHONY: hiveutil
 hiveutil: generate
-	go build -o bin/hiveutil github.com/openshift/hive/contrib/cmd/hiveutil
+	go build -o bin/hiveutil $(LDFLAGS) github.com/openshift/hive/contrib/cmd/hiveutil
 
 # Build hiveadmission binary
 .PHONY: hiveadmission
 hiveadmission:
-	go build -o bin/hiveadmission github.com/openshift/hive/cmd/hiveadmission
+	go build -o bin/hiveadmission $(LDFLAGS) github.com/openshift/hive/cmd/hiveadmission
 
 # Build v1alpha1 aggregated API server
 .PHONY: hive-apiserver
 hive-apiserver:
-	go build -o bin/hive-apiserver github.com/openshift/hive/cmd/hive-apiserver
+	go build -o bin/hive-apiserver $(LDFLAGS) github.com/openshift/hive/cmd/hive-apiserver
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 .PHONY: run

--- a/cmd/hive-apiserver/main.go
+++ b/cmd/hive-apiserver/main.go
@@ -17,7 +17,8 @@ import (
 	"k8s.io/component-base/logs"
 
 	"github.com/openshift/hive/pkg/certs"
-	"github.com/openshift/hive/pkg/cmd/hive-apiserver"
+	hiveapiserver "github.com/openshift/hive/pkg/cmd/hive-apiserver"
+	"github.com/openshift/hive/pkg/version"
 )
 
 func main() {
@@ -30,6 +31,8 @@ func main() {
 
 	logs.InitLogs()
 	defer logs.FlushLogs()
+
+	log.Infof("Version: %s @ %s", version.String, version.Commit)
 
 	log.SetLevel(log.InfoLevel)
 

--- a/cmd/hiveadmission/main.go
+++ b/cmd/hiveadmission/main.go
@@ -10,9 +10,11 @@ import (
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	hivevalidatingwebhooks "github.com/openshift/hive/pkg/apis/hive/v1/validating-webhooks"
 	"github.com/openshift/hive/pkg/certs"
+	"github.com/openshift/hive/pkg/version"
 )
 
 func main() {
+	log.Infof("Version: %s @ %s", version.String, version.Commit)
 	log.Info("Starting CRD Validation Webhooks.")
 
 	// TODO: figure out a way to combine logrus and klog logging levels. The team has decided that hardcoding this is ok for now.

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/controller"
 	"github.com/openshift/hive/pkg/controller/utils"
+	"github.com/openshift/hive/pkg/version"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -56,6 +57,7 @@ func newRootCommand() *cobra.Command {
 				log.WithError(err).Fatal("Cannot parse log level")
 			}
 			log.SetLevel(level)
+			log.Infof("Version: %s @ %s", version.String, version.Commit)
 			log.Debug("debug logging enabled")
 
 			// Parse leader election options

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/hive/pkg/apis"
 	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/operator"
+	"github.com/openshift/hive/pkg/version"
 
 	oappsv1 "github.com/openshift/api/apps/v1"
 
@@ -53,6 +54,7 @@ func newRootCommand() *cobra.Command {
 				log.WithError(err).Fatal("Cannot parse log level")
 			}
 			log.SetLevel(level)
+			log.Infof("Version: %s @ %s", version.String, version.Commit)
 			log.Debug("debug logging enabled")
 
 			// Parse leader election options

--- a/contrib/cmd/hiveutil/main.go
+++ b/contrib/cmd/hiveutil/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/hive/contrib/pkg/testresource"
 	"github.com/openshift/hive/contrib/pkg/v1migration"
 	"github.com/openshift/hive/contrib/pkg/verification"
+	"github.com/openshift/hive/contrib/pkg/version"
 	"github.com/openshift/hive/pkg/imageset"
 	"github.com/openshift/hive/pkg/installmanager"
 )
@@ -54,6 +55,7 @@ func newHiveutilCommand() *cobra.Command {
 	cmd.AddCommand(certificate.NewCertificateCommand())
 	cmd.AddCommand(adm.NewAdmCommand())
 	cmd.AddCommand(labelobjects.NewLabelObjectsCommand())
+	cmd.AddCommand(version.NewVersionCommand())
 
 	return cmd
 }

--- a/contrib/pkg/version/version.go
+++ b/contrib/pkg/version/version.go
@@ -1,0 +1,22 @@
+package version
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	pkgversion "github.com/openshift/hive/pkg/version"
+)
+
+// NewVersionCommand creates a command that generates and outputs the cluster report.
+func NewVersionCommand() *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Prints version information for the command",
+		Run: func(cmd *cobra.Command, args []string) {
+			log.SetLevel(log.InfoLevel)
+			log.Infof("%s @ %s", pkgversion.String, pkgversion.Commit)
+		},
+	}
+	return cmd
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,18 @@
+// Package version includes the version information.
+package version
+
+import "fmt"
+
+var (
+	// Raw is the string representation of the version. This will be replaced
+	// with the calculated version at build time.
+	// set in the Makefile.
+	Raw = "was not built with version info"
+
+	// String is the human-friendly representation of the version.
+	String = fmt.Sprintf("openshift/hive %s", Raw)
+
+	// Commit is the commit hash from which the software was built.
+	// Set via LDFLAGS in Makefile.
+	Commit = ""
+)


### PR DESCRIPTION
Add LDFLAGS to inject version details for each build based on the git
tag and commit SHA.

Add a hiveutil version subcommand.

Log the version info at the startup of all other commands.