### PR TITLE
add lifetime field to clusterclaim

### DIFF
--- a/config/crds/hive.openshift.io_clusterclaims.yaml
+++ b/config/crds/hive.openshift.io_clusterclaims.yaml
@@ -36,6 +36,11 @@ spec:
               description: ClusterPoolName is the name of the cluster pool from which
                 to claim a cluster.
               type: string
+            lifetime:
+              description: Lifetime is the maximum lifetime of the claim after it
+                is assigned a cluster. If the claim still exists when the lifetime
+                has elapsed, the claim will be deleted by Hive.
+              type: string
             namespace:
               description: Namespace is the namespace containing the ClusterDeployment
                 of the claimed cluster. This field will be set by the ClusterPool

--- a/pkg/apis/hive/v1/clusterclaim_types.go
+++ b/pkg/apis/hive/v1/clusterclaim_types.go
@@ -19,6 +19,11 @@ type ClusterClaimSpec struct {
 	// This field will be set by the ClusterPool when the claim is assigned a cluster.
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
+
+	// Lifetime is the maximum lifetime of the claim after it is assigned a cluster. If the claim still exists
+	// when the lifetime has elapsed, the claim will be deleted by Hive.
+	// +optional
+	Lifetime *metav1.Duration `json:"lifetime,omitempty"`
 }
 
 // ClusterClaimStatus defines the observed state of ClusterClaim.

--- a/pkg/apis/hive/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/hive/v1/zz_generated.deepcopy.go
@@ -406,6 +406,11 @@ func (in *ClusterClaimSpec) DeepCopyInto(out *ClusterClaimSpec) {
 		*out = make([]rbacv1.Subject, len(*in))
 		copy(*out, *in)
 	}
+	if in.Lifetime != nil {
+		in, out := &in.Lifetime, &out.Lifetime
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -950,7 +950,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testSecret(corev1.SecretTypeDockerConfigJson, pullSecretSecret, corev1.DockerConfigJsonKey, "{}"),
 				testSecret(corev1.SecretTypeDockerConfigJson, constants.GetMergedPullSecretName(testClusterDeployment()), corev1.DockerConfigJsonKey, "{}"),
 			},
-			expectedRequeueAfter: 8*time.Hour + 60*time.Second,
+			expectedRequeueAfter: 8 * time.Hour,
 		},
 		{
 			name: "Wait after failed provision",

--- a/pkg/test/clusterclaim/clusterclaim.go
+++ b/pkg/test/clusterclaim/clusterclaim.go
@@ -1,7 +1,10 @@
 package clusterclaim
 
 import (
+	"time"
+
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
@@ -100,5 +103,11 @@ func WithCondition(cond hivev1.ClusterClaimCondition) Option {
 			}
 		}
 		clusterClaim.Status.Conditions = append(clusterClaim.Status.Conditions, cond)
+	}
+}
+
+func WithLifetime(lifetime time.Duration) Option {
+	return func(clusterClaim *hivev1.ClusterClaim) {
+		clusterClaim.Spec.Lifetime = &metav1.Duration{Duration: lifetime}
 	}
 }


### PR DESCRIPTION
The `.spec.lifetime` field has been added to the ClusterClaim type. The lifetime field determines how long a ClusterClaim can live once it has been assigned a cluster. When the lifetime of a ClusterClaim elapses, the clusterclaim controller will delete the ClusterClaim.

https://issues.redhat.com/browse/CO-1133

/assign @dgoodwin 
/cc @akhil-rane 