### PR TITLE
Fix metrics crash on new InstallLaunchError condition.

### DIFF
--- a/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -259,6 +259,7 @@ type ClusterDeploymentCondition struct {
 // ClusterDeploymentConditionType is a valid value for ClusterDeploymentCondition.Type
 type ClusterDeploymentConditionType string
 
+// WARNING: All ClusterDeploymentConditionTypes should be added to the AllClusterDeploymentConditions slice below.
 const (
 	// ClusterImageSetNotFoundCondition is set when the ClusterImageSet referenced by the
 	// ClusterDeployment is not found.
@@ -324,6 +325,7 @@ var AllClusterDeploymentConditions = []ClusterDeploymentConditionType{
 	SyncSetFailedCondition,
 	RelocationFailedCondition,
 	ClusterHibernatingCondition,
+	InstallLaunchErrorCondition,
 }
 
 // Cluster hibernating reasons

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -524,6 +524,13 @@ func (ca *clusterAccumulator) processCluster(cd *hivev1.ClusterDeployment) {
 	// Process conditions regardless if installed or not:
 	for _, cond := range cd.Status.Conditions {
 		if cond.Status == corev1.ConditionTrue {
+			// Should have been handled by the initialization above which ensures we have 0's in the metrics for
+			// conditions that are not currently present on any clusters. This is a safety check to avoid crashing Hive
+			// in the event a developer adds a new condition but misses the list of all types.
+			if ca.conditions[cond.Type] == nil {
+				log.Warnf("condition type %s missing from AllClusterDeploymentConditions slice", cond.Type)
+				ca.conditions[cond.Type] = map[string]int{}
+			}
 			ca.conditions[cond.Type][clusterType]++
 		}
 	}

--- a/pkg/controller/metrics/metrics_test.go
+++ b/pkg/controller/metrics/metrics_test.go
@@ -39,6 +39,10 @@ func TestClusterAccumulator(t *testing.T) {
 				hivev1.ClusterImageSetNotFoundCondition,
 				hivev1.ControlPlaneCertificateNotFoundCondition,
 			}),
+		testClusterDeploymentWithConditions("b1", "managed", fiveMinsAgo, false,
+			[]hivev1.ClusterDeploymentConditionType{
+				hivev1.InstallLaunchErrorCondition,
+			}),
 		testClusterDeployment("c", "managed", tenMinsAgo, false),
 
 		// One managed cluster installing between 1h and 2h:
@@ -72,9 +76,9 @@ func TestClusterAccumulator(t *testing.T) {
 		accumulator.processCluster(&cd)
 	}
 
-	assert.Equal(t, 12, accumulator.total["managed"])
+	assert.Equal(t, 13, accumulator.total["managed"])
 	assert.Equal(t, 4, accumulator.installed["managed"])
-	assert.Equal(t, 8, accumulator.uninstalled["0h"]["managed"])
+	assert.Equal(t, 9, accumulator.uninstalled["0h"]["managed"])
 	assert.Equal(t, 5, accumulator.uninstalled["1h"]["managed"])
 	assert.Equal(t, 4, accumulator.uninstalled["2h"]["managed"])
 	assert.Equal(t, 2, accumulator.uninstalled["8h"]["managed"])
@@ -107,9 +111,9 @@ func TestClusterAccumulator(t *testing.T) {
 	for _, cd := range clusters {
 		accumulator.processCluster(&cd)
 	}
-	assert.Equal(t, 8, accumulator.total["managed"])
+	assert.Equal(t, 9, accumulator.total["managed"])
 	assert.Equal(t, 2, accumulator.installed["managed"])
-	assert.Equal(t, 6, accumulator.uninstalled["0h"]["managed"])
+	assert.Equal(t, 7, accumulator.uninstalled["0h"]["managed"])
 	assert.Equal(t, 3, accumulator.uninstalled["1h"]["managed"])
 	assert.Equal(t, 2, accumulator.uninstalled["2h"]["managed"])
 	assert.Equal(t, 0, accumulator.uninstalled["8h"]["managed"])


### PR DESCRIPTION
In 8b7044b12ee5de1cc9c54c46a91b9b946aefa854 a new ClusterDeployment
condition type was added, but it was not added to the list of
AllClusterDeploymentConditions.

When encountered in the wild the metrics code would attempt to increment
an int in a map we expected to be initialized to 0 but was instead nil.

This change adds the condition type to the list of all, adds a warning
comment, and a safety check and log warning if this happens again in the
future.