### PR TITLE
clear ClusterImageSetNotFound condition when imageset exists

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -1012,6 +1012,9 @@ func (r *ReconcileClusterDeployment) getClusterImageSet(cd *hivev1.ClusterDeploy
 		}
 		return nil, err
 	}
+	if err := r.setImageSetNotFoundCondition(cd, false, cdLog); err != nil {
+		return nil, err
+	}
 	return imageSet, nil
 }
 


### PR DESCRIPTION
When the ClusterImageSet is found after not being found, the clusterdeployment controller is not setting the status of the
ClusterImageSetNotFound condition to false. These changes fix the controller so that it does set the condition to false
when the ClusterImageSet is found.

https://issues.redhat.com/browse/CO-906