### PR TITLE
validation: base domain that is a managed domain

### DIFF
--- a/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook.go
+++ b/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook.go
@@ -671,15 +671,22 @@ func validateIngressList(newObject *hivev1.ClusterDeploymentSpec) bool {
 }
 
 func validateDomain(domain string, validDomains []string) bool {
+	matchFound := false
 	for _, validDomain := range validDomains {
-		if strings.HasSuffix(domain, "."+validDomain) {
-			childPart := strings.TrimSuffix(domain, "."+validDomain)
-			if !strings.Contains(childPart, ".") {
-				return true
-			}
+		// Do not allow the base domain to be the same as one of the managed domains.
+		if domain == validDomain {
+			return false
+		}
+		dottedValidDomain := "." + validDomain
+		if !strings.HasSuffix(domain, dottedValidDomain) {
+			continue
+		}
+		childPart := strings.TrimSuffix(domain, dottedValidDomain)
+		if !strings.ContainsRune(childPart, '.') {
+			matchFound = true
 		}
 	}
-	return false
+	return matchFound
 }
 
 func validateIngress(newObject *hivev1.ClusterDeployment, contextLogger *log.Entry) *admissionv1beta1.AdmissionResponse {

--- a/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/clusterdeployment_validating_admission_hook_test.go
@@ -456,8 +456,20 @@ func TestClusterDeploymentValidate(t *testing.T) {
 			expectedAllowed: true,
 		},
 		{
-			name:            "Test invalid managed domain",
+			name:            "Test base domain is not child of a managed domain",
+			newObject:       clusterDeploymentWithManagedDomain("bar.bad-domain.com"),
+			operation:       admissionv1beta1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name:            "Test base domain is not direct child of a managed domain",
 			newObject:       clusterDeploymentWithManagedDomain("baz.foo.bbb.com"),
+			operation:       admissionv1beta1.Create,
+			expectedAllowed: false,
+		},
+		{
+			name:            "Test base domain is not same as one of the managed domains",
+			newObject:       clusterDeploymentWithManagedDomain("foo.aaa.com"),
 			operation:       admissionv1beta1.Create,
 			expectedAllowed: false,
 		},


### PR DESCRIPTION
When one managed domain is a child of another managed domain, the the user can create a ClusterDeployment with a base domain that is the same as the child managed domain. This will cause problems when it comes time to change the recordsets in the base domain. These changes will have the validating webhook reject the ClusterDeployment.

For example, if there are managed domains of example.com and child.example.com, then the user should not be allowed to create a ClusterDeployment with a base domain of child.example.com.