### PR TITLE
Fix panic while adding machinepool in existing vpc

### DIFF
--- a/pkg/controller/remotemachineset/awsactuator.go
+++ b/pkg/controller/remotemachineset/awsactuator.go
@@ -45,7 +45,7 @@ var (
 )
 
 // NewAWSActuator is the constructor for building a AWSActuator
-func NewAWSActuator(awsCreds *corev1.Secret, region string, pool *hivev1.MachinePool, remoteMachineSets []machineapi.MachineSet, scheme *runtime.Scheme, logger log.FieldLogger) (*AWSActuator, error) {
+func NewAWSActuator(client client.Client, awsCreds *corev1.Secret, region string, pool *hivev1.MachinePool, remoteMachineSets []machineapi.MachineSet, scheme *runtime.Scheme, logger log.FieldLogger) (*AWSActuator, error) {
 	awsClient, err := awsclient.NewClientFromSecret(awsCreds, region)
 	if err != nil {
 		logger.WithError(err).Warn("failed to create AWS client")
@@ -62,6 +62,7 @@ func NewAWSActuator(awsCreds *corev1.Secret, region string, pool *hivev1.Machine
 		}
 	}
 	actuator := &AWSActuator{
+		client:    client,
 		awsClient: awsClient,
 		logger:    logger,
 		region:    region,

--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -779,7 +779,7 @@ func (r *ReconcileRemoteMachineSet) createActuator(cd *hivev1.ClusterDeployment,
 		); err != nil {
 			return nil, err
 		}
-		return NewAWSActuator(creds, cd.Spec.Platform.AWS.Region, pool, remoteMachineSets, r.scheme, logger)
+		return NewAWSActuator(r.Client, creds, cd.Spec.Platform.AWS.Region, pool, remoteMachineSets, r.scheme, logger)
 	case cd.Spec.Platform.GCP != nil:
 		creds := &corev1.Secret{}
 		if err := r.Get(


### PR DESCRIPTION
Currently, adding machinepool to the cluster installed in existing vpc panics
when subnets are invalid. This is because kubernetes client used to update
machinepool object is not initialized. This PR fixes it.

jira: https://issues.redhat.com/browse/CO-992