### PR TITLE
Add "local" cloud provider option

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -98,11 +98,12 @@ Configure kubectl/oc to talk to your new cluster:
 export KUBECONFIG="$(kind get kubeconfig-path --name="hive")"
 ```
 
-**NOTE:** If you do not have `cfssljson` and `cfssl` installed, run the following command to install, otherwise, ignore this.
+**NOTE:** If you do not have `cfssljson`, `cfssl`, or `kind` installed, run the following command to install, otherwise, ignore this.
 
 ```bash
 go install github.com/cloudflare/cfssl/cmd/cfssljson
 go install github.com/cloudflare/cfssl/cmd/cfssl
+GO111MODULE="on" go get sigs.k8s.io/kind@v0.5.1
 ```
 
 You can now build your local Hive source as a container, push to the local registry, and deploy Hive. Because we are not running on OpenShift we must also create a secret with certificates for the hiveadmission webhooks.
@@ -130,7 +131,7 @@ To create a kind cluster and adopt:
 
 ```bash
 ./hack/create-kind-cluster.sh cluster1
-bin/hiveutil create-cluster --base-domain=new-installer.openshift.com kind-cluster1 --adopt --adopt-admin-kubeconfig=$(kind get kubeconfig-path --name="cluster1") --adopt-infra-id=fakeinfra --adopt-cluster-id=fakeid
+bin/hiveutil create-cluster --base-domain=new-installer.openshift.com kind-cluster1 --adopt --cloud=local --adopt-admin-kubeconfig=$(kind get kubeconfig-path --name="cluster1") --adopt-infra-id=fakeinfra --adopt-cluster-id=fakeid
 ```
 
 NOTE: when using a kind cluster not all controllers will be functioning properly as it is not an OpenShift cluster and thus lacks some of the CRDs our controllers use. (ClusterState, RemoteMachineSet, etc)

--- a/pkg/clusterresource/builder.go
+++ b/pkg/clusterresource/builder.go
@@ -2,6 +2,7 @@ package clusterresource
 
 import (
 	"fmt"
+
 	"github.com/ghodss/yaml"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"

--- a/pkg/clusterresource/local.go
+++ b/pkg/clusterresource/local.go
@@ -1,0 +1,54 @@
+package clusterresource
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	installertypes "github.com/openshift/installer/pkg/types"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	hivev1baremetal "github.com/openshift/hive/pkg/apis/hive/v1/baremetal"
+)
+
+var _ CloudBuilder = (*LocalCloudBuilder)(nil)
+
+// LocalCloudBuilder encapsulates cluster artifact generation logic specific to a local cluster.
+type LocalCloudBuilder struct {
+}
+
+func (p *LocalCloudBuilder) generateCredentialsSecret(o *Builder) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      p.credsSecretName(o),
+			Namespace: o.Namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"local-kubeconfig": o.AdoptAdminKubeconfig,
+		},
+	}
+}
+
+func (p *LocalCloudBuilder) addClusterDeploymentPlatform(o *Builder, cd *hivev1.ClusterDeployment) {
+	cd.Spec.Platform = hivev1.Platform{
+		BareMetal: &hivev1baremetal.Platform{},
+	}
+}
+
+func (p *LocalCloudBuilder) addMachinePoolPlatform(o *Builder, mp *hivev1.MachinePool) {
+	// Nothing to do here
+}
+
+func (p *LocalCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installertypes.InstallConfig) {
+	// Nothing to do here
+}
+
+func (p *LocalCloudBuilder) credsSecretName(o *Builder) string {
+	return fmt.Sprintf("%s-local-creds", o.Name)
+}


### PR DESCRIPTION
Currently if you follow the docs in [/docs/developing.md] to create and adopt a cluster locally, the process will fail. The adoption process makes the assumption that the cluster being adopted is within a cloud provider and will attempt to parse credentials that may or may not exist.

This adds the `local` cloud provider and stubs out required objects required for cluster adoption. It also updates the development docs to use the new flag.

Tested this locally and it works great! (Though I had to downgrade my version of `kind`. I might shoot another patch forward that supports 0.5.x and and 0.7.0+)