### PR TITLE
replace references to managedDNS with manageDNS

### DIFF
--- a/config/crds/hive_v1_hiveconfig.yaml
+++ b/config/crds/hive_v1_hiveconfig.yaml
@@ -118,7 +118,7 @@ spec:
               type: boolean
             managedDomains:
               description: 'ManagedDomains is the list of DNS domains that are managed
-                by the Hive cluster When specifying ''managedDNS: true'' in a ClusterDeployment,
+                by the Hive cluster When specifying ''manageDNS: true'' in a ClusterDeployment,
                 the ClusterDeployment''s baseDomain should be a direct child of one
                 of these domains, otherwise the ClusterDeployment creation will result
                 in a validation error.'

--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -520,7 +520,7 @@ To use this feature:
            domains:
            - hive.example.com
 
-  1. Specify which domains Hive is allowed to manage by adding them to the `.spec.managedDomains[].domains` list. When specifying `managedDNS: true` in a ClusterDeployment, the ClusterDeployment's baseDomain must be a direct child of one of these domains, otherwise the ClusterDeployment creation will result in a validation error. The baseDomain must also be unique to that cluster and must not be used in any other ClusterDeployment, including on separate Hive instances.
+  1. Specify which domains Hive is allowed to manage by adding them to the `.spec.managedDomains[].domains` list. When specifying `manageDNS: true` in a ClusterDeployment, the ClusterDeployment's baseDomain must be a direct child of one of these domains, otherwise the ClusterDeployment creation will result in a validation error. The baseDomain must also be unique to that cluster and must not be used in any other ClusterDeployment, including on separate Hive instances.
 
      As such, a domain may exist in the `.spec.managedDomains[].domains` list in multiple Hive instances. Note that the specified credentials must be valid to add and remove NS record entries for all domains listed in `.spec.managedDomains[].domains`.
 

--- a/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -252,7 +252,7 @@ const (
 	InstallFailingCondition ClusterDeploymentConditionType = "InstallFailing"
 
 	// DNSNotReadyCondition indicates that the the DNSZone object created for the clusterDeployment
-	// (ie managedDNS==true) has not yet indicated that the DNS zone is successfully responding to queries.
+	// (ie manageDNS==true) has not yet indicated that the DNS zone is successfully responding to queries.
 	DNSNotReadyCondition ClusterDeploymentConditionType = "DNSNotReady"
 
 	// ProvisionFailedCondition indicates that a provision failed

--- a/pkg/apis/hive/v1/hiveconfig_types.go
+++ b/pkg/apis/hive/v1/hiveconfig_types.go
@@ -15,7 +15,7 @@ type HiveConfigSpec struct {
 	TargetNamespace string `json:"targetNamespace,omitempty"`
 
 	// ManagedDomains is the list of DNS domains that are managed by the Hive cluster
-	// When specifying 'managedDNS: true' in a ClusterDeployment, the ClusterDeployment's
+	// When specifying 'manageDNS: true' in a ClusterDeployment, the ClusterDeployment's
 	// baseDomain should be a direct child of one of these domains, otherwise the
 	// ClusterDeployment creation will result in a validation error.
 	// +optional

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -8838,7 +8838,7 @@ spec:
               type: boolean
             managedDomains:
               description: 'ManagedDomains is the list of DNS domains that are managed
-                by the Hive cluster When specifying ''managedDNS: true'' in a ClusterDeployment,
+                by the Hive cluster When specifying ''manageDNS: true'' in a ClusterDeployment,
                 the ClusterDeployment''s baseDomain should be a direct child of one
                 of these domains, otherwise the ClusterDeployment creation will result
                 in a validation error.'

--- a/v1alpha1apiserver/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
+++ b/v1alpha1apiserver/pkg/apis/hive/v1alpha1/clusterdeployment_types.go
@@ -253,7 +253,7 @@ const (
 	InstallFailingCondition ClusterDeploymentConditionType = "InstallFailing"
 
 	// DNSNotReadyCondition indicates that the the DNSZone object created for the clusterDeployment
-	// (ie managedDNS==true) has not yet indicated that the DNS zone is successfully responding to queries.
+	// (ie manageDNS==true) has not yet indicated that the DNS zone is successfully responding to queries.
 	DNSNotReadyCondition ClusterDeploymentConditionType = "DNSNotReady"
 
 	// ProvisionFailedCondition indicates that a provision failed

--- a/v1alpha1apiserver/pkg/apis/hive/v1alpha1/hiveconfig_types.go
+++ b/v1alpha1apiserver/pkg/apis/hive/v1alpha1/hiveconfig_types.go
@@ -7,8 +7,8 @@ import (
 
 // HiveConfigSpec defines the desired state of Hive
 type HiveConfigSpec struct {
-	// ManagedDomains is the list of DNS domains that are allowed to be used by the 'managedDNS' feature.
-	// When specifying 'managedDNS: true' in a ClusterDeployment, the ClusterDeployment's
+	// ManagedDomains is the list of DNS domains that are allowed to be used by the 'manageDNS' feature.
+	// When specifying 'manageDNS: true' in a ClusterDeployment, the ClusterDeployment's
 	// baseDomain must be a direct child of one of these domains, otherwise the
 	// ClusterDeployment creation will result in a validation error.
 	// +optional

--- a/v1alpha1apiserver/pkg/hive/apis/hive/clusterdeployment_types.go
+++ b/v1alpha1apiserver/pkg/hive/apis/hive/clusterdeployment_types.go
@@ -253,7 +253,7 @@ const (
 	InstallFailingCondition ClusterDeploymentConditionType = "InstallFailing"
 
 	// DNSNotReadyCondition indicates that the the DNSZone object created for the clusterDeployment
-	// (ie managedDNS==true) has not yet indicated that the DNS zone is successfully responding to queries.
+	// (ie manageDNS==true) has not yet indicated that the DNS zone is successfully responding to queries.
 	DNSNotReadyCondition ClusterDeploymentConditionType = "DNSNotReady"
 
 	// ProvisionFailedCondition indicates that a provision failed

--- a/v1alpha1apiserver/pkg/hive/apis/hive/hiveconfig_types.go
+++ b/v1alpha1apiserver/pkg/hive/apis/hive/hiveconfig_types.go
@@ -7,8 +7,8 @@ import (
 
 // HiveConfigSpec defines the desired state of Hive
 type HiveConfigSpec struct {
-	// ManagedDomains is the list of DNS domains that are allowed to be used by the 'managedDNS' feature.
-	// When specifying 'managedDNS: true' in a ClusterDeployment, the ClusterDeployment's
+	// ManagedDomains is the list of DNS domains that are allowed to be used by the 'manageDNS' feature.
+	// When specifying 'manageDNS: true' in a ClusterDeployment, the ClusterDeployment's
 	// baseDomain must be a direct child of one of these domains, otherwise the
 	// ClusterDeployment creation will result in a validation error.
 	// +optional

--- a/v1alpha1apiserver/vendor/github.com/openshift/hive/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/v1alpha1apiserver/vendor/github.com/openshift/hive/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -251,7 +251,7 @@ const (
 	InstallFailingCondition ClusterDeploymentConditionType = "InstallFailing"
 
 	// DNSNotReadyCondition indicates that the the DNSZone object created for the clusterDeployment
-	// (ie managedDNS==true) has not yet indicated that the DNS zone is successfully responding to queries.
+	// (ie manageDNS==true) has not yet indicated that the DNS zone is successfully responding to queries.
 	DNSNotReadyCondition ClusterDeploymentConditionType = "DNSNotReady"
 
 	// ProvisionFailedCondition indicates that a provision failed

--- a/v1alpha1apiserver/vendor/github.com/openshift/hive/pkg/apis/hive/v1/hiveconfig_types.go
+++ b/v1alpha1apiserver/vendor/github.com/openshift/hive/pkg/apis/hive/v1/hiveconfig_types.go
@@ -15,7 +15,7 @@ type HiveConfigSpec struct {
 	TargetNamespace string `json:"targetNamespace,omitempty"`
 
 	// ManagedDomains is the list of DNS domains that are managed by the Hive cluster
-	// When specifying 'managedDNS: true' in a ClusterDeployment, the ClusterDeployment's
+	// When specifying 'manageDNS: true' in a ClusterDeployment, the ClusterDeployment's
 	// baseDomain should be a direct child of one of these domains, otherwise the
 	// ClusterDeployment creation will result in a validation error.
 	// +optional


### PR DESCRIPTION
I believe the references to `managedDNS` in the docs are incorrect and they
should be changed to `manageDNS`.