### PR TITLE
[Selector]SyncSet label on cluster resources

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -49,9 +49,15 @@ const (
 	ClusterPoolNameLabel = "hive.openshift.io/cluster-pool-name"
 
 	// SyncSetNameLabel is the label that is used to identify a relationship to a given syncset object.
+	// It is used in two places:
+	// 1) The SyncSetInstance
+	// 2) Each resource pushed down to the managed cluster at the behest of the SyncSet object.
 	SyncSetNameLabel = "hive.openshift.io/syncset-name"
 
 	// SelectorSyncSetNameLabel is the label that is used to identify a relationship to a given selector syncset object.
+	// It is used in two places:
+	// 1) The SyncSetInstance
+	// 2) Each resource pushed down to the managed cluster at the behest of the SelectorSyncSet object.
 	SelectorSyncSetNameLabel = "hive.openshift.io/selector-syncset-name"
 
 	// PVCTypeLabel is the label that is used to identify what a PVC is being used for.


### PR DESCRIPTION
For discoverability by service personnel, add a label to each resource pushed into the cluster at the behest of a [Selector]SyncSet. The label is identical to what's put on the SyncSetInstance, e.g.:

`hive.openshift.io/selector-syncset-name: ccs-dedicated-admins-environment`

Jira: [OSD-4848](https://issues.redhat.com/browse/OSD-4848)