### PR TITLE
Log first success times when we report the metrics.

### DIFF
--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -517,8 +517,10 @@ func (r *ReconcileClusterSync) applySyncSets(
 			}
 			applyTime := now.Sub(startTime).Seconds()
 			if syncSet.AsMetaObject().GetNamespace() == "" {
+				logger.WithField("applyTime", applyTime).Debug("observed first successful apply of SelectorSyncSet for cluster")
 				metricTimeToApplySelectorSyncSet.WithLabelValues(syncSet.AsMetaObject().GetName()).Observe(applyTime)
 			} else {
+				logger.WithField("applyTime", applyTime).Debug("observed first successful apply of SyncSet for cluster")
 				metricTimeToApplySyncSet.Observe(applyTime)
 			}
 		}


### PR DESCRIPTION
This will give us some info to dig a little deeper in terms of which
cluster was involved and what to search for in logs.

/assign @suhanime 