### PR TITLE
Handle applying resources too large to include in an annotation

### DIFF
--- a/config/crds/hive.openshift.io_selectorsyncsets.yaml
+++ b/config/crds/hive.openshift.io_selectorsyncsets.yaml
@@ -78,6 +78,13 @@ spec:
                     are ANDed.
                   type: object
               type: object
+            omitAnnotation:
+              description: OmitAnnotation if true indicates that the usual annotation
+                used by the apply command will be omitted from the target resources.
+                This results in some loss of functionality when syncing removal of
+                map entries, but it makes it possible to sync large resources that
+                otherwise could not be synced.
+              type: boolean
             patches:
               description: Patches is the list of patches to apply.
               items:

--- a/config/crds/hive.openshift.io_selectorsyncsets.yaml
+++ b/config/crds/hive.openshift.io_selectorsyncsets.yaml
@@ -34,6 +34,19 @@ spec:
             and patches to sync along with a ClusterDeploymentSelector indicating
             which clusters the SelectorSyncSet applies to in any namespace.
           properties:
+            applyBehavior:
+              description: ApplyBehavior indicates how resources in this syncset will
+                be applied to the target cluster. The default value of "Apply" indicates
+                that resources should be applied using the 'oc apply' command. If
+                no value is set, "Apply" is assumed. A value of "CreateOnly" indicates
+                that the resource will only be created if it does not already exist
+                in the target cluster. Otherwise, it will be left alone. A value of
+                "CreateOrUpdate" indicates that the resource will be created/updated
+                without the use of the 'oc apply' command, allowing larger resources
+                to be synced, but losing some functionality of the 'oc apply' command
+                such as the ability to remove annotations, labels, and other map entries
+                in general.
+              type: string
             clusterDeploymentSelector:
               description: ClusterDeploymentSelector is a LabelSelector indicating
                 which clusters the SelectorSyncSet applies to in any namespace.
@@ -78,13 +91,6 @@ spec:
                     are ANDed.
                   type: object
               type: object
-            omitAnnotation:
-              description: OmitAnnotation if true indicates that the usual annotation
-                used by the apply command will be omitted from the target resources.
-                This results in some loss of functionality when syncing removal of
-                map entries, but it makes it possible to sync large resources that
-                otherwise could not be synced.
-              type: boolean
             patches:
               description: Patches is the list of patches to apply.
               items:

--- a/config/crds/hive.openshift.io_selectorsyncsets.yaml
+++ b/config/crds/hive.openshift.io_selectorsyncsets.yaml
@@ -46,6 +46,11 @@ spec:
                 to be synced, but losing some functionality of the 'oc apply' command
                 such as the ability to remove annotations, labels, and other map entries
                 in general.
+              enum:
+              - ""
+              - Apply
+              - CreateOnly
+              - CreateOrUpdate
               type: string
             clusterDeploymentSelector:
               description: ClusterDeploymentSelector is a LabelSelector indicating

--- a/config/crds/hive.openshift.io_syncsets.yaml
+++ b/config/crds/hive.openshift.io_syncsets.yaml
@@ -34,6 +34,19 @@ spec:
             to sync along with ClusterDeploymentRefs indicating which clusters the
             SyncSet applies to in the SyncSet's namespace.
           properties:
+            applyBehavior:
+              description: ApplyBehavior indicates how resources in this syncset will
+                be applied to the target cluster. The default value of "Apply" indicates
+                that resources should be applied using the 'oc apply' command. If
+                no value is set, "Apply" is assumed. A value of "CreateOnly" indicates
+                that the resource will only be created if it does not already exist
+                in the target cluster. Otherwise, it will be left alone. A value of
+                "CreateOrUpdate" indicates that the resource will be created/updated
+                without the use of the 'oc apply' command, allowing larger resources
+                to be synced, but losing some functionality of the 'oc apply' command
+                such as the ability to remove annotations, labels, and other map entries
+                in general.
+              type: string
             clusterDeploymentRefs:
               description: ClusterDeploymentRefs is the list of LocalObjectReference
                 indicating which clusters the SyncSet applies to in the SyncSet's
@@ -48,13 +61,6 @@ spec:
                     type: string
                 type: object
               type: array
-            omitAnnotation:
-              description: OmitAnnotation if true indicates that the usual annotation
-                used by the apply command will be omitted from the target resources.
-                This results in some loss of functionality when syncing removal of
-                map entries, but it makes it possible to sync large resources that
-                otherwise could not be synced.
-              type: boolean
             patches:
               description: Patches is the list of patches to apply.
               items:

--- a/config/crds/hive.openshift.io_syncsets.yaml
+++ b/config/crds/hive.openshift.io_syncsets.yaml
@@ -48,6 +48,13 @@ spec:
                     type: string
                 type: object
               type: array
+            omitAnnotation:
+              description: OmitAnnotation if true indicates that the usual annotation
+                used by the apply command will be omitted from the target resources.
+                This results in some loss of functionality when syncing removal of
+                map entries, but it makes it possible to sync large resources that
+                otherwise could not be synced.
+              type: boolean
             patches:
               description: Patches is the list of patches to apply.
               items:

--- a/config/crds/hive.openshift.io_syncsets.yaml
+++ b/config/crds/hive.openshift.io_syncsets.yaml
@@ -46,6 +46,11 @@ spec:
                 to be synced, but losing some functionality of the 'oc apply' command
                 such as the ability to remove annotations, labels, and other map entries
                 in general.
+              enum:
+              - ""
+              - Apply
+              - CreateOnly
+              - CreateOrUpdate
               type: string
             clusterDeploymentRefs:
               description: ClusterDeploymentRefs is the list of LocalObjectReference

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/golangci/golangci-lint v1.23.8
 	github.com/google/uuid v1.1.1
 	github.com/heptio/velero v1.0.0
+	github.com/jonboulle/clockwork v0.1.0
 	github.com/json-iterator/go v1.1.9
 	github.com/miekg/dns v1.1.15
 	github.com/modern-go/reflect2 v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -2512,6 +2512,7 @@ k8s.io/apimachinery v0.17.3/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0
 k8s.io/apimachinery v0.18.0/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
 k8s.io/apimachinery v0.18.2 h1:44CmtbmkzVDAhCpRVSiP2R5PPrC2RtlIv/MoB8xpdRA=
 k8s.io/apimachinery v0.18.2/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
+k8s.io/apimachinery v0.18.3 h1:pOGcbVAhxADgUYnjS08EFXs9QMl8qaH5U4fr5LGUrSk=
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
 k8s.io/apiserver v0.0.0-20190918200908-1e17798da8c1/go.mod h1:4FuDU+iKPjdsdQSN3GsEKZLB/feQsj1y9dhhBDVV2Ns=
 k8s.io/apiserver v0.0.0-20191121020624-6eed2f5a3289/go.mod h1:7P+0qMKoaggchirHLUSCVD22ohdkjN19+qQOKcAdfbI=

--- a/pkg/apis/hive/v1/syncset_types.go
+++ b/pkg/apis/hive/v1/syncset_types.go
@@ -22,25 +22,26 @@ const (
 )
 
 // SyncSetApplyBehavior is a string representing the behavior to use when
-// aplying a syncset to t arget cluster.
+// aplying a syncset to target cluster.
+// +kubebuilder:validation:Enum="";Apply;CreateOnly;CreateOrUpdate
 type SyncSetApplyBehavior string
 
 const (
 	// ApplySyncSetApplyBehavior is the default apply behavior. It will result
 	// in resources getting applied using the 'oc apply' command to the target
 	// cluster.
-	ApplySyncSetApplyBehavior = "Apply"
+	ApplySyncSetApplyBehavior SyncSetApplyBehavior = "Apply"
 
 	// CreateOnlySyncSetApplyBehavior results in resources only getting created
 	// if they do not exist, otherwise they are left alone.
-	CreateOnlySyncSetApplyBehavior = "CreateOnly"
+	CreateOnlySyncSetApplyBehavior SyncSetApplyBehavior = "CreateOnly"
 
 	// CreateOrUpdateSyncSetApplyBehavior results in resources getting created if
 	// they do not exist, otherwise they are updated with the contents of the
 	// syncset resource. This is different from Apply behavior in that an annotation
 	// is not added to the target resource with the "lastApplied" value. It allows
 	// for syncing larger resources, but loses the ability to sync map entry deletes.
-	CreateOrUpdateSyncSetApplyBehavior = "CreateOrUpdate"
+	CreateOrUpdateSyncSetApplyBehavior SyncSetApplyBehavior = "CreateOrUpdate"
 )
 
 // SyncSetPatchApplyMode is a string representing the mode with which to apply

--- a/pkg/apis/hive/v1/syncset_types.go
+++ b/pkg/apis/hive/v1/syncset_types.go
@@ -21,6 +21,28 @@ const (
 	SyncResourceApplyMode SyncSetResourceApplyMode = "Sync"
 )
 
+// SyncSetApplyBehavior is a string representing the behavior to use when
+// aplying a syncset to t arget cluster.
+type SyncSetApplyBehavior string
+
+const (
+	// ApplySyncSetApplyBehavior is the default apply behavior. It will result
+	// in resources getting applied using the 'oc apply' command to the target
+	// cluster.
+	ApplySyncSetApplyBehavior = "Apply"
+
+	// CreateOnlySyncSetApplyBehavior results in resources only getting created
+	// if they do not exist, otherwise they are left alone.
+	CreateOnlySyncSetApplyBehavior = "CreateOnly"
+
+	// CreateOrUpdateSyncSetApplyBehavior results in resources getting created if
+	// they do not exist, otherwise they are updated with the contents of the
+	// syncset resource. This is different from Apply behavior in that an annotation
+	// is not added to the target resource with the "lastApplied" value. It allows
+	// for syncing larger resources, but loses the ability to sync map entry deletes.
+	CreateOrUpdateSyncSetApplyBehavior = "CreateOrUpdate"
+)
+
 // SyncSetPatchApplyMode is a string representing the mode with which to apply
 // SyncSet Patches.
 type SyncSetPatchApplyMode string
@@ -199,12 +221,17 @@ type SyncSetCommonSpec struct {
 	// +optional
 	Secrets []SecretMapping `json:"secretMappings,omitempty"`
 
-	// OmitAnnotation if true indicates that the usual annotation used by the apply command
-	// will be omitted from the target resources. This results in some loss of functionality
-	// when syncing removal of map entries, but it makes it possible to sync large resources
-	// that otherwise could not be synced.
+	// ApplyBehavior indicates how resources in this syncset will be applied to the target
+	// cluster. The default value of "Apply" indicates that resources should be applied
+	// using the 'oc apply' command. If no value is set, "Apply" is assumed.
+	// A value of "CreateOnly" indicates that the resource will only be created if it does
+	// not already exist in the target cluster. Otherwise, it will be left alone.
+	// A value of "CreateOrUpdate" indicates that the resource will be created/updated without
+	// the use of the 'oc apply' command, allowing larger resources to be synced, but losing
+	// some functionality of the 'oc apply' command such as the ability to remove annotations,
+	// labels, and other map entries in general.
 	// +optional
-	OmitAnnotation bool `json:"omitAnnotation,omitempty"`
+	ApplyBehavior SyncSetApplyBehavior `json:"applyBehavior,omitempty"`
 }
 
 // SelectorSyncSetSpec defines the SyncSetCommonSpec resources and patches to sync along

--- a/pkg/apis/hive/v1/syncset_types.go
+++ b/pkg/apis/hive/v1/syncset_types.go
@@ -198,6 +198,13 @@ type SyncSetCommonSpec struct {
 	// Secrets is the list of secrets to sync along with their respective destinations.
 	// +optional
 	Secrets []SecretMapping `json:"secretMappings,omitempty"`
+
+	// OmitAnnotation if true indicates that the usual annotation used by the apply command
+	// will be omitted from the target resources. This results in some loss of functionality
+	// when syncing removal of map entries, but it makes it possible to sync large resources
+	// that otherwise could not be synced.
+	// +optional
+	OmitAnnotation bool `json:"omitAnnotation,omitempty"`
 }
 
 // SelectorSyncSetSpec defines the SyncSetCommonSpec resources and patches to sync along

--- a/pkg/controller/syncsetinstance/syncsetinstance_controller_test.go
+++ b/pkg/controller/syncsetinstance/syncsetinstance_controller_test.go
@@ -1201,6 +1201,10 @@ func (f *fakeHelper) CreateOrUpdateRuntimeObject(object runtime.Object, scheme *
 	return f.ApplyRuntimeObject(object, scheme)
 }
 
+func (f *fakeHelper) CreateRuntimeObject(object runtime.Object, scheme *runtime.Scheme) (resource.ApplyResult, error) {
+	return f.ApplyRuntimeObject(object, scheme)
+}
+
 func (f *fakeHelper) ApplyRuntimeObject(object runtime.Object, scheme *runtime.Scheme) (resource.ApplyResult, error) {
 	data, err := json.Marshal(object)
 	if err != nil {
@@ -1210,6 +1214,10 @@ func (f *fakeHelper) ApplyRuntimeObject(object runtime.Object, scheme *runtime.S
 }
 
 func (f *fakeHelper) CreateOrUpdate(data []byte) (resource.ApplyResult, error) {
+	return f.Apply(data)
+}
+
+func (f *fakeHelper) Create(data []byte) (resource.ApplyResult, error) {
 	return f.Apply(data)
 }
 

--- a/pkg/controller/syncsetinstance/syncsetinstance_controller_test.go
+++ b/pkg/controller/syncsetinstance/syncsetinstance_controller_test.go
@@ -1197,11 +1197,19 @@ func (f *fakeHelper) newHelper(*rest.Config, log.FieldLogger) Applier {
 	return f
 }
 
+func (f *fakeHelper) CreateOrUpdateRuntimeObject(object runtime.Object, scheme *runtime.Scheme) (resource.ApplyResult, error) {
+	return f.ApplyRuntimeObject(object, scheme)
+}
+
 func (f *fakeHelper) ApplyRuntimeObject(object runtime.Object, scheme *runtime.Scheme) (resource.ApplyResult, error) {
 	data, err := json.Marshal(object)
 	if err != nil {
 		return "", fmt.Errorf("cannot serialize runtime object: %s", err)
 	}
+	return f.Apply(data)
+}
+
+func (f *fakeHelper) CreateOrUpdate(data []byte) (resource.ApplyResult, error) {
 	return f.Apply(data)
 }
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -10210,6 +10210,19 @@ spec:
             and patches to sync along with a ClusterDeploymentSelector indicating
             which clusters the SelectorSyncSet applies to in any namespace.
           properties:
+            applyBehavior:
+              description: ApplyBehavior indicates how resources in this syncset will
+                be applied to the target cluster. The default value of "Apply" indicates
+                that resources should be applied using the 'oc apply' command. If
+                no value is set, "Apply" is assumed. A value of "CreateOnly" indicates
+                that the resource will only be created if it does not already exist
+                in the target cluster. Otherwise, it will be left alone. A value of
+                "CreateOrUpdate" indicates that the resource will be created/updated
+                without the use of the 'oc apply' command, allowing larger resources
+                to be synced, but losing some functionality of the 'oc apply' command
+                such as the ability to remove annotations, labels, and other map entries
+                in general.
+              type: string
             clusterDeploymentSelector:
               description: ClusterDeploymentSelector is a LabelSelector indicating
                 which clusters the SelectorSyncSet applies to in any namespace.
@@ -10254,13 +10267,6 @@ spec:
                     are ANDed.
                   type: object
               type: object
-            omitAnnotation:
-              description: OmitAnnotation if true indicates that the usual annotation
-                used by the apply command will be omitted from the target resources.
-                This results in some loss of functionality when syncing removal of
-                map entries, but it makes it possible to sync large resources that
-                otherwise could not be synced.
-              type: boolean
             patches:
               description: Patches is the list of patches to apply.
               items:
@@ -11417,6 +11423,19 @@ spec:
             to sync along with ClusterDeploymentRefs indicating which clusters the
             SyncSet applies to in the SyncSet's namespace.
           properties:
+            applyBehavior:
+              description: ApplyBehavior indicates how resources in this syncset will
+                be applied to the target cluster. The default value of "Apply" indicates
+                that resources should be applied using the 'oc apply' command. If
+                no value is set, "Apply" is assumed. A value of "CreateOnly" indicates
+                that the resource will only be created if it does not already exist
+                in the target cluster. Otherwise, it will be left alone. A value of
+                "CreateOrUpdate" indicates that the resource will be created/updated
+                without the use of the 'oc apply' command, allowing larger resources
+                to be synced, but losing some functionality of the 'oc apply' command
+                such as the ability to remove annotations, labels, and other map entries
+                in general.
+              type: string
             clusterDeploymentRefs:
               description: ClusterDeploymentRefs is the list of LocalObjectReference
                 indicating which clusters the SyncSet applies to in the SyncSet's
@@ -11431,13 +11450,6 @@ spec:
                     type: string
                 type: object
               type: array
-            omitAnnotation:
-              description: OmitAnnotation if true indicates that the usual annotation
-                used by the apply command will be omitted from the target resources.
-                This results in some loss of functionality when syncing removal of
-                map entries, but it makes it possible to sync large resources that
-                otherwise could not be synced.
-              type: boolean
             patches:
               description: Patches is the list of patches to apply.
               items:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -10254,6 +10254,13 @@ spec:
                     are ANDed.
                   type: object
               type: object
+            omitAnnotation:
+              description: OmitAnnotation if true indicates that the usual annotation
+                used by the apply command will be omitted from the target resources.
+                This results in some loss of functionality when syncing removal of
+                map entries, but it makes it possible to sync large resources that
+                otherwise could not be synced.
+              type: boolean
             patches:
               description: Patches is the list of patches to apply.
               items:
@@ -11424,6 +11431,13 @@ spec:
                     type: string
                 type: object
               type: array
+            omitAnnotation:
+              description: OmitAnnotation if true indicates that the usual annotation
+                used by the apply command will be omitted from the target resources.
+                This results in some loss of functionality when syncing removal of
+                map entries, but it makes it possible to sync large resources that
+                otherwise could not be synced.
+              type: boolean
             patches:
               description: Patches is the list of patches to apply.
               items:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -10222,6 +10222,11 @@ spec:
                 to be synced, but losing some functionality of the 'oc apply' command
                 such as the ability to remove annotations, labels, and other map entries
                 in general.
+              enum:
+              - ""
+              - Apply
+              - CreateOnly
+              - CreateOrUpdate
               type: string
             clusterDeploymentSelector:
               description: ClusterDeploymentSelector is a LabelSelector indicating
@@ -11435,6 +11440,11 @@ spec:
                 to be synced, but losing some functionality of the 'oc apply' command
                 such as the ability to remove annotations, labels, and other map entries
                 in general.
+              enum:
+              - ""
+              - Apply
+              - CreateOnly
+              - CreateOrUpdate
               type: string
             clusterDeploymentRefs:
               description: ClusterDeploymentRefs is the list of LocalObjectReference

--- a/pkg/resource/apply.go
+++ b/pkg/resource/apply.go
@@ -141,6 +141,9 @@ func (r *Helper) createOrUpdateResource(f cmdutil.Factory, obj []byte, errOut io
 		OpenapiSchema: openAPISchema,
 	}
 	sourceBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, sourceObj)
+	if err != nil {
+		return "", err
+	}
 	patch, _, err := patcher.Patch(info.Object, sourceBytes, info.Source, info.Namespace, info.Name, errOut)
 	if err != nil {
 		return "", err

--- a/test/integration/resource/createonly_test.go
+++ b/test/integration/resource/createonly_test.go
@@ -1,0 +1,124 @@
+package resource
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/openshift/hive/pkg/resource"
+)
+
+func TestCreateOnly(t *testing.T) {
+	tests := []struct {
+		name           string
+		existing       []runtime.Object
+		expectedResult resource.ApplyResult
+		apply          runtime.Object
+		validate       func(t *testing.T, info *resource.Info, ns string)
+	}{
+		{
+			name:           "create resource",
+			apply:          testConfigMap(),
+			expectedResult: resource.CreatedApplyResult,
+			validate: func(t *testing.T, info *resource.Info, ns string) {
+				expected := testConfigMap()
+				if info.Name != expected.Name {
+					t.Errorf("unexpected info name: %s", info.Name)
+				}
+				if info.Namespace != ns {
+					t.Errorf("unexpected info namespace: %s", info.Namespace)
+				}
+				if info.Kind != "ConfigMap" {
+					t.Errorf("unexpected info kind: %s", info.Kind)
+				}
+
+				cm := &corev1.ConfigMap{}
+				err := c.Get(context.TODO(), types.NamespacedName{Name: info.Name, Namespace: info.Namespace}, cm)
+				if err != nil {
+					t.Errorf("unexpected error retrieving configmap: %v", err)
+					return
+				}
+				if !reflect.DeepEqual(expected.Data, cm.Data) {
+					t.Errorf("unexpected configmap data: %v", cm.Data)
+				}
+			},
+		},
+		{
+			name:           "update resource",
+			existing:       []runtime.Object{testConfigMap()},
+			expectedResult: resource.UnchangedApplyResult,
+			apply: func() runtime.Object {
+				cm := testConfigMap()
+				cm.Data["foo"] = "baz"
+				return cm
+			}(),
+			validate: func(t *testing.T, info *resource.Info, ns string) {
+				cm := &corev1.ConfigMap{}
+				err := c.Get(context.TODO(), types.NamespacedName{Name: info.Name, Namespace: info.Namespace}, cm)
+				if err != nil {
+					t.Errorf("unexpected error retrieving configmap: %v", err)
+					return
+				}
+				if cm.Data["foo"] == "baz" {
+					t.Errorf("unexpected data: %v", cm.Data)
+				}
+			},
+		},
+	}
+
+	configs := []string{"restconfig", "kubeconfig"}
+
+	for _, test := range tests {
+		for _, clientConfig := range configs {
+			t.Run(test.name, func(t *testing.T) {
+				logger := log.WithField("test", test.name)
+				namespace := &corev1.Namespace{}
+				namespace.GenerateName = "apply-test-"
+				err := c.Create(context.TODO(), namespace)
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
+				}
+				var h *resource.Helper
+				if clientConfig == "kubeconfig" {
+					h = resource.NewHelper(kubeconfig, logger)
+				} else {
+					h = resource.NewHelperFromRESTConfig(cfg, logger)
+				}
+				accessor := meta.NewAccessor()
+				for _, obj := range test.existing {
+					o := obj.DeepCopyObject()
+					accessor.SetNamespace(o, namespace.Name)
+					_, err := h.CreateRuntimeObject(o, scheme.Scheme)
+					if err != nil {
+						t.Fatalf("unexpected err: %v", err)
+					}
+				}
+				accessor.SetNamespace(test.apply, namespace.Name)
+				data, err := h.Serialize(test.apply, scheme.Scheme)
+				t.Logf("The serialized resource:\n%s\n", string(data))
+				info, err := h.Info(data)
+				if err != nil {
+					t.Errorf("unexpected error calling info: %v", err)
+					return
+				}
+				applyResult, err := h.Create(data)
+				if err != nil {
+					t.Errorf("unexpected error calling apply: %v", err)
+					return
+				}
+				if applyResult != test.expectedResult {
+					t.Errorf("unexpected apply result: %v", applyResult)
+				}
+				test.validate(t, info, namespace.Name)
+			})
+		}
+	}
+}


### PR DESCRIPTION
If a resource is too large to include in an annotation, we currently fail to apply it via syncsets. This PR adds an applyBehavior field that can be set to either Apply (default), CreateOrUpdate, or CreateOnly
https://issues.redhat.com/browse/CO-379

CreateOrUpdate allows large resources to be synced, and its behavior is almost like Apply. However, we lose some functionality by not having the original resource in an annotation.

### What we lose with CreateOrUpdate
Because the original configuration is not present in the object, we lose the ability to delete previously-created keys in structs. (Lists should be ok afaik)
An example:
My original syncset: { "foo": "1", "bar": "2", "baz": "3"} 
That gets created on the target cluster...
then I change my syncset to {"foo": "1", "bar": "2"}
After applying the new change, the resource will remain unchanged on the target cluster because apply doesn't know that my intent was to delete "baz".

### One alternative:
With every update, we delete and recreate the resource - drawback: the resource will get re-created every time we resync syncsetinstances.

### Another alternative:
We replace the content of the resource with whatever is in the syncset, only keeping cluster-created metadata (resourceVersion, selfLink, etc). drawback: we don't know if there is server-side defaulting or some other change that gets applied every time that we create/update the resource, causing churn with every re-apply.