### PR TITLE
perform DNS cleanup after failed install for GCP

### DIFF
--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -583,7 +583,12 @@ func cleanupFailedProvision(dynClient client.Client, cd *hivev1.ClusterDeploymen
 		if err != nil {
 			return err
 		}
-		return uninstaller.Run()
+
+		if err := uninstaller.Run(); err != nil {
+			return err
+		}
+
+		return cleanupDNSZone(dynClient, cd, logger)
 	case cd.Spec.Platform.OpenStack != nil:
 		metadata := &installertypes.ClusterMetadata{
 			InfraID: infraID,

--- a/pkg/test/dnszone/dnszone.go
+++ b/pkg/test/dnszone/dnszone.go
@@ -3,6 +3,7 @@ package dnszone
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
@@ -113,5 +114,14 @@ func WithLabelOwner(owner *hivev1.ClusterDeployment) Option {
 func WithZone(zone string) Option {
 	return func(dnsZone *hivev1.DNSZone) {
 		dnsZone.Spec.Zone = zone
+	}
+}
+
+func WithGCPPlatform() Option {
+	return func(dnsZone *hivev1.DNSZone) {
+		dnsZone.Spec.GCP = &hivev1.GCPDNSZoneSpec{}
+		dnsZone.Status.GCP = &hivev1.GCPDNSZoneStatus{
+			ZoneName: pointer.StringPtr("testZoneName"),
+		}
 	}
 }


### PR DESCRIPTION
Similar to how we try to clean up stray DNS records after failed installation (when the ClusterDeployment has ManagedDNS), do the same for GCP.

Share the existing zone cleanup code from the dnszone controller.