### PR TITLE
protect against accidental deletes of installed clusters

### DIFF
--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -70,6 +70,15 @@ spec:
                       type: boolean
                   type: object
               type: object
+            deleteProtection:
+              description: DeleteProtection can be set to "enabled" to turn on automatic
+                delete protection for ClusterDeployments. When enabled, Hive will
+                add the "hive.openshift.io/protected-delete" annotation to new ClusterDeployments.
+                Once a ClusterDeployment has been installed, a user must remove the
+                annotation from a ClusterDeployment prior to deleting it.
+              enum:
+              - enabled
+              type: string
             deprovisionsDisabled:
               description: DeprovisionsDisabled can be set to true to block deprovision
                 jobs from running.

--- a/config/hiveadmission/clusterdeployment-webhook.yaml
+++ b/config/hiveadmission/clusterdeployment-webhook.yaml
@@ -15,6 +15,7 @@ webhooks:
   - operations:
     - CREATE
     - UPDATE
+    - DELETE
     apiGroups:
     - hive.openshift.io
     apiVersions:

--- a/pkg/apis/hive/v1/hiveconfig_types.go
+++ b/pkg/apis/hive/v1/hiveconfig_types.go
@@ -66,6 +66,14 @@ type HiveConfigSpec struct {
 
 	// DeprovisionsDisabled can be set to true to block deprovision jobs from running.
 	DeprovisionsDisabled *bool `json:"deprovisionsDisabled,omitempty"`
+
+	// DeleteProtection can be set to "enabled" to turn on automatic delete protection for ClusterDeployments. When
+	// enabled, Hive will add the "hive.openshift.io/protected-delete" annotation to new ClusterDeployments. Once a
+	// ClusterDeployment has been installed, a user must remove the annotation from a ClusterDeployment prior to
+	// deleting it.
+	// +kubebuilder:validation:Enum=enabled
+	// +optional
+	DeleteProtection DeleteProtectionType `json:"deleteProtection,omitempty"`
 }
 
 // HiveConfigStatus defines the observed state of Hive
@@ -160,6 +168,12 @@ type ManageDNSGCPConfig struct {
 	// +optional
 	CredentialsSecretRef corev1.LocalObjectReference `json:"credentialsSecretRef,omitempty"`
 }
+
+type DeleteProtectionType string
+
+const (
+	DeleteProtectionEnabled DeleteProtectionType = "enabled"
+)
 
 // +genclient:nonNamespaced
 // +genclient

--- a/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook.go
+++ b/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook.go
@@ -450,6 +450,14 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateDelete(request *admis
 		"method":    "validateDelete",
 	})
 
+	// If running on OpenShift 3.11, OldObject will not be populated. All we can do is accept the DELETE request.
+	if len(request.OldObject.Raw) == 0 {
+		logger.Info("Cannot validate the DELETE since OldObject is empty")
+		return &admissionv1beta1.AdmissionResponse{
+			Allowed: true,
+		}
+	}
+
 	oldObject := &hivev1.ClusterDeployment{}
 	if err := a.decoder.DecodeRaw(request.OldObject, oldObject); err != nil {
 		logger.Errorf("Failed unmarshaling Object: %v", err.Error())

--- a/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
@@ -690,6 +690,12 @@ func TestClusterDeploymentValidate(t *testing.T) {
 			operation:       admissionv1beta1.Delete,
 			expectedAllowed: true,
 		},
+		{
+			name:            "Test delete on OpenShift 3.11",
+			oldObject:       nil,
+			operation:       admissionv1beta1.Delete,
+			expectedAllowed: true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
@@ -658,6 +658,38 @@ func TestClusterDeploymentValidate(t *testing.T) {
 			operation:       admissionv1beta1.Create,
 			expectedAllowed: true,
 		},
+		{
+			name:            "Test valid delete",
+			oldObject:       validAWSClusterDeployment(),
+			operation:       admissionv1beta1.Delete,
+			expectedAllowed: true,
+		},
+		{
+			name: "Test protected delete",
+			oldObject: func() *hivev1.ClusterDeployment {
+				cd := validAWSClusterDeployment()
+				if cd.Annotations == nil {
+					cd.Annotations = make(map[string]string, 1)
+				}
+				cd.Annotations[constants.ProtectedDeleteAnnotation] = "true"
+				return cd
+			}(),
+			operation:       admissionv1beta1.Delete,
+			expectedAllowed: false,
+		},
+		{
+			name: "Test protected delete annotation false",
+			oldObject: func() *hivev1.ClusterDeployment {
+				cd := validAWSClusterDeployment()
+				if cd.Annotations == nil {
+					cd.Annotations = make(map[string]string, 1)
+				}
+				cd.Annotations[constants.ProtectedDeleteAnnotation] = "false"
+				return cd
+			}(),
+			operation:       admissionv1beta1.Delete,
+			expectedAllowed: true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -128,6 +128,14 @@ const (
 	// for the cluster provision to complete by running `openshift-install wait-for install-complete` command.
 	WaitForInstallCompleteExecutionsAnnotation = "hive.openshift.io/wait-for-install-complete-executions"
 
+	// ProtectedDeleteAnnotation is an annotation used on ClusterDeployments to indicate that the ClusterDeployment
+	// cannot be deleted. The annotation must be removed in order to delete the ClusterDeployment.
+	ProtectedDeleteAnnotation = "hive.openshift.io/protected-delete"
+
+	// ProtectedDeleteEnvVar is the name of the environment variable used to tell the controller manager whether
+	// protected delete is enabled.
+	ProtectedDeleteEnvVar = "PROTECTED_DELETE"
+
 	// ManagedDomainsFileEnvVar if present, points to a simple text
 	// file that includes a valid managed domain per line. Cluster deployments
 	// requesting that their domains be managed must have a base domain

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -155,6 +156,13 @@ func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 	r.remoteClusterAPIClientBuilder = func(cd *hivev1.ClusterDeployment) remoteclient.Builder {
 		return remoteclient.NewBuilder(r.Client, cd, controllerName)
 	}
+
+	protectedDeleteEnvVar := os.Getenv(constants.ProtectedDeleteEnvVar)
+	if protectedDelete, err := strconv.ParseBool(protectedDeleteEnvVar); protectedDelete && err == nil {
+		logger.Info("Protected Delete enabled")
+		r.protectedDelete = true
+	}
+
 	return r
 }
 
@@ -248,6 +256,8 @@ type ReconcileClusterDeployment struct {
 	// remoteClusterAPIClientBuilder is a function pointer to the function that gets a builder for building a client
 	// for the remote cluster's API server
 	remoteClusterAPIClientBuilder func(cd *hivev1.ClusterDeployment) remoteclient.Builder
+
+	protectedDelete bool
 }
 
 // Reconcile reads that state of the cluster for a ClusterDeployment object and makes changes based on the state read
@@ -807,6 +817,13 @@ func (r *ReconcileClusterDeployment) reconcileCompletedProvision(cd *hivev1.Clus
 	}
 
 	cd.Spec.Installed = true
+
+	if r.protectedDelete {
+		if _, annotationPresent := cd.Annotations[constants.ProtectedDeleteAnnotation]; !annotationPresent {
+			initializeAnnotations(cd)
+			cd.Annotations[constants.ProtectedDeleteAnnotation] = "true"
+		}
+	}
 
 	if err := r.Update(context.TODO(), cd); err != nil {
 		cdLog.WithError(err).Log(controllerutils.LogLevel(err), "failed to set the Installed flag")

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -819,6 +819,10 @@ func (r *ReconcileClusterDeployment) reconcileCompletedProvision(cd *hivev1.Clus
 	cd.Spec.Installed = true
 
 	if r.protectedDelete {
+		// Set protected delete on for the ClusterDeployment.
+		// If the ClusterDeployment already has the ProtectedDelete annotation, do not overwrite it. This allows the
+		// user an opportunity to explicitly exclude a ClusterDeployment from delete protection at the time of
+		// creation of the ClusterDeployment.
 		if _, annotationPresent := cd.Annotations[constants.ProtectedDeleteAnnotation]; !annotationPresent {
 			initializeAnnotations(cd)
 			cd.Annotations[constants.ProtectedDeleteAnnotation] = "true"
@@ -1161,6 +1165,10 @@ func (r *ReconcileClusterDeployment) ensureManagedDNSZoneDeleted(cd *hivev1.Clus
 }
 
 func (r *ReconcileClusterDeployment) syncDeletedClusterDeployment(cd *hivev1.ClusterDeployment, cdLog log.FieldLogger) (reconcile.Result, error) {
+	if controllerutils.IsDeleteProtected(cd) {
+		cdLog.Error("deprovision blocked for ClusterDeployment with protected delete on")
+		return reconcile.Result{}, nil
+	}
 
 	result, err := r.ensureManagedDNSZoneDeleted(cd, cdLog)
 	if result != nil {

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
@@ -190,6 +190,10 @@ func (r *ReconcileClusterDeprovision) Reconcile(request reconcile.Request) (reco
 		rLog.Error("ClusterDeprovision created for ClusterDeployment that has not been deleted")
 		return reconcile.Result{}, nil
 	}
+	if controllerutils.IsDeleteProtected(cd) {
+		rLog.Error("deprovision blocked for ClusterDeployment with protected delete on")
+		return reconcile.Result{}, nil
+	}
 
 	// Check if deprovisions are currently disabled: (originates in HiveConfig in real world)
 	if r.deprovisionsDisabled {

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller_test.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller_test.go
@@ -84,6 +84,22 @@ func TestClusterDeprovisionReconcile(t *testing.T) {
 			expectErr: true,
 		},
 		{
+			name:        "no-op if cluster deployment has delete protection on",
+			deprovision: testClusterDeprovision(),
+			deployment: func() *hivev1.ClusterDeployment {
+				cd := testClusterDeployment()
+				if cd.Annotations == nil {
+					cd.Annotations = make(map[string]string, 1)
+				}
+				cd.Annotations[constants.ProtectedDeleteAnnotation] = "true"
+				return cd
+			}(),
+			validate: func(t *testing.T, c client.Client) {
+				validateNoJobExists(t, c)
+			},
+			expectErr: true,
+		},
+		{
 			name:        "create uninstall job",
 			deprovision: testClusterDeprovision(),
 			deployment:  testDeletedClusterDeployment(),

--- a/pkg/controller/utils/clusterdeployment.go
+++ b/pkg/controller/utils/clusterdeployment.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"strconv"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
+)
+
+func IsDeleteProtected(cd *hivev1.ClusterDeployment) bool {
+	protectedDelete, err := strconv.ParseBool(cd.Annotations[constants.ProtectedDeleteAnnotation])
+	return protectedDelete && err == nil
+}

--- a/pkg/controller/utils/clusterdeployment_test.go
+++ b/pkg/controller/utils/clusterdeployment_test.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openshift/hive/pkg/constants"
+	"github.com/openshift/hive/pkg/test/clusterdeployment"
+	"github.com/openshift/hive/pkg/test/generic"
+)
+
+func TestIsDeleteProtected(t *testing.T) {
+	cases := []struct {
+		name           string
+		absent         bool
+		value          string
+		expectedResult bool
+	}{
+		{
+			name:           "absent",
+			absent:         true,
+			expectedResult: false,
+		},
+		{
+			name:           "true",
+			value:          "true",
+			expectedResult: true,
+		},
+		{
+			name:           "false",
+			value:          "false",
+			expectedResult: false,
+		},
+		{
+			name:           "empty",
+			value:          "",
+			expectedResult: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var options []clusterdeployment.Option
+			if !tc.absent {
+				options = append(
+					options,
+					clusterdeployment.Generic(generic.WithAnnotation(constants.ProtectedDeleteAnnotation, tc.value)),
+				)
+			}
+			cd := clusterdeployment.Build(options...)
+			actualResult := IsDeleteProtected(cd)
+			assert.Equal(t, tc.expectedResult, actualResult, "unexpected result")
+		})
+	}
+}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -383,6 +383,7 @@ webhooks:
   - operations:
     - CREATE
     - UPDATE
+    - DELETE
     apiGroups:
     - hive.openshift.io
     apiVersions:
@@ -8945,6 +8946,15 @@ spec:
                       type: boolean
                   type: object
               type: object
+            deleteProtection:
+              description: DeleteProtection can be set to "enabled" to turn on automatic
+                delete protection for ClusterDeployments. When enabled, Hive will
+                add the "hive.openshift.io/protected-delete" annotation to new ClusterDeployments.
+                Once a ClusterDeployment has been installed, a user must remove the
+                annotation from a ClusterDeployment prior to deleting it.
+              enum:
+              - enabled
+              type: string
             deprovisionsDisabled:
               description: DeprovisionsDisabled can be set to true to block deprovision
                 jobs from running.

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -133,6 +133,14 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helpe
 		hiveContainer.Env = append(hiveContainer.Env, tmpEnvVar)
 	}
 
+	if instance.Spec.DeleteProtection == hivev1.DeleteProtectionEnabled {
+		hLog.Info("Delete Protection enabled")
+		hiveContainer.Env = append(hiveContainer.Env, corev1.EnvVar{
+			Name:  hiveconstants.ProtectedDeleteEnvVar,
+			Value: "true",
+		})
+	}
+
 	if err := r.includeAdditionalCAs(hLog, h, instance, hiveDeployment); err != nil {
 		return err
 	}

--- a/pkg/test/generic/generic.go
+++ b/pkg/test/generic/generic.go
@@ -52,11 +52,13 @@ func WithAnnotationsPopulated() Option {
 	}
 }
 
+// WithAnnotation adds an annotation with the specified key and value to the supplied object.
+// If there is already an annotation with the specified key, it will be replaced.
 func WithAnnotation(key, value string) Option {
 	return func(meta hivev1.MetaRuntimeObject) {
 		annotations := meta.GetAnnotations()
 		if annotations == nil {
-			annotations = map[string]string{}
+			annotations = make(map[string]string, 1)
 		}
 		annotations[key] = value
 		meta.SetAnnotations(annotations)


### PR DESCRIPTION
The admission webhook for CluterDeployments has been modified to inspect
DELETE requests as well. The webhook will reject any DELETE request for
a ClusterDeployment that has the "hive.openshift.io/protected-delete" annotation
set to a true value. In order to delete such a ClusterDeployment, a user
is required to delete the annotation prior to making the DELETE request.

The "deleteProtection" field has been added to the HiveConfig. When the
field is set to "enabled", the clusterdeployment controller will add the
"hive.openshift.io/protected-delete" annotation to the ClusterDeployment
when transitioning the ClusterDeployment to installed.

https://issues.redhat.com/browse/CO-277