### PR TITLE
additional-trust-bundle support added to hiveutil

### DIFF
--- a/contrib/pkg/createcluster/create.go
+++ b/contrib/pkg/createcluster/create.go
@@ -308,7 +308,7 @@ create-cluster CLUSTER_DEPLOYMENT_NAME --cloud=ovirt --ovirt-api-vip 192.168.1.2
 	flags.StringVar(&opt.OvirtCACerts, "ovirt-ca-certs", "", "Path to oVirt CA certificate, multiple CA paths can be : delimited")
 
 	// Additional CA Trust Bundle
-	flags.StringVar(&opt.AdditionalTrustBundle , "additional-trust-bundle", "", "Path to a CA Trust Bundle which will be added to the nodes trusted certificate store.")
+	flags.StringVar(&opt.AdditionalTrustBundle, "additional-trust-bundle", "", "Path to a CA Trust Bundle which will be added to the nodes trusted certificate store.")
 
 	return cmd
 }
@@ -483,7 +483,7 @@ func (o *Options) GenerateObjects() ([]runtime.Object, error) {
 
 	additionalTrustBundle, err := o.getAdditionalTrustBundle()
 	if err != nil {
-			return nil, err
+		return nil, err
 	}
 
 	// Load installer manifest files:
@@ -501,21 +501,21 @@ func (o *Options) GenerateObjects() ([]runtime.Object, error) {
 	}
 
 	builder := &clusterresource.Builder{
-		Name:               	o.Name,
-		Namespace:          	o.Namespace,
-		WorkerNodesCount:   	o.WorkerNodesCount,
-		PullSecret:         	pullSecret,
-		SSHPrivateKey:      	sshPrivateKey,
-		SSHPublicKey:       	sshPublicKey,
-		InstallOnce:        	o.InstallOnce,
-		BaseDomain:         	o.BaseDomain,
-		ManageDNS:          	o.ManageDNS,
-		DeleteAfter:        	o.DeleteAfter,
-		Labels:             	labels,
-		InstallerManifests: 	manifestFileData,
-		MachineNetwork:    		o.MachineNetwork,
-		SkipMachinePools:   	o.SkipMachinePools,
-		AdditionalTrustBundle: 	additionalTrustBundle,
+		Name:                  o.Name,
+		Namespace:             o.Namespace,
+		WorkerNodesCount:      o.WorkerNodesCount,
+		PullSecret:            pullSecret,
+		SSHPrivateKey:         sshPrivateKey,
+		SSHPublicKey:          sshPublicKey,
+		InstallOnce:           o.InstallOnce,
+		BaseDomain:            o.BaseDomain,
+		ManageDNS:             o.ManageDNS,
+		DeleteAfter:           o.DeleteAfter,
+		Labels:                labels,
+		InstallerManifests:    manifestFileData,
+		MachineNetwork:        o.MachineNetwork,
+		SkipMachinePools:      o.SkipMachinePools,
+		AdditionalTrustBundle: additionalTrustBundle,
 	}
 	if o.Adopt {
 		kubeconfigBytes, err := ioutil.ReadFile(o.AdoptAdminKubeConfig)
@@ -789,24 +789,23 @@ func (o *Options) getSSHPrivateKey() (string, error) {
 	return "", nil
 }
 
-func (o *Options) getAdditionalTrustBundle()(string, error) {
+func (o *Options) getAdditionalTrustBundle() (string, error) {
 	if len(o.AdditionalTrustBundle) > 0 {
-			data, err := ioutil.ReadFile(o.AdditionalTrustBundle)
-			if err != nil {
-					log.Error("Cannot read AdditionalTrustBundle file")
-					return "", err
-			}
-			if err := validate.CABundle(string(data)); err != nil {
-				  log.Error("AdditionalTrustBundle is not valid")
-				  return "", err
-			}
-			additionalTrustBundle := string(data)
-			return additionalTrustBundle, nil
+		data, err := ioutil.ReadFile(o.AdditionalTrustBundle)
+		if err != nil {
+			log.Error("Cannot read AdditionalTrustBundle file")
+			return "", err
+		}
+		if err := validate.CABundle(string(data)); err != nil {
+			log.Error("AdditionalTrustBundle is not valid")
+			return "", err
+		}
+		additionalTrustBundle := string(data)
+		return additionalTrustBundle, nil
 	}
 	log.Debug("No AdditionalTrustBundle provided")
 	return "", nil
 }
-
 
 func (o *Options) getManifestFileBytes() (map[string][]byte, error) {
 	if o.ManifestsDir == "" && !o.SimulateBootstrapFailure {

--- a/pkg/clusterresource/builder.go
+++ b/pkg/clusterresource/builder.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/openshift/installer/pkg/ipnet"
-	"github.com/openshift/installer/pkg/validate"
 	installertypes "github.com/openshift/installer/pkg/types"
+	"github.com/openshift/installer/pkg/validate"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -155,7 +155,7 @@ func (o *Builder) Validate() error {
 	if len(o.AdditionalTrustBundle) > 0 {
 		if err := validate.CABundle(o.AdditionalTrustBundle); err != nil {
 			return fmt.Errorf("AdditionalTrustBundle is not valid: %s", err.Error())
-	  }
+		}
 	}
 
 	return nil
@@ -337,7 +337,7 @@ func (o *Builder) generateInstallConfigSecret() (*corev1.Secret, error) {
 				Replicas: &o.WorkerNodesCount,
 			},
 		},
-		AdditionalTrustBundle:  o.AdditionalTrustBundle,
+		AdditionalTrustBundle: o.AdditionalTrustBundle,
 	}
 
 	o.CloudBuilder.addInstallConfigPlatform(o, installConfig)

--- a/pkg/clusterresource/builder.go
+++ b/pkg/clusterresource/builder.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/openshift/installer/pkg/ipnet"
+	"github.com/openshift/installer/pkg/validate"
 	installertypes "github.com/openshift/installer/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -109,6 +110,10 @@ type Builder struct {
 
 	// SkipMachinePools should be true if you do not want Hive to manage MachineSets in the spoke cluster once it is installed.
 	SkipMachinePools bool
+
+	// AdditionalTrustBundle is a PEM-encoded X.509 certificate bundle
+	// that will be added to the nodes' trusted certificate store.
+	AdditionalTrustBundle string
 }
 
 // Validate ensures that the builder's fields are logically configured and usable to generate the cluster resources.
@@ -145,6 +150,12 @@ func (o *Builder) Validate() error {
 		if len(o.AdoptAdminKubeconfig) > 0 || o.AdoptInfraID != "" || o.AdoptClusterID != "" || o.AdoptAdminUsername != "" || o.AdoptAdminPassword != "" {
 			return fmt.Errorf("cannot set adoption fields if Adopt is false")
 		}
+	}
+
+	if len(o.AdditionalTrustBundle) > 0 {
+		if err := validate.CABundle(o.AdditionalTrustBundle); err != nil {
+			return fmt.Errorf("AdditionalTrustBundle is not valid: %s", err.Error())
+	  }
 	}
 
 	return nil
@@ -326,6 +337,7 @@ func (o *Builder) generateInstallConfigSecret() (*corev1.Secret, error) {
 				Replicas: &o.WorkerNodesCount,
 			},
 		},
+		AdditionalTrustBundle:  o.AdditionalTrustBundle,
 	}
 
 	o.CloudBuilder.addInstallConfigPlatform(o, installConfig)


### PR DESCRIPTION
Hi Hive-Team,

we are using a private CA for our private cloud endpoints. Currently kubeutil does not support this feature. I added the functionality to the code. Please merge or let me know what is missing.

