### PR TITLE
use image pull policy IfNotPresent for OpenShift images

### DIFF
--- a/pkg/imageset/generate.go
+++ b/pkg/imageset/generate.go
@@ -43,7 +43,7 @@ func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAcco
 			{
 				Name:            "release",
 				Image:           releaseImage,
-				ImagePullPolicy: corev1.PullAlways,
+				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
 				Args:            []string{"cp -v /release-manifests/image-references /common/image-references"},
 				VolumeMounts:    volumeMounts,

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -362,7 +362,7 @@ func InstallerPodSpec(
 		{
 			Name:            "installer",
 			Image:           installerImage,
-			ImagePullPolicy: corev1.PullAlways,
+			ImagePullPolicy: corev1.PullIfNotPresent,
 			Env:             env,
 			Command:         []string{"/bin/sh", "-c"},
 			// Large file copy here has shown to cause problems in clusters under load, safer to copy then rename to the file the install manager is waiting for
@@ -373,7 +373,7 @@ func InstallerPodSpec(
 		{
 			Name:            "cli",
 			Image:           cliImage,
-			ImagePullPolicy: corev1.PullAlways,
+			ImagePullPolicy: corev1.PullIfNotPresent,
 			Env:             env,
 			Command:         []string{"/bin/sh", "-c"},
 			// Large file copy here has shown to cause problems in clusters under load, safer to copy then rename to the file the install manager is waiting for


### PR DESCRIPTION
For containers that are using an OpenShift image, use the IfNotPresent pull policy instead of the Always pull policy. The OpenShift images should not be changing.

This changes makes it possible to use OpenShift release images for the CI registry when running on Kind.