### PR TITLE
Detect install pod stuck in pending phase

### DIFF
--- a/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -304,6 +304,9 @@ const (
 	// ClusterHibernatingCondition is set when the ClusterDeployment is either
 	// transitioning to/from a hibernating state or is in a hibernating state.
 	ClusterHibernatingCondition ClusterDeploymentConditionType = "Hibernating"
+
+	// InstallLaunchErrorCondition is set when a cluster provision fails to launch an install pod
+	InstallLaunchErrorCondition ClusterDeploymentConditionType = "InstallLaunchError"
 )
 
 // AllClusterDeploymentConditions is a slice containing all condition types. This can be used for dealing with

--- a/pkg/apis/hive/v1/clusterprovision_types.go
+++ b/pkg/apis/hive/v1/clusterprovision_types.go
@@ -105,6 +105,9 @@ const (
 
 	// ClusterProvisionJobCreated is set when the install job is created for a cluster provision.
 	ClusterProvisionJobCreated ClusterProvisionConditionType = "ClusterProvisionJobCreated"
+
+	// InstallPodStuckCondition is set when the install pod is stuck
+	InstallPodStuckCondition ClusterProvisionConditionType = "InstallPodStuck"
 )
 
 // +genclient


### PR DESCRIPTION
This PR adds a ClusterDeployment condition to detect install pod stuck in the pending phase. The install pod will be in the pending phase for sometime after creating a job. To handle this the pod status check is performed only if 60 seconds have elapsed after creating the job.

jira: https://issues.redhat.com/browse/CO-1037