### PR TITLE
use full GCP machineset names in OpenShift 4.4.7

### DIFF
--- a/pkg/controller/remotemachineset/gcpactuator.go
+++ b/pkg/controller/remotemachineset/gcpactuator.go
@@ -35,7 +35,7 @@ const (
 )
 
 var (
-	versionsSupportingFullNames = semver.MustParseRange(">=4.4.8")
+	versionsSupportingFullNames = semver.MustParseRange(">=4.4.7")
 )
 
 // GCPActuator encapsulates the pieces necessary to be able to generate

--- a/pkg/controller/remotemachineset/gcpactuator_test.go
+++ b/pkg/controller/remotemachineset/gcpactuator_test.go
@@ -564,18 +564,18 @@ func TestRequireLeases(t *testing.T) {
 		expectedResult  bool
 	}{
 		{
-			name:           "before 4.4.8",
-			clusterVersion: "4.4.7",
+			name:           "before 4.4.7",
+			clusterVersion: "4.4.6",
 			expectedResult: true,
 		},
 		{
-			name:           "4.4.8",
-			clusterVersion: "4.4.8",
+			name:           "4.4.7",
+			clusterVersion: "4.4.7",
 			expectedResult: false,
 		},
 		{
-			name:           "after 4.4.8",
-			clusterVersion: "4.4.9",
+			name:           "after 4.4.7",
+			clusterVersion: "4.4.8",
 			expectedResult: false,
 		},
 		{


### PR DESCRIPTION
OpenShift 4.4.7 uses full GCP machineset names