### PR TITLE
Fix bug in label ownership reconciliation

### DIFF
--- a/contrib/pkg/labelobjects/labelobjects_test.go
+++ b/contrib/pkg/labelobjects/labelobjects_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/hive/pkg/test/persistentvolumeclaim"
 	"github.com/openshift/hive/pkg/test/secret"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	log "github.com/sirupsen/logrus"
@@ -261,7 +262,7 @@ func TestLabelClusterProvisions(t *testing.T) {
 
 			// Act
 			actualError := l.labelClusterProvisions()
-			actualObjects, _ := controllerutils.GetRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.ClusterProvisionList{}}, namespace)
+			actualObjects, _ := controllerutils.ListRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.ClusterProvisionList{}}, client.InNamespace(namespace))
 
 			// Assert
 			assert.Equal(t, test.expectedError, actualError)
@@ -310,7 +311,7 @@ func TestLabelInstallLogPVCs(t *testing.T) {
 
 			// Act
 			actualError := l.labelInstallLogPVCs()
-			actualObjects, _ := controllerutils.GetRuntimeObjects(l.client, []runtime.Object{&corev1.PersistentVolumeClaimList{}}, namespace)
+			actualObjects, _ := controllerutils.ListRuntimeObjects(l.client, []runtime.Object{&corev1.PersistentVolumeClaimList{}}, client.InNamespace(namespace))
 
 			// Assert
 			assert.Equal(t, test.expectedError, actualError)
@@ -359,7 +360,7 @@ func TestLabelImageSetJobs(t *testing.T) {
 
 			// Act
 			actualError := l.labelImageSetJobs()
-			actualObjects, _ := controllerutils.GetRuntimeObjects(l.client, []runtime.Object{&batchv1.JobList{}}, namespace)
+			actualObjects, _ := controllerutils.ListRuntimeObjects(l.client, []runtime.Object{&batchv1.JobList{}}, client.InNamespace(namespace))
 
 			// Assert
 			assert.Equal(t, test.expectedError, actualError)
@@ -404,7 +405,7 @@ func TestLabelClusterDeprovisionRequests(t *testing.T) {
 
 			// Act
 			actualError := l.labelClusterDeprovisionsRequests()
-			actualObjects, _ := controllerutils.GetRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.ClusterDeprovisionRequestList{}}, namespace)
+			actualObjects, _ := controllerutils.ListRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.ClusterDeprovisionRequestList{}}, client.InNamespace(namespace))
 
 			// Assert
 			assert.Equal(t, test.expectedError, actualError)
@@ -450,7 +451,7 @@ func TestLabelDNSZones(t *testing.T) {
 
 			// Act
 			actualError := l.labelDNSZones()
-			actualObjects, _ := controllerutils.GetRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.DNSZoneList{}}, namespace)
+			actualObjects, _ := controllerutils.ListRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.DNSZoneList{}}, client.InNamespace(namespace))
 
 			// Assert
 			assert.Equal(t, test.expectedError, actualError)
@@ -502,7 +503,7 @@ func TestLabelMergedPullSecrets(t *testing.T) {
 
 			// Act
 			actualError := l.labelMergedPullSecrets()
-			actualObjects, _ := controllerutils.GetRuntimeObjects(l.client, []runtime.Object{&corev1.SecretList{}}, namespace)
+			actualObjects, _ := controllerutils.ListRuntimeObjects(l.client, []runtime.Object{&corev1.SecretList{}}, client.InNamespace(namespace))
 
 			// Assert
 			assert.Equal(t, test.expectedError, actualError)
@@ -553,7 +554,7 @@ func TestLabelClusterDeprovisionJobs(t *testing.T) {
 
 			// Act
 			actualError := l.labelClusterDeprovisionJobs()
-			actualObjects, _ := controllerutils.GetRuntimeObjects(l.client, []runtime.Object{&batchv1.JobList{}}, namespace)
+			actualObjects, _ := controllerutils.ListRuntimeObjects(l.client, []runtime.Object{&batchv1.JobList{}}, client.InNamespace(namespace))
 
 			// Assert
 			assert.Equal(t, test.expectedError, actualError)
@@ -604,7 +605,7 @@ func TestLabelClusterProvisionJobs(t *testing.T) {
 
 			// Act
 			actualError := l.labelClusterProvisionJobs()
-			actualObjects, _ := controllerutils.GetRuntimeObjects(l.client, []runtime.Object{&batchv1.JobList{}}, namespace)
+			actualObjects, _ := controllerutils.ListRuntimeObjects(l.client, []runtime.Object{&batchv1.JobList{}}, client.InNamespace(namespace))
 
 			// Assert
 			assert.Equal(t, test.expectedError, actualError)
@@ -649,7 +650,7 @@ func TestLabelClusterState(t *testing.T) {
 
 			// Act
 			actualError := l.labelClusterStates()
-			actualObjects, _ := controllerutils.GetRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.ClusterStateList{}}, namespace)
+			actualObjects, _ := controllerutils.ListRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.ClusterStateList{}}, client.InNamespace(namespace))
 
 			// Assert
 			assert.Equal(t, test.expectedError, actualError)
@@ -699,7 +700,7 @@ func TestLabelControlPlaneCertificateSyncSets(t *testing.T) {
 
 			// Act
 			actualError := l.labelControlPlaneCertificateSyncSets()
-			actualObjects, _ := controllerutils.GetRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.SyncSetList{}}, namespace)
+			actualObjects, _ := controllerutils.ListRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.SyncSetList{}}, client.InNamespace(namespace))
 
 			// Assert
 			assert.Equal(t, test.expectedError, actualError)
@@ -749,7 +750,7 @@ func TestLabelRemoteIngressSyncSets(t *testing.T) {
 
 			// Act
 			actualError := l.labelRemoteIngressSyncSets()
-			actualObjects, _ := controllerutils.GetRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.SyncSetList{}}, namespace)
+			actualObjects, _ := controllerutils.ListRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.SyncSetList{}}, client.InNamespace(namespace))
 
 			// Assert
 			assert.Equal(t, test.expectedError, actualError)
@@ -799,7 +800,7 @@ func TestLabelIdentityProviderSyncSets(t *testing.T) {
 
 			// Act
 			actualError := l.labelIdentityProviderSyncSets()
-			actualObjects, _ := controllerutils.GetRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.SyncSetList{}}, namespace)
+			actualObjects, _ := controllerutils.ListRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.SyncSetList{}}, client.InNamespace(namespace))
 
 			// Assert
 			assert.Equal(t, test.expectedError, actualError)
@@ -849,7 +850,7 @@ func TestLabelKubeconfigSecrets(t *testing.T) {
 
 			// Act
 			actualError := l.labelKubeconfigSecrets()
-			actualObjects, _ := controllerutils.GetRuntimeObjects(l.client, []runtime.Object{&corev1.SecretList{}}, namespace)
+			actualObjects, _ := controllerutils.ListRuntimeObjects(l.client, []runtime.Object{&corev1.SecretList{}}, client.InNamespace(namespace))
 
 			// Assert
 			assert.Equal(t, test.expectedError, actualError)
@@ -901,7 +902,7 @@ func TestLabelKubeAdminCredsSecrets(t *testing.T) {
 
 			// Act
 			actualError := l.labelKubeAdminCredsSecrets()
-			actualObjects, _ := controllerutils.GetRuntimeObjects(l.client, []runtime.Object{&corev1.SecretList{}}, namespace)
+			actualObjects, _ := controllerutils.ListRuntimeObjects(l.client, []runtime.Object{&corev1.SecretList{}}, client.InNamespace(namespace))
 
 			// Assert
 			assert.Equal(t, test.expectedError, actualError)
@@ -951,7 +952,7 @@ func TestLabelSyncSetInstances(t *testing.T) {
 
 			// Act
 			actualError := l.labelSyncSetInstances()
-			actualObjects, _ := controllerutils.GetRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.SyncSetInstanceList{}}, namespace)
+			actualObjects, _ := controllerutils.ListRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.SyncSetInstanceList{}}, client.InNamespace(namespace))
 
 			// Assert
 			assert.Equal(t, test.expectedError, actualError)
@@ -1001,7 +1002,7 @@ func TestLabelSelectorSyncSetInstances(t *testing.T) {
 
 			// Act
 			actualError := l.labelSelectorSyncSetInstances()
-			actualObjects, _ := controllerutils.GetRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.SyncSetInstanceList{}}, namespace)
+			actualObjects, _ := controllerutils.ListRuntimeObjects(l.client, []runtime.Object{&hivev1alpha1.SyncSetInstanceList{}}, client.InNamespace(namespace))
 
 			// Assert
 			assert.Equal(t, test.expectedError, actualError)

--- a/pkg/apis/hive/v1/metaruntimeobject.go
+++ b/pkg/apis/hive/v1/metaruntimeobject.go
@@ -1,0 +1,12 @@
+package v1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+)
+
+// MetaRuntimeObject allows for the generic specification of hive objects since all hive objects implement both the meta and runtime object interfaces.
+type MetaRuntimeObject interface {
+	metav1.Object
+	runtime.Object
+}

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -287,7 +287,57 @@ func (r *ReconcileClusterDeployment) Reconcile(request reconcile.Request) (resul
 		return reconcile.Result{}, err
 	}
 
+	// Ensure owner references are correctly set
+	err = controllerutils.ReconcileOwnerReferences(cd, generateOwnershipUniqueKeys(cd), r, r.scheme, r.logger)
+	if err != nil {
+		cdLog.WithError(err).Error("Error reconciling object ownership")
+		return reconcile.Result{}, err
+	}
+
 	return r.reconcile(request, cd, cdLog)
+}
+
+func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerutils.OwnershipUniqueKey {
+	return []*controllerutils.OwnershipUniqueKey{
+		{
+			TypeToList:    &hivev1.ClusterProvisionList{},
+			LabelSelector: map[string]string{constants.ClusterDeploymentNameLabel: owner.GetName()},
+		},
+		{
+			TypeToList: &corev1.PersistentVolumeClaimList{},
+			LabelSelector: map[string]string{
+				constants.ClusterDeploymentNameLabel: owner.GetName(),
+				constants.PVCTypeLabel:               constants.PVCTypeInstallLogs,
+			},
+		},
+		{
+			TypeToList: &batchv1.JobList{},
+			LabelSelector: map[string]string{
+				constants.ClusterDeploymentNameLabel: owner.GetName(),
+				constants.JobTypeLabel:               constants.JobTypeImageSet,
+			},
+		},
+		{
+			TypeToList: &hivev1.ClusterDeprovisionList{},
+			LabelSelector: map[string]string{
+				constants.ClusterDeploymentNameLabel: owner.GetName(),
+			},
+		},
+		{
+			TypeToList: &hivev1.DNSZoneList{},
+			LabelSelector: map[string]string{
+				constants.ClusterDeploymentNameLabel: owner.GetName(),
+				constants.DNSZoneTypeLabel:           constants.DNSZoneTypeChild,
+			},
+		},
+		{
+			TypeToList: &corev1.SecretList{},
+			LabelSelector: map[string]string{
+				constants.ClusterDeploymentNameLabel: owner.GetName(),
+				constants.SecretTypeLabel:            constants.SecretTypeMergedPullSecret,
+			},
+		},
+	}
 }
 
 func (r *ReconcileClusterDeployment) addAdditionalKubeconfigCAs(cd *hivev1.ClusterDeployment,

--- a/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
+++ b/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
@@ -186,6 +186,13 @@ func (r *ReconcileSyncIdentityProviders) Reconcile(request reconcile.Request) (r
 		return reconcile.Result{}, err
 	}
 
+	// Ensure owner references are correctly set
+	err = controllerutils.ReconcileOwnerReferences(cd, generateOwnershipUniqueKeys(cd), r, r.scheme, contextLogger)
+	if err != nil {
+		contextLogger.WithError(err).Error("Error reconciling object ownership")
+		return reconcile.Result{}, err
+	}
+
 	// If the clusterdeployment is deleted, do not reconcile.
 	if cd.DeletionTimestamp != nil {
 		return reconcile.Result{}, nil
@@ -375,4 +382,16 @@ func addSelectorSyncIdentityProviderLoggerFields(logger log.FieldLogger, ssidp *
 		"Kind": ssidp.Kind,
 		"Name": ssidp.Name,
 	})
+}
+
+func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerutils.OwnershipUniqueKey {
+	return []*controllerutils.OwnershipUniqueKey{
+		{
+			TypeToList: &hivev1.SyncSetList{},
+			LabelSelector: map[string]string{
+				constants.ClusterDeploymentNameLabel: owner.GetName(),
+				constants.SyncSetTypeLabel:           constants.SyncSetTypeIdentityProvider,
+			},
+		},
+	}
 }

--- a/pkg/controller/utils/ownership.go
+++ b/pkg/controller/utils/ownership.go
@@ -1,0 +1,110 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+
+	librarygocontroller "github.com/openshift/library-go/pkg/controller"
+)
+
+// OwnershipUniqueKey contains the uniquly identifiable pattern for ensuring ownership labels are correct applied for a type.
+type OwnershipUniqueKey struct {
+	LabelSelector map[string]string
+	TypeToList    runtime.Object
+}
+
+// ReconcileOwnerReferences ensures that given owner is in fact the actual owner for all types in typesToList given a specific labelSelector
+func ReconcileOwnerReferences(owner hivev1.MetaRuntimeObject, ownershipKeys []*OwnershipUniqueKey, kubeclient client.Client, scheme *runtime.Scheme, logger log.FieldLogger) error {
+	errlist := []error{}
+
+	for _, ownershipKey := range ownershipKeys {
+		objects, err := ListRuntimeObjects(kubeclient, []runtime.Object{ownershipKey.TypeToList}, client.MatchingLabels(ownershipKey.LabelSelector))
+		if err != nil {
+			errlist = append(errlist, errors.Wrap(err, "failed listing objects owned by clusterdeployment according to label"))
+			continue
+		}
+
+		for _, object := range objects {
+			mrObject, ok := object.(hivev1.MetaRuntimeObject)
+			if !ok {
+				// This should never happen since all hive objects implement both the meta and runtime object interfaces.
+				logger.Warnf("Failed converting object to MetaRuntimeObject")
+				continue
+			}
+
+			err := SyncControllerReference(owner, mrObject, kubeclient, scheme, logger)
+			if err != nil {
+				errlist = append(errlist, err)
+			}
+		}
+	}
+
+	return utilerrors.NewAggregate(errlist)
+}
+
+// SyncControllerReference ensures that the object passed in has a controller owner reference of the owner passed in. It then updates the object in Kube.
+// If there is already a controller owner reference set and it's set to the passed in owner, it does nothing.
+// If there is already a controller owner reference, but it's set to a different owner than the one passed in, it will set the controller owner reference to the owner that is passed in.
+// If there isn't a controller owner reference, it will add one.
+func SyncControllerReference(owner hivev1.MetaRuntimeObject, object hivev1.MetaRuntimeObject, kubeclient client.Client, scheme *runtime.Scheme, logger log.FieldLogger) error {
+	objectNamespacedName := object.GetNamespace() + "/" + object.GetName()
+	ownerNamespacedName := owner.GetNamespace() + "/" + owner.GetName()
+
+	objectGVK, err := apiutil.GVKForObject(object, scheme)
+	if err != nil {
+		logger.WithField("objectNamespacedName", objectNamespacedName).Warn("getting GVK for object")
+		return nil // Not returning error because that could stop the overall reconciliation. Just logging a warning.
+	}
+
+	ownerGVK, err := apiutil.GVKForObject(owner, scheme)
+	if err != nil {
+		logger.WithField("ownerNamespacedName", ownerNamespacedName).Warn("getting GVK for owner")
+		return nil // Not returning error because that could stop the overall reconciliation. Just logging a warning.
+	}
+
+	objectLogger := logger.WithFields(log.Fields{
+		"ownerKind":            ownerGVK.Kind,
+		"ownerNamespacedName":  ownerNamespacedName,
+		"objectKind":           objectGVK.Kind,
+		"objectNamespacedName": objectNamespacedName,
+	})
+
+	// Remove any other controller ref (librarygocontroller doesn't look at controller references, so it won't do this).
+	for i, ref := range object.GetOwnerReferences() {
+		if ref.Controller != nil && *ref.Controller {
+			if ref.UID != owner.GetUID() {
+				ownerRefs := object.GetOwnerReferences()
+				ownerRefs[i] = ownerRefs[len(ownerRefs)-1]              // Copy last element in the slice over the top of the controller owner reference.
+				object.SetOwnerReferences(ownerRefs[:len(ownerRefs)-1]) // Remove the last element (since it's now in the position pointed to i)
+			}
+			break // There can be only 1 controller owner ref, so we don't need to loop after we find it.
+		}
+	}
+
+	// Add the controller reference if it doesn't already exist.
+	ownerRef := metav1.NewControllerRef(owner, ownerGVK)
+	ownerRefsChanged := librarygocontroller.EnsureOwnerRef(object, *ownerRef)
+
+	if !ownerRefsChanged {
+		objectLogger.Debug("Object has correct ownership. No changes necessary.")
+		return nil
+	}
+
+	if err := kubeclient.Update(context.TODO(), object); err != nil {
+		return errors.Wrapf(err, "could not update object %v %v", objectGVK.Kind, objectNamespacedName)
+	}
+
+	objectLogger.Info("Successfully set owner reference using labels")
+	return nil
+}

--- a/pkg/controller/utils/ownership.go
+++ b/pkg/controller/utils/ownership.go
@@ -29,7 +29,7 @@ func ReconcileOwnerReferences(owner hivev1.MetaRuntimeObject, ownershipKeys []*O
 	errlist := []error{}
 
 	for _, ownershipKey := range ownershipKeys {
-		objects, err := ListRuntimeObjects(kubeclient, []runtime.Object{ownershipKey.TypeToList}, client.MatchingLabels(ownershipKey.LabelSelector))
+		objects, err := ListRuntimeObjects(kubeclient, []runtime.Object{ownershipKey.TypeToList}, client.MatchingLabels(ownershipKey.LabelSelector), client.InNamespace(owner.GetNamespace()))
 		if err != nil {
 			errlist = append(errlist, errors.Wrap(err, "failed listing objects owned by clusterdeployment according to label"))
 			continue

--- a/pkg/controller/utils/ownership_test.go
+++ b/pkg/controller/utils/ownership_test.go
@@ -1,0 +1,186 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/openshift/hive/pkg/apis"
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	testName = "foo-lqmsh"
+)
+
+func validOwnershipUniqueKey(owner *hivev1.ClusterDeployment) *OwnershipUniqueKey {
+	return &OwnershipUniqueKey{
+		TypeToList: &hivev1.DNSZoneList{},
+		LabelSelector: map[string]string{
+			constants.ClusterDeploymentNameLabel: owner.Name,
+			constants.DNSZoneTypeLabel:           constants.DNSZoneTypeChild,
+		},
+	}
+}
+
+func validOwnershipUniqueKeys(owner *hivev1.ClusterDeployment) []*OwnershipUniqueKey {
+	return []*OwnershipUniqueKey{
+		validOwnershipUniqueKey(owner),
+	}
+}
+
+func validClusterDeployment() *hivev1.ClusterDeployment {
+	return &hivev1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        testName,
+			Namespace:   testNamespace,
+			UID:         types.UID("1234"),
+			Annotations: map[string]string{},
+			Labels:      map[string]string{},
+		},
+	}
+}
+
+func validOtherClusterDeployment() *hivev1.ClusterDeployment {
+	return &hivev1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        testName + "-other",
+			Namespace:   testNamespace,
+			UID:         types.UID("abcd"),
+			Annotations: map[string]string{},
+			Labels:      map[string]string{},
+		},
+	}
+}
+
+func validDNSZoneWithLabelOwner(labelOwner hivev1.MetaRuntimeObject, scheme *runtime.Scheme) *hivev1.DNSZone {
+	zone := &hivev1.DNSZone{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "dnszoneobject",
+			Namespace:  "ns",
+			Generation: 6,
+			Finalizers: []string{hivev1.FinalizerDNSZone},
+			UID:        types.UID("abcdef"),
+			Labels: map[string]string{
+				constants.ClusterDeploymentNameLabel: labelOwner.GetName(),
+				constants.DNSZoneTypeLabel:           constants.DNSZoneTypeChild,
+			},
+		},
+		Spec: hivev1.DNSZoneSpec{
+			Zone: "blah.example.com",
+			AWS: &hivev1.AWSDNSZoneSpec{
+				CredentialsSecretRef: corev1.LocalObjectReference{
+					Name: "somesecret",
+				},
+				AdditionalTags: []hivev1.AWSResourceTag{
+					{
+						Key:   "foo",
+						Value: "bar",
+					},
+				},
+			},
+		},
+		Status: hivev1.DNSZoneStatus{
+			AWS: &hivev1.AWSDNSZoneStatus{
+				ZoneID: aws.String("1234"),
+			},
+		},
+	}
+
+	return zone
+}
+
+func validDNSZoneWithMissingOwnership(owner hivev1.MetaRuntimeObject, scheme *runtime.Scheme) *hivev1.DNSZone {
+	zone := validDNSZoneWithLabelOwner(owner, scheme)
+	return zone
+}
+
+func validDNSZoneWithControllerOwnership(labelOwner, controllerOwner hivev1.MetaRuntimeObject, scheme *runtime.Scheme) *hivev1.DNSZone {
+	zone := validDNSZoneWithLabelOwner(labelOwner, scheme)
+	controllerutil.SetControllerReference(controllerOwner, zone, scheme)
+	return zone
+}
+
+func TestReconcile(t *testing.T) {
+	testscheme := scheme.Scheme
+	apis.AddToScheme(testscheme)
+
+	tests := []struct {
+		name                                 string
+		owner                                hivev1.MetaRuntimeObject
+		listRuntimeObjectsOwnershipUniqueKey *OwnershipUniqueKey
+		ownershipUniqueKeys                  []*OwnershipUniqueKey
+		existingObjects                      []runtime.Object
+		expectedObjects                      []runtime.Object
+	}{
+		{
+			name:                                 "no objects in kube (do nothing)",
+			owner:                                validClusterDeployment(),
+			listRuntimeObjectsOwnershipUniqueKey: validOwnershipUniqueKey(validClusterDeployment()),
+			ownershipUniqueKeys:                  validOwnershipUniqueKeys(validClusterDeployment()),
+		},
+		{
+			name:                                 "ownership set correctly (do nothing)",
+			owner:                                validClusterDeployment(),
+			listRuntimeObjectsOwnershipUniqueKey: validOwnershipUniqueKey(validClusterDeployment()),
+			ownershipUniqueKeys:                  validOwnershipUniqueKeys(validClusterDeployment()),
+			existingObjects: []runtime.Object{
+				validDNSZoneWithControllerOwnership(validClusterDeployment(), validClusterDeployment(), testscheme),
+			},
+			expectedObjects: []runtime.Object{
+				validDNSZoneWithControllerOwnership(validClusterDeployment(), validClusterDeployment(), testscheme),
+			},
+		},
+		{
+			name:                                 "ownership missing (add ownership back)",
+			owner:                                validClusterDeployment(),
+			listRuntimeObjectsOwnershipUniqueKey: validOwnershipUniqueKey(validClusterDeployment()),
+			ownershipUniqueKeys:                  validOwnershipUniqueKeys(validClusterDeployment()),
+			existingObjects: []runtime.Object{
+				validDNSZoneWithMissingOwnership(validClusterDeployment(), testscheme),
+			},
+			expectedObjects: []runtime.Object{
+				validDNSZoneWithControllerOwnership(validClusterDeployment(), validClusterDeployment(), testscheme),
+			},
+		},
+		{
+			name:                                 "ownership incorrect (fix it)",
+			owner:                                validClusterDeployment(),
+			listRuntimeObjectsOwnershipUniqueKey: validOwnershipUniqueKey(validClusterDeployment()),
+			ownershipUniqueKeys:                  validOwnershipUniqueKeys(validClusterDeployment()),
+			existingObjects: []runtime.Object{
+				validDNSZoneWithControllerOwnership(validClusterDeployment(), validOtherClusterDeployment(), testscheme),
+			},
+			expectedObjects: []runtime.Object{
+				validDNSZoneWithControllerOwnership(validClusterDeployment(), validClusterDeployment(), testscheme),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Arrange
+			fakeKubeClient := fake.NewFakeClientWithScheme(testscheme, test.existingObjects...)
+			logger := log.WithField("fake", "fake")
+
+			// Act
+			err := ReconcileOwnerReferences(test.owner, test.ownershipUniqueKeys, fakeKubeClient, testscheme, logger)
+			actualObjects, listErr := ListRuntimeObjects(fakeKubeClient, []runtime.Object{test.listRuntimeObjectsOwnershipUniqueKey.TypeToList}, client.MatchingLabels(test.listRuntimeObjectsOwnershipUniqueKey.LabelSelector))
+
+			// Assert
+			assert.NoError(t, err, "Unexpected error from ReconcileOwnerReferences")
+			assert.NoError(t, listErr, "Unexpected error from ListRuntimeObjects")
+			assert.ElementsMatch(t, test.expectedObjects, actualObjects, "The returned objects don't match the expected objects")
+		})
+	}
+}

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -129,13 +129,13 @@ func LogLevel(err error) log.Level {
 	}
 }
 
-// GetRuntimeObjects returns a slice of runtime objects returned from the kubernetes client based on the passed in list of types to return.
-func GetRuntimeObjects(c client.Client, typesToList []runtime.Object, namespace string) ([]runtime.Object, error) {
+// ListRuntimeObjects returns a slice of runtime objects returned from the kubernetes client based on the passed in list of types to return and list options.
+func ListRuntimeObjects(c client.Client, typesToList []runtime.Object, opts ...client.ListOptionFunc) ([]runtime.Object, error) {
 	nsObjects := []runtime.Object{}
 
 	for _, t := range typesToList {
 		listObj := t.DeepCopyObject()
-		if err := c.List(context.TODO(), listObj, client.InNamespace(namespace)); err != nil {
+		if err := c.List(context.TODO(), listObj, opts...); err != nil {
 			return nil, err
 		}
 		list, err := meta.ExtractList(listObj)

--- a/pkg/controller/velerobackup/velerobackup_controller.go
+++ b/pkg/controller/velerobackup/velerobackup_controller.go
@@ -169,7 +169,7 @@ func (r *ReconcileBackup) Reconcile(request reconcile.Request) (reconcile.Result
 		}
 	}
 
-	objects, err := controllerutils.GetRuntimeObjects(r, hiveNamespaceScopedListTypes, request.Namespace)
+	objects, err := controllerutils.ListRuntimeObjects(r, hiveNamespaceScopedListTypes, client.InNamespace(request.Namespace))
 	if err != nil {
 		nsLogger.WithError(err).Error("Failed to list hive objects in namespace.")
 		return reconcile.Result{}, err

--- a/pkg/controller/velerobackup/velerobackup_controller_test.go
+++ b/pkg/controller/velerobackup/velerobackup_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -197,7 +198,7 @@ func TestReconcile(t *testing.T) {
 
 			// Act
 			actualResult, actualError := r.Reconcile(test.request)
-			actualObjects, err := controllerutils.GetRuntimeObjects(r, types, namespace)
+			actualObjects, err := controllerutils.ListRuntimeObjects(r, types, client.InNamespace(namespace))
 			lastBackupName, lastBackupTimestamp := ignoreUncomparedFields(test.expectedObjects, actualObjects)
 
 			// Assert
@@ -277,7 +278,7 @@ func TestGetRuntimeObjects(t *testing.T) {
 			r := fakeClientReconcileBackup(test.existingObjects)
 
 			// Act
-			actualObjects, actualError := controllerutils.GetRuntimeObjects(r, hiveNamespaceScopedListTypes, namespace)
+			actualObjects, actualError := controllerutils.ListRuntimeObjects(r, hiveNamespaceScopedListTypes, client.InNamespace(namespace))
 
 			// Assert
 			assert.NoError(t, actualError)


### PR DESCRIPTION
- [x] Fix bug that causes objects in other namespaces to be set with the incorrect owner if the owner's name in multiple namespaces is the same.
- [x] Update unit tests for bug fix
- [x] Manually test bug fix