### PR TITLE
update dockerfile to use make to build binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,9 @@ FROM openshift/origin-release:golang-1.13 as builder
 RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .
-RUN go build -mod=vendor -o bin/manager github.com/openshift/hive/cmd/manager
-RUN go build -mod=vendor -o bin/hiveutil github.com/openshift/hive/contrib/cmd/hiveutil
-RUN go build -mod=vendor -o bin/hiveadmission github.com/openshift/hive/cmd/hiveadmission
-RUN go build -mod=vendor -o bin/hive-operator github.com/openshift/hive/cmd/operator
-RUN go build -mod=vendor -o bin/hive-apiserver github.com/openshift/hive/cmd/hive-apiserver
+# Use 'binaries' target instead of 'build' to skip the generate step,
+# because those tools are not present.
+RUN make binaries
 
 FROM centos:7
 

--- a/Makefile
+++ b/Makefile
@@ -83,21 +83,27 @@ test-e2e-postinstall:
 
 # Builds all of hive's binaries (including utils).
 .PHONY: build
-build: manager hiveutil hiveadmission operator hive-apiserver
+build: generate binaries
+
+# Target for building the binaries without running generate, since the
+# tools for that are not present in the builder image used by the
+# Dockerfile.
+.PHONY: binaries
+binaries: manager hiveutil hiveadmission operator hive-apiserver
 
 
 # Build manager binary
 .PHONY: manager
-manager: generate
+manager:
 	go build $(GO_MOD_FLAGS) -o bin/manager $(LDFLAGS) github.com/openshift/hive/cmd/manager
 
 .PHONY: operator
-operator: generate
+operator:
 	go build $(GO_MOD_FLAGS) -o bin/hive-operator $(LDFLAGS) github.com/openshift/hive/cmd/operator
 
 # Build hiveutil binary
 .PHONY: hiveutil
-hiveutil: generate
+hiveutil:
 	go build $(GO_MOD_FLAGS) -o bin/hiveutil $(LDFLAGS) github.com/openshift/hive/contrib/cmd/hiveutil
 
 # Build hiveadmission binary


### PR DESCRIPTION
The Dockerfile was using go build directly, which meant the version
information was not being injected in the way expected. Switching to
use make required adding a new "binaries" target that does not include
the "generate" dependency because the builder image does not include
mockgen. The old "build" target is left in place with a dependency on
generate and binaries to provide backwards compatibility.