### PR TITLE
Add throttling to install failure reasons

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -36,6 +36,16 @@ data:
       - "failed to initialize the cluster: Cluster operator monitoring is still updating"
       installFailingReason: MonitoringOperatorStillUpdating
       installFailingMessage: Timeout waiting for the monitoring operator to become ready
+    - name: SimulatorThrottling
+      searchRegexStrings:
+      - "validate AWS credentials: checking install permissions: error simulating policy: Throttling: Rate exceeded"
+      installFailingReason: AWSAPIRateLimitExceeded
+      installFailingMessage: AWS API rate limit exceeded while simulating policy
+    - name: GeneralThrottling
+      searchRegexStrings:
+      - "Throttling: Rate exceeded"
+      installFailingReason: AWSAPIRateLimitExceeded
+      installFailingMessage: AWS API rate limit exceeded
     # Bare Metal
     - name: LibvirtSSHKeyPermissionDenied
       searchRegexStrings:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -5081,6 +5081,16 @@ data:
       - "failed to initialize the cluster: Cluster operator monitoring is still updating"
       installFailingReason: MonitoringOperatorStillUpdating
       installFailingMessage: Timeout waiting for the monitoring operator to become ready
+    - name: SimulatorThrottling
+      searchRegexStrings:
+      - "validate AWS credentials: checking install permissions: error simulating policy: Throttling: Rate exceeded"
+      installFailingReason: AWSAPIRateLimitExceeded
+      installFailingMessage: AWS API rate limit exceeded while simulating policy
+    - name: GeneralThrottling
+      searchRegexStrings:
+      - "Throttling: Rate exceeded"
+      installFailingReason: AWSAPIRateLimitExceeded
+      installFailingMessage: AWS API rate limit exceeded
     # Bare Metal
     - name: LibvirtSSHKeyPermissionDenied
       searchRegexStrings:


### PR DESCRIPTION
This PR adds following install failure reasons to install-log-regexes

1) simulator throttling: "validate AWS credentials: checking install permissions:
                                    error simulating policy: Throttling: Rate exceeded"
2) general throttling  :  "Throttling: Rate exceeded"