### PR TITLE
Implement hibernate-after annotation to auto-powerdown.

### DIFF
--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -201,6 +201,12 @@ spec:
                       type: string
                   type: object
               type: object
+            hibernateAfter:
+              description: HibernateAfter will transition a cluster to hibernating
+                power state after it has been running for the given duration. The
+                time that a cluster has been running is the time since the cluster
+                was installed or the time since the cluster last came out of hibernation.
+              type: string
             ingress:
               description: Ingress allows defining desired clusteringress/shards to
                 be configured on the cluster.

--- a/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -123,6 +123,12 @@ type ClusterDeploymentSpec struct {
 	// PowerState defaults to the Running state.
 	// +optional
 	PowerState ClusterPowerState `json:"powerState,omitempty"`
+
+	// HibernateAfter will transition a cluster to hibernating power state after it has been running for the
+	// given duration. The time that a cluster has been running is the time since the cluster was installed or the
+	// time since the cluster last came out of hibernation.
+	// +optional
+	HibernateAfter *metav1.Duration `json:"hibernateAfter,omitempty"`
 }
 
 // Provisioning contains settings used only for initial cluster provisioning.

--- a/pkg/apis/hive/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/hive/v1/zz_generated.deepcopy.go
@@ -563,6 +563,11 @@ func (in *ClusterDeploymentSpec) DeepCopyInto(out *ClusterDeploymentSpec) {
 		*out = new(ClusterPoolReference)
 		**out = **in
 	}
+	if in.HibernateAfter != nil {
+		in, out := &in.HibernateAfter, &out.HibernateAfter
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/clusterresource/builder.go
+++ b/pkg/clusterresource/builder.go
@@ -2,6 +2,7 @@ package clusterresource
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/openshift/installer/pkg/ipnet"
@@ -64,6 +65,9 @@ type Builder struct {
 	// DeleteAfter is the duration after which the cluster should be automatically destroyed, relative to
 	// creationTimestamp. Stored as an annotation on the ClusterDeployment.
 	DeleteAfter string
+
+	// HibernateAfter is the duration after which a running cluster should be automatically hibernated.
+	HibernateAfter *time.Duration
 
 	// ServingCert is the contents of a serving certificate to be used for the cluster.
 	ServingCert string
@@ -268,6 +272,10 @@ func (o *Builder) generateClusterDeployment() *hivev1.ClusterDeployment {
 
 	if o.DeleteAfter != "" {
 		cd.ObjectMeta.Annotations[deleteAfterAnnotation] = o.DeleteAfter
+	}
+
+	if o.HibernateAfter != nil {
+		cd.Spec.HibernateAfter = &metav1.Duration{Duration: *o.HibernateAfter}
 	}
 
 	if o.Adopt {

--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -1,6 +1,10 @@
 package clusterdeployment
 
 import (
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
@@ -119,8 +123,31 @@ func Installed() Option {
 	}
 }
 
+func InstalledTimestamp(instTime time.Time) Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Spec.Installed = true
+		clusterDeployment.Status.InstalledTimestamp = &metav1.Time{Time: instTime}
+	}
+}
+
+func WithClusterVersion(version string) Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Status.ClusterVersionStatus = &configv1.ClusterVersionStatus{
+			Desired: configv1.Update{
+				Version: version,
+			},
+		}
+	}
+}
+
 func WithPowerState(powerState hivev1.ClusterPowerState) Option {
 	return func(clusterDeployment *hivev1.ClusterDeployment) {
 		clusterDeployment.Spec.PowerState = powerState
+	}
+}
+
+func WithHibernateAfter(dur time.Duration) Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Spec.HibernateAfter = &metav1.Duration{Duration: dur}
 	}
 }


### PR DESCRIPTION
When a cluster has been in a running state (installed with no hibernate
condition, or hibernate condition=false) for more than the
hibernate-after duration, the cluster will be automatically put to
sleep.

Intended for dev clusters where you do not want them to accidentally be
left running beyond the workday.