### PR TITLE
protect against accidental deletes of installed clusters

### DIFF
--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -70,6 +70,15 @@ spec:
                       type: boolean
                   type: object
               type: object
+            deleteProtection:
+              description: DeleteProtection can be set to "enabled" to turn on automatic
+                delete protection for ClusterDeployments. When enabled, Hive will
+                add the "hive.openshift.io/protected-delete" annotation to new ClusterDeployments.
+                Once a ClusterDeployment has been installed, a user must remove the
+                annotation from a ClusterDeployment prior to deleting it.
+              enum:
+              - enabled
+              type: string
             deprovisionsDisabled:
               description: DeprovisionsDisabled can be set to true to block deprovision
                 jobs from running.

--- a/config/hiveadmission/clusterdeployment-webhook.yaml
+++ b/config/hiveadmission/clusterdeployment-webhook.yaml
@@ -15,6 +15,7 @@ webhooks:
   - operations:
     - CREATE
     - UPDATE
+    - DELETE
     apiGroups:
     - hive.openshift.io
     apiVersions:

--- a/pkg/apis/hive/v1/hiveconfig_types.go
+++ b/pkg/apis/hive/v1/hiveconfig_types.go
@@ -66,6 +66,14 @@ type HiveConfigSpec struct {
 
 	// DeprovisionsDisabled can be set to true to block deprovision jobs from running.
 	DeprovisionsDisabled *bool `json:"deprovisionsDisabled,omitempty"`
+
+	// DeleteProtection can be set to "enabled" to turn on automatic delete protection for ClusterDeployments. When
+	// enabled, Hive will add the "hive.openshift.io/protected-delete" annotation to new ClusterDeployments. Once a
+	// ClusterDeployment has been installed, a user must remove the annotation from a ClusterDeployment prior to
+	// deleting it.
+	// +kubebuilder:validation:Enum=enabled
+	// +optional
+	DeleteProtection DeleteProtectionType `json:"deleteProtection,omitempty"`
 }
 
 // HiveConfigStatus defines the observed state of Hive
@@ -160,6 +168,12 @@ type ManageDNSGCPConfig struct {
 	// +optional
 	CredentialsSecretRef corev1.LocalObjectReference `json:"credentialsSecretRef,omitempty"`
 }
+
+type DeleteProtectionType string
+
+const (
+	DeleteProtectionEnabled DeleteProtectionType = "enabled"
+)
 
 // +genclient:nonNamespaced
 // +genclient

--- a/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook.go
+++ b/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -21,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/manageddns"
 )
 
@@ -113,18 +115,18 @@ func (a *ClusterDeploymentValidatingAdmissionHook) Validate(admissionSpec *admis
 
 	contextLogger.Info("Validating request")
 
-	if admissionSpec.Operation == admissionv1beta1.Create {
+	switch admissionSpec.Operation {
+	case admissionv1beta1.Create:
 		return a.validateCreate(admissionSpec)
-	}
-
-	if admissionSpec.Operation == admissionv1beta1.Update {
+	case admissionv1beta1.Update:
 		return a.validateUpdate(admissionSpec)
-	}
-
-	// We're only validating creates and updates at this time, so all other operations are explicitly allowed.
-	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
-		Allowed: true,
+	case admissionv1beta1.Delete:
+		return a.validateDelete(admissionSpec)
+	default:
+		contextLogger.Info("Successful validation")
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: true,
+		}
 	}
 }
 
@@ -433,6 +435,59 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateUpdate(admissionSpec 
 
 	// If we get here, then all checks passed, so the object is valid.
 	contextLogger.Info("Successful validation")
+	return &admissionv1beta1.AdmissionResponse{
+		Allowed: true,
+	}
+}
+
+// validateDelete specifically validates delete operations for ClusterDeployment objects.
+func (a *ClusterDeploymentValidatingAdmissionHook) validateDelete(request *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+	logger := log.WithFields(log.Fields{
+		"operation": request.Operation,
+		"group":     request.Resource.Group,
+		"version":   request.Resource.Version,
+		"resource":  request.Resource.Resource,
+		"method":    "validateDelete",
+	})
+
+	oldObject := &hivev1.ClusterDeployment{}
+	if err := a.decoder.DecodeRaw(request.Object, oldObject); err != nil {
+		logger.Errorf("Failed unmarshaling Object: %v", err.Error())
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: false,
+			Result: &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: err.Error(),
+			},
+		}
+	}
+
+	logger.Data["object.Name"] = oldObject.Name
+
+	var allErrs field.ErrorList
+
+	if value, present := oldObject.Annotations[constants.ProtectedDeleteAnnotation]; present {
+		if enabled, err := strconv.ParseBool(value); enabled && err == nil {
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("metadata", "annotations", constants.ProtectedDeleteAnnotation),
+				oldObject.Annotations[constants.ProtectedDeleteAnnotation],
+				"cannot delete while annotation is present",
+			))
+		} else {
+			logger.WithField(constants.ProtectedDeleteAnnotation, value).Info("Protected Delete annotation present but not set to true")
+		}
+	}
+
+	if len(allErrs) > 0 {
+		logger.WithError(allErrs.ToAggregate()).Info("failed validation")
+		status := errors.NewInvalid(schemaGVK(request.Kind).GroupKind(), request.Name, allErrs).Status()
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: false,
+			Result:  &status,
+		}
+	}
+
+	logger.Info("Successful validation")
 	return &admissionv1beta1.AdmissionResponse{
 		Allowed: true,
 	}

--- a/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook.go
+++ b/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook.go
@@ -451,7 +451,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateDelete(request *admis
 	})
 
 	oldObject := &hivev1.ClusterDeployment{}
-	if err := a.decoder.DecodeRaw(request.Object, oldObject); err != nil {
+	if err := a.decoder.DecodeRaw(request.OldObject, oldObject); err != nil {
 		logger.Errorf("Failed unmarshaling Object: %v", err.Error())
 		return &admissionv1beta1.AdmissionResponse{
 			Allowed: false,

--- a/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
@@ -660,13 +660,13 @@ func TestClusterDeploymentValidate(t *testing.T) {
 		},
 		{
 			name:            "Test valid delete",
-			newObject:       validAWSClusterDeployment(),
+			oldObject:       validAWSClusterDeployment(),
 			operation:       admissionv1beta1.Delete,
 			expectedAllowed: true,
 		},
 		{
 			name: "Test protected delete",
-			newObject: func() *hivev1.ClusterDeployment {
+			oldObject: func() *hivev1.ClusterDeployment {
 				cd := validAWSClusterDeployment()
 				if cd.Annotations == nil {
 					cd.Annotations = make(map[string]string, 1)
@@ -679,7 +679,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 		},
 		{
 			name: "Test protected delete annotation false",
-			newObject: func() *hivev1.ClusterDeployment {
+			oldObject: func() *hivev1.ClusterDeployment {
 				cd := validAWSClusterDeployment()
 				if cd.Annotations == nil {
 					cd.Annotations = make(map[string]string, 1)

--- a/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
@@ -658,6 +658,38 @@ func TestClusterDeploymentValidate(t *testing.T) {
 			operation:       admissionv1beta1.Create,
 			expectedAllowed: true,
 		},
+		{
+			name:            "Test valid delete",
+			newObject:       validAWSClusterDeployment(),
+			operation:       admissionv1beta1.Delete,
+			expectedAllowed: true,
+		},
+		{
+			name: "Test protected delete",
+			newObject: func() *hivev1.ClusterDeployment {
+				cd := validAWSClusterDeployment()
+				if cd.Annotations == nil {
+					cd.Annotations = make(map[string]string, 1)
+				}
+				cd.Annotations[constants.ProtectedDeleteAnnotation] = "true"
+				return cd
+			}(),
+			operation:       admissionv1beta1.Delete,
+			expectedAllowed: false,
+		},
+		{
+			name: "Test protected delete annotation false",
+			newObject: func() *hivev1.ClusterDeployment {
+				cd := validAWSClusterDeployment()
+				if cd.Annotations == nil {
+					cd.Annotations = make(map[string]string, 1)
+				}
+				cd.Annotations[constants.ProtectedDeleteAnnotation] = "false"
+				return cd
+			}(),
+			operation:       admissionv1beta1.Delete,
+			expectedAllowed: true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -138,6 +138,14 @@ const (
 	// that drove the relocation.
 	RelocatedAnnotation = "hive.openshift.io/relocated"
 
+	// ProtectedDeleteAnnotation is an annotation used on ClusterDeployments to indicate that the ClusterDeployment
+	// cannot be deleted. The annotation must be removed in order to delete the ClusterDeployment.
+	ProtectedDeleteAnnotation = "hive.openshift.io/protected-delete"
+
+	// ProtectedDeleteEnvVar is the name of the environment variable used to tell the controller manager whether
+	// protected delete is enabled.
+	ProtectedDeleteEnvVar = "PROTECTED_DELETE"
+
 	// ManagedDomainsFileEnvVar if present, points to a simple text
 	// file that includes a valid managed domain per line. Cluster deployments
 	// requesting that their domains be managed must have a base domain

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -155,6 +156,13 @@ func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 	r.remoteClusterAPIClientBuilder = func(cd *hivev1.ClusterDeployment) remoteclient.Builder {
 		return remoteclient.NewBuilder(r.Client, cd, controllerName)
 	}
+
+	protectedDeleteEnvVar := os.Getenv(constants.ProtectedDeleteEnvVar)
+	if protectedDelete, err := strconv.ParseBool(protectedDeleteEnvVar); protectedDelete && err == nil {
+		logger.Info("Protected Delete enabled")
+		r.protectedDelete = true
+	}
+
 	return r
 }
 
@@ -248,6 +256,8 @@ type ReconcileClusterDeployment struct {
 	// remoteClusterAPIClientBuilder is a function pointer to the function that gets a builder for building a client
 	// for the remote cluster's API server
 	remoteClusterAPIClientBuilder func(cd *hivev1.ClusterDeployment) remoteclient.Builder
+
+	protectedDelete bool
 }
 
 // Reconcile reads that state of the cluster for a ClusterDeployment object and makes changes based on the state read
@@ -817,6 +827,13 @@ func (r *ReconcileClusterDeployment) reconcileCompletedProvision(cd *hivev1.Clus
 	}
 
 	cd.Spec.Installed = true
+
+	if r.protectedDelete {
+		if _, annotationPresent := cd.Annotations[constants.ProtectedDeleteAnnotation]; !annotationPresent {
+			initializeAnnotations(cd)
+			cd.Annotations[constants.ProtectedDeleteAnnotation] = "true"
+		}
+	}
 
 	if err := r.Update(context.TODO(), cd); err != nil {
 		cdLog.WithError(err).Log(controllerutils.LogLevel(err), "failed to set the Installed flag")

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
@@ -190,6 +190,10 @@ func (r *ReconcileClusterDeprovision) Reconcile(request reconcile.Request) (reco
 		rLog.Error("ClusterDeprovision created for ClusterDeployment that has not been deleted")
 		return reconcile.Result{}, nil
 	}
+	if controllerutils.IsDeleteProtected(cd) {
+		rLog.Error("deprovision blocked for ClusterDeployment with protected delete on")
+		return reconcile.Result{}, nil
+	}
 
 	// Check if deprovisions are currently disabled: (originates in HiveConfig in real world)
 	if r.deprovisionsDisabled {

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller_test.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller_test.go
@@ -84,6 +84,22 @@ func TestClusterDeprovisionReconcile(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name:        "no-op if cluster deployment has delete protection on",
+			deprovision: testClusterDeprovision(),
+			deployment: func() *hivev1.ClusterDeployment {
+				cd := testClusterDeployment()
+				if cd.Annotations == nil {
+					cd.Annotations = make(map[string]string, 1)
+				}
+				cd.Annotations[constants.ProtectedDeleteAnnotation] = "true"
+				return cd
+			}(),
+			validate: func(t *testing.T, c client.Client) {
+				validateNoJobExists(t, c)
+			},
+			expectErr: true,
+		},
+		{
 			name:        "create uninstall job",
 			deprovision: testClusterDeprovision(),
 			deployment:  testDeletedClusterDeployment(),

--- a/pkg/controller/utils/clusterdeployment.go
+++ b/pkg/controller/utils/clusterdeployment.go
@@ -24,3 +24,8 @@ func ShouldSyncCluster(cd *hivev1.ClusterDeployment, logger log.FieldLogger) boo
 	}
 	return true
 }
+
+func IsDeleteProtected(cd *hivev1.ClusterDeployment) bool {
+	protectedDelete, err := strconv.ParseBool(cd.Annotations[constants.ProtectedDeleteAnnotation])
+	return protectedDelete && err == nil
+}

--- a/pkg/controller/utils/clusterdeployment_test.go
+++ b/pkg/controller/utils/clusterdeployment_test.go
@@ -72,3 +72,47 @@ func TestShouldSyncCluster(t *testing.T) {
 		})
 	}
 }
+
+func TestIsDeleteProtected(t *testing.T) {
+	cases := []struct {
+		name           string
+		absent         bool
+		value          string
+		expectedResult bool
+	}{
+		{
+			name:           "absent",
+			absent:         true,
+			expectedResult: false,
+		},
+		{
+			name:           "true",
+			value:          "true",
+			expectedResult: true,
+		},
+		{
+			name:           "false",
+			value:          "false",
+			expectedResult: false,
+		},
+		{
+			name:           "empty",
+			value:          "",
+			expectedResult: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var options []clusterdeployment.Option
+			if !tc.absent {
+				options = append(
+					options,
+					clusterdeployment.Generic(generic.WithAnnotation(constants.ProtectedDeleteAnnotation, tc.value)),
+				)
+			}
+			cd := clusterdeployment.Build(options...)
+			actualResult := IsDeleteProtected(cd)
+			assert.Equal(t, tc.expectedResult, actualResult, "unexpected result")
+		})
+	}
+}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -383,6 +383,7 @@ webhooks:
   - operations:
     - CREATE
     - UPDATE
+    - DELETE
     apiGroups:
     - hive.openshift.io
     apiVersions:
@@ -8945,6 +8946,15 @@ spec:
                       type: boolean
                   type: object
               type: object
+            deleteProtection:
+              description: DeleteProtection can be set to "enabled" to turn on automatic
+                delete protection for ClusterDeployments. When enabled, Hive will
+                add the "hive.openshift.io/protected-delete" annotation to new ClusterDeployments.
+                Once a ClusterDeployment has been installed, a user must remove the
+                annotation from a ClusterDeployment prior to deleting it.
+              enum:
+              - enabled
+              type: string
             deprovisionsDisabled:
               description: DeprovisionsDisabled can be set to true to block deprovision
                 jobs from running.

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -133,6 +133,14 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helpe
 		hiveContainer.Env = append(hiveContainer.Env, tmpEnvVar)
 	}
 
+	if instance.Spec.DeleteProtection == hivev1.DeleteProtectionEnabled {
+		hLog.Info("Delete Protection enabled")
+		hiveContainer.Env = append(hiveContainer.Env, corev1.EnvVar{
+			Name:  hiveconstants.ProtectedDeleteEnvVar,
+			Value: "true",
+		})
+	}
+
 	if err := r.includeAdditionalCAs(hLog, h, instance, hiveDeployment); err != nil {
 		return err
 	}

--- a/pkg/test/generic/generic.go
+++ b/pkg/test/generic/generic.go
@@ -52,11 +52,13 @@ func WithAnnotationsPopulated() Option {
 	}
 }
 
+// WithAnnotation adds an annotation with the specified key and value to the supplied object.
+// If there is already an annotation with the specified key, it will be replaced.
 func WithAnnotation(key, value string) Option {
 	return func(meta hivev1.MetaRuntimeObject) {
 		annotations := meta.GetAnnotations()
 		if annotations == nil {
-			annotations = map[string]string{}
+			annotations = make(map[string]string, 1)
 		}
 		annotations[key] = value
 		meta.SetAnnotations(annotations)


### PR DESCRIPTION
The admission webhook for CluterDeployments has been modified to inspect DELETE requests as well. The webhook will reject any DELETE request for a ClusterDeployment that has the "hive.openshift.io/protected-delete" annotation set to a true value. In order to delete such a ClusterDeployment, a user is required to delete the annotation prior to making the DELETE request.

The "deleteProtection" field has been added to the HiveConfig. When the field is set to "enabled", the clusterdeployment controller will add the "hive.openshift.io/protected-delete" annotation to the ClusterDeployment when transitioning the ClusterDeployment to installed.

https://issues.redhat.com/browse/CO-277