### PR TITLE
machinepool condition for unsupported spot instances

### DIFF
--- a/pkg/apis/hive/v1/machinepool_types.go
+++ b/pkg/apis/hive/v1/machinepool_types.go
@@ -145,6 +145,10 @@ const (
 
 	// InvalidSubnetsMachinePoolCondition is true when there are missing or invalid entries in the subnet field
 	InvalidSubnetsMachinePoolCondition MachinePoolConditionType = "InvalidSubnets"
+
+	// UnsupportedConfigurationMachinePoolCondition is true when the configuration of the MachinePool is unsupported
+	// by the cluster.
+	UnsupportedConfigurationMachinePoolCondition MachinePoolConditionType = "UnsupportedConfiguration"
 )
 
 // +genclient

--- a/pkg/controller/remotemachineset/remotemachineset_controller_test.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller_test.go
@@ -966,3 +966,12 @@ func printAWSMachineProviderConfig(cfg *awsprovider.AWSMachineProviderConfig) st
 	}
 	return string(b)
 }
+
+func withClusterVersion(cd *hivev1.ClusterDeployment, version string) *hivev1.ClusterDeployment {
+	cd.Status.ClusterVersionStatus = &openshiftapiv1.ClusterVersionStatus{
+		Desired: openshiftapiv1.Update{
+			Version: version,
+		},
+	}
+	return cd
+}


### PR DESCRIPTION
Add the UnsupportedConfiguration condition to the MachinePool type. This condition is used to indicate that the cluster does not support the configuration specified in the MachinePool. If the MachinePool specifies spot instances but the cluster is running an OpenShift version earlier than 4.5, then the UnsupportedConfiguration condition will be set on the MachinePool and not MachineSets will be generated.

https://issues.redhat.com/browse/CO-1042