### PR TITLE
Block SyncSets with secret ref in another namespace.

### DIFF
--- a/pkg/controller/syncsetinstance/syncsetinstance_controller.go
+++ b/pkg/controller/syncsetinstance/syncsetinstance_controller.go
@@ -264,6 +264,15 @@ func (r *ReconcileSyncSetInstance) Reconcile(request reconcile.Request) (reconci
 		return reconcile.Result{}, err
 	}
 
+	// Prevent users with permissions to create a SyncSet from referencing Secrets in another namespace
+	// and copying them into their clusters. This should be caught in admission, but just incase we have
+	// a check here to refuse to reconcile. Error is logged but not returned as there's no point re-reconciling
+	// this unless the SyncSet is edited. This check is not relevant for SelectorSyncSets which have no namespace.
+	if r.hasSourceSecretsInAnotherNamespace(ssi, spec) {
+		ssiLog.Warn("syncsetinstance has a source secret in another namespace")
+		return reconcile.Result{}, nil
+	}
+
 	remoteClientBuilder := r.remoteClusterAPIClientBuilder(cd)
 	dynamicClient, unreachable, requeue := remoteclient.ConnectToRemoteClusterWithDynamicClient(
 		cd,
@@ -301,6 +310,19 @@ func (r *ReconcileSyncSetInstance) Reconcile(request reconcile.Request) (reconci
 
 	reapplyDuration := r.ssiReapplyDuration(ssi)
 	return reconcile.Result{RequeueAfter: reapplyDuration}, nil
+}
+
+func (r *ReconcileSyncSetInstance) hasSourceSecretsInAnotherNamespace(ssi *hivev1.SyncSetInstance, spec *hivev1.SyncSetCommonSpec) bool {
+	// This check is not relevant for SelectorSyncSets
+	if ssi.Spec.SyncSetRef == nil {
+		return false
+	}
+	for _, secret := range spec.Secrets {
+		if secret.SourceRef.Namespace != ssi.Namespace && secret.SourceRef.Namespace != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // ssiReapplyDuration returns the shortest time.Duration to meet reapplyInterval from successfully applied

--- a/pkg/controller/syncsetinstance/syncsetinstance_controller_test.go
+++ b/pkg/controller/syncsetinstance/syncsetinstance_controller_test.go
@@ -376,6 +376,22 @@ func TestSyncSetReconcile(t *testing.T) {
 			expectApplied: true,
 		},
 		{
+			name: "Skip syncset with secret references in another namespace",
+			existingObjs: []runtime.Object{
+				func() *corev1.Secret {
+					s := testSecret("foo", "bar")
+					s.Namespace = "anotherns"
+					return s
+				}(),
+			},
+			syncSet: func() *hivev1.SyncSet {
+				secretMapping := testSecretMapping("foo")
+				secretMapping.SourceRef.Namespace = "anotherns"
+				return testSyncSetWithSecretMappings("ss1", secretMapping)
+			}(),
+			expectApplied: false,
+		},
+		{
 			name:    "Local secret does not exist",
 			syncSet: testSyncSetWithSecretMappings("ss1", testSecretMapping("foo")),
 			validate: func(t *testing.T, ssi *hivev1.SyncSetInstance) {


### PR DESCRIPTION
Blocked during admission, but as a secondary check we also make sure not
to reconcile such a SyncSet and log a warning.

This change is not relevant for SelectorSyncSets which are cluster
scoped.