### PR TITLE
reap namespaces created for ClusterPool after clusters deleted

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/controller/clusterdeployment"
 	"github.com/openshift/hive/pkg/controller/clusterdeprovision"
+	"github.com/openshift/hive/pkg/controller/clusterpoolnamespace"
 	"github.com/openshift/hive/pkg/controller/clusterprovision"
 	"github.com/openshift/hive/pkg/controller/clusterrelocate"
 	"github.com/openshift/hive/pkg/controller/clusterstate"
@@ -64,6 +65,7 @@ type controllerSetupFunc func(manager.Manager) error
 var controllerFuncs = map[string]controllerSetupFunc{
 	clusterdeployment.ControllerName:    clusterdeployment.Add,
 	clusterdeprovision.ControllerName:   clusterdeprovision.Add,
+	clusterpoolnamespace.ControllerName: clusterpoolnamespace.Add,
 	clusterprovision.ControllerName:     clusterprovision.Add,
 	clusterrelocate.ControllerName:      clusterrelocate.Add,
 	clusterstate.ControllerName:         clusterstate.Add,

--- a/config/controllers/hive_controllers_role.yaml
+++ b/config/controllers/hive_controllers_role.yaml
@@ -30,6 +30,7 @@ rules:
   - configmaps
   - events
   - persistentvolumeclaims
+  - namespaces
   verbs:
   - get
   - list
@@ -42,7 +43,6 @@ rules:
   - ""
   resources:
   - pods
-  - namespaces
   verbs:
   - get
   - list

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -43,6 +43,10 @@ const (
 	// ClusterProvisionNameLabel is the label that is used to identify a relationship to a given cluster provision object.
 	ClusterProvisionNameLabel = "hive.openshift.io/cluster-provision-name"
 
+	// OriginClusterPoolNameLabel is the label that is used to signal that a cluster was originally created for a ClusterPool.
+	// It should always remain set even after a cluster is assigned to fill a request and thus removed from the pool.
+	OriginClusterPoolNameLabel = "hive.openshift.io/origin-cluster-pool-name"
+
 	// SyncSetNameLabel is the label that is used to identify a relationship to a given syncset object.
 	SyncSetNameLabel = "hive.openshift.io/syncset-name"
 

--- a/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller.go
+++ b/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller.go
@@ -1,0 +1,157 @@
+package clusterpoolnamespace
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
+	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+)
+
+const (
+	ControllerName                                 = "clusterpoolnamespace"
+	minimumLifetime                                = 5 * time.Minute
+	durationBetweenDeletingClusterDeploymentChecks = 1 * time.Minute
+)
+
+// Add creates a new ClusterDeployment Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager) error {
+	return AddToManager(mgr, NewReconciler(mgr))
+}
+
+// NewReconciler returns a new reconcile.Reconciler
+func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
+	r := &ReconcileClusterPoolNamespace{
+		Client: controllerutils.NewClientWithMetricsOrDie(mgr, ControllerName),
+		logger: log.WithField("controller", ControllerName),
+	}
+	return r
+}
+
+// AddToManager adds a new Controller to mgr with r as the reconcile.Reconciler
+func AddToManager(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New(
+		fmt.Sprintf("%s-controller", ControllerName),
+		mgr,
+		controller.Options{
+			Reconciler:              r,
+			MaxConcurrentReconciles: controllerutils.GetConcurrentReconciles(),
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to Namespaces
+	if err := c.Watch(&source.Kind{Type: &corev1.Namespace{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+
+	// Watch for changes to ClusterDeployment
+	cdMapFn := func(a handler.MapObject) []reconcile.Request {
+		cd := a.Object.(*hivev1.ClusterDeployment)
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{Name: cd.Namespace},
+		}}
+	}
+	if err := c.Watch(
+		&source.Kind{Type: &hivev1.ClusterDeployment{}},
+		&handler.EnqueueRequestsFromMapFunc{
+			ToRequests: handler.ToRequestsFunc(cdMapFn),
+		},
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileClusterPoolNamespace{}
+
+// ReconcileClusterPoolNamespace reconciles a Namespace object for the purpose of reaping namespaces created for
+// ClusterPool clusters after the clusters have been deleted.
+type ReconcileClusterPoolNamespace struct {
+	client.Client
+	logger log.FieldLogger
+}
+
+// Reconcile deletes a Namespace if it no longer contains any ClusterDeployments.
+func (r *ReconcileClusterPoolNamespace) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	start := time.Now()
+	logger := r.logger.WithField("namespace", request.Name)
+
+	logger.Info("reconciling namespace")
+	defer func() {
+		dur := time.Since(start)
+		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName).Observe(dur.Seconds())
+		logger.WithField("elapsed", dur).Info("reconcile complete")
+	}()
+
+	// Fetch the Namespace instance
+	namespace := &corev1.Namespace{}
+	switch err := r.Get(context.Background(), request.NamespacedName, namespace); {
+	case apierrors.IsNotFound(err):
+		return reconcile.Result{}, nil
+	case err != nil:
+		return reconcile.Result{}, err
+	}
+
+	// If the Namespace is deleted, do not reconcile.
+	if namespace.DeletionTimestamp != nil {
+		return reconcile.Result{}, nil
+	}
+
+	// If the namespace was not created for a ClusterPool cluster, ignore it
+	if _, ok := namespace.Labels[constants.OriginClusterPoolNameLabel]; !ok {
+		return reconcile.Result{}, nil
+	}
+
+	if lifetime := time.Since(namespace.CreationTimestamp.Time); lifetime < minimumLifetime {
+		logger.WithField("lifetime", lifetime).Debug("namespace is not old enough to delete; waiting longer for ClusterDeployment to be created")
+		return reconcile.Result{RequeueAfter: minimumLifetime - lifetime}, nil
+	}
+
+	cdList := &hivev1.ClusterDeploymentList{}
+	if err := r.List(context.Background(), cdList, client.InNamespace(namespace.Name)); err != nil {
+		logger.WithError(err).Log(controllerutils.LogLevel(err), "could not list ClusterDeployments")
+		return reconcile.Result{}, err
+	}
+
+	if len(cdList.Items) == 0 {
+		logger.Info("deleting namespace since it contains no ClusterDeployments")
+		if err := r.Delete(context.Background(), namespace); err != nil {
+			logger.WithError(err).Log(controllerutils.LogLevel(err), "error deleting namespace")
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{}, nil
+	}
+
+	// If all of the ClusterDeployments have been deleted, then we need to due a Requeue After since the watch will
+	// not trigger when the ClusterDeployment is finally removed from storage.
+	for _, cd := range cdList.Items {
+		if cd.DeletionTimestamp == nil {
+			logger.WithField("clusterDeployment", cd.Name).Debug("ClusterDeployment has not been deleted")
+			return reconcile.Result{}, nil
+		}
+	}
+
+	logger.Debug("all ClusterDeployments deleted; waiting longer for ClusterDeployments to be removed from storage")
+	return reconcile.Result{RequeueAfter: durationBetweenDeletingClusterDeploymentChecks}, nil
+}

--- a/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller_test.go
+++ b/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller_test.go
@@ -1,0 +1,155 @@
+package clusterpoolnamespace
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
+	testcd "github.com/openshift/hive/pkg/test/clusterdeployment"
+	testgeneric "github.com/openshift/hive/pkg/test/generic"
+	testnamespace "github.com/openshift/hive/pkg/test/namespace"
+)
+
+const (
+	namespaceName = "test-namespace"
+	cdName        = "test-cluster-deployment"
+	crName        = "test-cluster-relocator"
+)
+
+func TestReconcileClusterPoolNamespace_Reconcile_Movement(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.DebugLevel)
+
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	hivev1.AddToScheme(scheme)
+
+	namespaceWithoutLabelBuilder := testnamespace.FullBuilder(namespaceName, scheme)
+	namespaceBuilder := namespaceWithoutLabelBuilder.GenericOptions(
+		testgeneric.WithLabel(constants.OriginClusterPoolNameLabel, "test-cluster-pool"),
+	)
+
+	validateNoRequeueAfter := func(t *testing.T, requeueAfter time.Duration, startTime, endTime time.Time) {
+		assert.Zero(t, requeueAfter, "unexpected non-zero requeue after")
+	}
+	validateWaitForCDGoneRequeueAfter := func(t *testing.T, requeueAfter time.Duration, startTime, endTime time.Time) {
+		assert.Equal(t, durationBetweenDeletingClusterDeploymentChecks, requeueAfter, "expected requeue after for checking deleting ClusterDeployments")
+	}
+
+	cases := []struct {
+		name                 string
+		namespaceBuilder     testnamespace.Builder
+		extraNamespaceOption func(startTime time.Time) testnamespace.Option
+		resources            []runtime.Object
+		expectDeleted        bool
+		validateRequeueAfter func(t *testing.T, requeueAfter time.Duration, startTime, endTime time.Time)
+	}{
+		{
+			name:                 "no clusterdeployments",
+			namespaceBuilder:     namespaceBuilder,
+			expectDeleted:        true,
+			validateRequeueAfter: validateNoRequeueAfter,
+		},
+		{
+			name:             "non-deleted clusterdeployment",
+			namespaceBuilder: namespaceBuilder,
+			resources: []runtime.Object{
+				testcd.FullBuilder(namespaceName, "test-cd", scheme).Build(),
+			},
+			expectDeleted:        false,
+			validateRequeueAfter: validateNoRequeueAfter,
+		},
+		{
+			name:             "deleted clusterdeployment",
+			namespaceBuilder: namespaceBuilder,
+			resources: []runtime.Object{
+				testcd.FullBuilder(namespaceName, "test-cd", scheme).
+					GenericOptions(testgeneric.Deleted()).
+					Build(),
+			},
+			expectDeleted:        false,
+			validateRequeueAfter: validateWaitForCDGoneRequeueAfter,
+		},
+		{
+			name:             "deleted and non-deleted clusterdeployments",
+			namespaceBuilder: namespaceBuilder,
+			resources: []runtime.Object{
+				testcd.FullBuilder(namespaceName, "test-cd-1", scheme).Build(),
+				testcd.FullBuilder(namespaceName, "test-cd-2", scheme).
+					GenericOptions(testgeneric.Deleted()).
+					Build(),
+			},
+			expectDeleted:        false,
+			validateRequeueAfter: validateNoRequeueAfter,
+		},
+		{
+			name:                 "deleted namespace",
+			namespaceBuilder:     namespaceBuilder.GenericOptions(testgeneric.Deleted()),
+			expectDeleted:        false,
+			validateRequeueAfter: validateNoRequeueAfter,
+		},
+		{
+			name:                 "namespace without clusterpool label",
+			namespaceBuilder:     namespaceWithoutLabelBuilder,
+			expectDeleted:        false,
+			validateRequeueAfter: validateNoRequeueAfter,
+		},
+		{
+			name:             "namespace too young",
+			namespaceBuilder: namespaceBuilder,
+			extraNamespaceOption: func(startTime time.Time) testnamespace.Option {
+				return func(namespace *corev1.Namespace) {
+					namespace.CreationTimestamp.Time = startTime.Add(-1 * time.Minute)
+				}
+			},
+			expectDeleted: false,
+			validateRequeueAfter: func(t *testing.T, requeueAfter time.Duration, startTime, endTime time.Time) {
+				// CreationTimestamp only has granularity to the second, so add a 1-second buffer on each end of the limits.
+				upperBound := minimumLifetime - 1*time.Minute + 1*time.Second
+				lowerBound := minimumLifetime - 1*time.Minute - endTime.Sub(startTime) - 1*time.Second
+				assert.LessOrEqual(t, lowerBound.Seconds(), requeueAfter.Seconds(), "requeue after too small for waiting for ClusterDeployment creation")
+				assert.GreaterOrEqual(t, upperBound.Seconds(), requeueAfter.Seconds(), "requeue after too large for waiting for ClusterDeployment creation")
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			startTime := time.Now()
+			if tc.namespaceBuilder != nil {
+				builder := tc.namespaceBuilder
+				if tc.extraNamespaceOption != nil {
+					builder = builder.Options(tc.extraNamespaceOption(startTime))
+				}
+				tc.resources = append(tc.resources, builder.Build())
+			}
+			c := fake.NewFakeClientWithScheme(scheme, tc.resources...)
+
+			reconciler := &ReconcileClusterPoolNamespace{
+				Client: c,
+				logger: logger,
+			}
+			namespaceKey := client.ObjectKey{Name: namespaceName}
+			result, err := reconciler.Reconcile(reconcile.Request{NamespacedName: namespaceKey})
+			endTime := time.Now()
+			require.NoError(t, err, "unexpected error during reconcile")
+
+			namespace := &corev1.Namespace{}
+			err = c.Get(context.Background(), namespaceKey, namespace)
+			assert.Equal(t, tc.expectDeleted, apierrors.IsNotFound(err), "unexpected state of namespace existence")
+
+			tc.validateRequeueAfter(t, result.RequeueAfter, startTime, endTime)
+		})
+	}
+}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -960,6 +960,7 @@ rules:
   - configmaps
   - events
   - persistentvolumeclaims
+  - namespaces
   verbs:
   - get
   - list
@@ -972,7 +973,6 @@ rules:
   - ""
   resources:
   - pods
-  - namespaces
   verbs:
   - get
   - list


### PR DESCRIPTION
When the ClusterPool creates a new cluster, it creates a namespace to house the ClusterDeployment. When the ClusterDeployment is deleted, the namespace then needs to be deleted to avoid leaking namespaces. To this end, these changes add a clusterpoolnamespace controller which will sync namespaces and delete them when appropriate. All namespaces
created for ClusterPools will have a hive.openshift.io/origin-cluster-pool-name label. The new controller will delete a namespace with that label if the namespace does not contain any ClusterDeployments. The controller will wait 5 minutes after the creation of the namespace before deleting the namespace to give time for the ClusterDeployment to be created.

https://issues.redhat.com/browse/CO-1014