### PR TITLE
standardize on GCP creds flags/env vars

### DIFF
--- a/contrib/pkg/deprovision/gcp.go
+++ b/contrib/pkg/deprovision/gcp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/installer/pkg/types"
 	typesgcp "github.com/openshift/installer/pkg/types/gcp"
 
+	gcputils "github.com/openshift/hive/contrib/pkg/utils/gcp"
 	"github.com/openshift/hive/pkg/gcpclient"
 )
 
@@ -61,8 +62,12 @@ func (o *gcpOptions) Validate(cmd *cobra.Command) error {
 		log.Info("Region is required")
 		return fmt.Errorf("missing region")
 	}
-	credsFile := os.Getenv("GOOGLE_CREDENTIALS")
-	projectID, err := gcpclient.ProjectIDFromFile(credsFile)
+
+	creds, err := gcputils.GetCreds("")
+	if err != nil {
+		return errors.Wrap(err, "failed to get GCP credentials")
+	}
+	projectID, err := gcpclient.ProjectID(creds)
 	if err != nil {
 		return errors.Wrap(err, "could not get GCP project ID")
 	}

--- a/contrib/pkg/utils/gcp/gcp.go
+++ b/contrib/pkg/utils/gcp/gcp.go
@@ -16,7 +16,7 @@ import (
 // are not set.
 func GetCreds(credsFile string) ([]byte, error) {
 	credsFilePath := filepath.Join(os.Getenv("HOME"), ".gcp", constants.GCPCredentialsName)
-	if l := os.Getenv("GCP_SHARED_CREDENTIALS_FILE"); l != "" {
+	if l := os.Getenv("GOOGLE_CREDENTIALS"); l != "" {
 		credsFilePath = l
 	}
 	if credsFile != "" {

--- a/docs/hiveutil.md
+++ b/docs/hiveutil.md
@@ -30,7 +30,7 @@ bin/hiveutil create-cluster --base-domain=mydomain.example.com --cloud=azure --a
 
 #### Create Cluster on GCP
 
-Credentials will be read from `~/.gcp/osServiceAccount.json`, which can be created by:
+Credentials will be read from either `~/.gcp/osServiceAccount.json`, the contents of the `GOOGLE_CREDENTIALS` environment variable, or the value provided with the `--creds-file` parameter (in increasing order of preference). GCP credentials can be created by:
 
  1. Login to GCP console at https://console.cloud.google.com/
  1. Create a service account with the owner role.
@@ -38,11 +38,11 @@ Credentials will be read from `~/.gcp/osServiceAccount.json`, which can be creat
  1. Select JSON for the key type.
  1. Download resulting JSON file and save to `~/.gcp/osServiceAccount.json`.
 
-Alternatively you can specify a GCP credentials file with `--creds-file` or the `GCP_SHARED_CREDENTIALS_FILE` environment variable.
-
 ```bash
 bin/hiveutil create-cluster --base-domain=mydomain.example.com --cloud=gcp mycluster
 ```
+
+NOTE: For deprovisioning a cluster, `hiveutil` will use creds from `~/.gcp/osServiceAccount.json` or the `GOOGLE_CREDENTIALS` environment variable (with the environment variable prefered).
 
 ### Other Commands
 


### PR DESCRIPTION
Fix up the difference where when using hiveutil to create a cluster you would set GCP_SHARED_CREDENTIALS_FILE, but on deprovision you would set GOOGLE_CREDENTIALS.

Standardize around the installer's use of GOOGLE_CREDENTIALS. Update the docs to more clearly specify that we actually search for ~/.gcp/osServiceAccount.json, GOOGLE_CREDENTIALS and the --creds-file parameter. Also add a --creds-file parameter for deprovision to make it more similar to the create-cluster workflow.