### PR TITLE
ClusterRelocate to move ClusterDeployments between Hive instances

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openshift/hive/pkg/controller/clusterdeployment"
 	"github.com/openshift/hive/pkg/controller/clusterdeprovision"
 	"github.com/openshift/hive/pkg/controller/clusterprovision"
+	"github.com/openshift/hive/pkg/controller/clusterrelocate"
 	"github.com/openshift/hive/pkg/controller/clusterstate"
 	"github.com/openshift/hive/pkg/controller/clusterversion"
 	"github.com/openshift/hive/pkg/controller/controlplanecerts"
@@ -63,6 +64,7 @@ var controllerFuncs = map[string]controllerSetupFunc{
 	clusterdeployment.ControllerName:    clusterdeployment.Add,
 	clusterdeprovision.ControllerName:   clusterdeprovision.Add,
 	clusterprovision.ControllerName:     clusterprovision.Add,
+	clusterrelocate.ControllerName:      clusterrelocate.Add,
 	clusterstate.ControllerName:         clusterstate.Add,
 	clusterversion.ControllerName:       clusterversion.Add,
 	controlplanecerts.ControllerName:    controlplanecerts.Add,

--- a/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -431,6 +431,19 @@ type CertificateBundleStatus struct {
 	Generated bool `json:"generated"`
 }
 
+// RelocateStatus is the status of a cluster relocate.
+// This is used in the value of the "hive.openshift.io/relocate" annotation.
+type RelocateStatus string
+
+const (
+	// RelocateOutgoing indicates that a resource is on the source side of an in-progress relocate
+	RelocateOutgoing RelocateStatus = "outgoing"
+	// RelocateComplete indicates that a resource is on the source side of a completed relocate
+	RelocateComplete RelocateStatus = "complete"
+	// RelocateIncoming indicates that a resource is on the destination side of an in-progress relocate
+	RelocateIncoming RelocateStatus = "incoming"
+)
+
 func init() {
 	SchemeBuilder.Register(&ClusterDeployment{}, &ClusterDeploymentList{})
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -140,6 +140,16 @@ const (
 	// protected delete is enabled.
 	ProtectedDeleteEnvVar = "PROTECTED_DELETE"
 
+	// RelocateAnnotation is an annotation used on ClusterDeployments and DNSZones to indicate that the resource
+	// is involved in a relocation between Hive instances.
+	// The value of the annotation has the format "{ClusterRelocate}/{Status}", where
+	// {ClusterRelocate} is the name of the ClusterRelocate that is driving the relocation and
+	// {Status} is the status of the relocate. The status is outgoing, completed, or incoming.
+	// An outgoing status indicates that the resource is on the source side of an in-progress relocate.
+	// A completed status indicates that the resource is on the source side of a completed relocate.
+	// An incoming status indicates that the resource is on the destination side of an in-progress relocate.
+	RelocateAnnotation = "hive.openshift.io/relocate"
+
 	// ManagedDomainsFileEnvVar if present, points to a simple text
 	// file that includes a valid managed domain per line. Cluster deployments
 	// requesting that their domains be managed must have a base domain

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -531,6 +531,19 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 		return reconcile.Result{}, nil
 	}
 
+	// If the ClusterDeployment is being relocated to another Hive instance, stop any current provisioning and do not
+	// do any more reconciling.
+	switch _, relocateStatus, err := controllerutils.IsRelocating(cd); {
+	case err != nil:
+		return reconcile.Result{}, errors.Wrap(err, "could not determine relocate status")
+	case relocateStatus == hivev1.RelocateOutgoing:
+		result, err := r.stopProvisioning(cd, cdLog)
+		if result == nil {
+			result = &reconcile.Result{}
+		}
+		return *result, err
+	}
+
 	// Indicate that the cluster is still installing:
 	hivemetrics.MetricClusterDeploymentProvisionUnderwaySeconds.WithLabelValues(
 		cd.Name,
@@ -1173,39 +1186,40 @@ func (r *ReconcileClusterDeployment) ensureManagedDNSZoneDeleted(cd *hivev1.Clus
 }
 
 func (r *ReconcileClusterDeployment) syncDeletedClusterDeployment(cd *hivev1.ClusterDeployment, cdLog log.FieldLogger) (reconcile.Result, error) {
+	switch _, relocateStatus, err := controllerutils.IsRelocating(cd); {
+	case err != nil:
+		cdLog.WithError(err).Error("could not determine relocate status")
+		return reconcile.Result{}, errors.Wrap(err, "could not determine relocate status")
+	case relocateStatus == hivev1.RelocateComplete:
+		cdLog.Info("clusterdeployment relocated, removing finalizer")
+		err := r.removeClusterDeploymentFinalizer(cd, cdLog)
+		if err != nil {
+			cdLog.WithError(err).Log(controllerutils.LogLevel(err), "error removing finalizer")
+		}
+		return reconcile.Result{}, err
+	case relocateStatus != "":
+		cdLog.Debug("ClusterDeployment is in the middle of a relocate. Wait until relocate has been completed or aborted before doing finalization.")
+		return reconcile.Result{}, nil
+	}
+
 	if controllerutils.IsDeleteProtected(cd) {
 		cdLog.Error("deprovision blocked for ClusterDeployment with protected delete on")
 		return reconcile.Result{}, nil
 	}
 
-	result, err := r.ensureManagedDNSZoneDeleted(cd, cdLog)
-	if result != nil {
+	switch result, err := r.ensureManagedDNSZoneDeleted(cd, cdLog); {
+	case result != nil:
 		return *result, err
-	}
-	if err != nil {
+	case err != nil:
 		return reconcile.Result{}, err
 	}
 
 	// Wait for outstanding provision to be removed before creating deprovision request
-	if cd.Status.ProvisionRef != nil {
-		provision := &hivev1.ClusterProvision{}
-		switch err := r.Get(context.TODO(), types.NamespacedName{Name: cd.Status.ProvisionRef.Name, Namespace: cd.Namespace}, provision); {
-		case apierrors.IsNotFound(err):
-			cdLog.Debug("linked provision removed")
-		case err != nil:
-			cdLog.WithError(err).Error("could not get provision")
-			return reconcile.Result{}, err
-		case provision.DeletionTimestamp == nil:
-			if err := r.Delete(context.TODO(), provision); err != nil {
-				cdLog.WithError(err).Log(controllerutils.LogLevel(err), "could not delete provision")
-				return reconcile.Result{}, err
-			}
-			cdLog.Info("deleted outstanding provision")
-			return reconcile.Result{RequeueAfter: defaultRequeueTime}, nil
-		default:
-			cdLog.Debug("still waiting for outstanding provision to be removed")
-			return reconcile.Result{RequeueAfter: defaultRequeueTime}, nil
-		}
+	switch result, err := r.stopProvisioning(cd, cdLog); {
+	case result != nil:
+		return *result, err
+	case err != nil:
+		return reconcile.Result{}, err
 	}
 
 	// Skips creation of deprovision request if PreserveOnDelete is true and cluster is installed
@@ -1213,7 +1227,7 @@ func (r *ReconcileClusterDeployment) syncDeletedClusterDeployment(cd *hivev1.Clu
 		if cd.Spec.Installed {
 			cdLog.Warn("skipping creation of deprovisioning request for installed cluster due to PreserveOnDelete=true")
 			if controllerutils.HasFinalizer(cd, hivev1.FinalizerDeprovision) {
-				err = r.removeClusterDeploymentFinalizer(cd, cdLog)
+				err := r.removeClusterDeploymentFinalizer(cd, cdLog)
 				if err != nil {
 					cdLog.WithError(err).Log(controllerutils.LogLevel(err), "error removing finalizer")
 				}
@@ -1228,7 +1242,7 @@ func (r *ReconcileClusterDeployment) syncDeletedClusterDeployment(cd *hivev1.Clu
 
 	if cd.Spec.ClusterMetadata == nil {
 		cdLog.Warn("skipping uninstall for cluster that never had clusterID set")
-		err = r.removeClusterDeploymentFinalizer(cd, cdLog)
+		err := r.removeClusterDeploymentFinalizer(cd, cdLog)
 		if err != nil {
 			cdLog.WithError(err).Log(controllerutils.LogLevel(err), "error removing finalizer")
 		}
@@ -1309,6 +1323,31 @@ func (r *ReconcileClusterDeployment) syncDeletedClusterDeployment(cd *hivev1.Clu
 	cdLog.Debug("deprovision request not yet completed")
 
 	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileClusterDeployment) stopProvisioning(cd *hivev1.ClusterDeployment, cdLog log.FieldLogger) (*reconcile.Result, error) {
+	if cd.Status.ProvisionRef == nil {
+		return nil, nil
+	}
+	provision := &hivev1.ClusterProvision{}
+	switch err := r.Get(context.TODO(), types.NamespacedName{Name: cd.Status.ProvisionRef.Name, Namespace: cd.Namespace}, provision); {
+	case apierrors.IsNotFound(err):
+		cdLog.Debug("linked provision removed")
+		return nil, nil
+	case err != nil:
+		cdLog.WithError(err).Error("could not get provision")
+		return nil, err
+	case provision.DeletionTimestamp == nil:
+		if err := r.Delete(context.TODO(), provision); err != nil {
+			cdLog.WithError(err).Log(controllerutils.LogLevel(err), "could not delete provision")
+			return nil, err
+		}
+		cdLog.Info("deleted outstanding provision")
+		return &reconcile.Result{RequeueAfter: defaultRequeueTime}, nil
+	default:
+		cdLog.Debug("still waiting for outstanding provision to be removed")
+		return &reconcile.Result{RequeueAfter: defaultRequeueTime}, nil
+	}
 }
 
 func (r *ReconcileClusterDeployment) addClusterDeploymentFinalizer(cd *hivev1.ClusterDeployment) error {

--- a/pkg/controller/clusterrelocate/clientwrapper_test.go
+++ b/pkg/controller/clusterrelocate/clientwrapper_test.go
@@ -1,0 +1,26 @@
+package clusterrelocate
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type deleteBlockingClientWrapper struct {
+	client.Client
+}
+
+var _ client.Client = (*deleteBlockingClientWrapper)(nil)
+
+func (c *deleteBlockingClientWrapper) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+	a, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	now := metav1.Now()
+	a.SetDeletionTimestamp(&now)
+	return c.Update(ctx, obj)
+}

--- a/pkg/controller/clusterrelocate/clusterrelocate_controller.go
+++ b/pkg/controller/clusterrelocate/clusterrelocate_controller.go
@@ -1,0 +1,826 @@
+package clusterrelocate
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+	"github.com/openshift/hive/pkg/remoteclient"
+)
+
+const (
+	ControllerName = "clusterRelocate"
+)
+
+var (
+	typesToCopy = func() []runtime.Object {
+		return []runtime.Object{
+			&corev1.SecretList{},
+			&corev1.ConfigMapList{},
+			&hivev1.MachinePoolList{},
+			&hivev1.SyncSetList{},
+			&hivev1.SyncIdentityProviderList{},
+		}
+	}
+
+	metricSuccessfulClusterRelocations = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "hive_cluster_relocations",
+		Help: "Total number of successful cluster relocations.",
+	}, []string{"cluster_relocate"})
+
+	metricAbortedClusterRelocations = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "hive_aborted_cluster_relocations",
+		Help: "Total number of aborted cluster relocations.",
+	}, []string{"cluster_relocate", "reason"})
+)
+
+func init() {
+	metrics.Registry.MustRegister(metricSuccessfulClusterRelocations)
+	metrics.Registry.MustRegister(metricAbortedClusterRelocations)
+}
+
+// Add creates a new ClusterRelocate controller and adds it to the manager with default RBAC.
+func Add(mgr manager.Manager) error {
+	logger := log.WithField("controller", ControllerName)
+	r := &ReconcileClusterRelocate{
+		Client: controllerutils.NewClientWithMetricsOrDie(mgr, ControllerName),
+		logger: logger,
+	}
+	r.remoteClusterAPIClientBuilder = func(secret *corev1.Secret) remoteclient.Builder {
+		return remoteclient.NewBuilderFromKubeconfig(r.Client, secret)
+	}
+
+	c, err := controller.New("clusterrelocate-controller", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: controllerutils.GetConcurrentReconciles()})
+	if err != nil {
+		logger.WithError(err).Error("error creating controller")
+		return err
+	}
+
+	// Watch for changes to ClusterDeployment
+	if err := c.Watch(&source.Kind{Type: &hivev1.ClusterDeployment{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		logger.WithError(err).Error("Error watching ClusterDeployment")
+		return err
+	}
+
+	// Watch for changes to ClusterRelocate
+	if err := c.Watch(&source.Kind{Type: &hivev1.ClusterRelocate{}}, &handler.EnqueueRequestsFromMapFunc{
+		ToRequests: handler.ToRequestsFunc(r.clusterRelocateHandlerFunc),
+	}); err != nil {
+		logger.WithError(err).Error("Error watching ClusterRelocate")
+		return err
+	}
+
+	return nil
+}
+
+func (r *ReconcileClusterRelocate) clusterRelocateHandlerFunc(a handler.MapObject) (requests []reconcile.Request) {
+	clusterRelocate := a.Object.(*hivev1.ClusterRelocate)
+
+	labelSelector, err := metav1.LabelSelectorAsSelector(&clusterRelocate.Spec.ClusterDeploymentSelector)
+	if err != nil {
+		r.logger.WithError(err).
+			WithField("clusterRelocate", clusterRelocate.Name).
+			Warn("cannot parse clusterdeployment selector")
+		return
+	}
+
+	clusterDeployments := &hivev1.ClusterDeploymentList{}
+	if err := r.List(context.Background(), clusterDeployments); err != nil {
+		r.logger.WithError(err).
+			WithField("clusterRelocate", clusterRelocate.Name).
+			Log(controllerutils.LogLevel(err), "failed to list clusterdeployments")
+		return
+	}
+
+	for _, cd := range clusterDeployments.Items {
+		if relocateName, _, _ := controllerutils.IsRelocating(&cd); relocateName != clusterRelocate.Name &&
+			!labelSelector.Matches(labels.Set(cd.Labels)) {
+			continue
+		}
+		requests = append(requests,
+			reconcile.Request{NamespacedName: types.NamespacedName{Name: cd.Name, Namespace: cd.Namespace}})
+	}
+
+	return
+}
+
+// ReconcileClusterRelocate is the reconciler for ClusterRelocate. It will sync on ClusterDeployment resources
+// and relocate those that match with a ClusterRelocate.
+type ReconcileClusterRelocate struct {
+	client.Client
+	logger log.FieldLogger
+
+	// remoteClusterAPIClientBuilder is a function pointer to the function that gets a builder for building a client
+	// for the remote cluster's API server
+	remoteClusterAPIClientBuilder func(secret *corev1.Secret) remoteclient.Builder
+}
+
+// Reconcile relocates ClusterDeployments matching with a ClusterRelocate to another Hive instance.
+func (r *ReconcileClusterRelocate) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	start := time.Now()
+	logger := r.logger.WithFields(log.Fields{
+		"controller":        ControllerName,
+		"clusterDeployment": request.NamespacedName.String(),
+	})
+
+	// For logging, we need to see when the reconciliation loop starts and ends.
+	logger.Info("reconciling cluster deployment")
+	defer func() {
+		dur := time.Since(start)
+		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName).Observe(dur.Seconds())
+		logger.WithField("elapsed", dur).Info("reconcile complete")
+	}()
+
+	// Fetch the ClusterDeployment instance
+	cd := &hivev1.ClusterDeployment{}
+	err := r.Get(context.TODO(), request.NamespacedName, cd)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Debug("cluster deployment not found")
+			return reconcile.Result{}, nil
+		}
+		logger.WithError(err).Error("Error getting cluster deployment")
+		return reconcile.Result{}, err
+	}
+
+	currentRelocateName, relocateStatus, err := controllerutils.IsRelocating(cd)
+	if err != nil {
+		logger.WithError(err).Error("could not determine relocate status")
+		return reconcile.Result{}, errors.Wrap(err, "could not determine relocate status")
+	}
+
+	// Complete the relocation on the destination side.
+	// The ClusterDeployment is the last resource copied during a relocation. Since the ClusterDeployment is marked as
+	// incoming, then this is the destination side of the relocation. As such, the relocation has been complete. All
+	// that is left to do, on the destination side, is to remove the relocate annotations from the ClusterDeployment and
+	// DNSZone.
+	if relocateStatus == hivev1.RelocateIncoming {
+		logger.Info("incoming relocation has completed")
+		if err := r.stopRelocating(cd, currentRelocateName, logger); err != nil {
+			return reconcile.Result{}, errors.Wrap(err, "failed to stop relocating")
+		}
+		// clear the current relocate name since the relocate has been completed and is no longer current
+		currentRelocateName = ""
+	}
+
+	if cd.DeletionTimestamp != nil {
+		// Stop relocating if the ClusterDeployment was deleted prior to completing the relocation
+		if relocateStatus == hivev1.RelocateOutgoing {
+			logger.Info("outgoing relocation aborted because ClusterDeployment was deleted")
+			if err := r.stopRelocating(cd, currentRelocateName, logger); err != nil {
+				return reconcile.Result{}, errors.Wrap(err, "failed to stop relocating")
+			}
+		} else {
+			logger.Debug("skipping deleted clusterdeployment")
+		}
+		return reconcile.Result{}, err
+	}
+
+	// Skip any copying actions for ClusterDeployment that has already been relocated
+	if relocateStatus == hivev1.RelocateComplete {
+		return r.finishRelocateCompletion(cd, currentRelocateName, logger)
+	}
+
+	desiredRelocates, err := r.findMatchingRelocates(cd, logger)
+	if err != nil {
+		logger.WithError(err).Error("could not find matching relocates")
+		return reconcile.Result{}, errors.Wrap(err, "could not find matching relocates")
+	}
+
+	// Do not do any relocation for a ClusterDeployment that does not match with exactly one ClusterRelocate
+	if len(desiredRelocates) != 1 {
+		return r.reconcileNoSingleMatch(cd, currentRelocateName, desiredRelocates, logger)
+	}
+
+	return r.reconcileSingleMatch(cd, relocateStatus, currentRelocateName, desiredRelocates[0], logger)
+}
+
+func (r *ReconcileClusterRelocate) reconcileSingleMatch(cd *hivev1.ClusterDeployment, oldRelocateStatus hivev1.RelocateStatus, oldRelocateName string, desiredRelocate *hivev1.ClusterRelocate, logger log.FieldLogger) (reconcile.Result, error) {
+	// Abort an in-progress relocate when the ClusterDeployment matches a different ClusterRelocate
+	if oldRelocateStatus == hivev1.RelocateOutgoing && oldRelocateName != desiredRelocate.Name {
+		logger.WithField("currentClusterRelocate", oldRelocateName).
+			WithField("desiredClusterRelocate", desiredRelocate.Name).
+			Warn("switching relocation")
+		if err := r.stopRelocating(cd, oldRelocateName, logger); err != nil {
+			return reconcile.Result{}, err
+		}
+		recordMetricForAbortedRelocate(oldRelocateName, "new_match")
+	}
+
+	logger = logger.WithField("clusterRelocate", desiredRelocate.Name)
+
+	kubeconfigSecret := &corev1.Secret{}
+	if err := r.Get(
+		context.Background(),
+		client.ObjectKey{
+			Namespace: desiredRelocate.Spec.KubeconfigSecretRef.Namespace,
+			Name:      desiredRelocate.Spec.KubeconfigSecretRef.Name,
+		},
+		kubeconfigSecret,
+	); err != nil {
+		logger.WithError(err).Log(controllerutils.LogLevel(err), "failed to get kubeconfig secret")
+		r.setRelocationFailedCondition(
+			cd,
+			corev1.ConditionTrue,
+			"MissingKubeconfigSecret",
+			fmt.Sprintf("missing kubeconfig secret for destination cluster: %v", err),
+			logger,
+		)
+		// return the error getting the kubeconfig secret rather than the update error
+		return reconcile.Result{}, errors.Wrap(err, "failed to get kubeconfig secret")
+	}
+
+	destClient, err := r.remoteClusterAPIClientBuilder(kubeconfigSecret).Build()
+	if err != nil {
+		logger.WithError(err).Warn("could not create a client for the destination cluster")
+		r.setRelocationFailedCondition(
+			cd,
+			corev1.ConditionTrue,
+			"NoConnection",
+			fmt.Sprintf("could not connect to destination cluster: %v", err),
+			logger,
+		)
+		// return the error making the remote connection rather than the update error
+		return reconcile.Result{}, errors.Wrap(err, "could not create a client for the destination cluster")
+	}
+
+	switch proceed, completed, err := r.checkForExistingClusterDeployment(cd, destClient, logger); {
+	case err != nil:
+		return reconcile.Result{}, err
+	case completed:
+		return r.finishRelocateCompletion(cd, desiredRelocate.Name, logger)
+	case !proceed:
+		return reconcile.Result{}, nil
+	}
+
+	if err := r.setRelocateAnnotation(cd, desiredRelocate.Name, hivev1.RelocateOutgoing, logger); err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "could not set relocate status to outgoing")
+	}
+
+	// Copy resources to destination cluster
+	if err := r.copy(cd, destClient, logger); err != nil {
+		r.setRelocationFailedCondition(
+			cd,
+			corev1.ConditionTrue,
+			"MoveFailed",
+			err.Error(),
+			logger,
+		)
+		// return the move error rather than the update error
+		return reconcile.Result{}, err
+	}
+
+	return r.finishRelocateCompletion(cd, desiredRelocate.Name, logger)
+}
+
+// setRelocateAnnotation sets the relocate annotation on the ClusterDeployment as well as on the child DNSZone, if there
+// is one.
+func (r *ReconcileClusterRelocate) setRelocateAnnotation(cd *hivev1.ClusterDeployment, relocateName string, status hivev1.RelocateStatus, logger log.FieldLogger) error {
+	dnsZone, err := r.dnsZone(cd, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to get DNSZone")
+	}
+
+	var objects []hivev1.MetaRuntimeObject
+	if dnsZone != nil {
+		// If setting to complete or clearing, do the DNSZone first. This ensures that if there is an error setting the
+		// annotation on the DNSZone, that it will be re-attempting on the next reconcile. If the ClusterDeployment is set
+		// first, then the next reconcile will not see that there is anything that needs to be done since the
+		// ClusterDeployment will already have the annotation in the right state.
+		if status == hivev1.RelocateComplete {
+			objects = []hivev1.MetaRuntimeObject{dnsZone, cd}
+		} else {
+			objects = []hivev1.MetaRuntimeObject{cd, dnsZone}
+		}
+	} else {
+		objects = []hivev1.MetaRuntimeObject{cd}
+	}
+
+	for _, obj := range objects {
+		if changed := controllerutils.SetRelocateAnnotation(obj, relocateName, status); !changed {
+			continue
+		}
+		if err := r.Update(context.Background(), obj); err != nil {
+			logger.WithError(err).Log(controllerutils.LogLevel(err), "failed to set relocate annotation")
+			return errors.Wrap(err, "failed to set relocate annotation")
+		}
+	}
+	return nil
+}
+
+// clearRelocateAnnotation deletes the relocate annotation from the ClusterDeployment as well as on the child DNSZone,
+// if there is one.
+func (r *ReconcileClusterRelocate) clearRelocateAnnotation(cd *hivev1.ClusterDeployment, logger log.FieldLogger) error {
+	dnsZone, err := r.dnsZone(cd, logger)
+	if err != nil {
+		return errors.Wrap(err, "failed to get DNSZone")
+	}
+	objects := make([]hivev1.MetaRuntimeObject, 0, 2)
+	if dnsZone != nil {
+		objects = append(objects, dnsZone)
+	}
+	objects = append(objects, cd)
+
+	for _, obj := range objects {
+		if changed := controllerutils.ClearRelocateAnnotation(obj); !changed {
+			continue
+		}
+		if err := r.Update(context.Background(), obj); err != nil {
+			logger.WithError(err).Log(controllerutils.LogLevel(err), "failed to clear relocate annotation")
+			return errors.Wrap(err, "failed to clear relocate annotation")
+		}
+	}
+	return nil
+}
+
+func (r *ReconcileClusterRelocate) finishRelocateCompletion(cd *hivev1.ClusterDeployment, relocateName string, logger log.FieldLogger) (reconcile.Result, error) {
+	if err := r.setRelocateAnnotation(cd, relocateName, hivev1.RelocateComplete, logger); err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "could not set relocate status to complete")
+	}
+
+	if err := r.setRelocationFailedCondition(
+		cd,
+		corev1.ConditionFalse,
+		"MoveSuccessful",
+		"move completed successfully",
+		logger,
+	); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// Delete the ClusterDeployment since it has been successfully relocated to a new Hive instance
+	if err := r.Delete(context.Background(), cd); err != nil {
+		logger.WithError(err).Log(controllerutils.LogLevel(err), "could not delete relocated clusterdeployment")
+		return reconcile.Result{}, errors.Wrap(err, "could not delete relocated clusterdeployment")
+	}
+
+	metricSuccessfulClusterRelocations.WithLabelValues(relocateName).Inc()
+
+	return reconcile.Result{}, nil
+
+}
+
+func (r *ReconcileClusterRelocate) findMatchingRelocates(cd *hivev1.ClusterDeployment, logger log.FieldLogger) ([]*hivev1.ClusterRelocate, error) {
+	clusterRelocates := &hivev1.ClusterRelocateList{}
+	if err := r.List(context.Background(), clusterRelocates); err != nil {
+		return nil, errors.Wrap(err, "failed to list clusterrelocates")
+	}
+	var matches []*hivev1.ClusterRelocate
+	for i, cr := range clusterRelocates.Items {
+		labelSelector, err := metav1.LabelSelectorAsSelector(&cr.Spec.ClusterDeploymentSelector)
+		if err != nil {
+			r.logger.WithError(err).
+				WithField("clusterRelocate", cr.Name).
+				Warn("cannot parse clusterdeployment selector")
+			continue
+		}
+		if labelSelector.Matches(labels.Set(cd.Labels)) {
+			matches = append(matches, &clusterRelocates.Items[i])
+		}
+	}
+	return matches, nil
+}
+
+func (r *ReconcileClusterRelocate) stopRelocating(cd *hivev1.ClusterDeployment, currentRelocateName string, logger log.FieldLogger) error {
+	if currentRelocateName == "" {
+		return nil
+	}
+	logger.WithField("clusterRelocate", currentRelocateName).Info("stopping relocation")
+	// TODO: Attempt to clean up resources already relocated
+	return r.clearRelocateAnnotation(cd, logger)
+}
+
+// reconcileNoSingleMatch reconciles a ClusterDeployment that does not match with exactly one ClusterRelocate.
+// Any in-progress relocates will be aborted.
+func (r *ReconcileClusterRelocate) reconcileNoSingleMatch(cd *hivev1.ClusterDeployment, currentRelocateName string, desiredRelocates []*hivev1.ClusterRelocate, logger log.FieldLogger) (reconcile.Result, error) {
+	names := make([]string, len(desiredRelocates))
+	for i, cr := range desiredRelocates {
+		names[i] = cr.Name
+	}
+	logger = logger.WithField("matchingRelocates", names)
+	if err := r.stopRelocating(cd, currentRelocateName, logger); err != nil {
+		logger.WithError(err).Log(controllerutils.LogLevel(err), "failed to stop relocation")
+		return reconcile.Result{}, errors.Wrap(err, "failed to stop relocation")
+	}
+	var (
+		abortedReason   string
+		status          corev1.ConditionStatus
+		reason, message string
+	)
+	if len(desiredRelocates) == 0 {
+		logger.Debug("no relocates match clusterdeployment")
+		abortedReason = "no_match"
+		status = corev1.ConditionFalse
+		reason = "NoMatchingRelocates"
+		message = "no ClusterRelocates match"
+	} else {
+		logger.Warn("cannot relocate clusterdeployment since it matches multiple clusterrelocates")
+		abortedReason = "multiple_matches"
+		status = corev1.ConditionTrue
+		reason = "MultipleMatchingRelocates"
+		message = fmt.Sprintf("multiple ClusterRelocates match: %s", strings.Join(names, ", "))
+	}
+	if err := r.setRelocationFailedCondition(cd, status, reason, message, logger); err != nil {
+		return reconcile.Result{}, err
+	}
+	recordMetricForAbortedRelocate(currentRelocateName, abortedReason)
+	return reconcile.Result{}, nil
+}
+
+// checkForExistingClusterDeployment checks whether the destination cluster already has the ClusterDeployment.
+// proceed: true if the reconcile should proceed with copying resources to the destination cluster
+// completed: true if the copy to the destination cluster has already been completed
+// returnErr: non-nil if there was an error
+//
+// If the ClusterDeployment does not exist on the destination cluster, then proceed with copying the
+// ClusterDeployment and its dependencies.
+//
+// If the ClusterDeployment exists on the destination cluster and is for the same base domain as the
+// ClusterDeployment on the source cluster, then the copy is complete. This is due to the ClusterDeployment always
+// being the last resource copied.
+//
+// If the ClusterDeployment exists on the destination cluster but is for a different base domain, then the
+// ClusterDeployment on the destination cluster is in conflict with the ClusterDeployment on the source cluster.
+// The ClusterDeployment on the destination cluster is for a separate Hive-managed cluster. There is nothing that
+// Hive can or should do to resolve this. The ClusterDeployment cannot be relocated to the destination cluster
+// unless the existing ClusterDeployment on the destination cluster is deleted.
+func (r *ReconcileClusterRelocate) checkForExistingClusterDeployment(cd *hivev1.ClusterDeployment, destClient client.Client, logger log.FieldLogger) (proceed bool, completed bool, returnErr error) {
+	cdKey, err := client.ObjectKeyFromObject(cd)
+	if err != nil {
+		logger.WithError(err).Error("could not get object key for clusterdeployment")
+		returnErr = errors.Wrap(err, "could not get object key for clusterdeployment")
+		return
+	}
+	destCD := &hivev1.ClusterDeployment{}
+	switch err := destClient.Get(context.Background(), cdKey, destCD); {
+	// no ClusterDeployment in destination cluster
+	case apierrors.IsNotFound(err):
+		logger.Info("clusterdeployment absent in destination cluster")
+		proceed = true
+	// error getting ClusterDeployment
+	case err != nil:
+		logger.WithError(err).Log(controllerutils.LogLevel(err), "failed to get clusterdeployment in destination cluster")
+		returnErr = errors.Wrap(err, "failed to get clusterdeployment in destination cluster")
+	// conflicting ClusterDeployment exists in destination cluster
+	case destCD.Spec.BaseDomain != cd.Spec.BaseDomain:
+		logger.Warn("clusterdeployment in destination cluster does not match the one being relocated")
+		returnErr = r.setRelocationFailedCondition(
+			cd,
+			corev1.ConditionTrue,
+			"ClusterDeploymentMismatch",
+			"The ClusterDeployment in the destination cluster does not match the one being relocated. To relocate this ClusterDeployment, the ClusterDeployment in the destination cluster first must be deleted.",
+			logger,
+		)
+	// ClusterDeployment already exists in destination cluster
+	default:
+		logger.Info("clusterdeployment already exists in destination cluster")
+		// The ClusterDeployment must be the last resource copied. If the ClusterDeployment exists on the
+		// destination cluster, then the copy is complete.
+		completed = true
+	}
+	return
+}
+
+func (r *ReconcileClusterRelocate) copy(cd *hivev1.ClusterDeployment, destClient client.Client, logger log.FieldLogger) error {
+	// create namespace
+	switch err := destClient.Create(context.Background(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cd.Namespace,
+		},
+	}); {
+	case apierrors.IsAlreadyExists(err):
+		logger.Info("namespace already exists in destination cluster")
+	case err != nil:
+		logger.WithError(err).Log(controllerutils.LogLevel(err), "failed to create namespace in destination cluster")
+		return errors.Wrap(err, "failed to create namespace in destination cluster")
+	default:
+		logger.Info("namespace created")
+	}
+
+	// copy dependent resources
+	for _, t := range typesToCopy() {
+		if err := r.copyResources(cd, destClient, t, logger); err != nil {
+			return errors.Wrapf(err, "failed to copy %T", t)
+		}
+	}
+
+	// copy dnszone
+	dnsZone, err := r.dnsZone(cd, logger)
+	if err != nil {
+		return errors.Wrap(err, "could not get DNSZone")
+	}
+	if dnsZone != nil {
+		logger = logger.WithField("type", reflect.TypeOf(dnsZone)).WithField("resource", dnsZone.Name)
+		if err := r.copyResource(dnsZone, destClient, false, logger); err != nil {
+			return errors.Wrap(err, "failed to copy dnszone")
+		}
+	}
+
+	// copy clusterdeployment
+	{
+		logger := logger.WithField("type", reflect.TypeOf(cd)).WithField("resource", cd.Name)
+		if err := r.copyResource(cd, destClient, true, logger); err != nil {
+			return errors.Wrap(err, "failed to copy clusterdeployment")
+		}
+	}
+
+	return nil
+}
+
+// copyResources copies all of the resources of the given object type in the namespace of the ClusterDeployment to the
+// destination cluster
+func (r *ReconcileClusterRelocate) copyResources(cd *hivev1.ClusterDeployment, destClient client.Client, objectList runtime.Object, logger log.FieldLogger) error {
+	logger = logger.WithField("type", reflect.TypeOf(objectList))
+	if err := r.List(context.Background(), objectList, client.InNamespace(cd.Namespace)); err != nil {
+		logger.WithError(err).Log(controllerutils.LogLevel(err), "could not list resources")
+		return errors.Wrapf(err, "failed to list %T", objectList)
+	}
+	objs, err := meta.ExtractList(objectList)
+	if err != nil {
+		logger.WithError(err).Error("could not extract resources from list")
+		return errors.Wrapf(err, "could not extract resources from %T", objectList)
+	}
+	for _, obj := range objs {
+		logger := logger.WithField("type", reflect.TypeOf(obj))
+		objMeta, err := meta.Accessor(obj)
+		if err != nil {
+			logger.WithError(err).Error("could not get object meta")
+			return errors.Wrapf(err, "could not get object meta for %T", obj)
+		}
+		logger = logger.WithField("resource", objMeta.GetName())
+		switch ignore, err := r.ignoreResource(obj, logger); {
+		case err != nil:
+			return errors.Wrap(err, "could not determine whether to ignore resource")
+		case ignore:
+			logger.Info("resource will not be copied since it is a resource that should be ignored")
+			continue
+		}
+		if err := r.copyResource(obj, destClient, false, logger); err != nil {
+			return errors.Wrapf(err, "could not copy %T resource %q", obj, objMeta.GetName())
+		}
+	}
+	return nil
+}
+
+func (r *ReconcileClusterRelocate) copyResource(obj runtime.Object, destClient client.Client, failIfExists bool, logger log.FieldLogger) error {
+	obj, err := prepareForComparison(obj)
+	if err != nil {
+		logger.WithError(err).Error("could not clear fields from source object")
+		return errors.Wrap(err, "could not clear fields from source object")
+	}
+	// Need to use a copy here so that `obj` is left unaltered if the resource already exists on the remote cluster.
+	objToCreate := obj.DeepCopyObject()
+	switch err := destClient.Create(context.Background(), objToCreate); {
+	case err == nil:
+		logger.Info("resource created in destination cluster")
+	case apierrors.IsAlreadyExists(err):
+		if failIfExists {
+			return errors.Wrap(err, "resource already exists in destination cluster")
+		}
+		logger.Info("resource already exists in destination cluster; replacing if there are changes")
+		if err := r.replaceResourceIfChanged(destClient, obj, logger); err != nil {
+			return errors.Wrap(err, "failed to sync existing resource")
+		}
+	default:
+		logger.WithError(err).Log(controllerutils.LogLevel(err), "could not create resource in destination cluster")
+		return errors.Wrap(err, "could not create resource in destination cluster")
+	}
+	return nil
+}
+
+func (r *ReconcileClusterRelocate) replaceResourceIfChanged(destClient client.Client, srcObj runtime.Object, logger log.FieldLogger) error {
+	// Get the object from the destination cluster
+	objKey, err := client.ObjectKeyFromObject(srcObj)
+	if err != nil {
+		logger.WithError(err).Error("could not get object key")
+		return errors.Wrap(err, "could not get object key")
+	}
+	destObj := reflect.New(reflect.TypeOf(srcObj).Elem()).Interface().(runtime.Object)
+	if err := destClient.Get(context.Background(), objKey, destObj); err != nil {
+		logger.WithError(err).Log(controllerutils.LogLevel(err), "could not get resource from destination cluster")
+		return errors.Wrap(err, "could not get resource from destination cluster")
+	}
+
+	// Prepare a copy of the object in the destination cluster for comparison with the object in the source cluster.
+	clearedDestObj, err := prepareForComparison(destObj)
+	if err != nil {
+		logger.WithError(err).Error("could not clear fields of destination resource")
+		return errors.Wrap(err, "could not clear fields of destination resource")
+	}
+	switch t := clearedDestObj.(type) {
+	case *hivev1.ClusterDeployment:
+		logger.Error("attempting to replace a ClusterDeployment")
+		return errors.New("resource already exists in destination cluster")
+	case *hivev1.MachinePool:
+		// The remotemachineset controller in the destination cluster is going to remove its finalizer until the
+		// ClusterDeployment exists in the destination cluster. This will cause the source and destination MachinePools
+		// to have differences requiring a replacement if we do not set the finalizers equal first.
+		t.Finalizers = srcObj.(*hivev1.MachinePool).Finalizers
+	}
+
+	// Check if there are any meaningful changes between the objects in the source and destination clusters
+	if reflect.DeepEqual(srcObj, clearedDestObj) {
+		// Do nothing. Resource in destination cluster is in sync.
+		return nil
+	}
+	if logger.WithFields(nil).Logger.IsLevelEnabled(log.DebugLevel) {
+		logger.WithField("diff", diff.ObjectReflectDiff(srcObj, clearedDestObj)).
+			Debug("resource in destination cluster is out of sync")
+	}
+
+	// Delete the object in the destination cluster and re-create it.
+	if err := destClient.Delete(context.Background(), destObj); err != nil {
+		logger.WithError(err).Log(controllerutils.LogLevel(err), "could not delete out-of-sync resource from destination cluster")
+		return errors.Wrap(err, "could not delete out-of-sync resource from destination cluster")
+	}
+	logger.Info("out-of-date resource deleted in destination cluster")
+	if err := destClient.Create(context.Background(), srcObj); err != nil {
+		logger.WithError(err).Log(controllerutils.LogLevel(err), "could not create resource in destination cluster")
+		return err
+	}
+	logger.Info("resource created in destination cluster")
+	return nil
+}
+
+func prepareForComparison(obj runtime.Object) (runtime.Object, error) {
+	obj = obj.DeepCopyObject()
+
+	// Clear the GroupVersionKind in case there are version mismatches between the source cluster and destination cluster.
+	obj.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{})
+
+	objMeta, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get object meta")
+	}
+	clearInstanceSpecificMeta(objMeta)
+
+	switch t := obj.(type) {
+	case *corev1.Secret, *corev1.ConfigMap:
+		// Do nothing
+	case *hivev1.MachinePool:
+		t.Status = hivev1.MachinePoolStatus{}
+	case *hivev1.SyncSet:
+		t.Status = hivev1.SyncSetStatus{}
+	case *hivev1.SyncIdentityProvider:
+		t.Status = hivev1.IdentityProviderStatus{}
+	case *hivev1.DNSZone:
+		t.Status = hivev1.DNSZoneStatus{}
+		if err := replaceOutgoingToIncoming(t); err != nil {
+			return nil, errors.Wrap(err, "could not set relocate status to incoming")
+		}
+	case *hivev1.ClusterDeployment:
+		t.Status = hivev1.ClusterDeploymentStatus{}
+		if err := replaceOutgoingToIncoming(t); err != nil {
+			return nil, errors.Wrap(err, "could not set relocate status to incoming")
+		}
+	default:
+		return nil, errors.Errorf("unknown type to relocate: %T", t)
+	}
+
+	return obj, nil
+}
+
+func clearInstanceSpecificMeta(to metav1.Object) {
+	to.SetSelfLink("")
+	to.SetUID("")
+	to.SetResourceVersion("")
+	to.SetGeneration(0)
+	to.SetCreationTimestamp(metav1.Time{})
+	to.SetOwnerReferences(nil)
+	to.SetClusterName("")
+	to.SetManagedFields(nil)
+}
+
+// replaceOutgoingToIncoming changes the relocate status from outgoing to incoming. This is used when copying a resource
+// to a destination cluster. On the source cluster, the status is outgoing. On the destination cluster, the status is
+// incoming.
+func replaceOutgoingToIncoming(obj hivev1.MetaRuntimeObject) error {
+	relocateName, relocateStatus, err := controllerutils.IsRelocating(obj)
+	if err != nil {
+		return errors.Wrap(err, "could not determine relocate status")
+	}
+	switch relocateStatus {
+	case hivev1.RelocateOutgoing:
+		controllerutils.SetRelocateAnnotation(obj, relocateName, hivev1.RelocateIncoming)
+	case hivev1.RelocateIncoming:
+		// Do nothing as it is already incoming
+	default:
+		return errors.Errorf("resource is not relocating out: status=%q", relocateStatus)
+	}
+	return nil
+}
+
+// ignoreResource determines whether a resource should be ignored during a copy to a destination cluster. An ignored
+// resource will not be copied.
+func (r *ReconcileClusterRelocate) ignoreResource(obj runtime.Object, logger log.FieldLogger) (bool, error) {
+	switch t := obj.(type) {
+	case *corev1.Secret:
+		return r.ignoreSecret(t, logger)
+	default:
+		return false, nil
+	}
+}
+
+// ignoreSecret determines whether a secret should be ignored during a copy to a destination cluster. An ignored
+// secret will not be copied.
+func (r *ReconcileClusterRelocate) ignoreSecret(secret *corev1.Secret, logger log.FieldLogger) (bool, error) {
+	if secret.Type == corev1.SecretTypeServiceAccountToken {
+		logger.Info("ignoring service account token secret")
+		return true, nil
+	}
+	for _, ownerRef := range secret.OwnerReferences {
+		if ownerRef.Kind != "Secret" {
+			continue
+		}
+		owner := &corev1.Secret{}
+		if err := r.Get(context.Background(), client.ObjectKey{Namespace: secret.Namespace, Name: ownerRef.Name}, owner); err != nil {
+			logger.WithField("owner", ownerRef.Name).WithError(err).Log(controllerutils.LogLevel(err), "could not get owner secret")
+			return false, err
+		}
+		if owner.Type == corev1.SecretTypeServiceAccountToken {
+			logger.Info("ignoring secret owned by a service account token secret")
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// dnsZone gets the DNSZone that is a child of the ClusterDeployment for the purposes of managed DNS.
+// If the ClusterDeployment is not using managed DNS or the child DNSZone does not exist, the return will be nil.
+func (r *ReconcileClusterRelocate) dnsZone(cd *hivev1.ClusterDeployment, logger log.FieldLogger) (*hivev1.DNSZone, error) {
+	if !cd.Spec.ManageDNS {
+		return nil, nil
+	}
+	dnsZone := &hivev1.DNSZone{}
+	switch err := r.Get(
+		context.Background(),
+		client.ObjectKey{Namespace: cd.Namespace, Name: controllerutils.DNSZoneName(cd.Name)},
+		dnsZone,
+	); {
+	case apierrors.IsNotFound(err):
+		logger.Info("no DNSZone found for ClusterDeployment with managed DNS")
+		return nil, nil
+	case err != nil:
+		logger.WithError(err).Log(controllerutils.LogLevel(err), "failed to get DNSZone")
+		return nil, err
+	default:
+		return dnsZone, nil
+	}
+}
+
+func (r *ReconcileClusterRelocate) setRelocationFailedCondition(cd *hivev1.ClusterDeployment, status corev1.ConditionStatus, reason, message string, logger log.FieldLogger) error {
+	updateConditionCheck := controllerutils.UpdateConditionIfReasonOrMessageChange
+	if status == corev1.ConditionFalse {
+		updateConditionCheck = controllerutils.UpdateConditionNever
+	}
+	conds, changed := controllerutils.SetClusterDeploymentConditionWithChangeCheck(
+		cd.Status.Conditions,
+		hivev1.RelocationFailedCondition,
+		status,
+		reason,
+		message,
+		updateConditionCheck,
+	)
+	if !changed {
+		return nil
+	}
+	cd.Status.Conditions = conds
+	if err := r.Status().Update(context.Background(), cd); err != nil {
+		logger.WithError(err).Log(controllerutils.LogLevel(err), "could not update conditions")
+		return errors.Wrap(err, "could not update conditions")
+	}
+	return nil
+}
+
+func recordMetricForAbortedRelocate(abortedRelocate, abortedReason string) {
+	if abortedReason == "" {
+		return
+	}
+	metricAbortedClusterRelocations.WithLabelValues(abortedRelocate, abortedReason).Inc()
+}

--- a/pkg/controller/clusterrelocate/clusterrelocate_controller_test.go
+++ b/pkg/controller/clusterrelocate/clusterrelocate_controller_test.go
@@ -1,0 +1,1071 @@
+package clusterrelocate
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+	"github.com/openshift/hive/pkg/remoteclient"
+	remoteclientmock "github.com/openshift/hive/pkg/remoteclient/mock"
+	testcd "github.com/openshift/hive/pkg/test/clusterdeployment"
+	testcr "github.com/openshift/hive/pkg/test/clusterrelocate"
+	testcm "github.com/openshift/hive/pkg/test/configmap"
+	testdnszone "github.com/openshift/hive/pkg/test/dnszone"
+	testgeneric "github.com/openshift/hive/pkg/test/generic"
+	testjob "github.com/openshift/hive/pkg/test/job"
+	testmp "github.com/openshift/hive/pkg/test/machinepool"
+	testnamespace "github.com/openshift/hive/pkg/test/namespace"
+	testsecret "github.com/openshift/hive/pkg/test/secret"
+	testsip "github.com/openshift/hive/pkg/test/syncidentityprovider"
+	testss "github.com/openshift/hive/pkg/test/syncset"
+)
+
+const (
+	namespace = "test-namespace"
+	cdName    = "test-cluster-deployment"
+	crName    = "test-cluster-relocator"
+
+	kubeconfigNamespace = "test-kubeconfig-namespace"
+	kubeconfigName      = "test-kubeconfig"
+
+	labelKey   = "test-key"
+	labelValue = "test-value"
+)
+
+func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.DebugLevel)
+
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	batchv1.AddToScheme(scheme)
+	hivev1.AddToScheme(scheme)
+
+	cdBuilder := testcd.FullBuilder(namespace, cdName, scheme).GenericOptions(
+		testgeneric.WithLabel(labelKey, labelValue),
+		testgeneric.WithFinalizer(hivev1.FinalizerDeprovision),
+	).Options(
+		func(cd *hivev1.ClusterDeployment) { cd.Spec.ManageDNS = true },
+	)
+	crBuilder := testcr.FullBuilder(crName, scheme).Options(
+		testcr.WithKubeconfigSecret(kubeconfigNamespace, kubeconfigName),
+		testcr.WithClusterDeploymentSelector(labelKey, labelValue),
+	)
+	secretBuilder := testsecret.FullBuilder(namespace, "test-secret", scheme)
+	cmBuilder := testcm.FullBuilder(namespace, "test-configmap", scheme)
+	mpBuilder := testmp.FullBuilder(namespace, "test-pool", cdName, scheme)
+	ssBuilder := testss.FullBuilder(namespace, "test-ss", scheme).Options(
+		testss.ForClusterDeployments(cdName),
+		testss.WithApplyMode(hivev1.SyncResourceApplyMode),
+	)
+	sipBuilder := testsip.FullBuilder(namespace, "test-sip", scheme).Options(
+		testsip.ForClusterDeployments(cdName),
+		testsip.ForIdentities("test-user"),
+	)
+	dnsZoneBuilder := testdnszone.FullBuilder(namespace, controllerutils.DNSZoneName(cdName), scheme).Options(
+		testdnszone.WithZone("test-zone"),
+	)
+	jobBuilder := testjob.FullBuilder(namespace, "test-job", scheme)
+	namespaceBuilder := testnamespace.FullBuilder(namespace, scheme)
+
+	cases := []struct {
+		name              string
+		cd                *hivev1.ClusterDeployment
+		srcResources      []runtime.Object
+		destResources     []runtime.Object
+		expectedResources []runtime.Object
+	}{
+		{
+			name: "no relocation",
+			cd:   cdBuilder.Build(),
+		},
+		{
+			name: "only clusterdeployment",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+			},
+		},
+		{
+			name: "existing clusterdeployment",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+			},
+			destResources: []runtime.Object{
+				cdBuilder.Build(),
+			},
+			expectedResources: []runtime.Object{
+				cdBuilder.Build(),
+			},
+		},
+		{
+			name: "out-of-date clusterdeployment",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+			},
+			destResources: []runtime.Object{
+				cdBuilder.Build(
+					func(cd *hivev1.ClusterDeployment) {
+						cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{}
+					},
+				),
+			},
+			expectedResources: []runtime.Object{
+				cdBuilder.Build(
+					func(cd *hivev1.ClusterDeployment) {
+						cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{}
+					},
+				),
+			},
+		},
+		{
+			name: "existing clusterdeployment with different status",
+			cd: cdBuilder.Build(
+				func(cd *hivev1.ClusterDeployment) {
+					cd.Status.Conditions = []hivev1.ClusterDeploymentCondition{}
+				},
+			),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+			},
+			destResources: []runtime.Object{
+				cdBuilder.Build(),
+			},
+			expectedResources: []runtime.Object{
+				cdBuilder.Build(),
+			},
+		},
+		{
+			name: "existing clusterdeployment with different instance-specific metadata",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+			},
+			destResources: []runtime.Object{
+				cdBuilder.Build(
+					testcd.Generic(testgeneric.WithResourceVersion("some-rv")),
+				),
+			},
+			expectedResources: []runtime.Object{
+				cdBuilder.Build(
+					testcd.Generic(testgeneric.WithResourceVersion("some-rv")),
+				),
+			},
+		},
+		{
+			name: "existing namespace",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+			},
+			destResources: []runtime.Object{
+				namespaceBuilder.Build(),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+			},
+		},
+		{
+			name: "single dependent",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				secretBuilder.Build(testsecret.WithDataKeyValue("test-key", []byte("test-data"))),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+				secretBuilder.Build(testsecret.WithDataKeyValue("test-key", []byte("test-data"))),
+			},
+		},
+		{
+			name: "multiple dependents",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				secretBuilder.Build(
+					testsecret.WithName("test-secret-1"),
+					testsecret.WithDataKeyValue("test-key-1", []byte("test-data-1")),
+				),
+				secretBuilder.Build(
+					testsecret.WithName("test-secret-2"),
+					testsecret.WithDataKeyValue("test-key-2", []byte("test-data-2")),
+				),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+				secretBuilder.Build(
+					testsecret.WithName("test-secret-1"),
+					testsecret.WithDataKeyValue("test-key-1", []byte("test-data-1")),
+				),
+				secretBuilder.Build(
+					testsecret.WithName("test-secret-2"),
+					testsecret.WithDataKeyValue("test-key-2", []byte("test-data-2")),
+				),
+			},
+		},
+		{
+			name: "dependent in other namespace",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				secretBuilder.Build(
+					testsecret.WithName("test-secret-1"),
+					testsecret.WithDataKeyValue("test-key-1", []byte("test-data-1")),
+				),
+				secretBuilder.Build(
+					testsecret.WithNamespace("other-namespace"),
+					testsecret.WithName("test-secret-2"),
+					testsecret.WithDataKeyValue("test-key-2", []byte("test-data-2")),
+				),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+				secretBuilder.Build(
+					testsecret.WithName("test-secret-1"),
+					testsecret.WithDataKeyValue("test-key-1", []byte("test-data-1")),
+				),
+			},
+		},
+		{
+			name: "existing dependent",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				secretBuilder.Build(testsecret.WithDataKeyValue("test-key", []byte("test-data"))),
+			},
+			destResources: []runtime.Object{
+				secretBuilder.Build(testsecret.WithDataKeyValue("test-key", []byte("test-data"))),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+				secretBuilder.Build(testsecret.WithDataKeyValue("test-key", []byte("test-data"))),
+			},
+		},
+		{
+			name: "out-of-date dependent",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				secretBuilder.Build(testsecret.WithDataKeyValue("test-key", []byte("test-data"))),
+			},
+			destResources: []runtime.Object{
+				secretBuilder.Build(testsecret.WithDataKeyValue("test-key", []byte("other-data"))),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+				secretBuilder.Build(testsecret.WithDataKeyValue("test-key", []byte("test-data"))),
+			},
+		},
+		{
+			name: "existing dependent with different status",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				mpBuilder.Build(
+					func(mp *hivev1.MachinePool) {
+						mp.Status.Conditions = []hivev1.MachinePoolCondition{}
+					},
+				),
+			},
+			destResources: []runtime.Object{
+				mpBuilder.Build(),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+				mpBuilder.Build(),
+			},
+		},
+		{
+			name: "existing dependent with different instance-specific metadata",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				secretBuilder.Build(
+					testsecret.WithDataKeyValue("test-key", []byte("test-data")),
+				),
+			},
+			destResources: []runtime.Object{
+				secretBuilder.Build(
+					testsecret.Generic(testgeneric.WithResourceVersion("some-rv")),
+					testsecret.WithDataKeyValue("test-key", []byte("test-data")),
+				),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+				secretBuilder.Build(
+					testsecret.Generic(testgeneric.WithResourceVersion("some-rv")),
+					testsecret.WithDataKeyValue("test-key", []byte("test-data")),
+				),
+			},
+		},
+		{
+			name: "ignore service account token",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				secretBuilder.Build(
+					testsecret.WithType(corev1.SecretTypeServiceAccountToken),
+					testsecret.WithDataKeyValue("test-key", []byte("test-data")),
+				),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+			},
+		},
+		{
+			name: "ignore secret owned by service account token",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				secretBuilder.Build(
+					testsecret.Generic(testgeneric.WithName("test-sa-token")),
+					testsecret.WithType(corev1.SecretTypeServiceAccountToken),
+					testsecret.WithDataKeyValue("test-key-sa-token", []byte("test-data-sa-token")),
+				),
+				secretBuilder.Build(
+					testsecret.Generic(testgeneric.WithName("test-dockercfg")),
+					testsecret.WithDataKeyValue("test-key-dockercfg", []byte("test-data-dockercfg")),
+					func(secret *corev1.Secret) {
+						secret.OwnerReferences = append(secret.OwnerReferences, metav1.OwnerReference{
+							Kind: "Secret",
+							Name: "test-sa-token",
+						})
+					},
+				),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+			},
+		},
+		{
+			name: "configmap",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				cmBuilder.Build(testcm.WithDataKeyValue("test-key", "test-data")),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+				cmBuilder.Build(testcm.WithDataKeyValue("test-key", "test-data")),
+			},
+		},
+		{
+			name: "machinepool",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				mpBuilder.Build(),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+				mpBuilder.Build(),
+			},
+		},
+		{
+			name: "syncset",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				ssBuilder.Build(),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+				ssBuilder.Build(),
+			},
+		},
+		{
+			name: "syncidentityprovider",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				sipBuilder.Build(),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+				sipBuilder.Build(),
+			},
+		},
+		{
+			name: "dnszone",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				dnsZoneBuilder.Build(),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+				dnsZoneBuilder.Build(
+					testdnszone.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+			},
+		},
+		{
+			name: "non-child dnszone",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				dnsZoneBuilder.Build(testdnszone.Generic(testgeneric.WithName("other-dnszone"))),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+			},
+		},
+		{
+			name: "non-dependent",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				jobBuilder.Build(),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+			},
+		},
+		{
+			name: "full",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				cdBuilder.Build(testcd.WithName("other-cluster-deployment")),
+				cdBuilder.Build(testcd.WithNamespace("other-namespace")),
+				secretBuilder.Build(
+					testsecret.WithName("test-secret-new"),
+					testsecret.WithDataKeyValue("test-key-new", []byte("test-data-new")),
+				),
+				secretBuilder.Build(
+					testsecret.WithName("test-secret-existing"),
+					testsecret.WithDataKeyValue("test-key-existing", []byte("test-data-existing")),
+				),
+				secretBuilder.Build(
+					testsecret.WithName("test-secret-out-of-date"),
+					testsecret.WithDataKeyValue("test-key-out-of-date", []byte("test-data-out-of-date")),
+				),
+				secretBuilder.Build(
+					testsecret.WithNamespace("other-namespace"),
+					testsecret.WithName("test-secret-other-namespace"),
+					testsecret.WithDataKeyValue("test-key-other-namespace", []byte("test-data-other-namespace")),
+				),
+				secretBuilder.Build(
+					testsecret.Generic(testgeneric.WithName("test-sa-token")),
+					testsecret.WithType(corev1.SecretTypeServiceAccountToken),
+					testsecret.WithDataKeyValue("test-key-sa-token", []byte("test-data-sa-token")),
+				),
+				secretBuilder.Build(
+					testsecret.Generic(testgeneric.WithName("test-dockercfg")),
+					testsecret.WithDataKeyValue("test-key-dockercfg", []byte("test-data-dockercfg")),
+					func(secret *corev1.Secret) {
+						secret.OwnerReferences = append(secret.OwnerReferences, metav1.OwnerReference{
+							Kind: "Secret",
+							Name: "test-sa-token",
+						})
+					},
+				),
+				cmBuilder.Build(
+					testcm.WithName("test-configmap-new"),
+					testcm.WithDataKeyValue("test-key-new", "test-data-new")),
+				cmBuilder.Build(
+					testcm.WithName("test-configmap-existing"),
+					testcm.WithDataKeyValue("test-key-existing", "test-data-existing")),
+				cmBuilder.Build(
+					testcm.WithName("test-configmap-out-of-date"),
+					testcm.WithDataKeyValue("test-key-out-of-date", "test-data-out-of-date")),
+				cmBuilder.Build(
+					testcm.WithNamespace("other-namespace"),
+					testcm.WithName("test-configmap-other-namespace"),
+					testcm.WithDataKeyValue("test-key-other-namespace", "test-data-other-namespace")),
+				mpBuilder.Build(
+					testmp.WithPoolNameForClusterDeployment("test-pool-new", cdName),
+				),
+				mpBuilder.Build(
+					testmp.WithPoolNameForClusterDeployment("test-pool-existing", cdName),
+				),
+				mpBuilder.Build(
+					testmp.WithPoolNameForClusterDeployment("test-pool-out-of-date", cdName),
+				),
+				mpBuilder.Build(
+					testmp.WithNamespace("other-namespace"),
+					testmp.WithPoolNameForClusterDeployment("test-pool-other-namespace", cdName),
+				),
+				ssBuilder.Build(
+					testss.WithName("test-syncset-new"),
+				),
+				ssBuilder.Build(
+					testss.WithName("test-syncset-existing"),
+				),
+				ssBuilder.Build(
+					testss.WithName("test-syncset-out-of-date"),
+				),
+				ssBuilder.Build(
+					testss.WithNamespace("other-namespace"),
+					testss.WithName("test-syncset-other-namespace"),
+				),
+				sipBuilder.Build(
+					testsip.WithName("test-sip-new"),
+				),
+				sipBuilder.Build(
+					testsip.WithName("test-sip-existing"),
+				),
+				sipBuilder.Build(
+					testsip.WithName("test-sip-out-of-date"),
+				),
+				sipBuilder.Build(
+					testsip.WithNamespace("other-namespace"),
+					testsip.WithName("test-sip-other-namespace"),
+				),
+				dnsZoneBuilder.Build(),
+				dnsZoneBuilder.Build(testdnszone.Generic(testgeneric.WithName("other-dnszone"))),
+				jobBuilder.Build(),
+				jobBuilder.Build(testjob.WithNamespace("other-namespace")),
+			},
+			destResources: []runtime.Object{
+				secretBuilder.Build(
+					testsecret.WithName("test-secret-existing"),
+					testsecret.WithDataKeyValue("test-key-existing", []byte("test-data-existing")),
+				),
+				secretBuilder.Build(
+					testsecret.WithName("test-secret-out-of-date"),
+					testsecret.WithDataKeyValue("test-key-out-of-date", []byte("other-test-data")),
+				),
+				cmBuilder.Build(
+					testcm.WithName("test-configmap-existing"),
+					testcm.WithDataKeyValue("test-key-existing", "test-data-existing")),
+				cmBuilder.Build(
+					testcm.WithName("test-configmap-out-of-date"),
+					testcm.WithDataKeyValue("test-key-out-of-date", "other-test-data")),
+				mpBuilder.Build(
+					testmp.WithPoolNameForClusterDeployment("test-pool-existing", cdName),
+				),
+				mpBuilder.Build(
+					testmp.WithPoolNameForClusterDeployment("test-pool-out-of-date", cdName),
+					func(mp *hivev1.MachinePool) {
+						mp.Spec.Autoscaling = &hivev1.MachinePoolAutoscaling{}
+					},
+				),
+				ssBuilder.Build(
+					testss.WithName("test-syncset-existing"),
+				),
+				ssBuilder.Build(
+					testss.WithName("test-syncset-out-of-date"),
+					testss.WithApplyMode(hivev1.SyncSetResourceApplyMode("other-mode")),
+				),
+				sipBuilder.Build(
+					testsip.WithName("test-sip-existing"),
+				),
+				sipBuilder.Build(
+					testsip.WithName("test-sip-out-of-date"),
+					testsip.ForIdentities("other-user"),
+				),
+			},
+			expectedResources: []runtime.Object{
+				namespaceBuilder.Build(),
+				cdBuilder.Build(
+					testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+				secretBuilder.Build(
+					testsecret.WithName("test-secret-new"),
+					testsecret.WithDataKeyValue("test-key-new", []byte("test-data-new")),
+				),
+				secretBuilder.Build(
+					testsecret.WithName("test-secret-existing"),
+					testsecret.WithDataKeyValue("test-key-existing", []byte("test-data-existing")),
+				),
+				secretBuilder.Build(
+					testsecret.WithName("test-secret-out-of-date"),
+					testsecret.WithDataKeyValue("test-key-out-of-date", []byte("test-data-out-of-date")),
+				),
+				cmBuilder.Build(
+					testcm.WithName("test-configmap-new"),
+					testcm.WithDataKeyValue("test-key-new", "test-data-new")),
+				cmBuilder.Build(
+					testcm.WithName("test-configmap-existing"),
+					testcm.WithDataKeyValue("test-key-existing", "test-data-existing")),
+				cmBuilder.Build(
+					testcm.WithName("test-configmap-out-of-date"),
+					testcm.WithDataKeyValue("test-key-out-of-date", "test-data-out-of-date")),
+				mpBuilder.Build(
+					testmp.WithPoolNameForClusterDeployment("test-pool-new", cdName),
+				),
+				mpBuilder.Build(
+					testmp.WithPoolNameForClusterDeployment("test-pool-existing", cdName),
+				),
+				mpBuilder.Build(
+					testmp.WithPoolNameForClusterDeployment("test-pool-out-of-date", cdName),
+				),
+				ssBuilder.Build(
+					testss.WithName("test-syncset-new"),
+				),
+				ssBuilder.Build(
+					testss.WithName("test-syncset-existing"),
+				),
+				ssBuilder.Build(
+					testss.WithName("test-syncset-out-of-date"),
+				),
+				sipBuilder.Build(
+					testsip.WithName("test-sip-new"),
+				),
+				sipBuilder.Build(
+					testsip.WithName("test-sip-existing"),
+				),
+				sipBuilder.Build(
+					testsip.WithName("test-sip-out-of-date"),
+				),
+				dnsZoneBuilder.Build(
+					testdnszone.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				),
+			},
+		},
+		{
+			name: "no match",
+			cd:   cdBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(testcr.WithClusterDeploymentSelector("other-key", "other-value")),
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.cd != nil {
+				tc.srcResources = append(tc.srcResources, tc.cd)
+			}
+			kubeconfigSecret := testsecret.FullBuilder(kubeconfigNamespace, "test-kubeconfig", scheme).Build(
+				testsecret.WithDataKeyValue("kubeconfig", []byte("some-kubeconfig-data")),
+			)
+			tc.srcResources = append(tc.srcResources, kubeconfigSecret)
+			srcClient := fake.NewFakeClientWithScheme(scheme, tc.srcResources...)
+			destClient := fake.NewFakeClientWithScheme(scheme, tc.destResources...)
+
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockRemoteClientBuilder := remoteclientmock.NewMockBuilder(mockCtrl)
+			mockRemoteClientBuilder.EXPECT().Build().Return(destClient, nil).AnyTimes()
+
+			reconciler := &ReconcileClusterRelocate{
+				Client: srcClient,
+				logger: logger,
+				remoteClusterAPIClientBuilder: func(secret *corev1.Secret) remoteclient.Builder {
+					assert.Equal(t, kubeconfigSecret, secret, "unexpected secret passed to remote client builder")
+					return mockRemoteClientBuilder
+				},
+			}
+			_, err := reconciler.Reconcile(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      cdName,
+					Namespace: namespace,
+				},
+			})
+			require.NoError(t, err, "unexpected error during reconcile")
+
+			for _, obj := range tc.expectedResources {
+				objKey, err := client.ObjectKeyFromObject(obj)
+				if !assert.NoError(t, err, "unexpected error getting object key") {
+					continue
+				}
+				destObj := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(runtime.Object)
+				err = destClient.Get(context.Background(), objKey, destObj)
+				if !assert.NoError(t, err, "unexpected error getting destination object") {
+					continue
+				}
+				assert.Equal(t, obj, destObj, "destination object different than expected object")
+			}
+		})
+	}
+}
+
+func TestReconcileClusterRelocate_Reconcile_RelocateStatus(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.DebugLevel)
+
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	hivev1.AddToScheme(scheme)
+
+	cdBuilder := testcd.FullBuilder(namespace, cdName, scheme).GenericOptions(
+		testgeneric.WithLabel(labelKey, labelValue),
+	).Options(
+		func(cd *hivev1.ClusterDeployment) { cd.Spec.ManageDNS = true },
+	)
+	crBuilder := testcr.FullBuilder(crName, scheme).Options(
+		testcr.WithKubeconfigSecret(kubeconfigNamespace, kubeconfigName),
+		testcr.WithClusterDeploymentSelector(labelKey, labelValue),
+	)
+	dnsZoneBuilder := testdnszone.FullBuilder(namespace, controllerutils.DNSZoneName(cdName), scheme)
+
+	cases := []struct {
+		name                              string
+		cd                                *hivev1.ClusterDeployment
+		dnsZone                           *hivev1.DNSZone
+		missingKubeconfigSecret           bool
+		srcResources                      []runtime.Object
+		destResources                     []runtime.Object
+		expectedError                     bool
+		expectedRelocateStatus            hivev1.RelocateStatus
+		expectedDeletionTimestamp         bool
+		expectedRelocationFailedCondition *hivev1.ClusterDeploymentCondition
+		validate                          func(t *testing.T, cd *hivev1.ClusterDeployment)
+	}{
+		{
+			name:    "fresh clusterdeployment",
+			cd:      cdBuilder.Build(),
+			dnsZone: dnsZoneBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+			},
+			expectedRelocateStatus:    hivev1.RelocateComplete,
+			expectedDeletionTimestamp: true,
+		},
+		{
+			name: "clusterdeployment with dnszone already relocating",
+			cd:   cdBuilder.Build(),
+			dnsZone: dnsZoneBuilder.Build(
+				testdnszone.Generic(withRelocateAnnotation("other-relocate", hivev1.RelocateOutgoing)),
+			),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+			},
+			expectedRelocateStatus:    hivev1.RelocateComplete,
+			expectedDeletionTimestamp: true,
+		},
+		{
+			name: "switch relocates",
+			cd: cdBuilder.Build(
+				testcd.Generic(withRelocateAnnotation("other-relocate", hivev1.RelocateOutgoing)),
+			),
+			dnsZone: dnsZoneBuilder.Build(
+				testdnszone.Generic(withRelocateAnnotation("other-relocate", hivev1.RelocateOutgoing)),
+			),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+			},
+			expectedRelocateStatus:    hivev1.RelocateComplete,
+			expectedDeletionTimestamp: true,
+		},
+		{
+			name:    "multiple relocates",
+			cd:      cdBuilder.Build(),
+			dnsZone: dnsZoneBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				crBuilder.Build(
+					testcr.Generic(testgeneric.WithName("other-relocate")),
+				),
+			},
+			expectedRelocationFailedCondition: &hivev1.ClusterDeploymentCondition{
+				Status: corev1.ConditionTrue,
+				Reason: "MultipleMatchingRelocates",
+			},
+		},
+		{
+			name: "multiple relocates when already relocating",
+			cd: cdBuilder.Build(
+				testcd.Generic(withRelocateAnnotation("other-relocate", hivev1.RelocateOutgoing)),
+			),
+			dnsZone: dnsZoneBuilder.Build(
+				testdnszone.Generic(withRelocateAnnotation("other-relocate", hivev1.RelocateOutgoing)),
+			),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+				crBuilder.Build(
+					testcr.Generic(testgeneric.WithName("other-relocate")),
+				),
+			},
+			expectedRelocationFailedCondition: &hivev1.ClusterDeploymentCondition{
+				Status: corev1.ConditionTrue,
+				Reason: "MultipleMatchingRelocates",
+			},
+		},
+		{
+			name: "already relocated clusterdeployment",
+			cd: cdBuilder.Build(
+				testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateComplete)),
+			),
+			dnsZone: dnsZoneBuilder.Build(
+				testdnszone.Generic(withRelocateAnnotation(crName, hivev1.RelocateComplete)),
+			),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+			},
+			expectedRelocateStatus:    hivev1.RelocateComplete,
+			expectedDeletionTimestamp: true,
+		},
+		{
+			name:    "already moved clusterdeployment",
+			cd:      cdBuilder.Build(),
+			dnsZone: dnsZoneBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+			},
+			destResources: []runtime.Object{
+				cdBuilder.Build(),
+			},
+			expectedRelocateStatus:    hivev1.RelocateComplete,
+			expectedDeletionTimestamp: true,
+		},
+		{
+			name: "already moved clusterdeployment with dnszone already completed",
+			cd:   cdBuilder.Build(),
+			dnsZone: dnsZoneBuilder.Build(
+				testdnszone.Generic(withRelocateAnnotation(crName, hivev1.RelocateComplete)),
+			),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+			},
+			destResources: []runtime.Object{
+				cdBuilder.Build(),
+			},
+			expectedRelocateStatus:    hivev1.RelocateComplete,
+			expectedDeletionTimestamp: true,
+		},
+		{
+			name: "clusterdeployment mismatch",
+			cd: cdBuilder.Build(
+				func(cd *hivev1.ClusterDeployment) {
+					cd.Spec.BaseDomain = "test-domain"
+				},
+			),
+			dnsZone: dnsZoneBuilder.Build(),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+			},
+			destResources: []runtime.Object{
+				cdBuilder.Build(
+					func(cd *hivev1.ClusterDeployment) {
+						cd.Spec.BaseDomain = "other-domain"
+					},
+				),
+			},
+			expectedRelocationFailedCondition: &hivev1.ClusterDeploymentCondition{
+				Status: corev1.ConditionTrue,
+				Reason: "ClusterDeploymentMismatch",
+			},
+		},
+		{
+			name: "incoming",
+			cd: cdBuilder.Build(
+				testcd.Generic(withRelocateAnnotation("other-relocate", hivev1.RelocateIncoming)),
+			),
+			dnsZone: dnsZoneBuilder.Build(
+				testdnszone.Generic(withRelocateAnnotation("other-relocate", hivev1.RelocateIncoming)),
+			),
+		},
+		{
+			name: "incoming with dnszone already released",
+			cd: cdBuilder.Build(
+				testcd.Generic(withRelocateAnnotation("other-relocate", hivev1.RelocateIncoming)),
+			),
+			dnsZone: dnsZoneBuilder.Build(),
+		},
+		{
+			name: "clusterdeployment deleted while outgoing",
+			cd: cdBuilder.Build(
+				testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateOutgoing)),
+				testcd.Generic(testgeneric.Deleted()),
+			),
+			dnsZone: dnsZoneBuilder.Build(
+				testdnszone.Generic(withRelocateAnnotation(crName, hivev1.RelocateOutgoing)),
+			),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+			},
+			expectedDeletionTimestamp: true,
+		},
+		{
+			name: "clusterdeployment deleted while incoming",
+			cd: cdBuilder.Build(
+				testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+				testcd.Generic(testgeneric.Deleted()),
+			),
+			dnsZone: dnsZoneBuilder.Build(
+				testdnszone.Generic(withRelocateAnnotation(crName, hivev1.RelocateIncoming)),
+			),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+			},
+			expectedDeletionTimestamp: true,
+		},
+		{
+			name: "clusterdeployment deleted while outgoing",
+			cd: cdBuilder.Build(
+				testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateOutgoing)),
+				testcd.Generic(testgeneric.Deleted()),
+			),
+			dnsZone: dnsZoneBuilder.Build(
+				testdnszone.Generic(withRelocateAnnotation(crName, hivev1.RelocateOutgoing)),
+			),
+			srcResources: []runtime.Object{
+				crBuilder.Build(),
+			},
+			expectedDeletionTimestamp: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.srcResources = append(tc.srcResources, tc.cd)
+			if tc.dnsZone != nil {
+				tc.srcResources = append(tc.srcResources, tc.dnsZone)
+			}
+			kubeconfigSecret := testsecret.FullBuilder(kubeconfigNamespace, "test-kubeconfig", scheme).Build(
+				testsecret.WithDataKeyValue("kubeconfig", []byte("some-kubeconfig-data")),
+			)
+			if !tc.missingKubeconfigSecret {
+				tc.srcResources = append(tc.srcResources, kubeconfigSecret)
+			}
+			srcClient := &deleteBlockingClientWrapper{fake.NewFakeClientWithScheme(scheme, tc.srcResources...)}
+			destClient := fake.NewFakeClientWithScheme(scheme, tc.destResources...)
+
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockRemoteClientBuilder := remoteclientmock.NewMockBuilder(mockCtrl)
+			mockRemoteClientBuilder.EXPECT().Build().Return(destClient, nil).AnyTimes()
+
+			reconciler := &ReconcileClusterRelocate{
+				Client: srcClient,
+				logger: logger,
+				remoteClusterAPIClientBuilder: func(secret *corev1.Secret) remoteclient.Builder {
+					assert.Equal(t, kubeconfigSecret, secret, "unexpected secret passed to remote client builder")
+					return mockRemoteClientBuilder
+				},
+			}
+			_, err := reconciler.Reconcile(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      cdName,
+					Namespace: namespace,
+				},
+			})
+			if tc.expectedError {
+				require.Error(t, err, "expected error during reconcile")
+			} else {
+				require.NoError(t, err, "unexpected error during reconcile")
+			}
+
+			cd := &hivev1.ClusterDeployment{}
+			err = srcClient.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: cdName}, cd)
+			require.NoError(t, err, "unexpected error fetching clusterdeployment")
+
+			var dnsZone *hivev1.DNSZone
+			if tc.dnsZone != nil {
+				dnsZone = &hivev1.DNSZone{}
+				err = srcClient.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: tc.dnsZone.Name}, dnsZone)
+				require.NoError(t, err, "unexpected error fetching dnszone")
+			}
+
+			if tc.expectedRelocateStatus != "" {
+				expectedAnnotationValue := fmt.Sprintf("%s/%s", crName, tc.expectedRelocateStatus)
+				assert.Equal(t, expectedAnnotationValue, cd.Annotations[constants.RelocateAnnotation], "unexpected relocate annotation on clusterdeployment")
+				if dnsZone != nil {
+					assert.Equal(t, expectedAnnotationValue, dnsZone.Annotations[constants.RelocateAnnotation], "unexpected relocate annotation on dnszone")
+				}
+			} else {
+				assert.NotContains(t, cd.Annotations, constants.RelocateAnnotation, "unexpected relocate annotation on clusterdeployment")
+				if dnsZone != nil {
+					assert.NotContains(t, dnsZone.Annotations, constants.RelocateAnnotation, "unexpected relocate annotation on dnszone")
+				}
+			}
+
+			if tc.expectedDeletionTimestamp {
+				assert.NotNil(t, cd.DeletionTimestamp, "expected ClusterDeployment to be deleted")
+			} else {
+				assert.Nil(t, cd.DeletionTimestamp, "expected ClusterDeployment to not be deleted")
+			}
+
+			cond := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.RelocationFailedCondition)
+			if tc.expectedRelocationFailedCondition != nil {
+				if assert.NotNil(t, cond, "missing relocating condition") {
+					assert.Equal(t, tc.expectedRelocationFailedCondition.Status, cond.Status, "unexpected condition status")
+					assert.Equal(t, tc.expectedRelocationFailedCondition.Reason, cond.Reason, "unexpected condition reason")
+				}
+			} else {
+				assert.Nil(t, cond, "unexpected relocation failed condition")
+			}
+
+			if tc.validate != nil {
+				tc.validate(t, cd)
+			}
+		})
+	}
+}
+
+func withRelocateAnnotation(clusterRelocateName string, status hivev1.RelocateStatus) testgeneric.Option {
+	return testgeneric.WithAnnotation(
+		constants.RelocateAnnotation,
+		fmt.Sprintf("%s/%s", clusterRelocateName, status),
+	)
+}

--- a/pkg/controller/dnszone/awsactuator_test.go
+++ b/pkg/controller/dnszone/awsactuator_test.go
@@ -81,7 +81,7 @@ func mockAWSZoneExists(expect *mock.MockClientMockRecorder, zone *hivev1.DNSZone
 	expect.GetHostedZone(gomock.Any()).Return(&route53.GetHostedZoneOutput{
 		HostedZone: &route53.HostedZone{
 			Id:   aws.String("1234"),
-			Name: aws.String("blah.example.com"),
+			Name: aws.String("blah.example.com."),
 		},
 	}, nil).Times(1)
 }
@@ -99,7 +99,7 @@ func mockCreateAWSZone(expect *mock.MockClientMockRecorder) {
 	expect.CreateHostedZone(gomock.Any()).Return(&route53.CreateHostedZoneOutput{
 		HostedZone: &route53.HostedZone{
 			Id:   aws.String("1234"),
-			Name: aws.String("blah.example.com"),
+			Name: aws.String("blah.example.com."),
 		},
 	}, nil).Times(1)
 }
@@ -163,7 +163,7 @@ func mockListAWSZonesByNameFound(expect *mock.MockClientMockRecorder, zone *hive
 		HostedZones: []*route53.HostedZone{
 			{
 				Id:              aws.String("1234"),
-				Name:            aws.String("blah.example.com"),
+				Name:            aws.String("blah.example.com."),
 				CallerReference: aws.String(string(zone.UID)),
 			},
 		},

--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -195,8 +195,7 @@ func (r *ReconcileRemoteMachineSet) Reconcile(request reconcile.Request) (reconc
 		return reconcile.Result{}, err
 	}
 
-	if cd.Annotations[constants.SyncsetPauseAnnotation] == "true" {
-		logger.Warn(constants.SyncsetPauseAnnotation, " is present, hence syncing to cluster is disabled")
+	if !controllerutils.ShouldSyncCluster(cd, logger) {
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/syncsetinstance/syncsetinstance_controller.go
+++ b/pkg/controller/syncsetinstance/syncsetinstance_controller.go
@@ -232,8 +232,7 @@ func (r *ReconcileSyncSetInstance) Reconcile(request reconcile.Request) (reconci
 		return reconcile.Result{}, err
 	}
 
-	if cd.Annotations[constants.SyncsetPauseAnnotation] == "true" {
-		log.Warn(constants.SyncsetPauseAnnotation, " is present, hence syncing to cluster is disabled")
+	if !controllerutils.ShouldSyncCluster(cd, ssiLog) {
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/utils/clusterdeployment.go
+++ b/pkg/controller/utils/clusterdeployment.go
@@ -1,7 +1,13 @@
 package utils
 
 import (
+	"errors"
+	"fmt"
 	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
@@ -10,4 +16,55 @@ import (
 func IsDeleteProtected(cd *hivev1.ClusterDeployment) bool {
 	protectedDelete, err := strconv.ParseBool(cd.Annotations[constants.ProtectedDeleteAnnotation])
 	return protectedDelete && err == nil
+}
+
+func ShouldSyncCluster(cd *hivev1.ClusterDeployment, logger log.FieldLogger) bool {
+	if paused, err := strconv.ParseBool(cd.Annotations[constants.SyncsetPauseAnnotation]); err == nil && paused {
+		logger.WithField("annotation", constants.SyncsetPauseAnnotation).Warn("syncing to cluster is disabled by annotation")
+		return false
+	}
+	if _, relocating := cd.Annotations[constants.RelocateAnnotation]; relocating {
+		logger.WithField("annotation", constants.RelocateAnnotation).Info("syncing to cluster is disabled by annotation")
+		return false
+	}
+	return true
+}
+
+func IsRelocating(obj metav1.Object) (relocateName string, status hivev1.RelocateStatus, err error) {
+	relocateValue, ok := obj.GetAnnotations()[constants.RelocateAnnotation]
+	if !ok {
+		return
+	}
+	relocateParts := strings.SplitN(relocateValue, "/", 2)
+	if len(relocateParts) != 2 {
+		err = errors.New("could not parse")
+		return
+	}
+	relocateName = relocateParts[0]
+	status = hivev1.RelocateStatus(relocateParts[1])
+	return
+}
+
+// SetRelocateAnnotation sets the relocate annotation on the specified object.
+func SetRelocateAnnotation(obj metav1.Object, relocateName string, relocateStatus hivev1.RelocateStatus) (changed bool) {
+	value := fmt.Sprintf("%s/%s", relocateName, relocateStatus)
+	annotations := obj.GetAnnotations()
+	changed = annotations[constants.RelocateAnnotation] != value
+	if annotations == nil {
+		annotations = make(map[string]string, 1)
+	}
+	annotations[constants.RelocateAnnotation] = value
+	obj.SetAnnotations(annotations)
+	return
+}
+
+func ClearRelocateAnnotation(obj metav1.Object) (changed bool) {
+	annotations := obj.GetAnnotations()
+	oldLength := len(annotations)
+	delete(annotations, constants.RelocateAnnotation)
+	if oldLength == len(annotations) {
+		return false
+	}
+	obj.SetAnnotations(annotations)
+	return true
 }

--- a/pkg/controller/utils/clusterdeployment_test.go
+++ b/pkg/controller/utils/clusterdeployment_test.go
@@ -3,8 +3,11 @@ package utils
 import (
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/test/clusterdeployment"
 	"github.com/openshift/hive/pkg/test/generic"
@@ -50,6 +53,169 @@ func TestIsDeleteProtected(t *testing.T) {
 			cd := clusterdeployment.Build(options...)
 			actualResult := IsDeleteProtected(cd)
 			assert.Equal(t, tc.expectedResult, actualResult, "unexpected result")
+		})
+	}
+}
+
+func TestShouldSyncCluster(t *testing.T) {
+	cases := []struct {
+		name     string
+		cd       *hivev1.ClusterDeployment
+		expected bool
+	}{
+		{
+			name:     "no annotation",
+			cd:       clusterdeployment.Build(),
+			expected: true,
+		},
+		{
+			name: "syncset annotation true",
+			cd: clusterdeployment.Build(
+				clusterdeployment.Generic(generic.WithAnnotation(constants.SyncsetPauseAnnotation, "true")),
+			),
+		},
+		{
+			name: "syncset annotation false",
+			cd: clusterdeployment.Build(
+				clusterdeployment.Generic(generic.WithAnnotation(constants.SyncsetPauseAnnotation, "false")),
+			),
+			expected: true,
+		},
+		{
+			name: "syncset annotation not parsable",
+			cd: clusterdeployment.Build(
+				clusterdeployment.Generic(generic.WithAnnotation(constants.SyncsetPauseAnnotation, "other")),
+			),
+			expected: true,
+		},
+		{
+			name: "relocate annotation",
+			cd: clusterdeployment.Build(
+				clusterdeployment.Generic(generic.WithAnnotation(constants.RelocateAnnotation, "some-relocate/outgoing")),
+			),
+			expected: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := ShouldSyncCluster(tc.cd, logrus.StandardLogger())
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestIsRelocating(t *testing.T) {
+	cases := []struct {
+		name                 string
+		obj                  hivev1.MetaRuntimeObject
+		expectedRelocateName string
+		expectedStatus       hivev1.RelocateStatus
+		expectError          bool
+	}{
+		{
+			name: "no annotation",
+			obj:  clusterdeployment.Build(),
+		},
+		{
+			name: "valid annotation",
+			obj: clusterdeployment.Build(
+				clusterdeployment.Generic(generic.WithAnnotation(constants.RelocateAnnotation, "test-relocate/outgoing")),
+			),
+			expectedRelocateName: "test-relocate",
+			expectedStatus:       hivev1.RelocateOutgoing,
+		},
+		{
+			name: "malformed annotation",
+			obj: clusterdeployment.Build(
+				clusterdeployment.Generic(generic.WithAnnotation(constants.RelocateAnnotation, "bad-value")),
+			),
+			expectError: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualRelocateName, actualStatus, actualError := IsRelocating(tc.obj)
+			if tc.expectError {
+				assert.Error(t, actualError, "expected error")
+				return
+			}
+			require.NoError(t, actualError, "unexpected error")
+			assert.Equal(t, tc.expectedRelocateName, actualRelocateName, "unexpected relocate name")
+			assert.Equal(t, tc.expectedStatus, actualStatus, "unexpected relocate status")
+		})
+	}
+}
+
+func TestSetRelocateAnnotation(t *testing.T) {
+	cases := []struct {
+		name                    string
+		obj                     hivev1.MetaRuntimeObject
+		relocateName            string
+		relocateStatus          hivev1.RelocateStatus
+		expectedAnnotationValue string
+		expectedChanged         bool
+	}{
+		{
+			name:                    "new annotation",
+			obj:                     clusterdeployment.Build(),
+			relocateName:            "test-relocate",
+			relocateStatus:          hivev1.RelocateOutgoing,
+			expectedAnnotationValue: "test-relocate/outgoing",
+			expectedChanged:         true,
+		},
+		{
+			name: "replace annotation",
+			obj: clusterdeployment.Build(
+				clusterdeployment.Generic(generic.WithAnnotation(constants.RelocateAnnotation, "other-relocate/outgoing")),
+			),
+			relocateName:            "test-relocate",
+			relocateStatus:          hivev1.RelocateOutgoing,
+			expectedAnnotationValue: "test-relocate/outgoing",
+			expectedChanged:         true,
+		},
+		{
+			name: "no change",
+			obj: clusterdeployment.Build(
+				clusterdeployment.Generic(generic.WithAnnotation(constants.RelocateAnnotation, "test-relocate/outgoing")),
+			),
+			relocateName:            "test-relocate",
+			relocateStatus:          hivev1.RelocateOutgoing,
+			expectedAnnotationValue: "test-relocate/outgoing",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualChanged := SetRelocateAnnotation(tc.obj, tc.relocateName, tc.relocateStatus)
+			actualAnnotationValue := tc.obj.GetAnnotations()[constants.RelocateAnnotation]
+			assert.Equal(t, tc.expectedAnnotationValue, actualAnnotationValue, "unexpected annotation value")
+			assert.Equal(t, tc.expectedChanged, actualChanged, "unexpected changed result")
+		})
+	}
+}
+
+func TestClearRelocateAnnotation(t *testing.T) {
+	cases := []struct {
+		name            string
+		obj             hivev1.MetaRuntimeObject
+		expectedChanged bool
+	}{
+		{
+			name: "no annotation",
+			obj:  clusterdeployment.Build(),
+		},
+		{
+			name: "existing annotation",
+			obj: clusterdeployment.Build(
+				clusterdeployment.Generic(generic.WithAnnotation(constants.RelocateAnnotation, "test-relocate/outgoing")),
+			),
+			expectedChanged: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualChanged := ClearRelocateAnnotation(tc.obj)
+			assert.NotContains(t, tc.obj.GetAnnotations(), constants.RelocateAnnotation, "unexpected relocate annotation")
+			assert.Equal(t, tc.expectedChanged, actualChanged, "unexpected changed result")
 		})
 	}
 }

--- a/pkg/controller/utils/dnszone.go
+++ b/pkg/controller/utils/dnszone.go
@@ -1,0 +1,101 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
+)
+
+func EnqueueDNSZonesOwnedByClusterDeployment(c client.Client, logger log.FieldLogger) handler.EventHandler {
+	return &handler.EnqueueRequestsFromMapFunc{ToRequests: handler.ToRequestsFunc(func(mapObj handler.MapObject) []reconcile.Request {
+		dnsZones := &hivev1.DNSZoneList{}
+		if err := c.List(
+			context.TODO(),
+			dnsZones,
+			client.InNamespace(mapObj.Meta.GetNamespace()),
+			client.MatchingLabels{
+				constants.DNSZoneTypeLabel:           constants.DNSZoneTypeChild,
+				constants.ClusterDeploymentNameLabel: mapObj.Meta.GetName(),
+			},
+		); err != nil {
+			logger.WithError(err).Log(LogLevel(err), "could not list DNS zones owned by ClusterDeployment")
+			return nil
+		}
+		requests := make([]reconcile.Request, len(dnsZones.Items))
+		for i, dnsZone := range dnsZones.Items {
+			request, err := client.ObjectKeyFromObject(&dnsZone)
+			if err != nil {
+				logger.WithError(err).Error("could not get object key for DNS zone")
+				continue
+			}
+			requests[i] = reconcile.Request{NamespacedName: request}
+		}
+		return requests
+	})}
+}
+
+// ReconcileDNSZoneForRelocation performs reconciliation on a DNSZone that is in the midst of a relocation to a new
+// Hive instance.
+// If the DNSZone is undergoing relocation, then the source Hive instance should not act on the DNSZone.
+// If the DNSZone is undergoing relocation, then the destination Hive instance should not act on the DNSZone except to
+// allow for a delete.
+// If the DSNZone has completed relocation, then the source Hive instance should not act on the DNSZone except to remove
+// the finalizer.
+func ReconcileDNSZoneForRelocation(c client.Client, logger log.FieldLogger, dnsZone *hivev1.DNSZone, finalizer string) (*reconcile.Result, error) {
+	_, relocateStatus, err := IsRelocating(dnsZone)
+	// Block reconciliation when relocate status cannot be determined.
+	if err != nil {
+		logger.WithField("annotation", constants.RelocateAnnotation).WithError(err).Error("could not determine whether DNSZone is relocating")
+		return nil, errors.Wrap(err, "could not determine whether DNSZone is relocating")
+	}
+	switch relocateStatus {
+	// Allow reconciliation when not relocating.
+	case "":
+		logger.Debug("DNSZone is not involved in a relocate")
+		return nil, nil
+	// Block reconciliation when relocating out to another cluster.
+	case hivev1.RelocateOutgoing:
+		logger.Info("reconciling DNSZone is disabled for outgoing relocate")
+		return &reconcile.Result{}, nil
+	// Block reconciliation when relocating in from another cluster. Remove the finalizer if the DNSZone has been
+	// deleted. This allows the DNSZone copied to the destination cluster to be deleted and replaced or to be deleted
+	// after a failed reconciliation.
+	case hivev1.RelocateIncoming:
+		logger.Info("reconciling DNSZone is disabled for incoming relocate")
+		if dnsZone.DeletionTimestamp != nil {
+			if err := removeFinalizerIfPresent(c, logger, dnsZone, finalizer); err != nil {
+				return nil, err
+			}
+		}
+		return &reconcile.Result{}, nil
+	// Clear finalizer on a DNSZone that has completed relocation out to another cluster.
+	case hivev1.RelocateComplete:
+		logger.Info("reconciling DNSZone is disabled after being relocated")
+		return &reconcile.Result{}, removeFinalizerIfPresent(c, logger, dnsZone, finalizer)
+	default:
+		logger.WithField("annotation", constants.RelocateAnnotation).Error("unknown relocate status")
+		return nil, errors.New("unknown relocate status")
+	}
+}
+
+func removeFinalizerIfPresent(c client.Client, logger log.FieldLogger, obj hivev1.MetaRuntimeObject, finalizer string) error {
+	if !HasFinalizer(obj, finalizer) {
+		return nil
+	}
+	logger = logger.WithField("finalizer", finalizer)
+	logger.Debug("Removing finalizer")
+	DeleteFinalizer(obj, finalizer)
+	if err := c.Update(context.TODO(), obj); err != nil {
+		logger.WithError(err).Log(LogLevel(err), "failed to remove finalizer")
+		return errors.Wrap(err, "failed to remove finalizer")
+	}
+	return nil
+}

--- a/pkg/controller/utils/dnszone_test.go
+++ b/pkg/controller/utils/dnszone_test.go
@@ -1,0 +1,114 @@
+package utils
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
+	testdnszone "github.com/openshift/hive/pkg/test/dnszone"
+	testgeneric "github.com/openshift/hive/pkg/test/generic"
+)
+
+func TestReconcileDNSZoneForRelocation(t *testing.T) {
+	const (
+		testNamespace   = "test-namespace"
+		testDNSZoneName = "test-dnszone"
+		testFinalizer   = "test-finalizer"
+	)
+	scheme := runtime.NewScheme()
+	hivev1.AddToScheme(scheme)
+	cases := []struct {
+		name              string
+		dnsZone           *hivev1.DNSZone
+		expectResult      bool
+		expectError       bool
+		expectNoFinalizer bool
+	}{
+		{
+			name: "no relocate annotation",
+			dnsZone: testdnszone.FullBuilder(testNamespace, testDNSZoneName, scheme).
+				GenericOptions(
+					testgeneric.WithFinalizer(testFinalizer),
+				).
+				Build(),
+		},
+		{
+			name: "relocate outgoing",
+			dnsZone: testdnszone.FullBuilder(testNamespace, testDNSZoneName, scheme).
+				GenericOptions(
+					testgeneric.WithFinalizer(testFinalizer),
+					testgeneric.WithAnnotation(constants.RelocateAnnotation, "some-relocate/outgoing"),
+				).
+				Build(),
+			expectResult: true,
+		},
+		{
+			name: "relocate complete",
+			dnsZone: testdnszone.FullBuilder(testNamespace, testDNSZoneName, scheme).
+				GenericOptions(
+					testgeneric.WithFinalizer(testFinalizer),
+					testgeneric.WithAnnotation(constants.RelocateAnnotation, "some-relocate/complete"),
+				).
+				Build(),
+			expectResult:      true,
+			expectNoFinalizer: true,
+		},
+		{
+			name: "relocate incoming",
+			dnsZone: testdnszone.FullBuilder(testNamespace, testDNSZoneName, scheme).
+				GenericOptions(
+					testgeneric.WithFinalizer(testFinalizer),
+					testgeneric.WithAnnotation(constants.RelocateAnnotation, "some-relocate/incoming"),
+				).
+				Build(),
+			expectResult: true,
+		},
+		{
+			name: "relocate with unknown status",
+			dnsZone: testdnszone.FullBuilder(testNamespace, testDNSZoneName, scheme).
+				GenericOptions(
+					testgeneric.WithFinalizer(testFinalizer),
+					testgeneric.WithAnnotation(constants.RelocateAnnotation, "some-relocate/other-status"),
+				).
+				Build(),
+			expectError: true,
+		},
+		{
+			name: "relocate with malformed annotation value",
+			dnsZone: testdnszone.FullBuilder(testNamespace, testDNSZoneName, scheme).
+				GenericOptions(
+					testgeneric.WithFinalizer(testFinalizer),
+					testgeneric.WithAnnotation(constants.RelocateAnnotation, "bad-value"),
+				).
+				Build(),
+			expectError: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := log.WithField("", "")
+			client := fake.NewFakeClientWithScheme(scheme, tc.dnsZone)
+			result, err := ReconcileDNSZoneForRelocation(client, logger, tc.dnsZone, testFinalizer)
+			if tc.expectResult {
+				assert.NotNil(t, result, "expected result")
+			} else {
+				assert.Nil(t, result, "expected no result")
+			}
+			if tc.expectError {
+				assert.Error(t, err, "expected error")
+			} else {
+				assert.NoError(t, err, "expected no error")
+			}
+			if tc.expectNoFinalizer {
+				assert.NotContains(t, tc.dnsZone.Finalizers, testFinalizer, "expected no finalizer")
+			} else {
+				assert.Contains(t, tc.dnsZone.Finalizers, testFinalizer, "expected finalizer")
+			}
+		})
+	}
+}

--- a/pkg/remoteclient/kubeconfig.go
+++ b/pkg/remoteclient/kubeconfig.go
@@ -1,0 +1,64 @@
+package remoteclient
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+)
+
+func NewBuilderFromKubeconfig(c client.Client, secret *corev1.Secret) Builder {
+	return &kubeconfigBuilder{
+		c:      c,
+		secret: secret,
+	}
+}
+
+type kubeconfigBuilder struct {
+	c      client.Client
+	secret *corev1.Secret
+}
+
+func (b *kubeconfigBuilder) Build() (client.Client, error) {
+	cfg, err := b.RESTConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	scheme := runtime.NewScheme()
+	corev1.SchemeBuilder.AddToScheme(scheme)
+	hivev1.SchemeBuilder.AddToScheme(scheme)
+
+	return client.New(cfg, client.Options{
+		Scheme: scheme,
+	})
+}
+
+func (b *kubeconfigBuilder) BuildDynamic() (dynamic.Interface, error) {
+	cfg, err := b.RESTConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+func (b *kubeconfigBuilder) UsePrimaryAPIURL() Builder {
+	return b
+}
+
+func (b *kubeconfigBuilder) UseSecondaryAPIURL() Builder {
+	return b
+}
+
+func (b *kubeconfigBuilder) RESTConfig() (*rest.Config, error) {
+	return restConfigFromSecret(b.secret)
+}

--- a/pkg/remoteclient/remoteclient.go
+++ b/pkg/remoteclient/remoteclient.go
@@ -135,7 +135,7 @@ func connectToRemoteCluster(
 
 // InitialURL returns the initial API URL for the ClusterDeployment.
 func InitialURL(c client.Client, cd *hivev1.ClusterDeployment) (string, error) {
-	cfg, err := restConfig(c, cd)
+	cfg, err := unadulteratedRESTConfig(c, cd)
 	if err != nil {
 		return "", err
 	}
@@ -254,25 +254,7 @@ func (b *builder) UseSecondaryAPIURL() Builder {
 }
 
 func (b *builder) RESTConfig() (*rest.Config, error) {
-	kubeconfigSecret := &corev1.Secret{}
-	if err := b.c.Get(
-		context.Background(),
-		client.ObjectKey{Namespace: b.cd.Namespace, Name: b.cd.Spec.ClusterMetadata.AdminKubeconfigSecretRef.Name},
-		kubeconfigSecret,
-	); err != nil {
-		return nil, errors.Wrap(err, "could not get admin kubeconfig secret")
-	}
-	kubeconfigData, ok := kubeconfigSecret.Data[constants.KubeconfigSecretKey]
-	if !ok {
-		return nil, errors.Errorf("admin kubeconfig secret does not contain %q data", constants.KubeconfigSecretKey)
-	}
-
-	config, err := clientcmd.Load(kubeconfigData)
-	if err != nil {
-		return nil, err
-	}
-	kubeConfig := clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{})
-	cfg, err := kubeConfig.ClientConfig()
+	cfg, err := unadulteratedRESTConfig(b.c, b.cd)
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +271,7 @@ func (b *builder) RESTConfig() (*rest.Config, error) {
 	return cfg, nil
 }
 
-func restConfig(c client.Client, cd *hivev1.ClusterDeployment) (*rest.Config, error) {
+func unadulteratedRESTConfig(c client.Client, cd *hivev1.ClusterDeployment) (*rest.Config, error) {
 	kubeconfigSecret := &corev1.Secret{}
 	if err := c.Get(
 		context.Background(),
@@ -298,11 +280,14 @@ func restConfig(c client.Client, cd *hivev1.ClusterDeployment) (*rest.Config, er
 	); err != nil {
 		return nil, errors.Wrap(err, "could not get admin kubeconfig secret")
 	}
+	return restConfigFromSecret(kubeconfigSecret)
+}
+
+func restConfigFromSecret(kubeconfigSecret *corev1.Secret) (*rest.Config, error) {
 	kubeconfigData, ok := kubeconfigSecret.Data[constants.KubeconfigSecretKey]
 	if !ok {
-		return nil, errors.Errorf("admin kubeconfig secret does not contain %q data", constants.KubeconfigSecretKey)
+		return nil, errors.Errorf("kubeconfig secret does not contain %q data", constants.KubeconfigSecretKey)
 	}
-
 	config, err := clientcmd.Load(kubeconfigData)
 	if err != nil {
 		return nil, err

--- a/pkg/test/generic/generic.go
+++ b/pkg/test/generic/generic.go
@@ -141,3 +141,11 @@ func WithoutFinalizer(finalizer string) Option {
 		meta.SetFinalizers(finalizers.List())
 	}
 }
+
+// Deleted sets a deletion timestamp on the object.
+func Deleted() Option {
+	return func(meta hivev1.MetaRuntimeObject) {
+		now := metav1.Now()
+		meta.SetDeletionTimestamp(&now)
+	}
+}


### PR DESCRIPTION
When a ClusterRelocate has a label selector that matches with a ClusterDeployment, the clusterrelocate controller will relocate the matching ClusterDeployment.

1. Set the hive.openshift.io/relocate annotation to outgoing on the ClusterDeployment and the DNSZone.
2. Copy secrets, configmaps, machinesets, syncsets, and syncidentityproviders.
3. Copy the DNSZone for the ClusterDeployment, with the relocate annotation set to incoming.
4. Copy the ClusterDeployment, with the relocate annotation set to incoming.
5. Set the relocate annotation on the DNSZone and ClusterDeployemnt to complete.

When a ClusterDeployment with a relocate annotation set to incoming is reconciled by the clusterRelocate controller, the relocate annotation is removed from the DNSZone and the ClusterDeployment. This indicates that the relocate has completed on the destination side.

When a ClusterDeployment has the relocated annotation, no controllers will do any mutation of the remote cluster (such as syncing syncsets). When the ClusterDeployment has the relocated annotation, then controllers will not run finalizer code when the ClusterDeployment is deleted.

Add a hive_cluster_relocations counter vec that tracks the total number of successful cluster relocations. The metric has a single
cluster_relocate label that is the name of the ClusterRelocate directing the relocation.

Add a hive_aborted_cluster_relocations counter vec that tracks the total number of aborted cluster relocations. The metrics has two labels: cluster_relocate and reason. The cluster_relocate label is the name of the ClusterRelocate directing the aborted relocation. The reason label is the reason why the relocate was aborted. Possible values for the reason label are "no_match", "multiple_matches", and "new_match".

The number of failing cluster relocates can be seen by looking at the hive_cluster_deployments_conditions metric and filtering on
a value of RelocationFailed for the condition label.

https://issues.redhat.com/browse/CO-653