### PR TITLE
stop adding MachinePool twice

### DIFF
--- a/pkg/clusterresource/builder.go
+++ b/pkg/clusterresource/builder.go
@@ -158,7 +158,6 @@ func (o *Builder) Build() ([]runtime.Object, error) {
 
 	var allObjects []runtime.Object
 	allObjects = append(allObjects, o.generateClusterDeployment())
-	allObjects = append(allObjects, o.generateMachinePool())
 	if !o.SkipMachinePoolGeneration {
 		allObjects = append(allObjects, o.generateMachinePool())
 	}


### PR DESCRIPTION
With https://github.com/openshift/hive/pull/1024, code was added to the create-cluster command to skip the MachinePool for certain platforms. However, the code that added the MachinePool indiscriminately was not removed. The result was that 1 MachinePool was added for some platforms and 2 duplicates MachinePools were added for other platform.