### PR TITLE
wait for dnszone to finish delete before clearing cd finalizer

### DIFF
--- a/pkg/test/clusterdeprovision/clusterdeprovision.go
+++ b/pkg/test/clusterdeprovision/clusterdeprovision.go
@@ -1,0 +1,88 @@
+package clusterdeprovision
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/test/generic"
+)
+
+// Option defines a function signature for any function that wants to be passed into Build
+type Option func(*hivev1.ClusterDeprovision)
+
+// Build runs each of the functions passed in to generate the object.
+func Build(opts ...Option) *hivev1.ClusterDeprovision {
+	retval := &hivev1.ClusterDeprovision{}
+	for _, o := range opts {
+		o(retval)
+	}
+
+	return retval
+}
+
+type Builder interface {
+	Build(opts ...Option) *hivev1.ClusterDeprovision
+
+	Options(opts ...Option) Builder
+
+	GenericOptions(opts ...generic.Option) Builder
+}
+
+func BasicBuilder() Builder {
+	return &builder{}
+}
+
+func FullBuilder(namespace, name string, typer runtime.ObjectTyper) Builder {
+	b := &builder{}
+	return b.GenericOptions(
+		generic.WithTypeMeta(typer),
+		generic.WithResourceVersion("1"),
+		generic.WithNamespace(namespace),
+		generic.WithName(name),
+	)
+}
+
+type builder struct {
+	options []Option
+}
+
+func (b *builder) Build(opts ...Option) *hivev1.ClusterDeprovision {
+	return Build(append(b.options, opts...)...)
+}
+
+func (b *builder) Options(opts ...Option) Builder {
+	return &builder{
+		options: append(b.options, opts...),
+	}
+}
+
+func (b *builder) GenericOptions(opts ...generic.Option) Builder {
+	options := make([]Option, len(opts))
+	for i, o := range opts {
+		options[i] = Generic(o)
+	}
+	return b.Options(options...)
+}
+
+// Generic allows common functions applicable to all objects to be used as Options to Build
+func Generic(opt generic.Option) Option {
+	return func(clusterDeprovision *hivev1.ClusterDeprovision) {
+		opt(clusterDeprovision)
+	}
+}
+
+// WithName sets the object.Name field when building an object with Build.
+func WithName(name string) Option {
+	return Generic(generic.WithName(name))
+}
+
+// WithNamespace sets the object.Namespace field when building an object with Build.
+func WithNamespace(namespace string) Option {
+	return Generic(generic.WithNamespace(namespace))
+}
+
+func Completed() Option {
+	return func(clusterDeprovision *hivev1.ClusterDeprovision) {
+		clusterDeprovision.Status.Completed = true
+	}
+}


### PR DESCRIPTION
Do not remove the deprovision finalizer from the ClusterDeployment until the DNSZone created for managed DNS has been removed from storage. This helps users that rely on the ClusterDeployment being removed from storage as a trigger for when it is safe to delete the namespace.

https://issues.redhat.com/browse/CO-966