### PR TITLE
hiveutil: remove --gcp-project-id from deprovision help

### DIFF
--- a/contrib/pkg/deprovision/gcp.go
+++ b/contrib/pkg/deprovision/gcp.go
@@ -27,7 +27,7 @@ type gcpOptions struct {
 func NewDeprovisionGCPCommand() *cobra.Command {
 	opt := &gcpOptions{}
 	cmd := &cobra.Command{
-		Use:   "gcp INFRAID --region=REGION --gcp-project-id=GCP_PROJECT_ID",
+		Use:   "gcp INFRAID --region=REGION",
 		Short: "Deprovision GCP assets (as created by openshift-installer)",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
The `hiveutil deprovision gcp` command no longer takes a --gcp-project-id flag. But the help message still tells the user to add it.