### PR TITLE
delete recordsets in cloud zones when deleting DNSZone

### DIFF
--- a/pkg/controller/dnszone/awsactuator.go
+++ b/pkg/controller/dnszone/awsactuator.go
@@ -412,6 +412,11 @@ func (a *AWSActuator) Delete() error {
 	}
 
 	logger := a.logger.WithField("zone", a.dnsZone.Spec.Zone).WithField("id", aws.StringValue(a.zoneID))
+
+	if err := a.deleteRecordSets(logger); err != nil {
+		return err
+	}
+
 	logger.Info("Deleting route53 hostedzone")
 	_, err := a.awsClient.DeleteHostedZone(&route53.DeleteHostedZoneInput{
 		Id: a.zoneID,
@@ -424,6 +429,49 @@ func (a *AWSActuator) Delete() error {
 		log.WithError(err).Log(logLevel, "Cannot delete hosted zone")
 	}
 	return err
+}
+
+func (a *AWSActuator) deleteRecordSets(logger log.FieldLogger) error {
+	logger.Info("Deleting route53 recordsets in hostedzone")
+	maxItems := "100"
+	listInput := &route53.ListResourceRecordSetsInput{
+		HostedZoneId: a.zoneID,
+		MaxItems:     &maxItems,
+	}
+	for {
+		listOutput, err := a.awsClient.ListResourceRecordSets(listInput)
+		if err != nil {
+			return err
+		}
+		var changes []*route53.Change
+		for _, recordSet := range listOutput.ResourceRecordSets {
+			// Ignore the 2 recordsets that are created with the hosted zone and that cannot be deleted
+			if n, t := aws.StringValue(recordSet.Name), aws.StringValue(recordSet.Type); n == controllerutils.Dotted(a.dnsZone.Spec.Zone) && (t == route53.RRTypeNs || t == route53.RRTypeSoa) {
+				continue
+			}
+			logger.WithField("name", aws.StringValue(recordSet.Name)).WithField("type", aws.StringValue(recordSet.Type)).Info("recordset set for deletion")
+			changes = append(changes, &route53.Change{
+				Action:            aws.String(route53.ChangeActionDelete),
+				ResourceRecordSet: recordSet,
+			})
+		}
+		if len(changes) > 0 {
+			logger.WithField("count", len(changes)).Info("deleting recordsets")
+			if _, err := a.awsClient.ChangeResourceRecordSets(&route53.ChangeResourceRecordSetsInput{
+				ChangeBatch:  &route53.ChangeBatch{Changes: changes},
+				HostedZoneId: a.zoneID,
+			}); err != nil {
+				return err
+			}
+		}
+		if listOutput.IsTruncated == nil || !*listOutput.IsTruncated {
+			break
+		}
+		listInput.StartRecordIdentifier = listOutput.NextRecordIdentifier
+		listInput.StartRecordName = listOutput.NextRecordName
+		listInput.StartRecordType = listOutput.NextRecordType
+	}
+	return nil
 }
 
 // GetNameServers returns the nameservers listed in the route53 hosted zone NS record.

--- a/pkg/controller/dnszone/awsactuator_test.go
+++ b/pkg/controller/dnszone/awsactuator_test.go
@@ -178,5 +178,6 @@ func mockListAWSZonesByNameFound(expect *mock.MockClientMockRecorder, zone *hive
 }
 
 func mockDeleteAWSZone(expect *mock.MockClientMockRecorder) {
+	expect.ListResourceRecordSets(gomock.Any()).Return(&route53.ListResourceRecordSetsOutput{}, nil).Times(1)
 	expect.DeleteHostedZone(gomock.Any()).Return(nil, nil).Times(1)
 }

--- a/pkg/controller/dnszone/azureactuator_test.go
+++ b/pkg/controller/dnszone/azureactuator_test.go
@@ -87,6 +87,9 @@ func mockCreateAzureZone(expect *mock.MockClientMockRecorder) {
 	}, nil).Times(1)
 }
 
-func mockDeleteAzureZone(expect *mock.MockClientMockRecorder) {
+func mockDeleteAzureZone(mockCtrl *gomock.Controller, expect *mock.MockClientMockRecorder) {
+	recordSetPage := mock.NewMockRecordSetPage(mockCtrl)
+	recordSetPage.EXPECT().NotDone().Return(false).Times(1)
+	expect.ListRecordSetsByZone(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(recordSetPage, nil)
 	expect.DeleteZone(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
 }

--- a/pkg/controller/dnszone/gcpactuator.go
+++ b/pkg/controller/dnszone/gcpactuator.go
@@ -95,6 +95,11 @@ func (a *GCPActuator) Delete() error {
 	}
 
 	logger := a.logger.WithField("zone", a.dnsZone.Spec.Zone).WithField("zoneName", a.managedZone.Name)
+
+	if err := a.deleteRecordSets(logger); err != nil {
+		return err
+	}
+
 	logger.Info("Deleting managed zone")
 	err := a.gcpClient.DeleteManagedZone(a.managedZone.Name)
 	if err != nil {
@@ -110,6 +115,37 @@ func (a *GCPActuator) Delete() error {
 		log.WithError(err).Log(logLevel, "Cannot delete managed zone")
 	}
 	return err
+}
+
+func (a *GCPActuator) deleteRecordSets(logger log.FieldLogger) error {
+	logger.Info("Deleting recordsets in managedzone")
+	listOpts := gcpclient.ListResourceRecordSetsOptions{}
+	for {
+		listOutput, err := a.gcpClient.ListResourceRecordSets(a.managedZone.Name, listOpts)
+		if err != nil {
+			return err
+		}
+		var recordSetsToDelete []*dns.ResourceRecordSet
+		for _, recordSet := range listOutput.Rrsets {
+			// Ignore the 2 recordsets that are created with the managed zone and that cannot be deleted
+			if n, t := recordSet.Name, recordSet.Type; n == controllerutils.Dotted(a.dnsZone.Spec.Zone) && (t == "NS" || t == "SOA") {
+				continue
+			}
+			logger.WithField("name", recordSet.Name).WithField("type", recordSet.Type).Info("recordset set for deletion")
+			recordSetsToDelete = append(recordSetsToDelete, recordSet)
+		}
+		if len(recordSetsToDelete) > 0 {
+			logger.WithField("count", len(recordSetsToDelete)).Info("deleting recordsets")
+			if err := a.gcpClient.DeleteResourceRecordSets(a.managedZone.Name, recordSetsToDelete); err != nil {
+				return err
+			}
+		}
+		if listOutput.NextPageToken == "" {
+			break
+		}
+		listOpts.PageToken = listOutput.NextPageToken
+	}
+	return nil
 }
 
 // Exists implements the Exists call of the actuator interface

--- a/pkg/controller/dnszone/gcpactuator_test.go
+++ b/pkg/controller/dnszone/gcpactuator_test.go
@@ -76,5 +76,6 @@ func mockCreateGCPZone(expect *mock.MockClientMockRecorder) {
 }
 
 func mockDeleteGCPZone(expect *mock.MockClientMockRecorder) {
+	expect.ListResourceRecordSets(gomock.Any(), gomock.Any()).Return(&dns.ResourceRecordSetsListResponse{}, nil)
 	expect.DeleteManagedZone(gomock.Any()).Return(nil).Times(1)
 }

--- a/pkg/gcpclient/client.go
+++ b/pkg/gcpclient/client.go
@@ -28,6 +28,8 @@ type Client interface {
 
 	DeleteResourceRecordSet(managedZone string, recordSet *dns.ResourceRecordSet) error
 
+	DeleteResourceRecordSets(managedZone string, recordSet []*dns.ResourceRecordSet) error
+
 	UpdateResourceRecordSet(managedZone string, addRecordSet, removeRecordSet *dns.ResourceRecordSet) error
 
 	GetManagedZone(managedZone string) (*dns.ManagedZone, error)
@@ -152,10 +154,14 @@ func (c *gcpClient) UpdateResourceRecordSet(managedZone string, addRecordSet, re
 }
 
 func (c *gcpClient) DeleteResourceRecordSet(managedZone string, recordSet *dns.ResourceRecordSet) error {
+	return c.DeleteResourceRecordSets(managedZone, []*dns.ResourceRecordSet{recordSet})
+}
+
+func (c *gcpClient) DeleteResourceRecordSets(managedZone string, recordSets []*dns.ResourceRecordSet) error {
 	return c.changeResourceRecordSet(
 		managedZone,
 		&dns.Change{
-			Deletions: []*dns.ResourceRecordSet{recordSet},
+			Deletions: recordSets,
 		},
 	)
 }

--- a/pkg/gcpclient/mock/client_generated.go
+++ b/pkg/gcpclient/mock/client_generated.go
@@ -93,6 +93,20 @@ func (mr *MockClientMockRecorder) DeleteResourceRecordSet(managedZone, recordSet
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResourceRecordSet", reflect.TypeOf((*MockClient)(nil).DeleteResourceRecordSet), managedZone, recordSet)
 }
 
+// DeleteResourceRecordSets mocks base method
+func (m *MockClient) DeleteResourceRecordSets(managedZone string, recordSet []*v10.ResourceRecordSet) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteResourceRecordSets", managedZone, recordSet)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteResourceRecordSets indicates an expected call of DeleteResourceRecordSets
+func (mr *MockClientMockRecorder) DeleteResourceRecordSets(managedZone, recordSet interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteResourceRecordSets", reflect.TypeOf((*MockClient)(nil).DeleteResourceRecordSets), managedZone, recordSet)
+}
+
 // UpdateResourceRecordSet mocks base method
 func (m *MockClient) UpdateResourceRecordSet(managedZone string, addRecordSet, removeRecordSet *v10.ResourceRecordSet) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
When deleting a DNSZone, the cloud zone cannot be deleted while there are still recordsets in the zone. Since the zone was created for the DNSZone, Hive can safely clear the recordsets.

https://issues.redhat.com/browse/CO-1071