### PR TITLE
Annotate remote resources with hive source(s)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
-	github.com/go-logr/logr v0.2.1-0.20200730175230-ee2de8da5be6 // indirect
+	github.com/go-logr/logr v0.2.1-0.20200730175230-ee2de8da5be6
 	github.com/golang/mock v1.4.4
 	github.com/golangci/golangci-lint v1.26.0
 	github.com/google/uuid v1.1.1

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -126,6 +126,10 @@ const (
 	// managed by Hive, and any manual changes may be undone the next time the resource is reconciled.
 	HiveManagedLabel = "hive.openshift.io/managed"
 
+	// HiveSourcesAnnotation is the key of an annotation added to any resources we sync to the remote cluster that lists
+	// the kind/name of the [Selector]SyncSet(s) that affect(s) it.
+	HiveSourcesAnnotation = "hive.openshift.io/sources"
+
 	// DisableInstallLogPasswordRedactionAnnotation is an annotation used on ClusterDeployments to disable the installmanager
 	// functionality which refuses to print output if it appears to contain a password or sensitive info. This can be
 	// useful in scenarios where debugging is needed and important info is being redacted. Set to "true".

--- a/pkg/controller/clustersync/commonsyncset.go
+++ b/pkg/controller/clustersync/commonsyncset.go
@@ -1,6 +1,8 @@
 package clustersync
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -17,6 +19,10 @@ type CommonSyncSet interface {
 
 	// GetSpec gets the common spec of the syncset
 	GetSpec() *hivev1.SyncSetCommonSpec
+
+	// GetSourceAnnotation produces a string of the form Kind/Name for use in the HiveSourcesAnnotation
+	// on a remote cluster
+	GetSourceAnnotation() string
 }
 
 // SyncSetAsCommon is a SyncSet typed as a CommonSyncSet
@@ -34,6 +40,11 @@ func (s *SyncSetAsCommon) GetSpec() *hivev1.SyncSetCommonSpec {
 	return &s.Spec.SyncSetCommonSpec
 }
 
+func (s *SyncSetAsCommon) GetSourceAnnotation() string {
+	obj := s.AsMetaObject()
+	return fmt.Sprintf("SyncSet/%s", obj.GetName())
+}
+
 // SelectorSyncSetAsCommon is a SelectorSyncSet typed as a CommonSyncSet
 type SelectorSyncSetAsCommon hivev1.SelectorSyncSet
 
@@ -47,4 +58,9 @@ func (s *SelectorSyncSetAsCommon) AsMetaObject() metav1.Object {
 
 func (s *SelectorSyncSetAsCommon) GetSpec() *hivev1.SyncSetCommonSpec {
 	return &s.Spec.SyncSetCommonSpec
+}
+
+func (s *SelectorSyncSetAsCommon) GetSourceAnnotation() string {
+	obj := s.AsMetaObject()
+	return fmt.Sprintf("SelectorSyncSet/%s", obj.GetName())
 }


### PR DESCRIPTION
For discoverability by service personnel, add an annotation to each resource pushed into the cluster at the behest of a [Selector]SyncSet. The annotation contains enough information to identify the hive [Selector]SyncSet(s) that affected the resource.

Example (not realistic):

`hive.openshift.io/sources: "SelectorSyncSet/ccs-dedicated-admins-environment SyncSet/groups"`

The idea is that you can backtrack from an in-cluster object to its hive
sources:

On the target cluster, get the annotation for the object in question:

```
$ oc get $somekind $somename -o jsonpath="{.metadata.annotations['hive\.openshift\.io/sources']}"
SelectorSyncSet/ccs-dedicated-admins-environment SyncSet/groups
```

And then on the hive, paste that into `oc get` in the ClusterDeployment's namespace (cluster-scoped things show up fine,
ignoring the namespace):
```
$ oc get -n $cd_namespace SelectorSyncSet/ccs-dedicated-admins-environment SyncSet/groups
NAME                                                                 AGE
selectorsyncset.hive.openshift.io/ccs-dedicated-admins-environment   50d

NAME                               AGE
syncset.hive.openshift.io/groups   3h5m

```

Jira: [OSD-4848](https://issues.redhat.com/browse/OSD-4848)