### PR TITLE
Fix unable to install CRD and CR in same syncset

### DIFF
--- a/pkg/resource/info.go
+++ b/pkg/resource/info.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
@@ -15,6 +16,7 @@ type Info struct {
 	APIVersion string
 	Kind       string
 	Resource   string
+	Object     *unstructured.Unstructured
 }
 
 // Info determines the name/namespace and type of the passed in resource bytes
@@ -55,5 +57,6 @@ func (r *Helper) getResourceInfo(f cmdutil.Factory, obj []byte) (*Info, error) {
 		Kind:       info.ResourceMapping().GroupVersionKind.Kind,
 		APIVersion: info.ResourceMapping().GroupVersionKind.GroupVersion().String(),
 		Resource:   info.ResourceMapping().Resource.Resource,
+		Object:     info.Object.(*unstructured.Unstructured),
 	}, nil
 }

--- a/test/integration/resource/info_test.go
+++ b/test/integration/resource/info_test.go
@@ -1,0 +1,34 @@
+package resource
+
+import (
+	"context"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift/hive/pkg/resource"
+)
+
+func TestInfo(t *testing.T) {
+	logger := log.WithFields(nil)
+	namespace := &corev1.Namespace{}
+	namespace.GenerateName = "info-test-"
+	err := c.Create(context.TODO(), namespace)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	h := resource.NewHelper(kubeconfig, logger)
+	i, err := h.Info([]byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+data:
+  test-key: test-value`))
+	require.NoError(t, err)
+	require.NotNil(t, i.Object)
+	assert.Equal(t, "test-configmap", i.Object.GetName())
+}


### PR DESCRIPTION
Currently, we first gather info about all the resources before creating them.This way 
we cannot create a CRD and CR in the same syncet, because to fetch the info about
the CR we need to first create the CRD. This PR fixes it by fetching info and creating 
one resource at a time.

Jira: https://issues.redhat.com/browse/CO-540