### PR TITLE
dockerfiles: use go 1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.13 as builder
+FROM openshift/origin-release:golang-1.15 as builder
 RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,5 @@
 #FROM registry.access.redhat.com/ubi7/ubi
-FROM openshift/origin-release:golang-1.13
+FROM openshift/origin-release:golang-1.15
 
 # ssh-agent required for gathering logs in some situations:
 RUN if ! rpm -q openssh-clients; then yum install -y openssh-clients && yum clean all && rm -rf /var/cache/yum/*; fi

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.13
+FROM openshift/origin-release:golang-1.15
 
 # setting Git username and email for workaround of
 # https://github.com/jenkinsci/docker/issues/519


### PR DESCRIPTION
Change dockerfiles to use go 1.15.

We need to upgrade the dependency on github.com/openshift/library-go. That necessitates upgrading github.com/openshift/build-machinery-go. That, in turn, requires that we build with at least go 1.14.4.