### PR TITLE
Revert "validation: decode correct object on clusterdeployment delete"

### DIFF
--- a/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook.go
+++ b/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook.go
@@ -451,7 +451,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateDelete(request *admis
 	})
 
 	oldObject := &hivev1.ClusterDeployment{}
-	if err := a.decoder.DecodeRaw(request.OldObject, oldObject); err != nil {
+	if err := a.decoder.DecodeRaw(request.Object, oldObject); err != nil {
 		logger.Errorf("Failed unmarshaling Object: %v", err.Error())
 		return &admissionv1beta1.AdmissionResponse{
 			Allowed: false,

--- a/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
@@ -660,13 +660,13 @@ func TestClusterDeploymentValidate(t *testing.T) {
 		},
 		{
 			name:            "Test valid delete",
-			oldObject:       validAWSClusterDeployment(),
+			newObject:       validAWSClusterDeployment(),
 			operation:       admissionv1beta1.Delete,
 			expectedAllowed: true,
 		},
 		{
 			name: "Test protected delete",
-			oldObject: func() *hivev1.ClusterDeployment {
+			newObject: func() *hivev1.ClusterDeployment {
 				cd := validAWSClusterDeployment()
 				if cd.Annotations == nil {
 					cd.Annotations = make(map[string]string, 1)
@@ -679,7 +679,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 		},
 		{
 			name: "Test protected delete annotation false",
-			oldObject: func() *hivev1.ClusterDeployment {
+			newObject: func() *hivev1.ClusterDeployment {
 				cd := validAWSClusterDeployment()
 				if cd.Annotations == nil {
 					cd.Annotations = make(map[string]string, 1)


### PR DESCRIPTION
This reverts commit c7bd4f82be829456846e875909eac9ceda0685b5.

There are reports that it is still preventing deletes.

/cc @staebler 