### PR TITLE
Add hive.openshift.io/managed annotation to resources synced to cluster.

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -114,6 +114,10 @@ const (
 	// SyncsetPauseAnnotation is a annotation used by clusterDeployment, if it's true, then we will disable syncing to a specific cluster
 	SyncsetPauseAnnotation = "hive.openshift.io/syncset-pause"
 
+	// HiveManagedAnnotation is an annotation added to any resources we sync to the remote cluster to help identify that they are
+	// managed by Hive, and any manual changes may be undone the next time the resource is reconciled.
+	HiveManagedAnnotation = "hive.openshift.io/managed"
+
 	// DisableInstallLogPasswordRedactionAnnotation is an annotation used on ClusterDeployments to disable the installmanager
 	// functionality which refuses to print output if it appears to contain a password or sensitive info. This can be
 	// useful in scenarios where debugging is needed and important info is being redacted. Set to "true".

--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -340,6 +340,12 @@ func (r *ReconcileRemoteMachineSet) generateMachineSets(
 
 		// Apply hive MachinePool taints to MachineSet MachineSpec.
 		ms.Spec.Template.Spec.Taints = pool.Spec.Taints
+
+		// Add the managed-by-Hive annotation:
+		if ms.Annotations == nil {
+			ms.Annotations = make(map[string]string, 1)
+		}
+		ms.Annotations[constants.HiveManagedAnnotation] = "true"
 	}
 
 	logger.Infof("generated %v worker machine sets", len(generatedMachineSets))

--- a/pkg/controller/remotemachineset/remotemachineset_controller_test.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller_test.go
@@ -809,6 +809,9 @@ func testMachineSet(name string, machineType string, unstompedAnnotation bool, r
 				"machine.openshift.io/cluster-api-cluster": testInfraID,
 			},
 			Generation: int64(generation),
+			Annotations: map[string]string{
+				constants.HiveManagedAnnotation: "true",
+			},
 		},
 		Spec: machineapi.MachineSetSpec{
 			Replicas: &msReplicas,
@@ -838,9 +841,7 @@ func testMachineSet(name string, machineType string, unstompedAnnotation bool, r
 	}
 	// Add a pre-existing annotation which we will ensure remains in updated machinesets.
 	if unstompedAnnotation {
-		ms.Annotations = map[string]string{
-			"hive.openshift.io/unstomped": "true",
-		}
+		ms.Annotations["hive.openshift.io/unstomped"] = "true"
 	}
 	return &ms
 }

--- a/pkg/controller/syncsetinstance/syncsetinstance_controller_test.go
+++ b/pkg/controller/syncsetinstance/syncsetinstance_controller_test.go
@@ -371,7 +371,7 @@ func TestSyncSetReconcile(t *testing.T) {
 			syncSet: testSyncSetWithSecretMappings("ss1", testSecretMapping("foo")),
 			validate: func(t *testing.T, ssi *hivev1.SyncSetInstance) {
 				validateSyncSetInstanceStatus(t, ssi.Status,
-					successfulSecretStatus(testSecret("foo", "bar")))
+					successfulSecretStatus(testSecretWithManagedAnnotation("foo", "bar")))
 			},
 			expectApplied: true,
 		},
@@ -412,7 +412,7 @@ func TestSyncSetReconcile(t *testing.T) {
 			validate: func(t *testing.T, ssi *hivev1.SyncSetInstance) {
 				validateSyncSetInstanceStatus(t, ssi.Status,
 					successfulSecretStatus(
-						testSecret("foo", "bar"),
+						testSecretWithManagedAnnotation("foo", "bar"),
 					))
 			},
 			expectApplied: true,
@@ -427,8 +427,8 @@ func TestSyncSetReconcile(t *testing.T) {
 			validate: func(t *testing.T, ssi *hivev1.SyncSetInstance) {
 				validateSyncSetInstanceStatus(t, ssi.Status,
 					successfulSecretStatus(
-						testSecret("foo", "bar"),
-						testSecret("baz", "bar"),
+						testSecretWithManagedAnnotation("foo", "bar"),
+						testSecretWithManagedAnnotation("baz", "bar"),
 					))
 			},
 			expectApplied: true,
@@ -442,7 +442,7 @@ func TestSyncSetReconcile(t *testing.T) {
 			syncSet: testSyncSetWithSecretMappings("ss1", testSecretMapping("foo")),
 			validate: func(t *testing.T, ssi *hivev1.SyncSetInstance) {
 				validateSyncSetInstanceStatus(t, ssi.Status,
-					successfulSecretStatus(testSecret("foo", "data_value***changed")))
+					successfulSecretStatus(testSecretWithManagedAnnotation("foo", "data_value***changed")))
 			},
 			expectApplied: true,
 		},
@@ -455,9 +455,9 @@ func TestSyncSetReconcile(t *testing.T) {
 			},
 			status: successfulSecretStatusWithTime(
 				[]runtime.Object{
-					testSecret("s1", "value1"),
-					testSecret("s2", "value2"),
-					testSecret("s3", "value3"),
+					testSecretWithManagedAnnotation("s1", "value1"),
+					testSecretWithManagedAnnotation("s2", "value2"),
+					testSecretWithManagedAnnotation("s3", "value3"),
 				},
 				metav1.NewTime(tenMinutesAgo)),
 			syncSet: testSyncSetWithSecretMappings("aaa",
@@ -467,9 +467,9 @@ func TestSyncSetReconcile(t *testing.T) {
 			),
 			validate: func(t *testing.T, ssi *hivev1.SyncSetInstance) {
 				validateSyncSetInstanceStatus(t, ssi.Status, successfulSecretStatus(
-					testSecret("s1", "value1"),
-					testSecret("s2", "value2***changed"),
-					testSecret("s3", "value3"),
+					testSecretWithManagedAnnotation("s1", "value1"),
+					testSecretWithManagedAnnotation("s2", "value2***changed"),
+					testSecretWithManagedAnnotation("s3", "value3"),
 				))
 				unchanged := []hivev1.SyncStatus{
 					ssi.Status.Secrets[0],
@@ -532,7 +532,7 @@ func TestSyncSetReconcile(t *testing.T) {
 			),
 			validate: func(t *testing.T, ssi *hivev1.SyncSetInstance) {
 				validateSyncSetInstanceStatus(t, ssi.Status, successfulSecretStatus(
-					testSecret("s1", "value1"),
+					testSecretWithManagedAnnotation("s1", "value1"),
 				))
 			},
 			expectApplied: true,
@@ -565,8 +565,8 @@ func TestSyncSetReconcile(t *testing.T) {
 				testSecret("foo", "bar"),
 			},
 			status: successfulSecretStatus(
-				testSecret("foo", "bar"),
-				testSecret("delete-error", "baz"),
+				testSecretWithManagedAnnotation("foo", "bar"),
+				testSecretWithManagedAnnotation("delete-error", "baz"),
 			),
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSyncSetWithSecretMappings("aaa", testSecretMapping("foo"))
@@ -574,9 +574,9 @@ func TestSyncSetReconcile(t *testing.T) {
 				return ss
 			}(),
 			validate: func(t *testing.T, ssi *hivev1.SyncSetInstance) {
-				status := successfulSecretStatus(testSecret("foo", "bar"))
+				status := successfulSecretStatus(testSecretWithManagedAnnotation("foo", "bar"))
 				status.Secrets = append(status.Secrets, deleteFailedSecretStatus("aaa",
-					testSecret("delete-error", "baz"),
+					testSecretWithManagedAnnotation("delete-error", "baz"),
 				).Secrets...)
 				validateSyncSetInstanceStatus(t, ssi.Status, status)
 			},
@@ -948,6 +948,14 @@ func testSecret(name, data string) *corev1.Secret {
 			testName: []byte(data),
 		},
 	}
+}
+
+func testSecretWithManagedAnnotation(name, data string) *corev1.Secret {
+	s := testSecret(name, data)
+	s.Annotations = map[string]string{
+		constants.HiveManagedAnnotation: "true",
+	}
+	return s
 }
 
 func testSecretWithOwner(name, data string) *corev1.Secret {

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -5,7 +5,6 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
-	"github.com/openshift/hive/pkg/constants"
 	"os"
 
 	"github.com/pkg/errors"
@@ -17,8 +16,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	apihelpers "github.com/openshift/hive/pkg/apis/helpers"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apihelpers "github.com/openshift/hive/pkg/apis/helpers"
+	"github.com/openshift/hive/pkg/constants"
 )
 
 // HasFinalizer returns true if the given object has the given finalizer

--- a/test/e2e/postinstall/syncsets/syncsets_suite_test.go
+++ b/test/e2e/postinstall/syncsets/syncsets_suite_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/test/e2e/common"
 )
 
@@ -126,6 +127,9 @@ var _ = Describe("Test Syncset and SelectorSyncSet func", func() {
 				err = targetClusterClient.Get(ctx, client.ObjectKey{Name: "foo", Namespace: "default"}, resultConfigMap)
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(resultConfigMap.Data).Should(Equal(map[string]string{"foo": "bar"}))
+
+				By("Verify the managed-by-Hive annotation was injected automatically")
+				Ω(resultConfigMap.Annotations[constants.HiveManagedAnnotation]).Should(Equal("true"))
 
 				By("Delete the syncset and verify syncset and syncsetinstance are deleted")
 				deleteSyncSets(hiveClient, clusterNamespace, "test-syncresource")


### PR DESCRIPTION
This affects only two areas, the remotemachineset controller, and
syncsetinstance.

SyncSet now decodes to unstructured data as we cannot decode to
runtime.Object if the type is not registered with our scheme, which is
not guaranteed with RawExtensions in SyncSets.