### PR TITLE
update DNSZone status after refresh AWS/Azure/GCP

### DIFF
--- a/config/crds/hive.openshift.io_dnszones.yaml
+++ b/config/crds/hive.openshift.io_dnszones.yaml
@@ -136,6 +136,10 @@ spec:
             azure:
               description: AzureDNSZoneStatus contains status information specific
                 to Azure
+              properties:
+                zoneName:
+                  description: ZoneName is the name of the zone on Azure
+                  type: string
               type: object
             conditions:
               description: Conditions includes more detailed status for the DNSZone

--- a/pkg/apis/hive/v1/dnszone_types.go
+++ b/pkg/apis/hive/v1/dnszone_types.go
@@ -126,6 +126,8 @@ type AWSDNSZoneStatus struct {
 
 // AzureDNSZoneStatus contains status information specific to Azure DNS zones
 type AzureDNSZoneStatus struct {
+	// ZoneName is the name of the zone on Azure
+	ZoneName *string `json:"zoneName,omitempty"`
 }
 
 // GCPDNSZoneStatus contains status information specific to GCP Cloud DNS zones

--- a/pkg/controller/dnszone/awsactuator.go
+++ b/pkg/controller/dnszone/awsactuator.go
@@ -227,6 +227,12 @@ func (a *AWSActuator) Refresh() error {
 		}
 		logger.Debug("Found hosted zone")
 		a.zoneID = &zoneID
+
+		// Update dnsZone status now that we have the zoneID
+		if err := a.ModifyStatus(); err != nil {
+			a.logger.WithError(err).Error("failed to update status after refresh")
+			return err
+		}
 	}
 
 	if a.zoneID == nil {

--- a/pkg/controller/dnszone/awsactuator_test.go
+++ b/pkg/controller/dnszone/awsactuator_test.go
@@ -174,3 +174,16 @@ func mockDeleteAWSZone(expect *mock.MockClientMockRecorder) {
 	expect.ListResourceRecordSets(gomock.Any()).Return(&route53.ListResourceRecordSetsOutput{}, nil).Times(1)
 	expect.DeleteHostedZone(gomock.Any()).Return(nil, nil).Times(1)
 }
+
+func mockGetResourcePages(expect *mock.MockClientMockRecorder) {
+	expect.GetResourcesPages(gomock.Any(), gomock.Any()).Return(nil).Do(func(i *resourcegroupstaggingapi.GetResourcesInput, f func(*resourcegroupstaggingapi.GetResourcesOutput, bool) bool) {
+		getResourcesOutput := &resourcegroupstaggingapi.GetResourcesOutput{
+			ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+				{
+					ResourceARN: aws.String("arn:aws:route53:::hostedzone/Z055920326CHQAW0WSG5N"),
+				},
+			},
+		}
+		f(getResourcesOutput, true)
+	})
+}

--- a/pkg/controller/dnszone/azureactuator.go
+++ b/pkg/controller/dnszone/azureactuator.go
@@ -156,6 +156,10 @@ func (a *AzureActuator) ModifyStatus() error {
 		return errors.New("managedZone is unpopulated")
 	}
 
+	a.dnsZone.Status.Azure = &hivev1.AzureDNSZoneStatus{
+		ZoneName: a.managedZone.Name,
+	}
+
 	return nil
 }
 
@@ -182,6 +186,13 @@ func (a *AzureActuator) Refresh() error {
 
 	logger.Debug("Found managed zone")
 	a.managedZone = &resp
+
+	// Update dnsZone status now that we have the zone's name
+	if err := a.ModifyStatus(); err != nil {
+		logger.WithError(err).Error("failed ot update DNSZone status")
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/controller/dnszone/dnszone_controller_test.go
+++ b/pkg/controller/dnszone/dnszone_controller_test.go
@@ -132,6 +132,23 @@ func TestReconcileDNSProviderForAWS(t *testing.T) {
 			},
 		},
 		{
+			name: "Delete DNSZone without status",
+			dnsZone: func() *hivev1.DNSZone {
+				dz := validDNSZoneBeingDeleted()
+				dz.Status.AWS = nil
+				return dz
+			}(),
+			setupAWSMock: func(expect *mock.MockClientMockRecorder) {
+				mockGetResourcePages(expect)
+				mockAWSZoneExists(expect, validDNSZoneWithAdditionalTags())
+				mockExistingAWSTags(expect)
+				mockDeleteAWSZone(expect)
+			},
+			validateZone: func(t *testing.T, zone *hivev1.DNSZone) {
+				assert.False(t, controllerutils.HasFinalizer(zone, hivev1.FinalizerDNSZone))
+			},
+		},
+		{
 			name:            "Existing zone, link to parent, reachable SOA",
 			dnsZone:         validDNSZoneWithLinkToParent(),
 			soaLookupResult: true,

--- a/pkg/controller/dnszone/gcpactuator.go
+++ b/pkg/controller/dnszone/gcpactuator.go
@@ -216,6 +216,13 @@ func (a *GCPActuator) Refresh() error {
 
 	logger.Debug("Found managed zone")
 	a.managedZone = resp
+
+	// Update dnsZone status now that we have the zone's name
+	if err := a.ModifyStatus(); err != nil {
+		logger.WithError(err).Error("failed to update DNSZone status")
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Populate DNSZone status immediately after fetching zoneID.
Add status fields for Azure to store the dns zone name like we do for the other clouds.