### PR TITLE
generate-operator-bundle.py improvements

### DIFF
--- a/config/templates/hive-csv-template.yaml
+++ b/config/templates/hive-csv-template.yaml
@@ -4,23 +4,84 @@ metadata:
   name: hive-operator-0.0.1
   namespace: placeholder
   annotations:
-    categories: A list of comma separated categories that your operator falls under.
+    capabilities: Seamless Upgrades
+    categories: OpenShift Optional
     certified: "false"
     description: OpenShift cluster provisioning and management at scale.
     containerImage: quay.io/dgoodwin/hive:latest
     createdAt: "2019-02-25T14:29:00Z"
-    support: Devan Goodwin
+    repository: https://github.com/openshift/hive
+    support: OpenShift Hive Team
+    alm-examples: |-
+      [{"apiVersion":"hive.openshift.io/v1","kind":"HiveConfig","metadata":{"name":"hive"},"spec":{"managedDomains":[{"aws":{"credentialsSecretRef":{"name":"my-route53-creds"}},"domains":["my-base-domain.example.com"]}]}}]
 spec:
-  displayName: Hive
-  description: OpenShift cluster provisioning and management at scale.
+  displayName: OpenShift Hive
+  description: |-
+    OpenShift Hive is an operator that runs on top of Kubernetes/OpenShift. Hive can be used to provision
+    and perform initial configuration of OpenShift clusters.
+
+    For provisioning OpenShift, Hive uses the [OpenShift installer](https://github.com/openshift/installer).
+
+    ### Supported cloud providers
+    * AWS
+    * Azure
+    * Google Cloud Platform
+
+    In the future Hive will support more cloud providers.
+
+    ## Documentation
+
+    * [Quick Start Guide](https://github.com/openshift/hive/blob/master/docs/quick_start.md)
+    * [Using Hive](https://github.com/openshift/hive/blob/master/docs/using-hive.md)
+    * [Hiveutil CLI](https://github.com/openshift/hive/blob/master/docs/hiveutil.md)
+    * [Frequently Asked Questions](https://github.com/openshift/hive/blob/master/docs/FAQs.md)
+    * [Architecture](https://github.com/openshift/hive/blob/master/docs/architecture.md)
+
+    See the [project README](https://github.com/openshift/hive#documentation) for more documentation.
+
+    ## Post Install Configuration
+
+    After installing the OpenShift Hive operator, create a cluster-scoped `HiveConfig` CR to configure Hive.
+    Upon creation of `HiveConfig`, the operator will configure Hive's pods.
+
+    Example `HiveConfig`:
+    ```yaml
+    ---
+      apiVersion: hive.openshift.io/v1
+      kind: HiveConfig
+      metadata:
+        name: hive
+      spec:
+        managedDomains:
+        - aws:
+            credentialsSecretRef:
+              name: my-route53-creds
+          domains:
+          - my-base-domain.example.com
+    ```
+
+    ## Create a cluster
+
+    To create a cluster with Hive, create a `ClusterDeployment` CR. You can also use the
+    [`hiveutil` tool](https://github.com/openshift/hive/blob/master/docs/hiveutil.md)'s `create-cluster` command
+    to create clusters.
   keywords:
   - kubernetes
   - openshift
   - multi-cluster
   - cluster
+  links:
+  - name: OpenShift Hive GitHub
+    url: https://github.com/openshift/hive
+  - name: "OpenShift Hive: Cluster-as-a-Service"
+    url: https://www.openshift.com/blog/openshift-hive-cluster-as-a-service
+  - name: OpenShift
+    url: https://www.openshift.com/
+  maintainers:
+    - name: OpenShift Hive Team
   version: 0.0.1
   provider:
-    name: Red Hat, Inc
+    name: Red Hat
   maturity: alpha
   installModes:
   - type: OwnNamespace
@@ -28,9 +89,9 @@ spec:
   - type: SingleNamespace
     supported: true
   - type: MultiNamespace
-    supported: false
+    supported: true
   - type: AllNamespaces
-    supported: false
+    supported: true
   install:
     strategy: deployment
     spec:
@@ -46,14 +107,4 @@ spec:
       displayName: Hive Config
       kind: HiveConfig
       name: hiveconfigs.hive.openshift.io
-      version: v1
-    - description: Defines an OpenShift cluster to be created.
-      displayName: Cluster Deployment
-      kind: ClusterDeployment
-      name: clusterdeployments.hive.openshift.io
-      version: v1
-    - description: Defines a DNSZone to be managed in a cloud provider.
-      displayName: DNS Zone
-      kind: DNSZone
-      name: dnszones.hive.openshift.io
       version: v1

--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -28,4 +28,4 @@ skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
 $CURRENT_DIR/app_sre_create_image_catalog.sh staging "$QUAY_IMAGE"
 
 # create and push production image catalog
-REMOVE_UNDEPLOYED=true $CURRENT_DIR/app_sre_create_image_catalog.sh production "$QUAY_IMAGE"
+$CURRENT_DIR/app_sre_create_image_catalog.sh production "$QUAY_IMAGE"

--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -6,11 +6,10 @@ BRANCH_CHANNEL="$1"
 QUAY_IMAGE="$2"
 
 GIT_HASH=`git rev-parse --short=7 HEAD`
-GIT_COMMIT_COUNT=`git rev-list 9c56c62c6d0180c27e1cc9cf195f4bbfd7a617dd..HEAD --count`
 
-# clone bundle repo
 SAAS_OPERATOR_DIR="saas-hive-operator-bundle"
-BUNDLE_DIR="$SAAS_OPERATOR_DIR/hive/"
+SAAS_OPERATOR_BUNDLE_DIR="$SAAS_OPERATOR_DIR/hive/"
+HIVE_BUNDLE_DIR="bundle/"
 
 rm -rf "$SAAS_OPERATOR_DIR"
 
@@ -19,67 +18,33 @@ git clone \
     https://app:${APP_SRE_BOT_PUSH_TOKEN}@gitlab.cee.redhat.com/service/saas-hive-operator-bundle.git \
     $SAAS_OPERATOR_DIR
 
-# remove any versions more recent than deployed hash
-REMOVED_VERSIONS=""
-if [[ "$REMOVE_UNDEPLOYED" == true ]]; then
-    DEPLOYED_HASH=$(
-        curl -s 'https://gitlab.cee.redhat.com/service/saas-hive/raw/master/hive-services/hive.yaml' | \
-            docker run --rm -i evns/yq -r '.services[]|select(.name="hive").hash'
-    )
-
-    delete=false
-    for version in `ls $BUNDLE_DIR | sort -t . -k 3 -g`; do
-        # skip if not directory
-        [ -d "$BUNDLE_DIR/$version" ] || continue
-
-        if [[ "$delete" == false ]]; then
-            short_hash=$(echo $version | cut -d- -f2)
-            short_hash=${short_hash##sha}
-
-            if [[ "$DEPLOYED_HASH" == "${short_hash}"* ]]; then
-                delete=true
-            fi
-        else
-            rm -rf "$BUNDLE_DIR/$version"
-            REMOVED_VERSIONS="$version $REMOVED_VERSIONS"
-        fi
-    done
-fi
 
 # generate bundle
-PREV_VERSION=$(ls $BUNDLE_DIR | sort -t . -k 3 -g | tail -n 1)
+PREV_VERSION=$((cd $SAAS_OPERATOR_BUNDLE_DIR && find -type d | xargs -n 1 basename) | sort -V  | tail -n 1)
 
-./hack/generate-operator-bundle.py \
-    $BUNDLE_DIR \
-    $PREV_VERSION \
-    $GIT_COMMIT_COUNT \
-    $GIT_HASH \
-    $QUAY_IMAGE:$GIT_HASH
+./hack/generate-operator-bundle.py osd --previous-version $PREV_VERSION --hive-image $QUAY_IMAGE:$GIT_HASH --channel $BRANCH_CHANNEL
 
-NEW_VERSION=$(ls $BUNDLE_DIR | sort -t . -k 3 -g | tail -n 1)
+NEW_VERSION=$((cd $HIVE_BUNDLE_DIR && find -type d | xargs -n 1 basename) | sort -V  | tail -n 1)
 
 if [ "$NEW_VERSION" = "$PREV_VERSION" ]; then
     # stopping script as that version was already built, so no need to rebuild it
     exit 0
 fi
 
-# create package yaml
-cat <<EOF > $BUNDLE_DIR/hive.package.yaml
-packageName: hive-operator
-channels:
-- name: $BRANCH_CHANNEL
-  currentCSV: hive-operator.v${NEW_VERSION}
-EOF
+# copy new csv
+cp -ax $HIVE_BUNDLE_DIR/$NEW_VERSION $SAAS_OPERATOR_BUNDLE_DIR/
+
+# copy package
+cp $HIVE_BUNDLE_DIR/hive.package.yaml $SAAS_OPERATOR_BUNDLE_DIR/
 
 # add, commit & push
 pushd $SAAS_OPERATOR_DIR
 
 git add .
 
-MESSAGE="add version $GIT_COMMIT_COUNT-$GIT_HASH
+MESSAGE="add version $NEW_VERSION
 
-replaces $PREV_VERSION
-removed versions: $REMOVED_VERSIONS"
+replaces $PREV_VERSION"
 
 git commit -m "$MESSAGE"
 git push origin "$BRANCH_CHANNEL"

--- a/hack/generate-operator-bundle.py
+++ b/hack/generate-operator-bundle.py
@@ -4,88 +4,170 @@
 # into a directory, and composes the ClusterServiceVersion which needs bits and
 # pieces of our rbac and deployment files.
 #
-# Usage ./hack/generate-operator-bundle.py OUTPUT_DIR PREVIOUS_VERSION GIT_NUM_COMMITS GIT_HASH HIVE_IMAGE
+# Usage: hack/generate-operator-bundle.py (osd|operatorhub)
 #
-# Commit count can be obtained with: git rev-list 9c56c62c6d0180c27e1cc9cf195f4bbfd7a617dd..HEAD --count
-# This is the first hive commit, if we tag a release we can then switch to using that tag and bump the base version.
+#  See help for options.
+#
 
+import argparse
 import datetime
 import os
-import sys
-import yaml
 import shutil
+import subprocess
+import yaml
 
-# This script will append the current number of commits given as an arg
-# (presumably since some past base tag), and the git hash arg for a final
-# version like: 0.1.189-3f73a592
-VERSION_BASE = "0.1"
 
-if len(sys.argv) != 6:
-    print("USAGE: %s OUTPUT_DIR PREVIOUS_VERSION GIT_NUM_COMMITS GIT_HASH HIVE_IMAGE" % sys.argv[0])
-    sys.exit(1)
+OSD_HIVE_IMAGE_DEFAULT = 'quay.io/app-sre/hive'
+OPERATORHUB_HIVE_IMAGE_DEFAULT = 'quay.io/openshift-hive/hive'
+CHANNEL_DEFAULT = 'alpha'
+BUNDLE_DIR = 'bundle'
+PACKAGE_FILE = os.path.join(BUNDLE_DIR, 'hive.package.yaml')
 
-outdir = sys.argv[1]
-prev_version = sys.argv[2]
-git_num_commits = sys.argv[3]
-git_hash = sys.argv[4]
-hive_image = sys.argv[5]
 
-full_version = "%s.%s-sha%s" % (VERSION_BASE, git_num_commits, git_hash)
-print("Generating CSV for version: %s" % full_version)
+def current_operatorhub_version():
+    result = subprocess.check_output("git describe --abbrev=0", shell=True).strip()
+    # remove the v -- OLM bundles need to start with the digit
+    if result[0] == 'v':
+        result = result[1:]
+    return result
 
-if not os.path.exists(outdir):
-    os.mkdir(outdir)
 
-version_dir = os.path.join(outdir, full_version)
-if not os.path.exists(version_dir):
-    os.mkdir(version_dir)
+def generate_operatorhub_version(prev_version=current_operatorhub_version()):
+    # bump the zstream
+    previous_z = int(prev_version.split('.')[-1])
+    new_z = previous_z + 1
+    new_version = "%s.%s" % ('.'.join(prev_version.split('.')[:-1]), new_z)
+    return new_version
 
-# Copy all CSV files over to the bundle output dir:
-crd_files = os.listdir('config/crds/')
-for file_name in crd_files:
-    full_path = os.path.join('config/crds', file_name)
-    if (os.path.isfile(os.path.join('config/crds', file_name))):
-        shutil.copy(full_path, os.path.join(version_dir, file_name))
 
-with open('config/templates/hive-csv-template.yaml', 'r') as stream:
-    csv = yaml.load(stream, Loader=yaml.SafeLoader)
+def generate_osd_version():
+    result = subprocess.check_output("git describe", shell=True).strip()
+    print(result)
+    # remove the v -- OLM bundles need to start with the digit
+    if result[0] == 'v':
+        result = result[1:]
+    return result
 
-csv['spec']['install']['spec']['clusterPermissions'] = []
 
-# Add our operator role to the CSV:
-with open('config/operator/operator_role.yaml', 'r') as stream:
-    operator_role = yaml.load(stream, Loader=yaml.SafeLoader)
-    csv['spec']['install']['spec']['clusterPermissions'].append(
-        {
-            'rules': operator_role['rules'],
-            'serviceAccountName': 'hive-operator',
-        })
+def generate_csv_operatorhub():
+    print("Generating CSV for operatorhub")
+    prev_version = current_operatorhub_version()
+    version = args.new_version
+    if not version:
+        version = generate_operatorhub_version(prev_version)
+    generate_csv_base(version, prev_version, args.hive_image)
+    generate_package(args.channel, version)
 
-# Add our deployment spec for the hive operator:
-with open('config/operator/operator_deployment.yaml', 'r') as stream:
-    operator_components = []
-    operator = yaml.load_all(stream, Loader=yaml.SafeLoader)
-    for doc in operator:
-        operator_components.append(doc)
-    operator_deployment = operator_components[1]
-    csv['spec']['install']['spec']['deployments'][0]['spec'] = operator_deployment['spec']
 
-# Update the deployment to use the defined image:
-csv['spec']['install']['spec']['deployments'][0]['spec']['template']['spec']['containers'][0]['image'] = hive_image
+def generate_csv_osd():
+    print("Generating CSV for OpenShift Dedicated")
+    version = generate_osd_version()
+    generate_csv_base(version, args.prev_version, args.hive_image)
+    generate_package(args.channel, version)
 
-# Update the versions to include git hash:
-csv['metadata']['name'] = "hive-operator.v%s" % full_version
-csv['spec']['version'] = full_version
-csv['spec']['replaces'] = "hive-operator.v%s" % prev_version
 
-# Set the CSV createdAt annotation:
-now = datetime.datetime.now()
-csv['metadata']['annotations']['createdAt'] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+def generate_csv_base(version, prev_version, hive_image):
+    print("Generating CSV for version: %s" % version)
 
-# Write the CSV to disk:
-csv_filename = "hive-operator.v%s.clusterserviceversion.yaml" % full_version
-csv_file = os.path.join(version_dir, csv_filename)
-with open(csv_file, 'w') as outfile:
-    yaml.dump(csv, outfile, default_flow_style=False)
-print("Wrote ClusterServiceVersion: %s" % csv_file)
+    crds_dir = 'config/crds'
+    csv_template = 'config/templates/hive-csv-template.yaml'
+    operator_role = 'config/operator/operator_role.yaml'
+    deployment_spec = 'config/operator/operator_deployment.yaml'
 
+    if not os.path.exists(BUNDLE_DIR):
+        os.mkdir(BUNDLE_DIR)
+
+    version_dir = os.path.join(BUNDLE_DIR, version)
+    if not os.path.exists(version_dir):
+        os.mkdir(version_dir)
+
+    # Copy all CSV files over to the bundle output dir:
+    crd_files = os.listdir(crds_dir)
+    for file_name in crd_files:
+        full_path = os.path.join(crds_dir, file_name)
+        if os.path.isfile(os.path.join(crds_dir, file_name)):
+            shutil.copy(full_path, os.path.join(version_dir, file_name))
+
+    with open(csv_template, 'r') as stream:
+        csv = yaml.load(stream, Loader=yaml.SafeLoader)
+
+    csv['spec']['install']['spec']['clusterPermissions'] = []
+
+    # Add our operator role to the CSV:
+    with open(operator_role, 'r') as stream:
+        operator_role = yaml.load(stream, Loader=yaml.SafeLoader)
+        csv['spec']['install']['spec']['clusterPermissions'].append(
+            {
+                'rules': operator_role['rules'],
+                'serviceAccountName': 'hive-operator',
+            })
+
+    # Add our deployment spec for the hive operator:
+    with open(deployment_spec, 'r') as stream:
+        operator_components = []
+        operator = yaml.load_all(stream, Loader=yaml.SafeLoader)
+        for doc in operator:
+            operator_components.append(doc)
+        operator_deployment = operator_components[1]
+        csv['spec']['install']['spec']['deployments'][0]['spec'] = operator_deployment['spec']
+
+    # Update the versions to include git hash:
+    csv['metadata']['name'] = "hive-operator.v%s" % version
+    csv['spec']['version'] = version
+    csv['spec']['replaces'] = "hive-operator.v%s" % prev_version
+
+    # Update the deployment to use the defined image:
+    image_ref = "%s:v%s" % (hive_image, version)
+    csv['spec']['install']['spec']['deployments'][0]['spec']['template']['spec']['containers'][0]['image'] = image_ref
+    csv['metadata']['annotations']['containerImage'] = image_ref
+
+    # Set the CSV createdAt annotation:
+    now = datetime.datetime.now()
+    csv['metadata']['annotations']['createdAt'] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Write the CSV to disk:
+    csv_filename = "hive-operator.v%s.clusterserviceversion.yaml" % version
+    csv_file = os.path.join(version_dir, csv_filename)
+    with open(csv_file, 'w') as outfile:
+        yaml.dump(csv, outfile, default_flow_style=False)
+    print("Wrote ClusterServiceVersion: %s" % csv_file)
+
+
+def generate_package(channel, version):
+    document_template = """
+      channels:
+      - currentCSV: %s
+        name: %s
+      defaultChannel: %s
+      packageName: hive-operator
+"""
+    name = "hive-operator.v%s" % version
+    document = document_template % (name, channel, channel)
+
+    with open(PACKAGE_FILE, 'w') as outfile:
+        yaml.dump(yaml.load(document, Loader=yaml.SafeLoader), outfile, default_flow_style=False)
+    print("Wrote package: %s" % PACKAGE_FILE)
+
+
+parser = argparse.ArgumentParser(
+    prog='OpenShift Hive Operator CSV generator',
+    description='created CSV and related artifacts for operatorhub.io and OpenShift Dedicated.',
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+)
+
+subparsers = parser.add_subparsers()
+
+osd_parser = subparsers.add_parser('osd', help='Generate CSV for OpenShift Dedicated deployment.')
+osd_parser.add_argument('--previous-version', dest='prev_version', metavar='VERSION', help='Previous version, the version being replaced')
+osd_parser.add_argument('--hive-image', dest='hive_image', metavar='IMAGE', help='The hive image to deploy', default=OSD_HIVE_IMAGE_DEFAULT)
+osd_parser.add_argument('--channel', dest='channel', metavar='CHANNEL', help='The operator channel to use', default=CHANNEL_DEFAULT)
+osd_parser.set_defaults(func=generate_csv_osd)
+
+operatorhub_parser = subparsers.add_parser('operatorhub', help='Generate CSV for operatorhub deployment.')
+operatorhub_parser.add_argument('--new-version', dest='new_version', metavar='VERSION', help='Override the new version in case of minor or major upgrade', default=None)
+operatorhub_parser.add_argument('--hive-image', dest='hive_image', metavar='IMAGE', help='The hive image to deploy', default=OPERATORHUB_HIVE_IMAGE_DEFAULT)
+operatorhub_parser.add_argument('--channel', dest='channel', metavar='CHANNEL', help='The operator channel to use', default=CHANNEL_DEFAULT)
+operatorhub_parser.set_defaults(func=generate_csv_operatorhub)
+
+args = parser.parse_args()
+args.func()

--- a/hack/generate-operator-bundle.py
+++ b/hack/generate-operator-bundle.py
@@ -117,7 +117,9 @@ def generate_csv_base(version, prev_version, hive_image):
     csv['spec']['replaces'] = "hive-operator.v%s" % prev_version
 
     # Update the deployment to use the defined image:
-    image_ref = "%s:v%s" % (hive_image, version)
+    image_ref = hive_image
+    if not ":" in image_ref:
+        image_ref = "%s:v%s" % (hive_image, version)
     csv['spec']['install']['spec']['deployments'][0]['spec']['template']['spec']['containers'][0]['image'] = image_ref
     csv['metadata']['annotations']['containerImage'] = image_ref
 


### PR DESCRIPTION
generate-operator-bundle.py improvements

- add argparsing
- add mode for operatorhub bundle generation
- refactor current mode for OpenShift Dedicated
- update some data in the CSV template
- change app-sre pipeline scripts to work with new generate-operator-bundle.py
  options and the new hive versioning scheme. This removes the old commit
  counting. It also removed the deletion of future commits from
  the bundle, because hive can never be rolled back, only forward.


/cc @dgoodwin 