### PR TITLE
add version labels to clusterdeployments

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -241,6 +241,18 @@ const (
 
 	// VSphereDataStoreEnvVar is the environment variable specifying the vSphere default datastore.
 	VSphereDataStoreEnvVar = "GOVC_DATASTORE"
+
+	// VersionMajorLabel is a label applied to ClusterDeployments to show the version of the cluster
+	// in the form "[MAJOR]".
+	VersionMajorLabel = "hive.openshift.io/version-major"
+
+	// VersionMajorMinorLabel is a label applied to ClusterDeployments to show the version of the cluster
+	// in the form "[MAJOR].[MINOR]".
+	VersionMajorMinorLabel = "hive.openshift.io/version-major-minor"
+
+	// VersionMajorMinorPatchLabel is a label applied to ClusterDeployments to show the version of the cluster
+	// in the form "[MAJOR].[MINOR].[PATCH]".
+	VersionMajorMinorPatchLabel = "hive.openshift.io/version-major-minor-patch"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment


### PR DESCRIPTION
Add the following labels to ClusterDeployments based on the desired version set in the cluster's ClusterVersion resource.
* hive.openshift.io/version-major
* hive.openshift.io/version-major-minor
* hive.openshift.io/version-major-minor-patch

https://issues.redhat.com/browse/CO-626