### PR TITLE
Fix connection refused error not setting unreachable condition

### DIFF
--- a/pkg/remoteclient/remoteclient.go
+++ b/pkg/remoteclient/remoteclient.go
@@ -126,7 +126,7 @@ func connectToRemoteCluster(
 	unreachable = true
 	logger.WithError(err).Info("remote cluster is unreachable")
 	SetUnreachableCondition(cd, err)
-	if err := localClient.Update(context.Background(), cd); err != nil {
+	if err := localClient.Status().Update(context.Background(), cd); err != nil {
 		logger.WithError(err).Log(utils.LogLevel(err), "could not update clusterdeployment with unreachable condition")
 		requeue = true
 	}


### PR DESCRIPTION
Currently, if remote cluster becomes unreachable, condition is not getting set
on the ClusterDeployment. This PR fixes it.

Jira: https://issues.redhat.com/browse/CO-932