### PR TITLE
test/integration/resource: fix dropped test errors

### DIFF
--- a/test/integration/resource/apply_test.go
+++ b/test/integration/resource/apply_test.go
@@ -133,6 +133,10 @@ func TestApply(t *testing.T) {
 				}
 				accessor.SetNamespace(test.apply, namespace.Name)
 				data, err := h.Serialize(test.apply, scheme.Scheme)
+				if err != nil {
+					t.Errorf("unexpected error calling serialize: %v", err)
+					return
+				}
 				t.Logf("The serialized resource:\n%s\n", string(data))
 				info, err := h.Info(data)
 				if err != nil {

--- a/test/integration/resource/createonly_test.go
+++ b/test/integration/resource/createonly_test.go
@@ -103,6 +103,11 @@ func TestCreateOnly(t *testing.T) {
 				}
 				accessor.SetNamespace(test.apply, namespace.Name)
 				data, err := h.Serialize(test.apply, scheme.Scheme)
+				if err != nil {
+					t.Errorf("unexpected error calling serialize: %v", err)
+					return
+				}
+
 				t.Logf("The serialized resource:\n%s\n", string(data))
 				info, err := h.Info(data)
 				if err != nil {

--- a/test/integration/resource/createupdate_test.go
+++ b/test/integration/resource/createupdate_test.go
@@ -118,6 +118,9 @@ func TestCreateOrUpdate(t *testing.T) {
 				}
 				accessor.SetNamespace(test.apply, namespace.Name)
 				data, err := h.Serialize(test.apply, scheme.Scheme)
+				if err != nil {
+					t.Errorf("unexpected error calling setnamespace: %v", err)
+				}
 				t.Logf("The serialized resource:\n%s\n", string(data))
 				info, err := h.Info(data)
 				if err != nil {


### PR DESCRIPTION
This fixes three dropped test errors in `test/integration/resource`.