### PR TITLE
deprovision: kill deprovision when creds change

### DIFF
--- a/contrib/pkg/deprovision/deprovision.go
+++ b/contrib/pkg/deprovision/deprovision.go
@@ -1,22 +1,83 @@
 package deprovision
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+
+	"github.com/openshift/library-go/pkg/controller/fileobserver"
 )
 
 // NewDeprovisionCommand is the entrypoint to create the 'deprovision' subcommand
 func NewDeprovisionCommand() *cobra.Command {
+	var credsDir string
 	cmd := &cobra.Command{
 		Use:   "deprovision",
 		Short: "Deprovision clusters in supported cloud providers",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Usage()
 		},
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if credsDir == "" {
+				return
+			}
+			go terminateWhenFilesChange(credsDir)
+		},
 	}
+	flags := cmd.PersistentFlags()
+	flags.StringVar(&credsDir, "creds-dir", "", "directory of the creds. Changes in the creds will cause the program to terminate")
 	cmd.AddCommand(NewDeprovisionAzureCommand())
 	cmd.AddCommand(NewDeprovisionGCPCommand())
 	cmd.AddCommand(NewDeprovisionOpenStackCommand())
 	cmd.AddCommand(NewDeprovisionvSphereCommand())
 	cmd.AddCommand(NewDeprovisionOvirtCommand())
 	return cmd
+}
+
+func terminateWhenFilesChange(dir string) {
+	fileContents := map[string][]byte{}
+	var filenames []string
+	if err := filepath.Walk(
+		dir,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return errors.Wrapf(err, "problem encountered walking %s", path)
+			}
+			if info.IsDir() {
+				return nil
+			}
+			data, err := ioutil.ReadFile(path)
+			if err != nil {
+				return errors.Wrapf(err, "could not read contents of %s", path)
+			}
+			fileContents[path] = data
+			filenames = append(filenames, path)
+			return nil
+		},
+	); err != nil {
+		log.WithError(err).Fatal("could not read files for creds watch")
+	}
+	obs, err := fileobserver.NewObserver(10 * time.Second)
+	if err != nil {
+		log.WithError(err).Fatal("could not set up file observer for creds watch")
+	}
+	obs.AddReactor(
+		func(filename string, action fileobserver.ActionType) error {
+			log.WithField("filename", filename).Fatal("exiting because creds file changed")
+			return nil
+		},
+		fileContents,
+		filenames...,
+	)
+	stop := make(chan struct{})
+	go func() {
+		log.WithField("files", filenames).Info("running file observer")
+		obs.Run(stop)
+		log.Fatal("file observer stopped")
+	}()
 }

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -583,6 +583,8 @@ func completeAzureDeprovisionJob(req *hivev1.ClusterDeprovision, job *batchv1.Jo
 				"azure",
 				"--loglevel",
 				"debug",
+				"--creds-dir",
+				azureAuthDir,
 				req.Spec.InfraID,
 			},
 			VolumeMounts: volumeMounts,
@@ -625,6 +627,8 @@ func completeGCPDeprovisionJob(req *hivev1.ClusterDeprovision, job *batchv1.Job)
 				"gcp",
 				"--loglevel",
 				"debug",
+				"--creds-dir",
+				gcpAuthDir,
 				"--region",
 				req.Spec.Platform.GCP.Region,
 				req.Spec.InfraID,
@@ -664,6 +668,8 @@ func completeOpenStackDeprovisionJob(req *hivev1.ClusterDeprovision, job *batchv
 				"openstack",
 				"--loglevel",
 				"debug",
+				"--creds-dir",
+				openStackCloudsDir,
 				"--cloud",
 				req.Spec.Platform.OpenStack.Cloud,
 				req.Spec.InfraID,
@@ -676,20 +682,37 @@ func completeOpenStackDeprovisionJob(req *hivev1.ClusterDeprovision, job *batchv
 }
 
 func completeVSphereDeprovisionJob(req *hivev1.ClusterDeprovision, job *batchv1.Job) {
+	const vsphereCredsDir = "/vsphere-creds"
 	volumes := []corev1.Volume{}
 	volumeMounts := []corev1.VolumeMount{}
-	volumes = append(volumes, corev1.Volume{
-		Name: "vsphere-certificates",
-		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				SecretName: req.Spec.Platform.VSphere.CertificatesSecretRef.Name,
+	volumes = append(volumes,
+		corev1.Volume{
+			Name: "vsphere-creds",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: req.Spec.Platform.VSphere.CredentialsSecretRef.Name,
+				},
 			},
 		},
-	})
-	volumeMounts = append(volumeMounts, corev1.VolumeMount{
-		Name:      "vsphere-certificates",
-		MountPath: vsphereCloudsDir,
-	})
+		corev1.Volume{
+			Name: "vsphere-certificates",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: req.Spec.Platform.VSphere.CertificatesSecretRef.Name,
+				},
+			},
+		},
+	)
+	volumeMounts = append(volumeMounts,
+		corev1.VolumeMount{
+			Name:      "vsphere-creds",
+			MountPath: vsphereCredsDir,
+		},
+		corev1.VolumeMount{
+			Name:      "vsphere-certificates",
+			MountPath: vsphereCloudsDir,
+		},
+	)
 
 	env := vSphereCredsEnvVars(req.Spec.Platform.VSphere.CredentialsSecretRef.Name)
 
@@ -700,8 +723,18 @@ func completeVSphereDeprovisionJob(req *hivev1.ClusterDeprovision, job *batchv1.
 			ImagePullPolicy: images.GetHiveImagePullPolicy(),
 			Env:             env,
 			Command:         []string{"/bin/sh", "-c"},
-			Args:            []string{fmt.Sprintf("cp -vr %s/. /etc/pki/ca-trust/source/anchors/ && update-ca-trust && /usr/bin/hiveutil deprovision vsphere --vsphere-vcenter %s --loglevel debug %s", vsphereCloudsDir, req.Spec.Platform.VSphere.VCenter, req.Spec.InfraID)},
-			VolumeMounts:    volumeMounts,
+			Args: []string{
+				fmt.Sprintf(
+					"cp -vr %s/. /etc/pki/ca-trust/source/anchors/ && "+
+						"update-ca-trust && "+
+						"/usr/bin/hiveutil deprovision vsphere --vsphere-vcenter %s --loglevel debug --creds-dir=%s %s",
+					vsphereCloudsDir,
+					req.Spec.Platform.VSphere.VCenter,
+					vsphereCredsDir,
+					req.Spec.InfraID,
+				),
+			},
+			VolumeMounts: volumeMounts,
 		},
 	}
 	job.Spec.Template.Spec.Containers = containers
@@ -749,8 +782,18 @@ func completeOvirtDeprovisionJob(req *hivev1.ClusterDeprovision, job *batchv1.Jo
 			ImagePullPolicy: images.GetHiveImagePullPolicy(),
 			Env:             env,
 			Command:         []string{"/bin/sh", "-c"},
-			Args:            []string{fmt.Sprintf("cp -vr %s/. /etc/pki/ca-trust/source/anchors/ && update-ca-trust && /usr/bin/hiveutil deprovision ovirt --ovirt-cluster-id %s --loglevel debug %s", ovirtCADir, req.Spec.Platform.Ovirt.ClusterID, req.Spec.InfraID)},
-			VolumeMounts:    volumeMounts,
+			Args: []string{
+				fmt.Sprintf(
+					"cp -vr %s/. /etc/pki/ca-trust/source/anchors/ && "+
+						"update-ca-trust && "+
+						"/usr/bin/hiveutil deprovision ovirt --ovirt-cluster-id %s --loglevel debug --certs-dir=%s %s",
+					ovirtCADir,
+					req.Spec.Platform.Ovirt.ClusterID,
+					ovirtCloudsDir,
+					req.Spec.InfraID,
+				),
+			},
+			VolumeMounts: volumeMounts,
 		},
 	}
 	job.Spec.Template.Spec.Containers = containers


### PR DESCRIPTION
The "--creds-dir" flag has been added to the `hiveutil deprovision` command. When this flag is used, the command will create a file observer watching for any changes to any files in that directory. If a change is detected, the command will be terminated.

The uninstall pods for platforms other than AWS have been updated to include the "--creds-dir" flag in the call to the deprovision
command.

https://issues.redhat.com/browse/CO-1135