### PR TITLE
Another attempt at clearing stuck DNSZones.

### DIFF
--- a/pkg/controller/dnsendpoint/dnsendpoint_controller.go
+++ b/pkg/controller/dnsendpoint/dnsendpoint_controller.go
@@ -188,8 +188,10 @@ func (r *ReconcileDNSEndpoint) Reconcile(request reconcile.Request) (reconcile.R
 	}
 
 	if result, err := controllerutils.ReconcileDNSZoneForRelocation(r.Client, dnsLog, instance, hivev1.FinalizerDNSEndpoint); err != nil {
+		dnsLog.WithError(err).Error("error reconciling dnszone for relocation")
 		return reconcile.Result{}, err
 	} else if result != nil {
+		dnsLog.Info("got result from reconcile dns zone for relocation")
 		return *result, nil
 	}
 

--- a/pkg/controller/dnszone/dnszone_controller.go
+++ b/pkg/controller/dnszone/dnszone_controller.go
@@ -140,8 +140,6 @@ func (r *ReconcileDNSZone) Reconcile(request reconcile.Request) (reconcile.Resul
 		return reconcile.Result{}, err
 	}
 
-	/* DISABLED TEMPORARILY: SEE https://issues.redhat.com/browse/CO-963
-
 	if result, err := controllerutils.ReconcileDNSZoneForRelocation(r.Client, dnsLog, desiredState, hivev1.FinalizerDNSZone); err != nil {
 		dnsLog.WithError(err).Error("error reconciling dnszone for relocation")
 		return reconcile.Result{}, err
@@ -149,7 +147,6 @@ func (r *ReconcileDNSZone) Reconcile(request reconcile.Request) (reconcile.Resul
 		dnsLog.Info("got result from reconcile dns zone for relocation")
 		return *result, nil
 	}
-	*/
 
 	// See if we need to sync. This is what rate limits our dns provider API usage, but allows for immediate syncing
 	// on spec changes and deletes.

--- a/pkg/controller/utils/dnszone.go
+++ b/pkg/controller/utils/dnszone.go
@@ -67,8 +67,9 @@ func ReconcileDNSZoneForRelocation(c client.Client, logger log.FieldLogger, dnsZ
 	switch err := c.Get(context.TODO(), client.ObjectKey{Namespace: dnsZone.Namespace, Name: cdName}, cd); {
 	case apierrors.IsNotFound(err):
 		logger.Info("owning ClusterDeployment not found")
-		// TODO: returning a result here may be causing problems in situations where somehow, the clusterdeployment is already gone for this dnszone.
-		return &reconcile.Result{}, nil
+		// TODO: verify this is safe, to allow the dns controllers to continue if the clusterdeployment is gone, which
+		// unfortunately appears to be possible
+		return nil, nil
 	case err != nil:
 		logger.WithError(err).Log(LogLevel(err), "could not get owning ClusterDeployment")
 		return &reconcile.Result{}, err

--- a/pkg/controller/utils/dnszone_test.go
+++ b/pkg/controller/utils/dnszone_test.go
@@ -73,7 +73,7 @@ func TestReconcileDNSZoneForRelocation(t *testing.T) {
 				).
 				Build(),
 			cd:           testcd.FullBuilder(testNamespace, testCDName, scheme).Build(),
-			expectResult: true,
+			expectResult: false,
 		},
 		{
 			name: "relocating clusterdeployment",


### PR DESCRIPTION
dnsendpoint controller used the same code recently disabled in dnszone
controller. It appears it is possible and common at least on 3.11 for
the ClusterDeployment to be deleted and gone, the namespace marked for
deletion, and but the DNSZone still hanging around, despite having an
owner ref with blockOwnerDeletion.