### PR TITLE
WIP: New osd pipeline

### DIFF
--- a/hack/app_sre_create_image_catalog_new.sh
+++ b/hack/app_sre_create_image_catalog_new.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -exv
+
+BRANCH_CHANNEL="production"
+QUAY_IMAGE="quay.io/gshereme/hive"
+
+if [[ -z "$OLD_DEPLOYMENT" ]]; then
+    echo "OLD_DEPLOYMENT must be defined" 1>&2
+    exit 1
+fi
+
+if [[ -z "$NEW_DEPLOYMENT" ]]; then
+    echo "NEW_DEPLOYMENT must be defined" 1>&2
+    exit 1
+fi
+
+OLD_BUNDLE_DIR=$(mktemp -d)
+NEW_BUNDLE_DIR="$(mktemp -d -p .)/hive"
+HIVE_BUNDLE_DIR="bundle"
+
+mkdir -p "${NEW_BUNDLE_DIR}"
+
+# TODO change to correct bundle URL
+git clone \
+    --branch $BRANCH_CHANNEL \
+    git@gitlab.cee.redhat.com:gshereme/saas-hive-operator-bundle.git \
+    $OLD_BUNDLE_DIR
+
+# build a new bundle of 2 (old and new). First, grab the old:
+pushd "${OLD_BUNDLE_DIR}/hive"
+PREV_VERSION=$(find . -name "*${OLD_DEPLOYMENT:0:7}" | xargs -n 1 basename)
+popd
+cp -r "${OLD_BUNDLE_DIR}/hive/${PREV_VERSION}" "${NEW_BUNDLE_DIR}/"
+
+pushd "${NEW_BUNDLE_DIR}/${PREV_VERSION}"
+OLD_CSV_FILE=$(ls -1 hive-operator*clusterserviceversion.yaml)
+
+# remove any replaces field in the old bundle
+podman run --rm -v .:/workdir mikefarah/yq yq d -i ${OLD_CSV_FILE} spec.replaces
+popd
+
+# generate bundle
+./hack/generate-operator-bundle-operatorhub.py osd --previous-version $PREV_VERSION --hive-image ${QUAY_IMAGE}:${NEW_DEPLOYMENT:0:7} --channel $BRANCH_CHANNEL
+NEW_VERSION=$((cd ${HIVE_BUNDLE_DIR} && find -type d | xargs -n 1 basename) | sort -V  | tail -n 1)
+
+# copy new csv
+cp -ax $HIVE_BUNDLE_DIR/$NEW_VERSION $NEW_BUNDLE_DIR/
+# copy package
+cp $HIVE_BUNDLE_DIR/hive.package.yaml $NEW_BUNDLE_DIR/
+
+# replace the saas-hive-operator-bundle content with this new bundle content
+pushd "${OLD_BUNDLE_DIR}/hive" && rm -rf * && popd
+cp -r "${NEW_BUNDLE_DIR}/" "${OLD_BUNDLE_DIR}/"
+pushd "${OLD_BUNDLE_DIR}/"
+ls -lart
+git add -A .
+git commit -m "bundle for ${OLD_DEPLOYMENT:0:7} --> ${NEW_DEPLOYMENT:0:7}"
+git push
+popd
+
+# build the registry image
+REGISTRY_IMG="quay.io/gshereme/hive-registry"
+DOCKERFILE_REGISTRY="Dockerfile.olm-registry"
+
+cat <<EOF > $DOCKERFILE_REGISTRY
+FROM quay.io/openshift/origin-operator-registry:latest
+
+COPY $NEW_BUNDLE_DIR manifests
+RUN initializer
+
+CMD ["registry-server", "-t", "/tmp/terminate.log"]
+EOF
+
+docker build -f $DOCKERFILE_REGISTRY --tag "${REGISTRY_IMG}:${BRANCH_CHANNEL}-${NEW_DEPLOYMENT:0:7}" .
+
+# TODO uncomment
+# # push image
+# skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+#     "docker-daemon:${REGISTRY_IMG}:${BRANCH_CHANNEL}-latest" \
+#     "docker://${REGISTRY_IMG}:${BRANCH_CHANNEL}-latest"
+
+# skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+#     "docker-daemon:${REGISTRY_IMG}:${BRANCH_CHANNEL}-latest" \
+#     "docker://${REGISTRY_IMG}:${BRANCH_CHANNEL}-${GIT_HASH}"

--- a/hack/generate-operator-bundle-operatorhub.py
+++ b/hack/generate-operator-bundle-operatorhub.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+#
+# Generate an operator bundle for publishing to OLM. Copies appropriate files
+# into a directory, and composes the ClusterServiceVersion which needs bits and
+# pieces of our rbac and deployment files.
+#
+# Usage: hack/generate-operator-bundle.py (osd|operatorhub)
+#
+#  See help for options.
+#
+
+import argparse
+import datetime
+import os
+import shutil
+import subprocess
+import yaml
+
+
+OSD_HIVE_IMAGE_DEFAULT = 'quay.io/app-sre/hive'
+OPERATORHUB_HIVE_IMAGE_DEFAULT = 'quay.io/openshift-hive/hive'
+CHANNEL_DEFAULT = 'alpha'
+BUNDLE_DIR = 'bundle'
+PACKAGE_FILE = os.path.join(BUNDLE_DIR, 'hive.package.yaml')
+
+
+def current_operatorhub_version():
+    result = subprocess.check_output("git describe --abbrev=0", shell=True).strip()
+    # remove the v -- OLM bundles need to start with the digit
+    if result[0] == 'v':
+        result = result[1:]
+    return result
+
+
+def generate_operatorhub_version(prev_version=current_operatorhub_version()):
+    # bump the zstream
+    previous_z = int(prev_version.split('.')[-1])
+    new_z = previous_z + 1
+    new_version = "%s.%s" % ('.'.join(prev_version.split('.')[:-1]), new_z)
+    return new_version
+
+
+def generate_osd_version():
+    result = subprocess.check_output("git describe", shell=True).strip()
+    print(result)
+    # remove the v -- OLM bundles need to start with the digit
+    if result[0] == 'v':
+        result = result[1:]
+    return result
+
+
+def generate_csv_operatorhub():
+    print("Generating CSV for operatorhub")
+    prev_version = current_operatorhub_version()
+    version = args.new_version
+    if not version:
+        version = generate_operatorhub_version(prev_version)
+    generate_csv_base(version, prev_version, args.hive_image)
+    generate_package(args.channel, version)
+
+
+def generate_csv_osd():
+    print("Generating CSV for OpenShift Dedicated")
+    version = generate_osd_version()
+    generate_csv_base(version, args.prev_version, args.hive_image)
+    generate_package(args.channel, version)
+
+
+def generate_csv_base(version, prev_version, hive_image):
+    print("Generating CSV for version: %s" % version)
+
+    crds_dir = 'config/crds'
+    csv_template = 'config/templates/hive-csv-template.yaml'
+    operator_role = 'config/operator/operator_role.yaml'
+    deployment_spec = 'config/operator/operator_deployment.yaml'
+
+    if not os.path.exists(BUNDLE_DIR):
+        os.mkdir(BUNDLE_DIR)
+
+    version_dir = os.path.join(BUNDLE_DIR, version)
+    if not os.path.exists(version_dir):
+        os.mkdir(version_dir)
+
+    # Copy all CSV files over to the bundle output dir:
+    crd_files = os.listdir(crds_dir)
+    for file_name in crd_files:
+        full_path = os.path.join(crds_dir, file_name)
+        if os.path.isfile(os.path.join(crds_dir, file_name)):
+            shutil.copy(full_path, os.path.join(version_dir, file_name))
+
+    with open(csv_template, 'r') as stream:
+        csv = yaml.load(stream, Loader=yaml.SafeLoader)
+
+    csv['spec']['install']['spec']['clusterPermissions'] = []
+
+    # Add our operator role to the CSV:
+    with open(operator_role, 'r') as stream:
+        operator_role = yaml.load(stream, Loader=yaml.SafeLoader)
+        csv['spec']['install']['spec']['clusterPermissions'].append(
+            {
+                'rules': operator_role['rules'],
+                'serviceAccountName': 'hive-operator',
+            })
+
+    # Add our deployment spec for the hive operator:
+    with open(deployment_spec, 'r') as stream:
+        operator_components = []
+        operator = yaml.load_all(stream, Loader=yaml.SafeLoader)
+        for doc in operator:
+            operator_components.append(doc)
+        operator_deployment = operator_components[1]
+        csv['spec']['install']['spec']['deployments'][0]['spec'] = operator_deployment['spec']
+
+    # Update the versions to include git hash:
+    csv['metadata']['name'] = "hive-operator.v%s" % version
+    csv['spec']['version'] = version
+    csv['spec']['replaces'] = "hive-operator.v%s" % prev_version
+
+    # Update the deployment to use the defined image:
+    image_ref = hive_image
+    if not ":" in image_ref:
+        image_ref = "%s:v%s" % (hive_image, version)
+    csv['spec']['install']['spec']['deployments'][0]['spec']['template']['spec']['containers'][0]['image'] = image_ref
+    csv['metadata']['annotations']['containerImage'] = image_ref
+
+    # Set the CSV createdAt annotation:
+    now = datetime.datetime.now()
+    csv['metadata']['annotations']['createdAt'] = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Write the CSV to disk:
+    csv_filename = "hive-operator.v%s.clusterserviceversion.yaml" % version
+    csv_file = os.path.join(version_dir, csv_filename)
+    with open(csv_file, 'w') as outfile:
+        yaml.dump(csv, outfile, default_flow_style=False)
+    print("Wrote ClusterServiceVersion: %s" % csv_file)
+
+
+def generate_package(channel, version):
+    document_template = """
+      channels:
+      - currentCSV: %s
+        name: %s
+      defaultChannel: %s
+      packageName: hive-operator
+"""
+    name = "hive-operator.v%s" % version
+    document = document_template % (name, channel, channel)
+
+    with open(PACKAGE_FILE, 'w') as outfile:
+        yaml.dump(yaml.load(document, Loader=yaml.SafeLoader), outfile, default_flow_style=False)
+    print("Wrote package: %s" % PACKAGE_FILE)
+
+
+parser = argparse.ArgumentParser(
+    prog='OpenShift Hive Operator CSV generator',
+    description='created CSV and related artifacts for operatorhub.io and OpenShift Dedicated.',
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+)
+
+subparsers = parser.add_subparsers()
+
+osd_parser = subparsers.add_parser('osd', help='Generate CSV for OpenShift Dedicated deployment.')
+osd_parser.add_argument('--previous-version', dest='prev_version', metavar='VERSION', help='Previous version, the version being replaced')
+osd_parser.add_argument('--hive-image', dest='hive_image', metavar='IMAGE', help='The hive image to deploy', default=OSD_HIVE_IMAGE_DEFAULT)
+osd_parser.add_argument('--channel', dest='channel', metavar='CHANNEL', help='The operator channel to use', default=CHANNEL_DEFAULT)
+osd_parser.set_defaults(func=generate_csv_osd)
+
+operatorhub_parser = subparsers.add_parser('operatorhub', help='Generate CSV for operatorhub deployment.')
+operatorhub_parser.add_argument('--new-version', dest='new_version', metavar='VERSION', help='Override the new version in case of minor or major upgrade', default=None)
+operatorhub_parser.add_argument('--hive-image', dest='hive_image', metavar='IMAGE', help='The hive image to deploy', default=OPERATORHUB_HIVE_IMAGE_DEFAULT)
+operatorhub_parser.add_argument('--channel', dest='channel', metavar='CHANNEL', help='The operator channel to use', default=CHANNEL_DEFAULT)
+operatorhub_parser.set_defaults(func=generate_csv_operatorhub)
+
+args = parser.parse_args()
+args.func()


### PR DESCRIPTION
WIP prototype. Just interested if you think it could work.
ignore generate-operator-bundle-operatorhub.py, I'm just basing on that commit.

new OpenShift Dedicated pipeline that builds bare-minimum catalogs

Create an OLM CatalogSource / registry with only two bundles --
the currently deployed version (old), and the version to upgrade to (new).
The old version previously replaced an older version when it was installed,
but here we strip that 'replaces:' from its CSV to make it the new head
of the replaces chain on every deploy.

Previously we had a difficult-to-maintain chain of every version ever:

```
v1 <---- channel head
and next time...
v1 <---- v2 (replaces v1) <---- channel head
and next time...
v1 <---- v2 (replaces v1) <---- v3 (replaces v2) <---- channel head
and next time...
v1 <---- v2 (replaces v1) <---- v3 (replaces v2) <---- v4 (replaces v3) <---- channel head
```

Now:

```
v1 <---- v2 (replaces v1) <---- channel head
and next time...
v2 <---- v3 (replaces v2) <---- channel head
and next time...
v3 <---- v4 (replaces v3) <---- channel head
and so on.
```

/cc @dgoodwin @jmelis @jharrington22 