### PR TITLE
GCP DNS cleanup after install failure

### DIFF
--- a/pkg/installmanager/dnscleanup.go
+++ b/pkg/installmanager/dnscleanup.go
@@ -9,10 +9,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	gcputils "github.com/openshift/hive/contrib/pkg/utils/gcp"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
-	awsclient "github.com/openshift/hive/pkg/awsclient"
+	"github.com/openshift/hive/pkg/awsclient"
 	dns "github.com/openshift/hive/pkg/controller/dnszone"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+	"github.com/openshift/hive/pkg/gcpclient"
 )
 
 // cleanupDNSZone will handle any needed DNS cleanup for ClusterDeployments with
@@ -31,6 +33,8 @@ func cleanupDNSZone(dynClient client.Client, cd *hivev1.ClusterDeployment, logge
 	switch {
 	case cd.Spec.Platform.AWS != nil:
 		return cleanupAWSDNSZone(dnsZone, cd.Spec.Platform.AWS.Region, logger)
+	case cd.Spec.Platform.GCP != nil:
+		return cleanupGCPDNSZone(dnsZone, logger)
 	default:
 		log.Debug("No DNS cleanup for platform type")
 		return nil
@@ -61,5 +65,37 @@ func cleanupAWSDNSZone(dnsZone *hivev1.DNSZone, region string, logger log.FieldL
 		return err
 	}
 	zoneLogger.Info("DNSZone cleaned")
+	return nil
+}
+
+func cleanupGCPDNSZone(dnsZone *hivev1.DNSZone, logger log.FieldLogger) error {
+	if dnsZone.Status.GCP == nil {
+		return fmt.Errorf("found non-GCP DNSZone for DNS ClusterDeployment")
+	}
+	if dnsZone.Status.GCP.ZoneName == nil {
+		// Shouldn't happen as we block installs until DNS is ready
+		return fmt.Errorf("DNSZone %s has no ZoneName set", dnsZone.Name)
+	}
+
+	logger = logger.WithField("zoneName", *dnsZone.Status.GCP.ZoneName)
+	logger.Info("cleaning up DNSZone")
+
+	creds, err := gcputils.GetCreds("")
+	if err != nil {
+		logger.WithError(err).Error("failed to get GCP creds")
+		return err
+	}
+
+	gcpClient, err := gcpclient.NewClient(creds)
+	if err != nil {
+		logger.WithError(err).Error("failed to create GCP client")
+		return err
+	}
+
+	if err := dns.DeleteGCPRecordSets(gcpClient, dnsZone, logger); err != nil {
+		logger.WithError(err).Error("failed to clean up DNS zone")
+		return err
+	}
+	logger.Info("DNSZone cleaned")
 	return nil
 }

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -564,7 +564,9 @@ func cleanupFailedProvision(dynClient client.Client, cd *hivev1.ClusterDeploymen
 		uninstaller.GraphAuthorizer = session.GraphAuthorizer
 		uninstaller.Authorizer = session.Authorizer
 
-		return uninstaller.Run()
+		if err := uninstaller.Run(); err != nil {
+			return err
+		}
 	case cd.Spec.Platform.GCP != nil:
 		credsFile := os.Getenv("GOOGLE_CREDENTIALS")
 		projectID, err := gcpclient.ProjectIDFromFile(credsFile)
@@ -584,7 +586,10 @@ func cleanupFailedProvision(dynClient client.Client, cd *hivev1.ClusterDeploymen
 		if err != nil {
 			return err
 		}
-		return uninstaller.Run()
+
+		if err := uninstaller.Run(); err != nil {
+			return err
+		}
 	case cd.Spec.Platform.OpenStack != nil:
 		metadata := &installertypes.ClusterMetadata{
 			InfraID: infraID,
@@ -601,7 +606,10 @@ func cleanupFailedProvision(dynClient client.Client, cd *hivev1.ClusterDeploymen
 		if err != nil {
 			return err
 		}
-		return uninstaller.Run()
+
+		if err := uninstaller.Run(); err != nil {
+			return err
+		}
 	case cd.Spec.Platform.VSphere != nil:
 		vSphereUsername := os.Getenv(constants.VSphereUsernameEnvVar)
 		if vSphereUsername == "" {
@@ -625,7 +633,10 @@ func cleanupFailedProvision(dynClient client.Client, cd *hivev1.ClusterDeploymen
 		if err != nil {
 			return err
 		}
-		return uninstaller.Run()
+
+		if err := uninstaller.Run(); err != nil {
+			return err
+		}
 	case cd.Spec.Platform.Ovirt != nil:
 		metadata := &installertypes.ClusterMetadata{
 			InfraID: infraID,
@@ -639,11 +650,16 @@ func cleanupFailedProvision(dynClient client.Client, cd *hivev1.ClusterDeploymen
 		if err != nil {
 			return err
 		}
-		return uninstaller.Run()
+
+		if err := uninstaller.Run(); err != nil {
+			return err
+		}
 	default:
 		logger.Warn("unknown platform for re-try cleanup")
 		return errors.New("unknown platform for re-try cleanup")
 	}
+
+	return cleanupDNSZone(dynClient, cd, logger)
 }
 
 // generateAssets runs openshift-install commands to generate on-disk assets we need to

--- a/pkg/test/dnszone/dnszone.go
+++ b/pkg/test/dnszone/dnszone.go
@@ -115,3 +115,14 @@ func WithZone(zone string) Option {
 		dnsZone.Spec.Zone = zone
 	}
 }
+
+// WithGCPPlatform will set the GCP spce and status fields non-nil and populate
+// the status fields with the provided name for the zone.
+func WithGCPPlatform(zoneName string) Option {
+	return func(dnsZone *hivev1.DNSZone) {
+		dnsZone.Spec.GCP = &hivev1.GCPDNSZoneSpec{}
+		dnsZone.Status.GCP = &hivev1.GCPDNSZoneStatus{
+			ZoneName: &zoneName,
+		}
+	}
+}


### PR DESCRIPTION
Have GCP dns cleanup be similar to how AWS is now handled (from https://github.com/openshift/hive/pull/1107 ).

Perform DNS cleanup after failed install for GCP.
    
Similar to how we try to clean up stray DNS records after a failed AWS installation (when the ClusterDeployment has ManagedDNS), do the same for GCP.
    
Share the existing zone cleanup code from the dnszone controller.
    
Actually make a GCP DNSZone for the DNSZone test for GCP
    
Consistently populate the DNSZone status after retriving the information from GCP API calls.
