### PR TITLE
Hibernation: increase delay to check for node readiness

### DIFF
--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -43,7 +43,7 @@ const (
 	// ready check after a cluster started resuming. This is to
 	// avoid a false positive when the node status is checked too
 	// soon after the cluster is ready
-	nodeCheckWaitTime = 2 * time.Minute
+	nodeCheckWaitTime = 4 * time.Minute
 )
 
 var (


### PR DESCRIPTION
It has been observed that certain clusters take longer than 2 minutes
to update their node status to "NotReady" when resuming from
hibernation. This introduces a quickfix of doubling the time that
the controller waits until it starts checking node status. However,
a longer term more deterministic fix is likely needed.