### PR TITLE
Add MachinePool support for bring your own VPC

### DIFF
--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -106,6 +106,13 @@ spec:
                       - size
                       - type
                       type: object
+                    subnets:
+                      description: Subnets is the list of subnets to which to attach
+                        the machines. There must be exactly one subnet for each availability
+                        zone used.
+                      items:
+                        type: string
+                      type: array
                     type:
                       description: InstanceType defines the ec2 instance type. eg.
                         m4-large

--- a/pkg/apis/hive/v1/aws/machinepool.go
+++ b/pkg/apis/hive/v1/aws/machinepool.go
@@ -6,6 +6,10 @@ type MachinePoolPlatform struct {
 	// Zones is list of availability zones that can be used.
 	Zones []string `json:"zones,omitempty"`
 
+	// Subnets is the list of subnets to which to attach the machines.
+	// There must be exactly one subnet for each availability zone used.
+	Subnets []string `json:"subnets,omitempty"`
+
 	// InstanceType defines the ec2 instance type.
 	// eg. m4-large
 	InstanceType string `json:"type"`

--- a/pkg/apis/hive/v1/machinepool_types.go
+++ b/pkg/apis/hive/v1/machinepool_types.go
@@ -136,6 +136,9 @@ const (
 	// NoMachinePoolNameLeasesAvailable is true when the cloud provider requires a name lease for the in-cluster MachineSet, but no
 	// leases are available.
 	NoMachinePoolNameLeasesAvailable MachinePoolConditionType = "NoMachinePoolNameLeasesAvailable"
+
+	// InvalidSubnetsMachinePoolCondition is true when there are missing or invalid entries in the subnet field
+	InvalidSubnetsMachinePoolCondition MachinePoolConditionType = "InvalidSubnets"
 )
 
 // +genclient

--- a/pkg/controller/remotemachineset/awsactuator_test.go
+++ b/pkg/controller/remotemachineset/awsactuator_test.go
@@ -2,37 +2,51 @@ package remotemachineset
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	machineapi "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/pointer"
 	awsprovider "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsproviderconfig/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/openshift/hive/pkg/apis"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	mockaws "github.com/openshift/hive/pkg/awsclient/mock"
 )
 
 func TestAWSActuator(t *testing.T) {
 	tests := []struct {
-		name                       string
-		mockAWSClient              func(*mockaws.MockClient)
-		clusterDeployment          *hivev1.ClusterDeployment
-		pool                       *hivev1.MachinePool
-		expectedMachineSetReplicas map[string]int64
-		expectedErr                bool
+		name                         string
+		mockAWSClient                func(*mockaws.MockClient)
+		clusterDeployment            *hivev1.ClusterDeployment
+		poolName                     string
+		existing                     []runtime.Object
+		expectedMachineSetReplicas   map[string]int64
+		expectedSubnetIDInMachineSet bool
+		expectedErr                  bool
+		expectedCondition            *hivev1.MachinePoolCondition
 	}{
 		{
 			name:              "generate single machineset for single zone",
 			clusterDeployment: testClusterDeployment(),
-			pool:              testMachinePool(),
+			poolName:          testMachinePool().Name,
+			existing: []runtime.Object{
+				testMachinePool(),
+			},
 			mockAWSClient: func(client *mockaws.MockClient) {
 				mockDescribeAvailabilityZones(client, []string{"zone1"})
 			},
@@ -43,7 +57,10 @@ func TestAWSActuator(t *testing.T) {
 		{
 			name:              "generate machinesets across zones",
 			clusterDeployment: testClusterDeployment(),
-			pool:              testMachinePool(),
+			poolName:          testMachinePool().Name,
+			existing: []runtime.Object{
+				testMachinePool(),
+			},
 			mockAWSClient: func(client *mockaws.MockClient) {
 				mockDescribeAvailabilityZones(client, []string{"zone1", "zone2", "zone3"})
 			},
@@ -56,11 +73,14 @@ func TestAWSActuator(t *testing.T) {
 		{
 			name:              "generate machinesets for specified zones",
 			clusterDeployment: testClusterDeployment(),
-			pool: func() *hivev1.MachinePool {
-				pool := testMachinePool()
-				pool.Spec.Platform.AWS.Zones = []string{"zone1", "zone2", "zone3"}
-				return pool
-			}(),
+			poolName:          testMachinePool().Name,
+			existing: []runtime.Object{
+				func() *hivev1.MachinePool {
+					pool := testMachinePool()
+					pool.Spec.Platform.AWS.Zones = []string{"zone1", "zone2", "zone3"}
+					return pool
+				}(),
+			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAWSMachineSetName("zone1"): 1,
 				generateAWSMachineSetName("zone2"): 1,
@@ -68,22 +88,115 @@ func TestAWSActuator(t *testing.T) {
 			},
 		},
 		{
+			name:              "generate machinesets for specified zones and subnets",
+			clusterDeployment: testClusterDeployment(),
+			poolName:          testMachinePool().Name,
+			existing: []runtime.Object{
+				func() *hivev1.MachinePool {
+					pool := testMachinePool()
+					pool.Spec.Platform.AWS.Zones = []string{"zone1", "zone2", "zone3"}
+					pool.Spec.Platform.AWS.Subnets = []string{"subnet-zone1", "subnet-zone2", "subnet-zone3"}
+					return pool
+				}(),
+			},
+			mockAWSClient: func(client *mockaws.MockClient) {
+				mockDescribeSubnets(client, []string{"zone1", "zone2", "zone3"}, []string{"subnet-zone1", "subnet-zone2", "subnet-zone3"})
+			},
+			expectedMachineSetReplicas: map[string]int64{
+				generateAWSMachineSetName("zone1"): 1,
+				generateAWSMachineSetName("zone2"): 1,
+				generateAWSMachineSetName("zone3"): 1,
+			},
+			expectedSubnetIDInMachineSet: true,
+		},
+		{
 			name:              "list zones returns zero",
 			clusterDeployment: testClusterDeployment(),
-			pool:              testMachinePool(),
+			poolName:          testMachinePool().Name,
+			existing: []runtime.Object{
+				testMachinePool(),
+			},
 			mockAWSClient: func(client *mockaws.MockClient) {
 				mockDescribeAvailabilityZones(client, nil)
 			},
 			expectedErr: true,
 		},
+		{
+			name:              "subnets specfied in the machinepool do not exist",
+			clusterDeployment: testClusterDeployment(),
+			poolName:          testMachinePool().Name,
+			existing: []runtime.Object{
+				func() *hivev1.MachinePool {
+					pool := testMachinePool()
+					pool.Spec.Platform.AWS.Zones = []string{"zone1", "zone2", "zone3"}
+					pool.Spec.Platform.AWS.Subnets = []string{"missing-subnet1", "missing-subnet2", "missing-subnet3"}
+					return pool
+				}(),
+			},
+			mockAWSClient: func(client *mockaws.MockClient) {
+				mockDescribeMissingSubnets(client, []string{"missing-subnet1", "missing-subnet2", "missing-subnet3"})
+			},
+			expectedErr: true,
+			expectedCondition: &hivev1.MachinePoolCondition{
+				Type:   hivev1.InvalidSubnetsMachinePoolCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "SubnetsNotFound",
+			},
+		},
+		{
+			name:              "more than one subnet for availability zone",
+			clusterDeployment: testClusterDeployment(),
+			poolName:          testMachinePool().Name,
+			existing: []runtime.Object{
+				func() *hivev1.MachinePool {
+					pool := testMachinePool()
+					pool.Spec.Platform.AWS.Zones = []string{"zone1", "zone2", "zone3"}
+					pool.Spec.Platform.AWS.Subnets = []string{"subnet-zone1", "subnet-zone2", "subnet-zone3"}
+					return pool
+				}(),
+			},
+			mockAWSClient: func(client *mockaws.MockClient) {
+				mockDescribeSubnets(client, []string{"zone1", "zone1", "zone2"}, []string{"subnet-zone1", "subnet-zone2", "subnet-zone3"})
+			},
+			expectedErr: true,
+			expectedCondition: &hivev1.MachinePoolCondition{
+				Type:   hivev1.InvalidSubnetsMachinePoolCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "MoreThanOneSubnetForZone",
+			},
+		},
+		{
+			name:              "no subnet for availability zone",
+			clusterDeployment: testClusterDeployment(),
+			poolName:          testMachinePool().Name,
+			existing: []runtime.Object{
+				func() *hivev1.MachinePool {
+					pool := testMachinePool()
+					pool.Spec.Platform.AWS.Zones = []string{"zone1", "zone2", "zone3"}
+					pool.Spec.Platform.AWS.Subnets = []string{"subnet-zone1", "subnet-zone2"}
+					return pool
+				}(),
+			},
+			mockAWSClient: func(client *mockaws.MockClient) {
+				mockDescribeSubnets(client, []string{"zone1", "zone2", "zone3"}, []string{"subnet-zone1", "subnet-zone2"})
+			},
+			expectedErr: true,
+			expectedCondition: &hivev1.MachinePoolCondition{
+				Type:   hivev1.InvalidSubnetsMachinePoolCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "NoSubnetForAvailabilityZone",
+			},
+		},
 	}
 
 	for _, test := range tests {
+		apis.AddToScheme(scheme.Scheme)
 		t.Run(test.name, func(t *testing.T) {
 
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 
+			fakeClient := fake.NewFakeClient(test.existing...)
 			awsClient := mockaws.NewMockClient(mockCtrl)
 
 			// set up mock expectations
@@ -92,18 +205,32 @@ func TestAWSActuator(t *testing.T) {
 			}
 
 			actuator := &AWSActuator{
-				client: awsClient,
-				logger: log.WithField("actuator", "awsactuator"),
-				region: testRegion,
-				amiID:  testAMI,
+				client:    fakeClient,
+				awsClient: awsClient,
+				logger:    log.WithField("actuator", "awsactuator"),
+				region:    testRegion,
+				amiID:     testAMI,
 			}
 
-			generatedMachineSets, _, err := actuator.GenerateMachineSets(test.clusterDeployment, test.pool, actuator.logger)
+			pool := &hivev1.MachinePool{}
+			err := fakeClient.Get(context.TODO(), types.NamespacedName{Namespace: testNamespace, Name: test.poolName}, pool)
+			require.NoError(t, err)
 
+			generatedMachineSets, _, err := actuator.GenerateMachineSets(test.clusterDeployment, pool, actuator.logger)
 			if test.expectedErr {
 				assert.Error(t, err, "expected error for test case")
 			} else {
-				validateAWSMachineSets(t, generatedMachineSets, test.expectedMachineSetReplicas)
+				validateAWSMachineSets(t, generatedMachineSets, test.expectedMachineSetReplicas, test.expectedSubnetIDInMachineSet)
+			}
+			if test.expectedCondition != nil {
+				for _, cond := range pool.Status.Conditions {
+					assert.Equal(t, cond.Type, test.expectedCondition.Type)
+					assert.Equal(t, cond.Status, test.expectedCondition.Status)
+					assert.Equal(t, cond.Reason, test.expectedCondition.Reason)
+				}
+			} else {
+				// Assuming if you didn't expect a condition, there shouldn't be any.
+				assert.Equal(t, 0, len(pool.Status.Conditions))
 			}
 		})
 	}
@@ -154,7 +281,7 @@ func TestGetAWSAMIID(t *testing.T) {
 	}
 }
 
-func validateAWSMachineSets(t *testing.T, mSets []*machineapi.MachineSet, expectedMSReplicas map[string]int64) {
+func validateAWSMachineSets(t *testing.T, mSets []*machineapi.MachineSet, expectedMSReplicas map[string]int64, expectedSubnetID bool) {
 	assert.Equal(t, len(expectedMSReplicas), len(mSets), "different number of machine sets generated than expected")
 
 	for _, ms := range mSets {
@@ -170,6 +297,12 @@ func validateAWSMachineSets(t *testing.T, mSets []*machineapi.MachineSet, expect
 
 		if assert.NotNil(t, awsProvider.AMI.ID, "missing AMI ID") {
 			assert.Equal(t, testAMI, *awsProvider.AMI.ID, "unexpected AMI ID")
+		}
+
+		if expectedSubnetID {
+			providerConfig := ms.Spec.Template.Spec.ProviderSpec.Value.Object.(*awsprovider.AWSMachineProviderConfig)
+			assert.NotNil(t, providerConfig.Subnet.ID, "missing subnet ID")
+			assert.Equal(t, "subnet-"+providerConfig.Placement.AvailabilityZone, *providerConfig.Subnet.ID, "unexpected subnet ID")
 		}
 	}
 }
@@ -191,6 +324,38 @@ func mockDescribeAvailabilityZones(client *mockaws.MockClient, zones []string) {
 		AvailabilityZones: availabilityZones,
 	}
 	client.EXPECT().DescribeAvailabilityZones(input).Return(output, nil)
+}
+
+func mockDescribeSubnets(client *mockaws.MockClient, zones []string, subnetIDs []string) {
+	idPointers := make([]*string, 0, len(subnetIDs))
+	for _, id := range subnetIDs {
+		idPointers = append(idPointers, aws.String(id))
+	}
+	input := &ec2.DescribeSubnetsInput{
+		SubnetIds: idPointers,
+	}
+	subnets := make([]*ec2.Subnet, len(subnetIDs))
+	for i := range subnetIDs {
+		subnets[i] = &ec2.Subnet{
+			SubnetId:         &subnetIDs[i],
+			AvailabilityZone: &zones[i],
+		}
+	}
+	output := &ec2.DescribeSubnetsOutput{
+		Subnets: subnets,
+	}
+	client.EXPECT().DescribeSubnets(input).Return(output, nil)
+}
+
+func mockDescribeMissingSubnets(client *mockaws.MockClient, subnetIDs []string) {
+	idPointers := make([]*string, 0, len(subnetIDs))
+	for _, id := range subnetIDs {
+		idPointers = append(idPointers, aws.String(id))
+	}
+	input := &ec2.DescribeSubnetsInput{
+		SubnetIds: idPointers,
+	}
+	client.EXPECT().DescribeSubnets(input).Return(nil, fmt.Errorf("InvalidSubnets"))
 }
 
 func generateAWSMachineSetName(zone string) string {

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -9291,6 +9291,13 @@ spec:
                       - size
                       - type
                       type: object
+                    subnets:
+                      description: Subnets is the list of subnets to which to attach
+                        the machines. There must be exactly one subnet for each availability
+                        zone used.
+                      items:
+                        type: string
+                      type: array
                     type:
                       description: InstanceType defines the ec2 instance type. eg.
                         m4-large


### PR DESCRIPTION
Currently, Hive can install the cluster in an already existent VPC. But when a
new MachinePool is created, Hive creates the MachineSets in the cluster without
specifying the subnet IDs, thus causing the Machine objects to get into failed
state. This PR adds an option to specify the subnet IDs to be used in the
MachinePool.

Fixes #886 