### PR TITLE
allow disabling controllers via HiveConfig

### DIFF
--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -83,6 +83,13 @@ spec:
               description: DeprovisionsDisabled can be set to true to block deprovision
                 jobs from running.
               type: boolean
+            disabledControllers:
+              description: DisabledControllers allows selectively disabling Hive controllers
+                by name. The name of an individual controller matches the name of
+                the controller as seen in the Hive logging output.
+              items:
+                type: string
+              type: array
             failedProvisionConfig:
               description: FailedProvisionConfig is used to configure settings related
                 to handling provision failures.

--- a/go.sum
+++ b/go.sum
@@ -2500,7 +2500,6 @@ k8s.io/apimachinery v0.18.0-rc.1/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU
 k8s.io/apimachinery v0.18.0/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
 k8s.io/apimachinery v0.18.2 h1:44CmtbmkzVDAhCpRVSiP2R5PPrC2RtlIv/MoB8xpdRA=
 k8s.io/apimachinery v0.18.2/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
-k8s.io/apimachinery v0.18.3 h1:pOGcbVAhxADgUYnjS08EFXs9QMl8qaH5U4fr5LGUrSk=
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
 k8s.io/apiserver v0.0.0-20190918200908-1e17798da8c1/go.mod h1:4FuDU+iKPjdsdQSN3GsEKZLB/feQsj1y9dhhBDVV2Ns=
 k8s.io/apiserver v0.0.0-20191121020624-6eed2f5a3289/go.mod h1:7P+0qMKoaggchirHLUSCVD22ohdkjN19+qQOKcAdfbI=

--- a/pkg/apis/hive/v1/hiveconfig_types.go
+++ b/pkg/apis/hive/v1/hiveconfig_types.go
@@ -74,6 +74,10 @@ type HiveConfigSpec struct {
 	// +kubebuilder:validation:Enum=enabled
 	// +optional
 	DeleteProtection DeleteProtectionType `json:"deleteProtection,omitempty"`
+
+	// DisabledControllers allows selectively disabling Hive controllers by name.
+	// The name of an individual controller matches the name of the controller as seen in the Hive logging output.
+	DisabledControllers []string `json:"disabledControllers,omitempty"`
 }
 
 // HiveConfigStatus defines the observed state of Hive

--- a/pkg/apis/hive/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/hive/v1/zz_generated.deepcopy.go
@@ -1547,6 +1547,11 @@ func (in *HiveConfigSpec) DeepCopyInto(out *HiveConfigSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.DisabledControllers != nil {
+		in, out := &in.DisabledControllers, &out.DisabledControllers
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -9072,6 +9072,13 @@ spec:
               description: DeprovisionsDisabled can be set to true to block deprovision
                 jobs from running.
               type: boolean
+            disabledControllers:
+              description: DisabledControllers allows selectively disabling Hive controllers
+                by name. The name of an individual controller matches the name of
+                the controller as seen in the Hive logging output.
+              items:
+                type: string
+              type: array
             failedProvisionConfig:
               description: FailedProvisionConfig is used to configure settings related
                 to handling provision failures.

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -70,12 +71,12 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h *resource.Helpe
 		)
 	}
 
+	if dc := instance.Spec.DisabledControllers; len(dc) != 0 {
+		hiveContainer.Args = append(hiveContainer.Args, "--disabled-controllers", strings.Join(dc, ","))
+	}
+
 	if level := instance.Spec.LogLevel; level != "" {
-		hiveDeployment.Spec.Template.Spec.Containers[0].Command = append(
-			hiveDeployment.Spec.Template.Spec.Containers[0].Command,
-			"--log-level",
-			level,
-		)
+		hiveContainer.Args = append(hiveContainer.Args, "--log-level", level)
 	}
 
 	if syncSetReapplyInterval := instance.Spec.SyncSetReapplyInterval; syncSetReapplyInterval != "" {


### PR DESCRIPTION
Introduce spec.disabledControllers as a list of strings that - when provided - will be used to set the `--disabled-controllers` param when the Hive operator is creating/updating the Hive controllers Deployment.

Also, move the log-level param to also live under spec.containers[].args (instead of spec.containers[].command).