### PR TITLE
Restart deprovision pods if credentials secret changes.

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -272,6 +272,9 @@ const (
 
 	// OvirtConfigEnvVar is the environment variable specifying the oVirt config path
 	OvirtConfigEnvVar = "OVIRT_CONFIG"
+
+	// AWSCredsMount is the location where the AWS credentials secret is mounted for uninstall pods.
+	AWSCredsMount = "/etc/aws-creds"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment


### PR DESCRIPTION
Previously the uninstall pod would never restart if it launched with
since deleted or bad creds, and the user updated the credentials secret.

This change switches to mounting the creds as a secret instead of
passing through env vars. The hiveutil wrapper code sets them as env
vars and establishes a file watch on the directory where the secret is
mounted. On any change or watch error we exit to restart the pod.

It seems to usually take about 1 minute for the secret changes to
surface in the pod.