### PR TITLE
create RBAC for accessing claimed cluster

### DIFF
--- a/config/crds/hive.openshift.io_clusterclaims.yaml
+++ b/config/crds/hive.openshift.io_clusterclaims.yaml
@@ -42,66 +42,35 @@ spec:
                 when the claim is assigned a cluster.
               type: string
             subjects:
-              description: Subjects hold object references to authorize access to
+              description: Subjects hold references to which to authorize access to
                 the claimed cluster.
               items:
-                description: 'ObjectReference contains enough information to let you
-                  inspect or modify the referred object. --- New uses of this type
-                  are discouraged because of difficulty describing its usage when
-                  embedded in APIs.  1. Ignored fields.  It includes many fields which
-                  are not generally honored.  For instance, ResourceVersion and FieldPath
-                  are both very rarely valid in actual usage.  2. Invalid usage help.  It
-                  is impossible to add specific help for individual usage.  In most
-                  embedded usages, there are particular     restrictions like, "must
-                  refer only to types A and B" or "UID not honored" or "name must
-                  be restricted".     Those cannot be well described when embedded.  3.
-                  Inconsistent validation.  Because the usages are different, the
-                  validation rules are different by usage, which makes it hard for
-                  users to predict what will happen.  4. The fields are both imprecise
-                  and overly precise.  Kind is not a precise mapping to a URL. This
-                  can produce ambiguity     during interpretation and require a REST
-                  mapping.  In most cases, the dependency is on the group,resource
-                  tuple     and the version of the actual struct is irrelevant.  5.
-                  We cannot easily change it.  Because this type is embedded in many
-                  locations, updates to this type     will affect numerous schemas.  Don''t
-                  make new APIs embed an underspecified API type they do not control.
-                  Instead of using this type, create a locally provided and used type
-                  that is well-focused on your reference. For example, ServiceReferences
-                  for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
-                  .'
+                description: Subject contains a reference to the object or user identities
+                  a role binding applies to.  This can either hold a direct API object
+                  reference, or a value for non-objects such as user and group names.
                 properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
+                  apiGroup:
+                    description: APIGroup holds the API group of the referenced subject.
+                      Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                      for User and Group subjects.
                     type: string
                   kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: Kind of object being referenced. Values defined by
+                      this API group are "User", "Group", and "ServiceAccount". If
+                      the Authorizer does not recognized the kind value, the Authorizer
+                      should report an error.
                     type: string
                   name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    description: Name of the object being referenced.
                     type: string
                   namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    description: Namespace of the referenced object.  If the object
+                      kind is non-namespace, such as "User" or "Group", and this value
+                      is not empty the Authorizer should report an error.
                     type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
+                required:
+                - kind
+                - name
                 type: object
               type: array
           required:

--- a/pkg/apis/hive/v1/clusterclaim_types.go
+++ b/pkg/apis/hive/v1/clusterclaim_types.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -10,9 +11,9 @@ type ClusterClaimSpec struct {
 	// ClusterPoolName is the name of the cluster pool from which to claim a cluster.
 	ClusterPoolName string `json:"clusterPoolName"`
 
-	// Subjects hold object references to authorize access to the claimed cluster.
+	// Subjects hold references to which to authorize access to the claimed cluster.
 	// +optional
-	Subjects []corev1.ObjectReference `json:"subjects,omitempty"`
+	Subjects []rbacv1.Subject `json:"subjects,omitempty"`
 
 	// Namespace is the namespace containing the ClusterDeployment of the claimed cluster.
 	// This field will be set by the ClusterPool when the claim is assigned a cluster.

--- a/pkg/apis/hive/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/hive/v1/zz_generated.deepcopy.go
@@ -14,6 +14,7 @@ import (
 	ovirt "github.com/openshift/hive/pkg/apis/hive/v1/ovirt"
 	vsphere "github.com/openshift/hive/pkg/apis/hive/v1/vsphere"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -402,7 +403,7 @@ func (in *ClusterClaimSpec) DeepCopyInto(out *ClusterClaimSpec) {
 	*out = *in
 	if in.Subjects != nil {
 		in, out := &in.Subjects, &out.Subjects
-		*out = make([]corev1.ObjectReference, len(*in))
+		*out = make([]rbacv1.Subject, len(*in))
 		copy(*out, *in)
 	}
 	return

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -28,8 +28,8 @@ import (
 	"github.com/openshift/hive/pkg/constants"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/resource"
-
 	k8slabels "github.com/openshift/hive/pkg/util/labels"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1233,7 +1233,7 @@ func (m *InstallManager) cleanupAdminPasswordSecret() error {
 }
 
 // deleteAnyExistingObject will look for any object that exists that matches the passed in 'obj' and will delete it if it exists
-func (m *InstallManager) deleteAnyExistingObject(namespacedName types.NamespacedName, obj runtime.Object) error {
+func (m *InstallManager) deleteAnyExistingObject(namespacedName types.NamespacedName, obj hivev1.MetaRuntimeObject) error {
 	return resource.DeleteAnyExistingObject(m.DynamicClient, namespacedName, obj, m.log)
 }
 

--- a/pkg/operator/hive/hiveapi.go
+++ b/pkg/operator/hive/hiveapi.go
@@ -5,7 +5,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes/scheme"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -144,7 +143,7 @@ func (r *ReconcileHiveConfig) tearDownHiveAPI(hLog log.FieldLogger, hiveNSName s
 
 	objects := []struct {
 		key    client.ObjectKey
-		object runtime.Object
+		object hivev1.MetaRuntimeObject
 	}{
 		{
 			key:    client.ObjectKey{Namespace: hiveNSName, Name: "hiveapi"},

--- a/pkg/test/clusterclaim/clusterclaim.go
+++ b/pkg/test/clusterclaim/clusterclaim.go
@@ -1,6 +1,7 @@
 package clusterclaim
 
 import (
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
@@ -80,6 +81,12 @@ func WithPool(poolName string) Option {
 func WithCluster(clusterName string) Option {
 	return func(clusterClaim *hivev1.ClusterClaim) {
 		clusterClaim.Spec.Namespace = clusterName
+	}
+}
+
+func WithSubjects(subjects []rbacv1.Subject) Option {
+	return func(clusterClaim *hivev1.ClusterClaim) {
+		clusterClaim.Spec.Subjects = subjects
 	}
 }
 


### PR DESCRIPTION
When a ClusterClaim is assigned a cluster, the clusterclaim controller will create a Role and RoleBinding in the namespace
of the ClusterDeployment. The Role will grant full permissions for Hive resources and GET permissions for the admin kubeconfig and password secrets. The RoleBinding will assign the role to the subjects specified in the ClusterClaim.

https://issues.redhat.com/browse/CO-1070