### PR TITLE
Revert "expose hiveAPIEnabled in hiveconfig template"

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -20,8 +20,6 @@ parameters:
   value: "[]"
 - name: DELETE_PROTECTION
   value: ""
-- name: HIVE_API_ENABLED
-  value: true
 
 objects:
 - apiVersion: operators.coreos.com/v1alpha1
@@ -64,4 +62,3 @@ objects:
     globalPullSecretRef:
       name: ${GLOBAL_PULL_SECRET}
     deleteProtection: ${DELETE_PROTECTION}
-    hiveAPIEnabled: ${HIVE_API_ENABLED}


### PR DESCRIPTION
This reverts commit 53c19cc2702ff7276517ec1047abec3937bb5cd8.

The template doesn't like the boolean -- it wants a string.
We don't feel like messing with this anymore because it is
temporary, so we will revert and instead ask SRE-P to change
it manually.

/cc @staebler @dgoodwin 