### PR TITLE
Implement Hive uninstallation via deleting HiveConfig 'hive'.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,10 @@ test-e2e-postdeploy:
 test-e2e-postinstall:
 	go test $(GO_MOD_FLAGS) -timeout 0 -count=1 ./test/e2e/postinstall/...
 
+.PHONY: test-e2e-uninstallhive
+test-e2e-uninstallhive:
+	go test $(GO_MOD_FLAGS) -timeout 0 -count=1 ./test/e2e/uninstallhive/...
+
 # Builds all of hive's binaries (including utils).
 .PHONY: build
 build: generate binaries

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/hive/pkg/version"
 
 	oappsv1 "github.com/openshift/api/apps/v1"
+	orbacv1 "github.com/openshift/api/authorization/v1"
 
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -113,7 +114,11 @@ func newRootCommand() *cobra.Command {
 				log.Fatal(err)
 			}
 
-			if err := oappsv1.AddToScheme(mgr.GetScheme()); err != nil {
+			if err := oappsv1.Install(mgr.GetScheme()); err != nil {
+				log.Fatal(err)
+			}
+
+			if err := orbacv1.Install(mgr.GetScheme()); err != nil {
 				log.Fatal(err)
 			}
 

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -229,3 +229,8 @@ fi
 
 echo "Running post-install tests"
 make test-e2e-postinstall
+
+echo "Uninstalling hive and validating cleanup"
+make test-e2e-uninstallhive
+
+

--- a/pkg/operator/hive/operatorutils.go
+++ b/pkg/operator/hive/operatorutils.go
@@ -1,24 +1,16 @@
 package hive
 
 import (
-	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
-	"github.com/openshift/hive/pkg/constants"
-	"github.com/openshift/hive/pkg/operator/assets"
-	"github.com/openshift/hive/pkg/resource"
-	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes/scheme"
-)
 
-var (
-	coreDeserializer = serializer.NewCodecFactory(scheme.Scheme).UniversalDeserializer()
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 )
 
 func getHiveNamespace(config *hivev1.HiveConfig) string {
@@ -29,43 +21,21 @@ func getHiveNamespace(config *hivev1.HiveConfig) string {
 	return config.Spec.TargetNamespace
 }
 
-func applyAssetWithNamespaceOverride(h *resource.Helper, assetPath, namespaceOverride string) error {
-	requiredObj, _, err := coreDeserializer.Decode(assets.MustAsset(assetPath), nil, nil)
-	if err != nil {
-		return errors.Wrapf(err, "unable to decode asset: %s", assetPath)
-	}
-	obj, _ := meta.Accessor(requiredObj)
-	obj.SetNamespace(namespaceOverride)
-	_, err = h.ApplyRuntimeObject(requiredObj, scheme.Scheme)
-	if err != nil {
-		return errors.Wrapf(err, "unable to apply asset: %s", assetPath)
-	}
-	return nil
-}
-
-func applyClusterRoleBindingAssetWithSubjectNamespaceOverride(h *resource.Helper, roleBindingAssetPath, namespaceOverride string) error {
-	rb := resourceread.ReadClusterRoleBindingV1OrDie(assets.MustAsset(roleBindingAssetPath))
-	for i := range rb.Subjects {
-		if rb.Subjects[i].Kind == "ServiceAccount" || rb.Subjects[i].Namespace != "" {
-			rb.Subjects[i].Namespace = namespaceOverride
-		}
-	}
-	_, err := h.ApplyRuntimeObject(rb, scheme.Scheme)
-	if err != nil {
-		return errors.Wrapf(err, "unable to apply asset: %s", roleBindingAssetPath)
-	}
-	return nil
-}
-
-func dynamicDelete(dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, name string, hLog log.FieldLogger) error {
-	rLog := hLog.WithFields(log.Fields{
-		"gvr":  gvr,
-		"name": name,
-	})
-	err := dynamicClient.Resource(gvr).Delete(name, &metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		rLog.WithError(err).Error("error deleting resource")
+func dynamicDelete(dynamicClient dynamic.Interface, gvrnsn gvrNSName, hLog log.FieldLogger) error {
+	rLog := hLog.WithField("resource", gvrnsn)
+	gvr := schema.GroupVersionResource{Group: gvrnsn.group, Version: gvrnsn.version, Resource: gvrnsn.resource}
+	if err := dynamicClient.Resource(gvr).Namespace(gvrnsn.namespace).Delete(gvrnsn.name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		rLog.WithError(err).Log(controllerutils.LogLevel(err), "error deleting resource")
 		return err
 	}
+	rLog.Info("resource deleted")
 	return nil
+}
+
+type gvrNSName struct {
+	group     string
+	version   string
+	resource  string
+	namespace string // empty for global resources
+	name      string
 }

--- a/pkg/operator/util/apply.go
+++ b/pkg/operator/util/apply.go
@@ -1,13 +1,30 @@
 package util
 
 import (
+	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+	"k8s.io/utils/pointer"
 
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	"github.com/openshift/hive/pkg/operator/assets"
 	"github.com/openshift/hive/pkg/resource"
 )
 
-// ApplyAsset loads a path from our bindata assets and applies it to the cluster.
+var (
+	coreDeserializer = serializer.NewCodecFactory(scheme.Scheme).UniversalDeserializer()
+)
+
+// ApplyAsset loads a path from our bindata assets and applies it to the cluster. This function does not apply
+// a HiveConfig owner reference for garbage collection, and should only be used for resources we explicitly want
+// to leave orphaned when Hive is uninstalled. See ApplyAssetWithGC for the more common use case.
 func ApplyAsset(h *resource.Helper, assetPath string, hLog log.FieldLogger) error {
 	assetLog := hLog.WithField("asset", assetPath)
 	assetLog.Debug("reading asset")
@@ -20,4 +37,80 @@ func ApplyAsset(h *resource.Helper, assetPath string, hLog log.FieldLogger) erro
 	}
 	assetLog.Infof("asset applied successfully: %v", result)
 	return nil
+}
+
+// ApplyAssetWithGC loads a path from our bindata assets, adds an OwnerReference to the HiveConfig
+// for garbage collection (used when uninstalling Hive), and applies it to the cluster.
+func ApplyAssetWithGC(h *resource.Helper, assetPath string, hc *hivev1.HiveConfig, hLog log.FieldLogger) error {
+	assetLog := hLog.WithField("asset", assetPath)
+	assetLog.Info("reading asset")
+	runtimeObj, err := readRuntimeObject(assetPath)
+	if err != nil {
+		return err
+	}
+	assetLog.Info("applying asset with GC")
+	result, err := ApplyRuntimeObjectWithGC(h, runtimeObj, hc)
+	if err != nil {
+		assetLog.WithError(err).Error("error applying asset")
+		return err
+	}
+	assetLog.Infof("asset applied successfully: %v", result)
+	return nil
+}
+
+// ApplyAssetWithNSOverrideAndGC loads the given asset, overrides the namespace, adds an owner reference to
+// HiveConfig for uninstall, and applies it to the cluster.
+func ApplyAssetWithNSOverrideAndGC(h *resource.Helper, assetPath, namespaceOverride string, hiveConfig *hivev1.HiveConfig) error {
+	requiredObj, _, err := coreDeserializer.Decode(assets.MustAsset(assetPath), nil, nil)
+	if err != nil {
+		return errors.Wrapf(err, "unable to decode asset: %s", assetPath)
+	}
+	obj, _ := meta.Accessor(requiredObj)
+	obj.SetNamespace(namespaceOverride)
+	_, err = ApplyRuntimeObjectWithGC(h, requiredObj, hiveConfig)
+	if err != nil {
+		return errors.Wrapf(err, "unable to apply asset: %s", assetPath)
+	}
+	return nil
+}
+
+// ApplyClusterRoleBindingAssetWithSubjectNSOverrideAndGC loads the given asset, overrides the namespace on the subject,
+// adds an owner reference to HiveConfig for uninstall, and applies it to the cluster.
+func ApplyClusterRoleBindingAssetWithSubjectNSOverrideAndGC(h *resource.Helper, roleBindingAssetPath, namespaceOverride string, hiveConfig *hivev1.HiveConfig) error {
+
+	rb := resourceread.ReadClusterRoleBindingV1OrDie(assets.MustAsset(roleBindingAssetPath))
+	for i := range rb.Subjects {
+		if rb.Subjects[i].Kind == "ServiceAccount" || rb.Subjects[i].Namespace != "" {
+			rb.Subjects[i].Namespace = namespaceOverride
+		}
+	}
+	_, err := ApplyRuntimeObjectWithGC(h, rb, hiveConfig)
+	if err != nil {
+		return errors.Wrapf(err, "unable to apply asset: %s", roleBindingAssetPath)
+	}
+	return nil
+}
+
+// ApplyRuntimeObjectWithGC adds an OwnerReference to the HiveConfig on the runtime object, and applies it to the cluster.
+func ApplyRuntimeObjectWithGC(h *resource.Helper, runtimeObj runtime.Object, hc *hivev1.HiveConfig) (resource.ApplyResult, error) {
+	obj, err := meta.Accessor(runtimeObj)
+	if err != nil {
+		return resource.UnknownApplyResult, err
+	}
+	ownerRef := v1.OwnerReference{
+		APIVersion:         hc.APIVersion,
+		Kind:               hc.Kind,
+		Name:               hc.Name,
+		UID:                hc.UID,
+		BlockOwnerDeletion: pointer.BoolPtr(true),
+	}
+	// This assumes we have full control of owner references for these resources the operator creates.
+	obj.SetOwnerReferences([]v1.OwnerReference{ownerRef})
+	return h.ApplyRuntimeObject(runtimeObj, scheme.Scheme)
+}
+
+func readRuntimeObject(assetPath string) (runtime.Object, error) {
+	codec := serializer.NewCodecFactory(scheme.Scheme)
+	// Additional SchemeGroupVersions may need to be added here if the operator needs to start deploying new types.
+	return runtime.Decode(codec.UniversalDecoder(rbacv1.SchemeGroupVersion), assets.MustAsset(assetPath))
 }

--- a/pkg/operator/util/apply.go
+++ b/pkg/operator/util/apply.go
@@ -6,7 +6,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/utils/pointer"
 
-	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -110,7 +109,6 @@ func ApplyRuntimeObjectWithGC(h *resource.Helper, runtimeObj runtime.Object, hc 
 }
 
 func readRuntimeObject(assetPath string) (runtime.Object, error) {
-	codec := serializer.NewCodecFactory(scheme.Scheme)
-	// Additional SchemeGroupVersions may need to be added here if the operator needs to start deploying new types.
-	return runtime.Decode(codec.UniversalDecoder(rbacv1.SchemeGroupVersion), assets.MustAsset(assetPath))
+	obj, _, err := coreDeserializer.Decode(assets.MustAsset(assetPath), nil, nil)
+	return obj, err
 }

--- a/test/e2e/common/utils.go
+++ b/test/e2e/common/utils.go
@@ -1,10 +1,23 @@
 package common
 
 import (
+	"fmt"
+	"os"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
 	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/operator/hive"
-	log "github.com/sirupsen/logrus"
-	"os"
+)
+
+const (
+	dynamicDeleteTimeout = time.Second * 30
 )
 
 func GetHiveNamespaceOrDie() string {
@@ -21,4 +34,32 @@ func GetHiveOperatorNamespaceOrDie() string {
 		log.Fatalf("required environment variable is not defined: %s", hive.HiveOperatorNamespaceEnvVar)
 	}
 	return namespace
+}
+
+// DynamicWaitForDeletion uses the dynamic client to wait for a resource to not exist.
+func DynamicWaitForDeletion(dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, namespace, name string, logger log.FieldLogger) error {
+	rLog := logger.WithFields(log.Fields{
+		"gvr":       gvr,
+		"namespace": namespace,
+		"name":      name,
+	})
+
+	for start := time.Now(); ; {
+		if time.Since(start) > dynamicDeleteTimeout {
+			rLog.Error("resource not deleted before timeout")
+			return fmt.Errorf("resource not deleted before timeout")
+		}
+		_, err := dynamicClient.Resource(gvr).Namespace(namespace).Get(name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			// resource does not exist
+			rLog.Info("resource successfully deleted")
+			return nil
+		} else if err != nil {
+			rLog.WithError(err).Info("unexpected error getting resource")
+		} else {
+			rLog.Info("resource still exists, sleeping...")
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
 }

--- a/test/e2e/uninstallhive/uninstallhive_test.go
+++ b/test/e2e/uninstallhive/uninstallhive_test.go
@@ -1,0 +1,94 @@
+package admission
+
+import (
+	"context"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/test/e2e/common"
+)
+
+func TestUninstallHive(t *testing.T) {
+	c := common.MustGetClient()
+	dynClient := common.MustGetDynamicClient()
+	logger := log.WithField("test", "TestUninstallHive")
+
+	hiveConfig := &hivev1.HiveConfig{}
+	err := c.Get(context.Background(), types.NamespacedName{Name: "hive"}, hiveConfig)
+	require.NoError(t, err, "error getting HiveConfig")
+
+	logger.Info("deleting HiveConfig 'hive'")
+	err = c.Delete(context.Background(), hiveConfig)
+	require.NoError(t, err, "error deleting HiveConfig")
+
+	// Wait for HiveConfig to disappear
+	err = common.DynamicWaitForDeletion(dynClient,
+		schema.GroupVersionResource{Group: "hive.openshift.io", Version: "v1", Resource: "hiveconfigs"},
+		"", "hive", logger)
+	require.NoError(t, err)
+
+	t.Run("hive-controllers deleted", func(t *testing.T) {
+		err = common.DynamicWaitForDeletion(dynClient,
+			schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			common.GetHiveNamespaceOrDie(), "hive-controllers", logger)
+		require.NoError(t, err)
+
+		err = common.DynamicWaitForDeletion(dynClient,
+			schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"},
+			common.GetHiveNamespaceOrDie(), "hive-controllers", logger)
+		require.NoError(t, err)
+
+		err = common.DynamicWaitForDeletion(dynClient,
+			schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"},
+			common.GetHiveNamespaceOrDie(), "hive-controllers", logger)
+		require.NoError(t, err)
+
+		err = common.DynamicWaitForDeletion(dynClient,
+			schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"},
+			common.GetHiveNamespaceOrDie(), "hive-frontend", logger)
+		require.NoError(t, err)
+
+		err = common.DynamicWaitForDeletion(dynClient,
+			schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"},
+			"", "hive-controllers", logger)
+		require.NoError(t, err)
+
+		err = common.DynamicWaitForDeletion(dynClient,
+			schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles"},
+			"", "hive-frontend", logger)
+		require.NoError(t, err)
+
+	})
+
+	t.Run("hiveadmission deleted", func(t *testing.T) {
+		err = common.DynamicWaitForDeletion(dynClient,
+			schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			common.GetHiveNamespaceOrDie(), "hiveadmission", logger)
+		require.NoError(t, err)
+
+		err = common.DynamicWaitForDeletion(dynClient,
+			schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"},
+			common.GetHiveNamespaceOrDie(), "hiveadmission", logger)
+		require.NoError(t, err)
+
+		err = common.DynamicWaitForDeletion(dynClient,
+			schema.GroupVersionResource{Group: "", Version: "v1", Resource: "serviceaccounts"},
+			common.GetHiveNamespaceOrDie(), "hiveadmission", logger)
+		require.NoError(t, err)
+
+		err = common.DynamicWaitForDeletion(dynClient,
+			schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "system:openshift:hive:hiveadmission"},
+			"", "hive-controllers", logger)
+		require.NoError(t, err)
+
+		err = common.DynamicWaitForDeletion(dynClient,
+			schema.GroupVersionResource{Group: "apiregistration.k8s.io", Version: "v1", Resource: "apiservices"},
+			"", "v1.admission.hive.openshift.io", logger)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
If the HiveConfig named 'hive' (the only name we recognize) is deleted,
Hive components will be torn down.

This is accomplished by automatically adding owner references to most
resources the hive-operator creates, to the HiveConfig hive. Once
deleted we let kubernetes garbage collection take care of cleaning
everything up.