### PR TITLE
CO-1114. Handle different worker-user-data secret name for 4.6.

### DIFF
--- a/pkg/controller/remotemachineset/awsactuator.go
+++ b/pkg/controller/remotemachineset/awsactuator.go
@@ -83,6 +83,10 @@ func (a *AWSActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *hi
 	if pool.Spec.Platform.AWS == nil {
 		return nil, false, errors.New("MachinePool is not for AWS")
 	}
+	clusterVersion, err := getClusterVersion(cd)
+	if err != nil {
+		return nil, false, fmt.Errorf("Unable to get cluster version: %v", err)
+	}
 
 	computePool := baseMachinePool(pool)
 	computePool.Platform.AWS = &installertypesaws.MachinePool{
@@ -121,7 +125,13 @@ func (a *AWSActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *hi
 	// from the machinepool / installconfig in the future.
 	userTags := map[string]string{}
 
-	installerMachineSets, err := installaws.MachineSets(cd.Spec.ClusterMetadata.InfraID, cd.Spec.Platform.AWS.Region, subnets, computePool, pool.Spec.Name, workerUserData, userTags)
+	workerUserDataSecret, err := workerUserData(clusterVersion)
+
+	if err != nil {
+		return nil, false, fmt.Errorf("error determining worker user data secret: %v", err)
+	}
+
+	installerMachineSets, err := installaws.MachineSets(cd.Spec.ClusterMetadata.InfraID, cd.Spec.Platform.AWS.Region, subnets, computePool, pool.Spec.Name, workerUserDataSecret, userTags)
 	if err != nil {
 		if strings.Contains(err.Error(), "no subnet for zone") {
 			conds, changed := controllerutils.SetMachinePoolConditionWithChangeCheck(

--- a/pkg/controller/remotemachineset/azureactuator.go
+++ b/pkg/controller/remotemachineset/azureactuator.go
@@ -55,6 +55,10 @@ func (a *AzureActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *
 	if pool.Spec.Platform.Azure == nil {
 		return nil, false, errors.New("MachinePool is not for Azure")
 	}
+	clusterVersion, err := getClusterVersion(cd)
+	if err != nil {
+		return nil, false, fmt.Errorf("Unable to get cluster version: %v", err)
+	}
 
 	ic := &installertypes.InstallConfig{
 		Platform: installertypes.Platform{
@@ -87,7 +91,13 @@ func (a *AzureActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *
 	// The imageID parameter is not used. The image is determined by the infraID.
 	const imageID = ""
 
-	installerMachineSets, err := installazure.MachineSets(cd.Spec.ClusterMetadata.InfraID, ic, computePool, imageID, workerRole, workerUserData)
+	workerUserDataSecret, err := workerUserData(clusterVersion)
+
+	if err != nil {
+		return nil, false, fmt.Errorf("error determining worker user data secret: %v", err)
+	}
+
+	installerMachineSets, err := installazure.MachineSets(cd.Spec.ClusterMetadata.InfraID, ic, computePool, imageID, workerRole, workerUserDataSecret)
 	return installerMachineSets, err == nil, errors.Wrap(err, "failed to generate machinesets")
 }
 

--- a/pkg/controller/remotemachineset/constants.go
+++ b/pkg/controller/remotemachineset/constants.go
@@ -1,10 +1,6 @@
 package remotemachineset
 
 const (
-
-	// workerUserData is the name of a secret in the cluster used for obtaining user data from MCO.
-	workerUserData = "worker-user-data"
-
 	// workerRole is used to locate installer created cloud resources such as subnets.
 	workerRole = "worker"
 )

--- a/pkg/controller/remotemachineset/ovirt.go
+++ b/pkg/controller/remotemachineset/ovirt.go
@@ -42,6 +42,10 @@ func (a *OvirtActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *
 	if pool.Spec.Platform.Ovirt == nil {
 		return nil, false, errors.New("MachinePool is not for oVirt")
 	}
+	clusterVersion, err := getClusterVersion(cd)
+	if err != nil {
+		return nil, false, fmt.Errorf("Unable to get cluster version: %v", err)
+	}
 
 	computePool := baseMachinePool(pool)
 
@@ -77,7 +81,13 @@ func (a *OvirtActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *
 	// cluster install), we should stick to this same name format, or update this line of code.
 	osImage := fmt.Sprintf("%s-rhcos", cd.Spec.ClusterMetadata.InfraID)
 
-	installerMachineSets, err := installovirt.MachineSets(cd.Spec.ClusterMetadata.InfraID, ic, computePool, osImage, workerRole, workerUserData)
+	workerUserDataSecret, err := workerUserData(clusterVersion)
+
+	if err != nil {
+		return nil, false, fmt.Errorf("error determining worker user data secret: %v", err)
+	}
+
+	installerMachineSets, err := installovirt.MachineSets(cd.Spec.ClusterMetadata.InfraID, ic, computePool, osImage, workerRole, workerUserDataSecret)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "failed to generate machinesets")
 	}

--- a/pkg/controller/remotemachineset/remotemachineset_controller_test.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/golang/mock/gomock"
+	openshiftapiv1 "github.com/openshift/api/config/v1"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
@@ -916,6 +917,11 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 				Type:   hivev1.UnreachableCondition,
 				Status: corev1.ConditionFalse,
 			}},
+			ClusterVersionStatus: &openshiftapiv1.ClusterVersionStatus{
+				Desired: openshiftapiv1.Update{
+					Version: "4.4.0",
+				},
+			},
 		},
 	}
 }

--- a/pkg/controller/remotemachineset/secrets.go
+++ b/pkg/controller/remotemachineset/secrets.go
@@ -1,0 +1,33 @@
+package remotemachineset
+
+import (
+	"fmt"
+
+	"github.com/blang/semver"
+)
+
+const (
+	// workerUserDataPre46 is the name of a secret in the cluster used for obtaining user data from MCO prior to 4.6.
+	workerUserDataPre46 = "worker-user-data"
+
+	// workerUserData46 is the name of a secret in the cluster used for obtaining user data from MCO after 4.6.
+	workerUserData46 = "worker-user-data-managed"
+)
+
+var (
+	workerUserDataAfter46 = semver.MustParseRange(">=4.6.0")
+)
+
+func workerUserData(version string) (string, error) {
+	parsedVersion, err := semver.ParseTolerant(version)
+
+	if err != nil {
+		return "", fmt.Errorf("error parsing version while getting workerUserData secret: %v", err)
+	}
+
+	if workerUserDataAfter46(parsedVersion) {
+		return workerUserData46, nil
+	}
+
+	return workerUserDataPre46, nil
+}

--- a/pkg/controller/remotemachineset/secrets_test.go
+++ b/pkg/controller/remotemachineset/secrets_test.go
@@ -1,0 +1,40 @@
+package remotemachineset
+
+import "testing"
+
+func TestWorkerUserData(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          string
+		expectedOutput string
+		shouldErr      bool
+	}{
+		{
+			name:           "pre 4.6",
+			input:          "4.4.0",
+			expectedOutput: "worker-user-data",
+		},
+		{
+			name:           "post 4.6",
+			input:          "4.6.0",
+			expectedOutput: "worker-user-data-managed",
+		},
+		{
+			name:      "error",
+			input:     "unparseable",
+			shouldErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		output, err := workerUserData(test.input)
+
+		if (err != nil) != test.shouldErr {
+			t.Errorf("test %s failure state should have been %t but was not", test.name, test.shouldErr)
+		}
+
+		if output != test.expectedOutput {
+			t.Errorf("test %s failed because output %s did not match expected output %s", test.name, output, test.expectedOutput)
+		}
+	}
+}


### PR DESCRIPTION
The worker-user-data secret name became worker-user-data-managed in 4.6.
Hive now supports alternate names for this secret.