### PR TITLE
controller: force .status.clusterVersionStatus.availableUpdates to empty array

### DIFF
--- a/pkg/controller/clusterversion/clusterversion_controller.go
+++ b/pkg/controller/clusterversion/clusterversion_controller.go
@@ -153,6 +153,13 @@ func (r *ReconcileClusterVersion) updateClusterVersionStatus(cd *hivev1.ClusterD
 	cdLog.WithField("clusterversion.status", clusterVersion.Status).Debug("remote cluster version status")
 	cd.Status.ClusterVersionStatus = clusterVersion.Status.DeepCopy()
 
+	// Force the AvailableUpdates field to an empty array instead of nil. When the field is nil, future reads will
+	// read it as an empty array. Then, when doing a deep equal to see if changes have been made, will consider that
+	// field changed, when it has not been.
+	if cd.Status.ClusterVersionStatus.AvailableUpdates == nil {
+		cd.Status.ClusterVersionStatus.AvailableUpdates = []openshiftapiv1.Update{}
+	}
+
 	if reflect.DeepEqual(cd.Status, origCD.Status) {
 		cdLog.Debug("status has not changed, nothing to update")
 		return nil

--- a/pkg/controller/clusterversion/clusterversion_controller_test.go
+++ b/pkg/controller/clusterversion/clusterversion_controller_test.go
@@ -72,7 +72,7 @@ func TestClusterVersionReconcile(t *testing.T) {
 				testKubeconfigSecret(),
 			},
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
-				expected := testRemoteClusterVersionStatus()
+				expected := testClusterVersionStatusWithEmptyAvailableUpdates()
 				if !reflect.DeepEqual(cd.Status.ClusterVersionStatus, expected) {
 					t.Errorf("did not get expected clusterversion status. Expected: \n%#v\nGot: \n%#v", expected, cd.Status.ClusterVersionStatus)
 				}
@@ -210,4 +210,10 @@ func testRemoteClusterVersionStatus() *configv1.ClusterVersionStatus {
 		ObservedGeneration: 123456789,
 		VersionHash:        "TESTVERSIONHASH",
 	}
+}
+
+func testClusterVersionStatusWithEmptyAvailableUpdates() *configv1.ClusterVersionStatus {
+	cvs := testRemoteClusterVersionStatus()
+	cvs.AvailableUpdates = []configv1.Update{}
+	return cvs
 }


### PR DESCRIPTION
Change the clusterversion controller so that when it writes the .status.clusterVersionStatus field, it replaces a nil availableUpdates field with an empty array. This is necessary to keep other controllers
that use a deep equal to determine whether the controller has made any changes to the ClusterDeployment from seeing the field as changed.