### PR TITLE
test: add expiration tags to e2e aws resources

### DIFF
--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -134,6 +134,7 @@ case "${CLOUD}" in
 "aws")
 	CREDS_FILE="${CLOUD_CREDS_DIR}/.awscred"
 	BASE_DOMAIN="${BASE_DOMAIN:-hive-ci.openshift.com}"
+	EXTRA_CREATE_CLUSTER_ARGS="--aws-user-tags expirationDate=$(date -d '4 hours' --iso=minutes --utc)"
 	;;
 "azure")
 	CREDS_FILE="${CLOUD_CREDS_DIR}/osServicePrincipal.json"

--- a/pkg/clusterresource/aws.go
+++ b/pkg/clusterresource/aws.go
@@ -29,6 +29,8 @@ type AWSCloudBuilder struct {
 	AccessKeyID string
 	// SecretAccessKey is the AWS secret access key.
 	SecretAccessKey string
+	// UserTags are user-provided tags to add to resources.
+	UserTags map[string]string
 }
 
 func (p *AWSCloudBuilder) generateCredentialsSecret(o *Builder) *corev1.Secret {
@@ -59,7 +61,8 @@ func (p *AWSCloudBuilder) addClusterDeploymentPlatform(o *Builder, cd *hivev1.Cl
 			CredentialsSecretRef: corev1.LocalObjectReference{
 				Name: p.credsSecretName(o),
 			},
-			Region: awsRegion,
+			Region:   awsRegion,
+			UserTags: p.UserTags,
 		},
 	}
 }


### PR DESCRIPTION
When running e2e tests on AWS, add the "expirationDate" user tag to the resources created so that the resources can be properly cleaned up by the pruner in case the deprovision fails.

https://issues.redhat.com/browse/CO-710