### PR TITLE
Aws dns cleanup refactor

### DIFF
--- a/pkg/controller/dnszone/awsactuator_test.go
+++ b/pkg/controller/dnszone/awsactuator_test.go
@@ -174,3 +174,16 @@ func mockDeleteAWSZone(expect *mock.MockClientMockRecorder) {
 	expect.ListResourceRecordSets(gomock.Any()).Return(&route53.ListResourceRecordSetsOutput{}, nil).Times(1)
 	expect.DeleteHostedZone(gomock.Any()).Return(nil, nil).Times(1)
 }
+
+func mockGetResourcePages(expect *mock.MockClientMockRecorder) {
+	expect.GetResourcesPages(gomock.Any(), gomock.Any()).Return(nil).Do(func(i *resourcegroupstaggingapi.GetResourcesInput, f func(*resourcegroupstaggingapi.GetResourcesOutput, bool) bool) {
+		getResourcesOutput := &resourcegroupstaggingapi.GetResourcesOutput{
+			ResourceTagMappingList: []*resourcegroupstaggingapi.ResourceTagMapping{
+				{
+					ResourceARN: aws.String("arn:aws:route53:::hostedzone/Z055920326CHQAW0WSG5N"),
+				},
+			},
+		}
+		f(getResourcesOutput, true)
+	})
+}

--- a/pkg/controller/dnszone/dnszone_controller_test.go
+++ b/pkg/controller/dnszone/dnszone_controller_test.go
@@ -132,6 +132,23 @@ func TestReconcileDNSProviderForAWS(t *testing.T) {
 			},
 		},
 		{
+			name: "Delete DNSZone without status",
+			dnsZone: func() *hivev1.DNSZone {
+				dz := validDNSZoneBeingDeleted()
+				dz.Status.AWS = nil
+				return dz
+			}(),
+			setupAWSMock: func(expect *mock.MockClientMockRecorder) {
+				mockGetResourcePages(expect)
+				mockAWSZoneExists(expect, validDNSZoneWithAdditionalTags())
+				mockExistingAWSTags(expect)
+				mockDeleteAWSZone(expect)
+			},
+			validateZone: func(t *testing.T, zone *hivev1.DNSZone) {
+				assert.False(t, controllerutils.HasFinalizer(zone, hivev1.FinalizerDNSZone))
+			},
+		},
+		{
 			name:            "Existing zone, link to parent, reachable SOA",
 			dnsZone:         validDNSZoneWithLinkToParent(),
 			soaLookupResult: true,

--- a/pkg/installmanager/dnscleanup.go
+++ b/pkg/installmanager/dnscleanup.go
@@ -1,56 +1,65 @@
 package installmanager
 
 import (
-	awsclient "github.com/openshift/hive/pkg/awsclient"
+	"context"
+	"fmt"
 
 	log "github.com/sirupsen/logrus"
 
-	awssdk "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/route53"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	awsclient "github.com/openshift/hive/pkg/awsclient"
+	dns "github.com/openshift/hive/pkg/controller/dnszone"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 )
 
-// cleanupDNSZone queries the Route53 zone and deletes any A records found. Other record
-// types may be added in the future, but right now this is the only one we're seeing
-// leak and conflict.
+// cleanupDNSZone will handle any needed DNS cleanup for ClusterDeployments with
+// ManageDNS enabled (this helps to clean up any stray DNS records on install failures)
+func cleanupDNSZone(dynClient client.Client, cd *hivev1.ClusterDeployment, logger log.FieldLogger) error {
+	if cd.Spec.ManageDNS == false {
+		return nil
+	}
+
+	dnsZone := &hivev1.DNSZone{}
+	dnsZoneNamespacedName := types.NamespacedName{Namespace: cd.Namespace, Name: controllerutils.DNSZoneName(cd.Name)}
+	if err := dynClient.Get(context.TODO(), dnsZoneNamespacedName, dnsZone); err != nil {
+		logger.WithError(err).Error("error looking up managed dnszone")
+	}
+
+	switch {
+	case cd.Spec.Platform.AWS != nil:
+		return cleanupAWSDNSZone(dnsZone, cd.Spec.Platform.AWS.Region, logger)
+	default:
+		log.Debug("No DNS cleanup for platform type")
+		return nil
+	}
+}
+
+// cleanupAWSDNSZone will return a DNS zone to the minimum set of DNS records
 // May no longer be necessary once https://jira.coreos.com/browse/CORS-1195 is fixed.
-func cleanupDNSZone(dnsZoneID, region string, logger log.FieldLogger) error {
-	zoneLogger := logger.WithField("dnsZoneID", dnsZoneID)
+func cleanupAWSDNSZone(dnsZone *hivev1.DNSZone, region string, logger log.FieldLogger) error {
+	if dnsZone.Status.AWS == nil {
+		return fmt.Errorf("found non-AWS DNSZone for AWS ClusterDeployment")
+	}
+	if dnsZone.Status.AWS.ZoneID == nil {
+		// Shouldn't really be possible as we block install until DNS is ready:
+		return fmt.Errorf("DNSZone %s has no ZoneID set", dnsZone.Name)
+	}
+
+	zoneLogger := logger.WithField("dnsZoneID", *dnsZone.Status.AWS.ZoneID)
 	zoneLogger.Info("cleaning up DNSZone")
 
 	awsClient, err := awsclient.NewClient(nil, "", "", region)
 	if err != nil {
 		return err
 	}
-	recordsOutput, err := awsClient.ListResourceRecordSets(
-		&route53.ListResourceRecordSetsInput{
-			HostedZoneId: awssdk.String(dnsZoneID),
-		},
-	)
-	if err != nil {
+
+	if err := dns.DeleteAWSRecordSets(awsClient, dnsZone, zoneLogger); err != nil {
+		logger.WithError(err).Error("failed to clean up DNS Zone")
 		return err
 	}
-	for _, r := range recordsOutput.ResourceRecordSets {
-		// We're only experiencing problems with A records, so these are all we cleanup for now:
-		if *r.Type == "A" {
-			zoneLogger.WithFields(log.Fields{"name": *r.Name, "type": *r.Type}).Info("deleting A record")
-			request := &route53.ChangeResourceRecordSetsInput{
-				ChangeBatch: &route53.ChangeBatch{
-					Changes: []*route53.Change{
-						{
-							Action:            awssdk.String("DELETE"),
-							ResourceRecordSet: r,
-						},
-					},
-				},
-				HostedZoneId: awssdk.String(dnsZoneID),
-			}
-			_, err := awsClient.ChangeResourceRecordSets(request)
-			if err != nil {
-				logger.WithError(err).WithField("recordset", r.Name).Warn("error deleting recordset")
-				return err
-			}
-		}
-	}
-	zoneLogger.Info("DNSZone A records deleted")
+	zoneLogger.Info("DNSZone cleaned")
 	return nil
 }

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -26,7 +26,6 @@ import (
 	contributils "github.com/openshift/hive/contrib/pkg/utils"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
-	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/resource"
 	k8slabels "github.com/openshift/hive/pkg/util/labels"
 
@@ -549,24 +548,7 @@ func cleanupFailedProvision(dynClient client.Client, cd *hivev1.ClusterDeploymen
 		// If we're managing DNS for this cluster, lookup the DNSZone and cleanup
 		// any leftover A records that may have leaked due to
 		// https://jira.coreos.com/browse/CORS-1195.
-		if cd.Spec.ManageDNS {
-			dnsZone := &hivev1.DNSZone{}
-			dnsZoneNamespacedName := types.NamespacedName{Namespace: cd.Namespace, Name: controllerutils.DNSZoneName(cd.Name)}
-			err := dynClient.Get(context.TODO(), dnsZoneNamespacedName, dnsZone)
-			if err != nil {
-				logger.WithError(err).Error("error looking up managed dnszone")
-				return err
-			}
-			if dnsZone.Status.AWS == nil {
-				return fmt.Errorf("found non-AWS DNSZone for AWS ClusterDeployment")
-			}
-			if dnsZone.Status.AWS.ZoneID == nil {
-				// Shouldn't really be possible as we block install until DNS is ready:
-				return fmt.Errorf("DNSZone %s has no ZoneID set", dnsZone.Name)
-			}
-			return cleanupDNSZone(*dnsZone.Status.AWS.ZoneID, cd.Spec.Platform.AWS.Region, logger)
-		}
-		return nil
+		return cleanupDNSZone(dynClient, cd, logger)
 	case cd.Spec.Platform.Azure != nil:
 		uninstaller := &azure.ClusterUninstaller{}
 		uninstaller.Logger = logger


### PR DESCRIPTION
Try number 2 to use one AWS DNS cleanup implementation.

Rework the DNSZone controller's AWS actuator code for DNS zone cleanup so that it is an exported function that can also be called during a failed cluster installation.
    
Rather than two similar DNS cleanup functions, unify onto one implementation that can be used by all callers.
    
This means we now remove more than just A records on a failed intall.
    
Also, populate DNSZone status immediately after fetching zoneID during Refresh() and Create()
    
Add test case to cover DNSZone being deleted without status.
    
Align with other actuators and just store entire AWS dnszone after receiving it.



