### PR TITLE
Add env var for devs to disable leader election.

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -175,8 +175,9 @@ NOTE: assumes you have [previously deployed Hive](install.md)
 
 ```bash
 oc scale -n hive deployment.v1.apps/hive-controllers --replicas=0
-make run
+DISABLE_LEADER_ELECTION="true" HIVE_NS="hive" make run
 ```
+Kind users should also specify `HIVE_IMAGE="localhost:5000/hive:latest"` as the default image location cannot be authenticated to from Kind clusters, resulting in inability to launch install pods.
 
 ## Developing Hiveutil Install Manager
 


### PR DESCRIPTION
Allows developers using make run to bypass the delay on startup waiting
for leader election timeouts.