### PR TITLE
Change hive.openshift.io/managed from annotation to label.

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -114,9 +114,9 @@ const (
 	// SyncsetPauseAnnotation is a annotation used by clusterDeployment, if it's true, then we will disable syncing to a specific cluster
 	SyncsetPauseAnnotation = "hive.openshift.io/syncset-pause"
 
-	// HiveManagedAnnotation is an annotation added to any resources we sync to the remote cluster to help identify that they are
+	// HiveManagedLabel is a label added to any resources we sync to the remote cluster to help identify that they are
 	// managed by Hive, and any manual changes may be undone the next time the resource is reconciled.
-	HiveManagedAnnotation = "hive.openshift.io/managed"
+	HiveManagedLabel = "hive.openshift.io/managed"
 
 	// DisableInstallLogPasswordRedactionAnnotation is an annotation used on ClusterDeployments to disable the installmanager
 	// functionality which refuses to print output if it appears to contain a password or sensitive info. This can be

--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -327,9 +327,11 @@ func (r *ReconcileRemoteMachineSet) generateMachineSets(
 		}
 
 		if ms.Labels == nil {
-			ms.Labels = map[string]string{}
+			ms.Labels = make(map[string]string, 2)
 		}
 		ms.Labels[machinePoolNameLabel] = pool.Spec.Name
+		// Add the managed-by-Hive label:
+		ms.Labels[constants.HiveManagedLabel] = "true"
 
 		// Apply hive MachinePool labels to MachineSet MachineSpec.
 		ms.Spec.Template.Spec.ObjectMeta.Labels = make(map[string]string, len(pool.Spec.Labels))
@@ -339,12 +341,6 @@ func (r *ReconcileRemoteMachineSet) generateMachineSets(
 
 		// Apply hive MachinePool taints to MachineSet MachineSpec.
 		ms.Spec.Template.Spec.Taints = pool.Spec.Taints
-
-		// Add the managed-by-Hive annotation:
-		if ms.Annotations == nil {
-			ms.Annotations = make(map[string]string, 1)
-		}
-		ms.Annotations[constants.HiveManagedAnnotation] = "true"
 	}
 
 	logger.Infof("generated %v worker machine sets", len(generatedMachineSets))

--- a/pkg/controller/remotemachineset/remotemachineset_controller_test.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller_test.go
@@ -682,7 +682,7 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 								t.Errorf("machineset %v has unexpected labels:\nexpected: %v\nactual: %v", eMS.Name, eMS.Labels, rMS.Labels)
 							}
 							if !reflect.DeepEqual(eMS.ObjectMeta.Annotations, rMS.ObjectMeta.Annotations) {
-								t.Errorf("machineset %v has unexpected annotations:\nexpected: %v\nactual: %v", eMS.Name, eMS.Labels, rMS.Labels)
+								t.Errorf("machineset %v has unexpected annotations:\nexpected: %v\nactual: %v", eMS.Name, eMS.Annotations, rMS.Annotations)
 							}
 							if !reflect.DeepEqual(eMS.Spec.Template.Spec.Labels, rMS.Spec.Template.Spec.Labels) {
 								t.Errorf("machineset %v machinespec has unexpected labels:\nexpected: %v\nactual: %v", eMS.Name, eMS.Spec.Template.Spec.Labels, rMS.Spec.Template.Spec.Labels)
@@ -807,11 +807,9 @@ func testMachineSet(name string, machineType string, unstompedAnnotation bool, r
 			Labels: map[string]string{
 				machinePoolNameLabel:                       machineType,
 				"machine.openshift.io/cluster-api-cluster": testInfraID,
+				constants.HiveManagedLabel:                 "true",
 			},
 			Generation: int64(generation),
-			Annotations: map[string]string{
-				constants.HiveManagedAnnotation: "true",
-			},
 		},
 		Spec: machineapi.MachineSetSpec{
 			Replicas: &msReplicas,
@@ -841,7 +839,9 @@ func testMachineSet(name string, machineType string, unstompedAnnotation bool, r
 	}
 	// Add a pre-existing annotation which we will ensure remains in updated machinesets.
 	if unstompedAnnotation {
-		ms.Annotations["hive.openshift.io/unstomped"] = "true"
+		ms.Annotations = map[string]string{
+			"hive.openshift.io/unstomped": "true",
+		}
 	}
 	return &ms
 }

--- a/pkg/controller/syncsetinstance/syncsetinstance_controller.go
+++ b/pkg/controller/syncsetinstance/syncsetinstance_controller.go
@@ -674,13 +674,13 @@ func (r *ReconcileSyncSetInstance) applySyncSetResources(ssi *hivev1.SyncSetInst
 }
 
 func applyResource(u *unstructured.Unstructured, logger log.FieldLogger, applyFn func(obj []byte) (hiveresource.ApplyResult, error)) error {
-	annotations := u.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string, 1)
+	labels := u.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string, 1)
 	}
 	// Inject the hive managed annotation to help end-users see that a resource is managed by hive:
-	annotations[constants.HiveManagedAnnotation] = "true"
-	u.SetAnnotations(annotations)
+	labels[constants.HiveManagedLabel] = "true"
+	u.SetLabels(labels)
 
 	bytes, err := json.Marshal(u)
 	if err != nil {
@@ -861,10 +861,10 @@ func (r *ReconcileSyncSetInstance) applySyncSetSecretMappings(ssi *hivev1.SyncSe
 		secret.OwnerReferences = nil
 
 		// Inject our managed-by-Hive annotation:
-		if secret.Annotations == nil {
-			secret.Annotations = make(map[string]string, 1)
+		if secret.Labels == nil {
+			secret.Labels = make(map[string]string, 1)
 		}
-		secret.Annotations[constants.HiveManagedAnnotation] = "true"
+		secret.Labels[constants.HiveManagedLabel] = "true"
 
 		var hash string
 		hash, applyErr = controllerutils.GetChecksumOfObject(secret)

--- a/pkg/controller/syncsetinstance/syncsetinstance_controller_test.go
+++ b/pkg/controller/syncsetinstance/syncsetinstance_controller_test.go
@@ -371,7 +371,7 @@ func TestSyncSetReconcile(t *testing.T) {
 			syncSet: testSyncSetWithSecretMappings("ss1", testSecretMapping("foo")),
 			validate: func(t *testing.T, ssi *hivev1.SyncSetInstance) {
 				validateSyncSetInstanceStatus(t, ssi.Status,
-					successfulSecretStatus(testSecretWithManagedAnnotation("foo", "bar")))
+					successfulSecretStatus(testSecretWithManagedLabel("foo", "bar")))
 			},
 			expectApplied: true,
 		},
@@ -412,7 +412,7 @@ func TestSyncSetReconcile(t *testing.T) {
 			validate: func(t *testing.T, ssi *hivev1.SyncSetInstance) {
 				validateSyncSetInstanceStatus(t, ssi.Status,
 					successfulSecretStatus(
-						testSecretWithManagedAnnotation("foo", "bar"),
+						testSecretWithManagedLabel("foo", "bar"),
 					))
 			},
 			expectApplied: true,
@@ -427,8 +427,8 @@ func TestSyncSetReconcile(t *testing.T) {
 			validate: func(t *testing.T, ssi *hivev1.SyncSetInstance) {
 				validateSyncSetInstanceStatus(t, ssi.Status,
 					successfulSecretStatus(
-						testSecretWithManagedAnnotation("foo", "bar"),
-						testSecretWithManagedAnnotation("baz", "bar"),
+						testSecretWithManagedLabel("foo", "bar"),
+						testSecretWithManagedLabel("baz", "bar"),
 					))
 			},
 			expectApplied: true,
@@ -442,7 +442,7 @@ func TestSyncSetReconcile(t *testing.T) {
 			syncSet: testSyncSetWithSecretMappings("ss1", testSecretMapping("foo")),
 			validate: func(t *testing.T, ssi *hivev1.SyncSetInstance) {
 				validateSyncSetInstanceStatus(t, ssi.Status,
-					successfulSecretStatus(testSecretWithManagedAnnotation("foo", "data_value***changed")))
+					successfulSecretStatus(testSecretWithManagedLabel("foo", "data_value***changed")))
 			},
 			expectApplied: true,
 		},
@@ -455,9 +455,9 @@ func TestSyncSetReconcile(t *testing.T) {
 			},
 			status: successfulSecretStatusWithTime(
 				[]runtime.Object{
-					testSecretWithManagedAnnotation("s1", "value1"),
-					testSecretWithManagedAnnotation("s2", "value2"),
-					testSecretWithManagedAnnotation("s3", "value3"),
+					testSecretWithManagedLabel("s1", "value1"),
+					testSecretWithManagedLabel("s2", "value2"),
+					testSecretWithManagedLabel("s3", "value3"),
 				},
 				metav1.NewTime(tenMinutesAgo)),
 			syncSet: testSyncSetWithSecretMappings("aaa",
@@ -467,9 +467,9 @@ func TestSyncSetReconcile(t *testing.T) {
 			),
 			validate: func(t *testing.T, ssi *hivev1.SyncSetInstance) {
 				validateSyncSetInstanceStatus(t, ssi.Status, successfulSecretStatus(
-					testSecretWithManagedAnnotation("s1", "value1"),
-					testSecretWithManagedAnnotation("s2", "value2***changed"),
-					testSecretWithManagedAnnotation("s3", "value3"),
+					testSecretWithManagedLabel("s1", "value1"),
+					testSecretWithManagedLabel("s2", "value2***changed"),
+					testSecretWithManagedLabel("s3", "value3"),
 				))
 				unchanged := []hivev1.SyncStatus{
 					ssi.Status.Secrets[0],
@@ -532,7 +532,7 @@ func TestSyncSetReconcile(t *testing.T) {
 			),
 			validate: func(t *testing.T, ssi *hivev1.SyncSetInstance) {
 				validateSyncSetInstanceStatus(t, ssi.Status, successfulSecretStatus(
-					testSecretWithManagedAnnotation("s1", "value1"),
+					testSecretWithManagedLabel("s1", "value1"),
 				))
 			},
 			expectApplied: true,
@@ -565,8 +565,8 @@ func TestSyncSetReconcile(t *testing.T) {
 				testSecret("foo", "bar"),
 			},
 			status: successfulSecretStatus(
-				testSecretWithManagedAnnotation("foo", "bar"),
-				testSecretWithManagedAnnotation("delete-error", "baz"),
+				testSecretWithManagedLabel("foo", "bar"),
+				testSecretWithManagedLabel("delete-error", "baz"),
 			),
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSyncSetWithSecretMappings("aaa", testSecretMapping("foo"))
@@ -574,9 +574,9 @@ func TestSyncSetReconcile(t *testing.T) {
 				return ss
 			}(),
 			validate: func(t *testing.T, ssi *hivev1.SyncSetInstance) {
-				status := successfulSecretStatus(testSecretWithManagedAnnotation("foo", "bar"))
+				status := successfulSecretStatus(testSecretWithManagedLabel("foo", "bar"))
 				status.Secrets = append(status.Secrets, deleteFailedSecretStatus("aaa",
-					testSecretWithManagedAnnotation("delete-error", "baz"),
+					testSecretWithManagedLabel("delete-error", "baz"),
 				).Secrets...)
 				validateSyncSetInstanceStatus(t, ssi.Status, status)
 			},
@@ -950,10 +950,10 @@ func testSecret(name, data string) *corev1.Secret {
 	}
 }
 
-func testSecretWithManagedAnnotation(name, data string) *corev1.Secret {
+func testSecretWithManagedLabel(name, data string) *corev1.Secret {
 	s := testSecret(name, data)
-	s.Annotations = map[string]string{
-		constants.HiveManagedAnnotation: "true",
+	s.Labels = map[string]string{
+		constants.HiveManagedLabel: "true",
 	}
 	return s
 }

--- a/test/e2e/postinstall/syncsets/syncsets_suite_test.go
+++ b/test/e2e/postinstall/syncsets/syncsets_suite_test.go
@@ -128,8 +128,8 @@ var _ = Describe("Test Syncset and SelectorSyncSet func", func() {
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(resultConfigMap.Data).Should(Equal(map[string]string{"foo": "bar"}))
 
-				By("Verify the managed-by-Hive annotation was injected automatically")
-				Ω(resultConfigMap.Annotations[constants.HiveManagedAnnotation]).Should(Equal("true"))
+				By("Verify the managed-by-Hive label was injected automatically")
+				Ω(resultConfigMap.Labels[constants.HiveManagedLabel]).Should(Equal("true"))
 
 				By("Delete the syncset and verify syncset and syncsetinstance are deleted")
 				deleteSyncSets(hiveClient, clusterNamespace, "test-syncresource")


### PR DESCRIPTION
This will allow using a selector in admission webhooks interested in
protecting these resources.