### PR TITLE
add support for full gcp machine pool names

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
+	golang.org/x/mod v0.2.0
 	golang.org/x/net v0.0.0-20200421231249-e086a090c8fd
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6
 	golang.org/x/tools v0.0.0-20200504152539-33427f1b0364 // indirect

--- a/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook.go
+++ b/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook.go
@@ -32,6 +32,7 @@ const (
 
 	defaultMasterPoolName = "master"
 	defaultWorkerPoolName = "worker"
+	legacyWorkerPoolName  = "w"
 )
 
 // MachinePoolValidatingAdmissionHook is a struct that is used to reference what code should be run by the generic-admission-server.
@@ -233,8 +234,10 @@ func validateMachinePoolName(pool *hivev1.MachinePool) field.ErrorList {
 	if pool.Name != fmt.Sprintf("%s-%s", pool.Spec.ClusterDeploymentRef.Name, pool.Spec.Name) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "name"), pool.Name, "name must be ${CD_NAME}-${POOL_NAME}, where ${CD_NAME} is the name of the clusterdeployment and ${POOL_NAME} is the name of the remote machine pool"))
 	}
-	if pool.Spec.Name == defaultMasterPoolName {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "name"), pool.Spec.Name, fmt.Sprintf("pool name cannot be %q", defaultMasterPoolName)))
+	for _, invalidName := range []string{defaultMasterPoolName, legacyWorkerPoolName} {
+		if pool.Spec.Name == invalidName {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "name"), pool.Spec.Name, fmt.Sprintf("pool name cannot be %q", invalidName)))
+		}
 	}
 	return allErrs
 }

--- a/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook_test.go
@@ -148,6 +148,15 @@ func Test_MachinePoolAdmission_Validate_Create(t *testing.T) {
 			}(),
 		},
 		{
+			name: "legacy worker pool name",
+			provision: func() *hivev1.MachinePool {
+				pool := testMachinePool()
+				pool.Name = fmt.Sprintf("%s-%s", pool.Spec.ClusterDeploymentRef.Name, legacyWorkerPoolName)
+				pool.Spec.Name = legacyWorkerPoolName
+				return pool
+			}(),
+		},
+		{
 			name: "invalid name",
 			provision: func() *hivev1.MachinePool {
 				pool := testMachinePool()

--- a/pkg/controller/remotemachineset/gcpactuator.go
+++ b/pkg/controller/remotemachineset/gcpactuator.go
@@ -3,24 +3,28 @@ package remotemachineset
 import (
 	"context"
 	"fmt"
-	machineapi "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
-	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+	"math/rand"
+	"strings"
+
+	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
-	"math/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	machineapi "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	installgcp "github.com/openshift/installer/pkg/asset/machines/gcp"
 	installertypes "github.com/openshift/installer/pkg/types"
 	installertypesgcp "github.com/openshift/installer/pkg/types/gcp"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/gcpclient"
 )
 
@@ -28,6 +32,10 @@ const (
 	// Omit m, the installer used this for the master machines. w is also removed as this is implicitly used
 	// by the installer for the original worker pool.
 	validLeaseChars = "abcdefghijklnopqrstuvxyz0123456789"
+)
+
+var (
+	versionsSupportingFullNames = semver.MustParseRange(">=4.4.8")
 )
 
 // GCPActuator encapsulates the pieces necessary to be able to generate
@@ -40,15 +48,22 @@ type GCPActuator struct {
 	projectID string
 	// expectations is a reference to the reconciler's TTLCache of machinepoolnamelease creates each machinepool
 	// expects to see.
-	expectations controllerutils.ExpectationsInterface
+	expectations   controllerutils.ExpectationsInterface
+	leasesRequired bool
 }
 
 var _ Actuator = &GCPActuator{}
 
 // NewGCPActuator is the constructor for building a GCPActuator
-func NewGCPActuator(client client.Client, gcpCreds *corev1.Secret, scheme *runtime.Scheme,
-	expectations controllerutils.ExpectationsInterface, logger log.FieldLogger) (*GCPActuator, error) {
-
+func NewGCPActuator(
+	client client.Client,
+	gcpCreds *corev1.Secret,
+	clusterVersion string,
+	remoteMachineSets []machineapi.MachineSet,
+	scheme *runtime.Scheme,
+	expectations controllerutils.ExpectationsInterface,
+	logger log.FieldLogger,
+) (*GCPActuator, error) {
 	gcpClient, err := gcpclient.NewClientFromSecret(gcpCreds)
 	if err != nil {
 		logger.WithError(err).Warn("failed to create GCP client with creds in clusterDeployment's secret")
@@ -62,12 +77,13 @@ func NewGCPActuator(client client.Client, gcpCreds *corev1.Secret, scheme *runti
 	}
 
 	actuator := &GCPActuator{
-		gcpClient:    gcpClient,
-		client:       client,
-		logger:       logger,
-		scheme:       scheme,
-		expectations: expectations,
-		projectID:    projectID,
+		gcpClient:      gcpClient,
+		client:         client,
+		logger:         logger,
+		scheme:         scheme,
+		expectations:   expectations,
+		projectID:      projectID,
+		leasesRequired: useLeases(clusterVersion, remoteMachineSets),
 	}
 	return actuator, nil
 }
@@ -85,14 +101,31 @@ func (a *GCPActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *hi
 		return nil, false, errors.New("MachinePool is not for GCP")
 	}
 
-	leaseChar, proceed, err := a.obtainLease(pool, cd, logger)
+	leases := &hivev1.MachinePoolNameLeaseList{}
+	err := a.client.List(context.TODO(), leases, client.InNamespace(pool.Namespace),
+		client.MatchingLabels(map[string]string{
+			constants.ClusterDeploymentNameLabel: cd.Name,
+		}))
 	if err != nil {
-		logger.WithError(err).Log(controllerutils.LogLevel(err), "error obtaining pool name lease")
+		logger.WithError(err).Log(controllerutils.LogLevel(err), "error fetching machinepoolleases")
 		return nil, false, err
 	}
 
-	if !proceed {
-		return nil, false, nil
+	poolName := pool.Spec.Name
+
+	// If leases are required by the cluster version or existing "w" worker machinesets in the cluster or are already
+	// being used as indicated by the existence of MachinePoolLeases, then use leases for determining the machine pool
+	// name.
+	if a.leasesRequired || len(leases.Items) > 0 {
+		leaseChar, proceed, err := a.obtainLease(pool, cd, leases)
+		if err != nil {
+			logger.WithError(err).Log(controllerutils.LogLevel(err), "error obtaining pool name lease")
+			return nil, false, err
+		}
+		if !proceed {
+			return nil, false, nil
+		}
+		poolName = leaseChar
 	}
 
 	ic := &installertypes.InstallConfig{
@@ -105,6 +138,7 @@ func (a *GCPActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *hi
 	}
 
 	computePool := baseMachinePool(pool)
+	computePool.Name = poolName
 	computePool.Platform.GCP = &installertypesgcp.MachinePool{
 		Zones:        pool.Spec.Platform.GCP.Zones,
 		InstanceType: pool.Spec.Platform.GCP.InstanceType,
@@ -131,9 +165,6 @@ func (a *GCPActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *hi
 		computePool.Platform.GCP.Zones = zones
 	}
 
-	// Installer code uses the first character of the computePool.Name in the MachineSet name,
-	// so we need to fake it to get it to use our leaseChar.
-	computePool.Name = string(leaseChar)
 	// Assuming all machine pools are workers at this time.
 	installerMachineSets, err := installgcp.MachineSets(cd.Spec.ClusterMetadata.InfraID, ic, computePool, imageID, workerRole, workerUserData)
 	return installerMachineSets, err == nil, errors.Wrap(err, "failed to generate machinesets")
@@ -198,21 +229,10 @@ func (a *GCPActuator) getImageID(cd *hivev1.ClusterDeployment, logger log.FieldL
 // for use in the name of the machine pool. We are severely restricted on name lengths on GCP
 // and effectively have one character of flexibility with the naming convention originating in
 // the installer.
-func (a *GCPActuator) obtainLease(pool *hivev1.MachinePool, cd *hivev1.ClusterDeployment, logger log.FieldLogger) (leaseChar string, proceed bool, leaseErr error) {
-	logger.Debugf("obtaining lease for pool: %s", pool.Name)
-
-	leases := &hivev1.MachinePoolNameLeaseList{}
-	err := a.client.List(context.TODO(), leases, client.InNamespace(pool.Namespace),
-		client.MatchingLabels(map[string]string{
-			constants.ClusterDeploymentNameLabel: cd.Name,
-		}))
-	if err != nil {
-		return "", false, err
-	}
-	logger.Debugf("found %d leases for cluster", len(leases.Items))
+func (a *GCPActuator) obtainLease(pool *hivev1.MachinePool, cd *hivev1.ClusterDeployment, leases *hivev1.MachinePoolNameLeaseList) (leaseChar string, proceed bool, leaseErr error) {
 	for _, l := range leases.Items {
 		if l.Labels[constants.MachinePoolNameLabel] == pool.Name {
-			logger.Debugf("machine pool already has lease: %s", l.Name)
+			a.logger.Debugf("machine pool already has lease: %s", l.Name)
 			// Ensure the lease name is in the format we expect, we know everything up to
 			// the last character.
 			leaseChar := l.Name[len(l.Name)-1:]
@@ -224,17 +244,17 @@ func (a *GCPActuator) obtainLease(pool *hivev1.MachinePool, cd *hivev1.ClusterDe
 		}
 	}
 
-	logger.Debugf("machine pool does not have a lease yet")
+	a.logger.Debugf("machine pool does not have a lease yet")
 
 	var leaseRune rune
-	// If the pool.Spec.Name == "worker", we want to preseve this MachinePool's "w" character that
+	// If the pool.Spec.Name == "worker", we want to preserve this MachinePool's "w" character that
 	// the installer would have selected so we do not cycle all worker nodes.
 	// Despite the separation of pool.Name and pool.Spec.Name, we do know that only one pool will
 	// have pool.Spec.Name worker as we validate that the pool must be named
 	// [clusterdeploymentname]-[pool.spec.name]
 	if pool.Spec.Name == "worker" {
 		leaseRune = 'w'
-		logger.Debug("selecting lease char 'w' for original worker pool")
+		a.logger.Debug("selecting lease char 'w' for original worker pool")
 	} else {
 		// Pool does not have a lease yet, lookup all currently available lease chars
 		availLeaseChars, err := a.findAvailableLeaseChars(cd, leases)
@@ -242,7 +262,7 @@ func (a *GCPActuator) obtainLease(pool *hivev1.MachinePool, cd *hivev1.ClusterDe
 			return "", false, err
 		}
 		if len(availLeaseChars) == 0 {
-			logger.Warn("no GCP MachinePoolNameLease characters available, setting condition")
+			a.logger.Warn("no GCP MachinePoolNameLease characters available, setting condition")
 			conds, changed := controllerutils.SetMachinePoolConditionWithChangeCheck(
 				pool.Status.Conditions,
 				hivev1.NoMachinePoolNameLeasesAvailable,
@@ -280,10 +300,10 @@ func (a *GCPActuator) obtainLease(pool *hivev1.MachinePool, cd *hivev1.ClusterDe
 		// Choose a random entry in the available chars to limit collisions while processing
 		// multiple machine pools at the same time. In this case the subsequent attempts to create
 		// the lease will fail due to name collisions and re-reconcile.
-		logger.Debug("selecting random lease char from available")
+		a.logger.Debug("selecting random lease char from available")
 		leaseRune = availLeaseChars[rand.Intn(len(availLeaseChars))]
 	}
-	logger.Debugf("selected lease char: %s", string(leaseRune))
+	a.logger.Debugf("selected lease char: %s", string(leaseRune))
 
 	leaseName := fmt.Sprintf("%s-%s", cd.Spec.ClusterMetadata.InfraID, string(leaseRune))
 	// Attempt to claim the lease:
@@ -306,15 +326,14 @@ func (a *GCPActuator) obtainLease(pool *hivev1.MachinePool, cd *hivev1.ClusterDe
 			},
 		},
 	}
-	logger.Debug("adding expectation for lease creation for this pool")
+	a.logger.Debug("adding expectation for lease creation for this pool")
 	expectKey := types.NamespacedName{Namespace: pool.Namespace, Name: pool.Name}.String()
 	a.expectations.ExpectCreations(expectKey, 1)
-	err = a.client.Create(context.TODO(), l)
-	if err != nil {
+	if err := a.client.Create(context.TODO(), l); err != nil {
 		a.expectations.DeleteExpectations(expectKey)
 		return "", false, err
 	}
-	logger.WithField("lease", leaseName).Infof("created lease, waiting until creation is observed")
+	a.logger.WithField("lease", leaseName).Infof("created lease, waiting until creation is observed")
 
 	return string(leaseRune), false, nil
 }
@@ -350,4 +369,29 @@ func (a *GCPActuator) findAvailableLeaseChars(cd *hivev1.ClusterDeployment, leas
 	}
 
 	return keys, nil
+}
+
+func useLeases(clusterVersion string, remoteMachineSets []machineapi.MachineSet) bool {
+	if v, err := semver.ParseTolerant(clusterVersion); err == nil {
+		if !versionsSupportingFullNames(v) {
+			return true
+		}
+	}
+	poolNames := make(map[string]bool)
+	for _, ms := range remoteMachineSets {
+		nameParts := strings.Split(ms.Name, "-")
+		if len(nameParts) < 3 {
+			continue
+		}
+		poolName := nameParts[len(nameParts)-2]
+		poolNames[poolName] = true
+	}
+	// If there are machinesets with a pool name of "w" and no machinesets with a pool name of "worker", then assume
+	// that the "w" pool is the worker pool created by the installer. If the installer-created "w" worker pool still
+	// exists, then we must continue to use leases.
+	// This will cause problems if a machineset is created on the cluster with a "w" pool name that is not the
+	// installer-created worker pool when there are Hive-managed pools that are not using leases. Hive will block
+	// through validation MachinePools with a pool name of "w", but the user could still create such machinesets on
+	// the cluster manually.
+	return poolNames["w"] && !poolNames["worker"]
 }

--- a/pkg/controller/remotemachineset/gcpactuator_test.go
+++ b/pkg/controller/remotemachineset/gcpactuator_test.go
@@ -556,7 +556,7 @@ func TestObtainLeaseChar(t *testing.T) {
 	}
 }
 
-func TestUseLeases(t *testing.T) {
+func TestRequireLeases(t *testing.T) {
 	cases := []struct {
 		name            string
 		clusterVersion  string
@@ -618,7 +618,7 @@ func TestUseLeases(t *testing.T) {
 			for i, n := range tc.machineSetNames {
 				machineSets[i].Name = n
 			}
-			actualResult := useLeases(tc.clusterVersion, machineSets)
+			actualResult := requireLeases(tc.clusterVersion, machineSets, log.WithFields(nil))
 			assert.Equal(t, tc.expectedResult, actualResult)
 		})
 	}


### PR DESCRIPTION
Starting with OpenShift 4.4.8, the restriction that machine pool names can only be a single character long has been lifted. As a consequence, the worker machinesets created by the installer now use the full name "worker", where Hive assumes that they will use the name "w".

These changes will use the full pool name when the cluster has a version of 4.5 or greater and continue to use name leases for clusters with older versions. However, for clusters that started as older versions and have been upgraded to 4.5 or greater, name leases will be used if there are existing leases or if Hive determines that the worker machinesets created by the installer--which used the "w" pool name--still exist.

https://issues.redhat.com/browse/CO-1030