### PR TITLE
pipeline: lock registry container to 4.5

### DIFF
--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -91,7 +91,7 @@ REGISTRY_IMG="quay.io/app-sre/hive-registry"
 DOCKERFILE_REGISTRY="Dockerfile.olm-registry"
 
 cat <<EOF > $DOCKERFILE_REGISTRY
-FROM quay.io/openshift/origin-operator-registry:latest
+FROM quay.io/openshift/origin-operator-registry:4.5
 
 COPY $SAAS_OPERATOR_DIR manifests
 RUN initializer


### PR DESCRIPTION
the :latest container appears broken. Probably a bad idea
to chase :latest in this build anyway.