### PR TITLE
Azure dns cleanup after install failure and retire ModifyStatus from Actuator

### DIFF
--- a/pkg/azureclient/client.go
+++ b/pkg/azureclient/client.go
@@ -106,6 +106,11 @@ func NewClientFromFile(filename string) (Client, error) {
 	return newClient(authJSONFromFileSource(filename))
 }
 
+// NewClient creates our client wrapper object for interacting with Azure using the Azure creds provided.
+func NewClient(creds []byte) (Client, error) {
+	return newClient(authJSONFromBytes(creds))
+}
+
 func newClient(authJSONSource func() ([]byte, error)) (*azureClient, error) {
 	authJSON, err := authJSONSource()
 	if err != nil {
@@ -153,6 +158,12 @@ func newClient(authJSONSource func() ([]byte, error)) (*azureClient, error) {
 		recordSetsClient:   &recordSetsClient,
 		zonesClient:        &zonesClient,
 	}, nil
+}
+
+func authJSONFromBytes(creds []byte) func() ([]byte, error) {
+	return func() ([]byte, error) {
+		return creds, nil
+	}
 }
 
 func authJSONFromSecretSource(secret *corev1.Secret) func() ([]byte, error) {

--- a/pkg/controller/dnszone/actuator.go
+++ b/pkg/controller/dnszone/actuator.go
@@ -3,6 +3,7 @@ package dnszone
 // Actuator interface is the interface that is used to add dns provider support to the dnszone controller.
 type Actuator interface {
 	// Create tells the actuator to make a zone in the dns provider.
+	// The platform-specific DNSZone status fields will be populated (eg the zone name).
 	Create() error
 
 	// Delete tells the actuator to remove the zone from the dns provider.
@@ -14,14 +15,12 @@ type Actuator interface {
 	// UpdateMetadata tells the actuator to update the zone's metadata in the dns provider.
 	UpdateMetadata() error
 
-	// ModifyStatus allows the actuator to modify the kube DnsZoneStatus object before it is committed to kube.
-	ModifyStatus() error
-
 	// GetNameServers returns a list of nameservers that service the zone in the dns provider.
 	GetNameServers() ([]string, error)
 
 	// Refresh signals to the actuator that it should get the latest version of the zone from the dns provider.
 	// Refresh MUST be called before any other function is called by the actuator.
+	// Refresh will update the DNSZone object's platform-specific status fields.
 	Refresh() error
 
 	// SetConditionsForError sets conditions on the dnszone given a specific error

--- a/pkg/controller/dnszone/awsactuator.go
+++ b/pkg/controller/dnszone/awsactuator.go
@@ -163,8 +163,8 @@ func (a *AWSActuator) syncTags() error {
 	return nil
 }
 
-// ModifyStatus updates the DnsZone's status with AWS specific information.
-func (a *AWSActuator) ModifyStatus() error {
+// modifyStatus updates the DnsZone's status with AWS specific information.
+func (a *AWSActuator) modifyStatus() error {
 	if a.hostedZone == nil {
 		return errors.New("zoneID is unpopulated")
 	}
@@ -229,7 +229,7 @@ func (a *AWSActuator) Refresh() error {
 		a.hostedZone = resp.HostedZone
 
 		// Update dnsZone status now that we have the zoneID
-		if err := a.ModifyStatus(); err != nil {
+		if err := a.modifyStatus(); err != nil {
 			a.logger.WithError(err).Error("failed to update status after refresh")
 			return err
 		}
@@ -361,7 +361,7 @@ func (a *AWSActuator) Create() error {
 	}
 
 	a.hostedZone = hostedZone
-	if err := a.ModifyStatus(); err != nil {
+	if err := a.modifyStatus(); err != nil {
 		logger.WithError(err).Error("failed to populate DNSZone status")
 		return err
 	}

--- a/pkg/controller/dnszone/azureactuator.go
+++ b/pkg/controller/dnszone/azureactuator.go
@@ -73,7 +73,7 @@ func (a *AzureActuator) Create() error {
 
 	logger.Debug("Managed zone successfully created")
 	a.managedZone = &managedZone
-	if err := a.ModifyStatus(); err != nil {
+	if err := a.modifyStatus(); err != nil {
 		logger.WithError(err).Error("failed to modify DNSZone status")
 		return err
 	}
@@ -155,8 +155,8 @@ func (a *AzureActuator) GetNameServers() ([]string, error) {
 	return *result, nil
 }
 
-// ModifyStatus implements the ModifyStatus call of the actuator interface
-func (a *AzureActuator) ModifyStatus() error {
+// modifyStatus updates the DnsZone's status with Azure specific information.
+func (a *AzureActuator) modifyStatus() error {
 	if a.managedZone == nil {
 		return errors.New("managedZone is unpopulated")
 	}
@@ -187,7 +187,7 @@ func (a *AzureActuator) Refresh() error {
 
 	logger.Debug("Found managed zone")
 	a.managedZone = &resp
-	if err := a.ModifyStatus(); err != nil {
+	if err := a.modifyStatus(); err != nil {
 		logger.WithError(err).Error("failed to modify DNSZone status")
 		return err
 	}

--- a/pkg/controller/dnszone/dnszone_controller.go
+++ b/pkg/controller/dnszone/dnszone_controller.go
@@ -298,14 +298,6 @@ func (r *ReconcileDNSZone) reconcileDNSProvider(actuator Actuator, dnsZone *hive
 		reconcileResult.RequeueAfter = domainAvailabilityCheckInterval
 	}
 
-	r.logger.Debug("Letting the actuator modify the DNSZone status before sending it to kube.")
-	err = actuator.ModifyStatus()
-	if err != nil {
-		r.logger.WithError(err).Error("error modifying DNSZone status")
-		reconcileResult.RequeueAfter = domainAvailabilityCheckInterval
-		return reconcileResult, err
-	}
-
 	return reconcileResult, r.updateStatus(nameServers, isZoneSOAAvailable, dnsZone)
 }
 

--- a/pkg/controller/dnszone/gcpactuator.go
+++ b/pkg/controller/dnszone/gcpactuator.go
@@ -85,7 +85,7 @@ func (a *GCPActuator) Create() error {
 
 	logger.Debug("Managed zone successfully created")
 	a.managedZone = managedZone
-	if err := a.ModifyStatus(); err != nil {
+	if err := a.modifyStatus(); err != nil {
 		logger.WithError(err).Error("failed to sync DNSZone status fields")
 		return err
 	}
@@ -169,8 +169,8 @@ func (a *GCPActuator) UpdateMetadata() error {
 	return nil
 }
 
-// ModifyStatus implements the ModifyStatus call of the actuator interface
-func (a *GCPActuator) ModifyStatus() error {
+// modifyStatus updates the DnsZone's status with GCP specific information.
+func (a *GCPActuator) modifyStatus() error {
 	if a.managedZone == nil {
 		return errors.New("managedZone is unpopulated")
 	}
@@ -226,7 +226,7 @@ func (a *GCPActuator) Refresh() error {
 
 	logger.Debug("Found managed zone")
 	a.managedZone = resp
-	if err := a.ModifyStatus(); err != nil {
+	if err := a.modifyStatus(); err != nil {
 		logger.WithError(err).Error("failed to sync DNSZone status fields")
 		return err
 	}


### PR DESCRIPTION
Cleanup DNS after install failure (like we do for AWS and GCP).

Update status as soon as we fetch the Azure DNS zone info (a no-op today).

Create new azureclient builder that takes the credentials as a byte array.

Additionally, retire the ModifyStatus function from the DNS actuator. Use it internally for all actuators.
