### PR TITLE
Disable DNSZone relocation temporarily.

### DIFF
--- a/pkg/controller/utils/dnszone.go
+++ b/pkg/controller/utils/dnszone.go
@@ -67,6 +67,7 @@ func ReconcileDNSZoneForRelocation(c client.Client, logger log.FieldLogger, dnsZ
 	switch err := c.Get(context.TODO(), client.ObjectKey{Namespace: dnsZone.Namespace, Name: cdName}, cd); {
 	case apierrors.IsNotFound(err):
 		logger.Info("owning ClusterDeployment not found")
+		// TODO: returning a result here may be causing problems in situations where somehow, the clusterdeployment is already gone for this dnszone.
 		return &reconcile.Result{}, nil
 	case err != nil:
 		logger.WithError(err).Log(LogLevel(err), "could not get owning ClusterDeployment")


### PR DESCRIPTION
We are seeing stuck terminating namespaces in some of our environments,
it appears it is possible for the ClusterDeployment to be gone when
reconciling a deleted DNSZone, despite the owner reference with
blockOwnerDeletion.

Add metrics to track the force deletion of dnszones which was quietly
being handled despite possibly leaking resources.