### PR TITLE
Add cluster deployment as owner reference to admin secrets

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -313,6 +313,7 @@ func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerut
 		{
 			TypeToList:    &hivev1.ClusterProvisionList{},
 			LabelSelector: map[string]string{constants.ClusterDeploymentNameLabel: owner.GetName()},
+			Controlled:    true,
 		},
 		{
 			TypeToList: &corev1.PersistentVolumeClaimList{},
@@ -320,6 +321,7 @@ func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerut
 				constants.ClusterDeploymentNameLabel: owner.GetName(),
 				constants.PVCTypeLabel:               constants.PVCTypeInstallLogs,
 			},
+			Controlled: true,
 		},
 		{
 			TypeToList: &batchv1.JobList{},
@@ -327,12 +329,14 @@ func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerut
 				constants.ClusterDeploymentNameLabel: owner.GetName(),
 				constants.JobTypeLabel:               constants.JobTypeImageSet,
 			},
+			Controlled: true,
 		},
 		{
 			TypeToList: &hivev1.ClusterDeprovisionList{},
 			LabelSelector: map[string]string{
 				constants.ClusterDeploymentNameLabel: owner.GetName(),
 			},
+			Controlled: true,
 		},
 		{
 			TypeToList: &hivev1.DNSZoneList{},
@@ -340,6 +344,7 @@ func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerut
 				constants.ClusterDeploymentNameLabel: owner.GetName(),
 				constants.DNSZoneTypeLabel:           constants.DNSZoneTypeChild,
 			},
+			Controlled: true,
 		},
 		{
 			TypeToList: &corev1.SecretList{},
@@ -347,6 +352,7 @@ func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerut
 				constants.ClusterDeploymentNameLabel: owner.GetName(),
 				constants.SecretTypeLabel:            constants.SecretTypeMergedPullSecret,
 			},
+			Controlled: true,
 		},
 	}
 }

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
@@ -297,6 +297,7 @@ func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerut
 				constants.ClusterDeprovisionNameLabel: owner.GetName(),
 				constants.JobTypeLabel:                constants.JobTypeDeprovision,
 			},
+			Controlled: true,
 		},
 	}
 }

--- a/pkg/controller/clusterprovision/clusterprovision_controller.go
+++ b/pkg/controller/clusterprovision/clusterprovision_controller.go
@@ -473,7 +473,7 @@ func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerut
 				constants.ClusterProvisionNameLabel: owner.GetName(),
 				constants.SecretTypeLabel:           constants.SecretTypeKubeConfig,
 			},
-			Controlled: true,
+			Controlled: false,
 		},
 		{
 			TypeToList: &corev1.SecretList{},
@@ -481,7 +481,7 @@ func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerut
 				constants.ClusterProvisionNameLabel: owner.GetName(),
 				constants.SecretTypeLabel:           constants.SecretTypeKubeAdminCreds,
 			},
-			Controlled: true,
+			Controlled: false,
 		},
 	}
 }

--- a/pkg/controller/clusterprovision/clusterprovision_controller.go
+++ b/pkg/controller/clusterprovision/clusterprovision_controller.go
@@ -465,6 +465,7 @@ func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerut
 				constants.ClusterProvisionNameLabel: owner.GetName(),
 				constants.JobTypeLabel:              constants.JobTypeProvision,
 			},
+			Controlled: true,
 		},
 		{
 			TypeToList: &corev1.SecretList{},
@@ -472,6 +473,7 @@ func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerut
 				constants.ClusterProvisionNameLabel: owner.GetName(),
 				constants.SecretTypeLabel:           constants.SecretTypeKubeConfig,
 			},
+			Controlled: true,
 		},
 		{
 			TypeToList: &corev1.SecretList{},
@@ -479,6 +481,7 @@ func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerut
 				constants.ClusterProvisionNameLabel: owner.GetName(),
 				constants.SecretTypeLabel:           constants.SecretTypeKubeAdminCreds,
 			},
+			Controlled: true,
 		},
 	}
 }

--- a/pkg/controller/clusterstate/clusterstate_controller.go
+++ b/pkg/controller/clusterstate/clusterstate_controller.go
@@ -336,6 +336,7 @@ func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerut
 			LabelSelector: map[string]string{
 				constants.ClusterDeploymentNameLabel: owner.GetName(),
 			},
+			Controlled: true,
 		},
 	}
 }

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller.go
@@ -447,6 +447,7 @@ func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerut
 				constants.ClusterDeploymentNameLabel: owner.GetName(),
 				constants.SyncSetTypeLabel:           constants.SyncSetTypeControlPlaneCerts,
 			},
+			Controlled: true,
 		},
 	}
 }

--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -445,6 +445,7 @@ func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerut
 				constants.ClusterDeploymentNameLabel: owner.GetName(),
 				constants.SyncSetTypeLabel:           constants.SyncSetTypeRemoteIngress,
 			},
+			Controlled: true,
 		},
 	}
 }

--- a/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
+++ b/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
@@ -392,6 +392,7 @@ func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerut
 				constants.ClusterDeploymentNameLabel: owner.GetName(),
 				constants.SyncSetTypeLabel:           constants.SyncSetTypeIdentityProvider,
 			},
+			Controlled: true,
 		},
 	}
 }

--- a/pkg/controller/syncset/syncset_controller.go
+++ b/pkg/controller/syncset/syncset_controller.go
@@ -495,6 +495,7 @@ func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerut
 			LabelSelector: map[string]string{
 				constants.ClusterDeploymentNameLabel: owner.GetName(),
 			},
+			Controlled: true,
 		},
 	}
 }

--- a/pkg/test/dnszone/dnszone.go
+++ b/pkg/test/dnszone/dnszone.go
@@ -89,9 +89,14 @@ func WithTypeMeta(typers ...runtime.ObjectTyper) Option {
 	return Generic(generic.WithTypeMeta(typers...))
 }
 
-// WithControllerOwnerReference sets the owner reference to the supplied object.
+// WithControllerOwnerReference sets the controller owner reference to the supplied object.
 func WithControllerOwnerReference(owner metav1.Object) Option {
 	return Generic(generic.WithControllerOwnerReference(owner))
+}
+
+// WithOwnerReference sets the owner reference to the supplied object.
+func WithOwnerReference(owner hivev1.MetaRuntimeObject) Option {
+	return Generic(generic.WithOwnerReference(owner))
 }
 
 // WithLabelOwner sets the labels so that the specific ClusterDeployment is the labeled as the owner.

--- a/pkg/test/generic/generic.go
+++ b/pkg/test/generic/generic.go
@@ -4,6 +4,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	librarygocontroller "github.com/openshift/library-go/pkg/controller"
+
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	k8slabels "github.com/openshift/hive/pkg/util/labels"
 
@@ -65,10 +67,20 @@ func WithAnnotation(key, value string) Option {
 	}
 }
 
-// WithControllerOwnerReference sets the owner reference to the supplied object.
+// WithControllerOwnerReference sets the controller owner reference to the supplied object.
 func WithControllerOwnerReference(owner metav1.Object) Option {
 	return func(meta hivev1.MetaRuntimeObject) {
 		controllerutil.SetControllerReference(owner, meta, scheme.Scheme)
+	}
+}
+
+// WithOwnerReference sets the owner reference to the supplied object.
+// BlockOwnerDeletion is set to true
+func WithOwnerReference(owner hivev1.MetaRuntimeObject) Option {
+	return func(meta hivev1.MetaRuntimeObject) {
+		ownerRef := metav1.NewControllerRef(owner, owner.GetObjectKind().GroupVersionKind())
+		ownerRef.Controller = nil
+		librarygocontroller.EnsureOwnerRef(meta, *ownerRef)
 	}
 }
 


### PR DESCRIPTION
To ensure admin secrets are not lost when the cluster has transitioned to installed and cluster provision is deleted, we add cluster deployment as additional owner reference to the admin secrets