### PR TITLE
deprovision: skip symlinks in creds file watch

### DIFF
--- a/contrib/pkg/deprovision/deprovision.go
+++ b/contrib/pkg/deprovision/deprovision.go
@@ -49,6 +49,11 @@ func terminateWhenFilesChange(dir string) {
 				return errors.Wrapf(err, "problem encountered walking %s", path)
 			}
 			if info.IsDir() {
+				// skip directories
+				return nil
+			}
+			if info.Mode()&os.ModeSymlink != 0 {
+				// skip symlinks
 				return nil
 			}
 			data, err := ioutil.ReadFile(path)


### PR DESCRIPTION
When finding the files to watch for creds changes, skip symlinks. The `..data` symlink links to a directory, causing which causes
the program to error out attempting to read the directory. The other symlinks point to files that are already included in the watch.