### PR TITLE
hibernate clusters created for ClusterPool

### DIFF
--- a/pkg/controller/clusterclaim/clusterclaim_controller.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller.go
@@ -308,6 +308,7 @@ func (r *ReconcileClusterClaim) reconcileForDeletedCluster(claim *hivev1.Cluster
 func (r *ReconcileClusterClaim) reconcileForNewAssignment(claim *hivev1.ClusterClaim, cd *hivev1.ClusterDeployment, logger log.FieldLogger) (reconcile.Result, error) {
 	logger.Info("cluster assigned to claim")
 	cd.Spec.ClusterPoolRef.ClaimName = claim.Name
+	cd.Spec.PowerState = hivev1.RunningClusterPowerState
 	if err := r.Update(context.Background(), cd); err != nil {
 		logger.WithError(err).Log(controllerutils.LogLevel(err), "could not set claim for ClusterDeployment")
 		return reconcile.Result{}, err

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -310,6 +310,7 @@ func (r *ReconcileClusterPool) createCluster(
 		}
 		poolRef := poolReference(clp)
 		cd.Spec.ClusterPoolRef = &poolRef
+		cd.Spec.PowerState = hivev1.HibernatingClusterPowerState
 		lastIndex := len(objs) - 1
 		objs[i], objs[lastIndex] = objs[lastIndex], objs[i]
 	}

--- a/pkg/controller/clusterpool/clusterpool_controller_test.go
+++ b/pkg/controller/clusterpool/clusterpool_controller_test.go
@@ -51,7 +51,9 @@ func TestReconcileClusterPool(t *testing.T) {
 			testcp.WithImageSet(imageSetName),
 		)
 	cdBuilder := func(name string) testcd.Builder {
-		return testcd.FullBuilder(name, name, scheme)
+		return testcd.FullBuilder(name, name, scheme).Options(
+			testcd.WithPowerState(hivev1.HibernatingClusterPowerState),
+		)
 	}
 	unclaimedCDBuilder := func(name string) testcd.Builder {
 		return cdBuilder(name).Options(
@@ -462,6 +464,10 @@ func TestReconcileClusterPool(t *testing.T) {
 				for _, cd := range cds.Items {
 					assert.NotEqual(t, expectedDeletedName, cd.Name, "expected cluster to have been deleted")
 				}
+			}
+
+			for _, cd := range cds.Items {
+				assert.Equal(t, hivev1.HibernatingClusterPowerState, cd.Spec.PowerState, "expected cluster to be hibernating")
 			}
 
 			pool := &hivev1.ClusterPool{}

--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -118,3 +118,9 @@ func Installed() Option {
 		clusterDeployment.Spec.Installed = true
 	}
 }
+
+func WithPowerState(powerState hivev1.ClusterPowerState) Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Spec.PowerState = powerState
+	}
+}


### PR DESCRIPTION
When a cluster is created for a ClusterPool, hibernate the cluster, as the cluster will not be used until it is assigned to a claim. As part of assigning a cluster to a claim, power the cluster back on.

https://issues.redhat.com/browse/CO-1073