### PR TITLE
Fix syncset unapplied metrics not clearing.

### DIFF
--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -334,6 +334,15 @@ func (mc *Calculator) calculateSelectorSyncSetMetrics(mcLog log.FieldLogger) {
 	}
 	for k, v := range sssInstancesTotal {
 		metricSelectorSyncSetClustersTotal.WithLabelValues(k).Set(float64(v))
+		// If this selector sync set currently has no unapplied instances, ensure any past unapplied metric is cleared:
+		if sssInstancesUnappliedTotal[k] == 0 {
+			cleared := metricSelectorSyncSetClustersUnappliedTotal.Delete(map[string]string{
+				"name": k,
+			})
+			if cleared {
+				mcLog.Debugf("cleared selector syncset clusters unapplied metric for cluster: %s", k)
+			}
+		}
 	}
 	for k, v := range sssInstancesUnappliedTotal {
 		metricSelectorSyncSetClustersUnappliedTotal.WithLabelValues(k).Set(float64(v))


### PR DESCRIPTION
When a selector sync set has failing instances, but all failure clear
and all instance has been applied, the metric was not being cleared.

This change will not clear unapplied metrics for any currently known
selector sync set if they do not have any failing instances.

NOTE: we still would have an issue if the selector sync set was entirely
deleted. This metric would not clear until the pod is restarted.