### PR TITLE
update library-go

### DIFF
--- a/config/crds/hive.openshift.io_checkpoints.yaml
+++ b/config/crds/hive.openshift.io_checkpoints.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: checkpoints.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterclaims.yaml
+++ b/config/crds/hive.openshift.io_clusterclaims.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clusterclaims.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clusterdeployments.hive.openshift.io
 spec:
@@ -651,9 +653,13 @@ spec:
                                   optional for env vars'
                                 type: string
                               divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
                                 description: Specifies the output format of the exposed
                                   resources, defaults to "1"
-                                type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                               resource:
                                 description: 'Required: resource to select'
                                 type: string

--- a/config/crds/hive.openshift.io_clusterdeprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterdeprovisions.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clusterdeprovisions.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterimagesets.yaml
+++ b/config/crds/hive.openshift.io_clusterimagesets.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clusterimagesets.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clusterpools.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterprovisions.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clusterprovisions.hive.openshift.io
 spec:
@@ -811,9 +813,13 @@ spec:
                                         optional for env vars'
                                       type: string
                                     divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
                                       description: Specifies the output format of
                                         the exposed resources, defaults to "1"
-                                      type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
                                     resource:
                                       description: 'Required: resource to select'
                                       type: string
@@ -962,11 +968,12 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
                                     description: Name or number of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
                                   scheme:
                                     description: Scheme to use for connecting to the
                                       host. Defaults to HTTP.
@@ -985,11 +992,12 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
                                     description: Number or name of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
@@ -1058,11 +1066,12 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
                                     description: Name or number of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
                                   scheme:
                                     description: Scheme to use for connecting to the
                                       host. Defaults to HTTP.
@@ -1081,11 +1090,12 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
                                     description: Number or name of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
@@ -1150,11 +1160,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -1191,11 +1202,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -1254,6 +1266,10 @@ spec:
                           - containerPort
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - containerPort
+                        - protocol
+                        x-kubernetes-list-type: map
                       readinessProbe:
                         description: 'Periodic probe of container service readiness.
                           Container will be removed from service endpoints if the
@@ -1313,11 +1329,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -1354,11 +1371,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -1375,13 +1393,21 @@ spec:
                         properties:
                           limits:
                             additionalProperties:
-                              type: string
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             description: 'Limits describes the maximum amount of compute
                               resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                           requests:
                             additionalProperties:
-                              type: string
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             description: 'Requests describes the minimum amount of
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
@@ -1605,11 +1631,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -1646,11 +1673,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -1945,9 +1973,13 @@ spec:
                                         optional for env vars'
                                       type: string
                                     divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
                                       description: Specifies the output format of
                                         the exposed resources, defaults to "1"
-                                      type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
                                     resource:
                                       description: 'Required: resource to select'
                                       type: string
@@ -2092,11 +2124,12 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
                                     description: Name or number of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
                                   scheme:
                                     description: Scheme to use for connecting to the
                                       host. Defaults to HTTP.
@@ -2115,11 +2148,12 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
                                     description: Number or name of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
@@ -2188,11 +2222,12 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
                                     description: Name or number of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
                                   scheme:
                                     description: Scheme to use for connecting to the
                                       host. Defaults to HTTP.
@@ -2211,11 +2246,12 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
                                     description: Number or name of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
@@ -2278,11 +2314,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -2319,11 +2356,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -2433,11 +2471,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -2474,11 +2513,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -2496,13 +2536,21 @@ spec:
                         properties:
                           limits:
                             additionalProperties:
-                              type: string
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             description: 'Limits describes the maximum amount of compute
                               resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                           requests:
                             additionalProperties:
-                              type: string
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             description: 'Requests describes the minimum amount of
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
@@ -2717,11 +2765,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -2758,11 +2807,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -3064,9 +3114,13 @@ spec:
                                         optional for env vars'
                                       type: string
                                     divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
                                       description: Specifies the output format of
                                         the exposed resources, defaults to "1"
-                                      type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
                                     resource:
                                       description: 'Required: resource to select'
                                       type: string
@@ -3215,11 +3269,12 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
                                     description: Name or number of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
                                   scheme:
                                     description: Scheme to use for connecting to the
                                       host. Defaults to HTTP.
@@ -3238,11 +3293,12 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
                                     description: Number or name of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
@@ -3311,11 +3367,12 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
                                     description: Name or number of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
                                   scheme:
                                     description: Scheme to use for connecting to the
                                       host. Defaults to HTTP.
@@ -3334,11 +3391,12 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: string
                                     - type: integer
+                                    - type: string
                                     description: Number or name of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
+                                    x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
@@ -3403,11 +3461,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -3444,11 +3503,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -3507,6 +3567,10 @@ spec:
                           - containerPort
                           type: object
                         type: array
+                        x-kubernetes-list-map-keys:
+                        - containerPort
+                        - protocol
+                        x-kubernetes-list-type: map
                       readinessProbe:
                         description: 'Periodic probe of container service readiness.
                           Container will be removed from service endpoints if the
@@ -3566,11 +3630,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -3607,11 +3672,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -3628,13 +3694,21 @@ spec:
                         properties:
                           limits:
                             additionalProperties:
-                              type: string
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             description: 'Limits describes the maximum amount of compute
                               resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                           requests:
                             additionalProperties:
-                              type: string
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
                             description: 'Requests describes the minimum amount of
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
@@ -3858,11 +3932,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -3899,11 +3974,12 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: string
                                 - type: integer
+                                - type: string
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -4041,7 +4117,11 @@ spec:
                   type: object
                 overhead:
                   additionalProperties:
-                    type: string
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
                   description: 'Overhead represents the resource overhead associated
                     with running a pod for a given RuntimeClass. This field will be
                     autopopulated at admission time by the RuntimeClass admission
@@ -4446,6 +4526,10 @@ spec:
                     - whenUnsatisfiable
                     type: object
                   type: array
+                  x-kubernetes-list-map-keys:
+                  - topologyKey
+                  - whenUnsatisfiable
+                  x-kubernetes-list-type: map
                 volumes:
                   description: 'List of volumes that can be mounted by containers
                     belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
@@ -4791,9 +4875,13 @@ spec:
                                         optional for env vars'
                                       type: string
                                     divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
                                       description: Specifies the output format of
                                         the exposed resources, defaults to "1"
-                                      type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
                                     resource:
                                       description: 'Required: resource to select'
                                       type: string
@@ -4816,6 +4904,9 @@ spec:
                               (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                             type: string
                           sizeLimit:
+                            anyOf:
+                            - type: integer
+                            - type: string
                             description: 'Total amount of local storage required for
                               this EmptyDir volume. The size limit is also applicable
                               for memory medium. The maximum usage on memory medium
@@ -4823,7 +4914,8 @@ spec:
                               specified here and the sum of memory limits of all containers
                               in a pod. The default is nil which means that the limit
                               is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                            type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
                         type: object
                       ephemeral:
                         description: "Ephemeral represents a volume that is handled
@@ -4936,14 +5028,22 @@ spec:
                                     properties:
                                       limits:
                                         additionalProperties:
-                                          type: string
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
                                           info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
-                                          type: string
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
                                         description: 'Requests describes the minimum
                                           amount of compute resources required. If
                                           Requests is omitted for a container, it
@@ -5501,10 +5601,14 @@ spec:
                                                   for volumes, optional for env vars'
                                                 type: string
                                               divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
                                                 description: Specifies the output
                                                   format of the exposed resources,
                                                   defaults to "1"
-                                                type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
                                               resource:
                                                 description: 'Required: resource to
                                                   select'

--- a/config/crds/hive.openshift.io_clusterrelocates.yaml
+++ b/config/crds/hive.openshift.io_clusterrelocates.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clusterrelocates.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterstates.yaml
+++ b/config/crds/hive.openshift.io_clusterstates.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clusterstates.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_dnszones.yaml
+++ b/config/crds/hive.openshift.io_dnszones.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: dnszones.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: hiveconfigs.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_machinepoolnameleases.yaml
+++ b/config/crds/hive.openshift.io_machinepoolnameleases.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: machinepoolnameleases.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: machinepools.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_selectorsyncidentityproviders.yaml
+++ b/config/crds/hive.openshift.io_selectorsyncidentityproviders.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: selectorsyncidentityproviders.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_selectorsyncsets.yaml
+++ b/config/crds/hive.openshift.io_selectorsyncsets.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: selectorsyncsets.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_syncidentityproviders.yaml
+++ b/config/crds/hive.openshift.io_syncidentityproviders.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: syncidentityproviders.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_syncsets.yaml
+++ b/config/crds/hive.openshift.io_syncsets.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: syncsets.hive.openshift.io
 spec:

--- a/config/crds/hiveinternal.openshift.io_clustersyncleases.yaml
+++ b/config/crds/hiveinternal.openshift.io_clustersyncleases.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clustersyncleases.hiveinternal.openshift.io
 spec:

--- a/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
+++ b/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clustersyncs.hiveinternal.openshift.io
 spec:

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -35,7 +35,7 @@
 
 - Git
 - Make
-- A recent Go distribution (>=1.13)
+- A recent Go distribution (>=1.15)
 
 ### External tools
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/hive
 
-go 1.13
+go 1.15
 
 require (
 	github.com/Azure/azure-sdk-for-go v43.2.0+incompatible
@@ -24,14 +24,14 @@ require (
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
-	github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc
+	github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7
 	github.com/openshift/cluster-api v0.0.0-20191129101638-b09907ac6668
 	github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20200120152131-1b09fd9e7156
 	github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20200504092944-27473ea1ae43
 	github.com/openshift/cluster-autoscaler-operator v0.0.0-20190521201101-62768a6ba480
 	github.com/openshift/generic-admission-server v1.14.1-0.20200903115324-4ddcdd976480
 	github.com/openshift/installer v0.9.0-master.0.20200817183917-ab4e753ff30b
-	github.com/openshift/library-go v0.0.0-20200429122220-9e6c27e916a0
+	github.com/openshift/library-go v0.0.0-20200918101923-1e4c94603efe
 	github.com/openshift/machine-api-operator v0.2.1-0.20200429102619-d36974451290
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -1292,20 +1292,19 @@ github.com/openshift-metal3/terraform-provider-ironic v0.2.3/go.mod h1:ux2W6gsCI
 github.com/openshift/api v0.0.0-20200205133042-34f0ec8dab87/go.mod h1:fT6U/JfG8uZzemTRwZA2kBDJP5nWz7v05UHnty/D+pk=
 github.com/openshift/api v0.0.0-20200320142426-0de0d539b0c3/go.mod h1:7k3+uZYOir97walbYUqApHUA2OPhkQpVJHt0n7GJ6P4=
 github.com/openshift/api v0.0.0-20200323095748-e7041f8762a3/go.mod h1:7k3+uZYOir97walbYUqApHUA2OPhkQpVJHt0n7GJ6P4=
-github.com/openshift/api v0.0.0-20200326152221-912866ddb162/go.mod h1:RKMJ5CBnljLfnej+BJ/xnOWc3kZDvJUaIAEq2oKSPtE=
-github.com/openshift/api v0.0.0-20200424083944-0422dc17083e/go.mod h1:VnbEzX8SAaRj7Yfl836NykdQIlbEjfL6/CD+AaJQg5Q=
+github.com/openshift/api v0.0.0-20200827090112-c05698d102cf/go.mod h1:M3xexPhgM8DISzzRpuFUy+jfPjQPIcs9yqEYj17mXV8=
 github.com/openshift/api v3.9.1-0.20190517100836-d5b34b957e91+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible h1:AvJ2SgJ7ekSlEL/wyeVMffxDkbKohp4JLge9wMtT23o=
 github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe h1:bu99IMkaN6o/JcxpWEb1eT8gDdL9hLcwOmfiVIbXWj8=
 github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe/go.mod h1:DOgBIuBcXuTD8uub0jL7h6gBdIBt3CFrwz6K2FtfMBA=
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
-github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc h1:Bu1p7+ItPqhJhmMve7sVluKCYV+o+x1Ede0WY2/BI8Q=
-github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
+github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7 h1:mOq7Mg1Q9d7nIDxe1SJ6pluMBQsbVxa6olyAGmfYWTg=
+github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20190617165122-8892c0adc000/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/client-go v0.0.0-20190923180330-3b6373338c9b/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/client-go v0.0.0-20200320150128-a906f3d8e723/go.mod h1:wNBSSt4RZTHhUWyhBE3gxTR32QpF9DB2SfS14u2IxuE=
-github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
+github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5/go.mod h1:5rGmrkQ8DJEUXA+AR3rEjfH+HFyg4/apY9iCQFgvPfE=
 github.com/openshift/cloud-credential-operator v0.0.0-20200316201045-d10080b52c9e h1:2gyl9UVyjHSWzdS56KUXxQwIhENbq2x2olqoMQSA/C8=
 github.com/openshift/cloud-credential-operator v0.0.0-20200316201045-d10080b52c9e/go.mod h1:iPn+uhIe7nkP5BMHe2QnbLtg5m/AIQ1xvz9s3cig5ss=
 github.com/openshift/cluster-api v0.0.0-20190805113604-f8de78af80fc/go.mod h1:mNsD1dsD4T57kV4/C6zTHke/Ro166xgnyyRZqkamiEU=
@@ -1333,8 +1332,8 @@ github.com/openshift/generic-admission-server v1.14.1-0.20200903115324-4ddcdd976
 github.com/openshift/installer v0.9.0-master.0.20200817183917-ab4e753ff30b h1:5FvmRzJKwu9ecTC6CYxEW/26BEfYFMN9e5SR5ujLj4I=
 github.com/openshift/installer v0.9.0-master.0.20200817183917-ab4e753ff30b/go.mod h1:24X05+CUCfQNRxCV6yw7i7WZZsD+yC3V7roFquRLJFc=
 github.com/openshift/library-go v0.0.0-20200324092245-db2a8546af81/go.mod h1:Qc5duoXHzAKyUfA0REIlG/rdfWzknOpp9SiDiyg5Y7A=
-github.com/openshift/library-go v0.0.0-20200429122220-9e6c27e916a0 h1:PWdXDFk+4DLTdoEc4G5v5YWvDaI098/Wvo6Y551A4sk=
-github.com/openshift/library-go v0.0.0-20200429122220-9e6c27e916a0/go.mod h1:2kWwXTkpoQJUN3jZ3QW88EIY1hdRMqxgRs2hheEW/pg=
+github.com/openshift/library-go v0.0.0-20200918101923-1e4c94603efe h1:MJqGN0NVONnTLDYPVIEH4uo6i3gAK7LAkhLnyFO8Je0=
+github.com/openshift/library-go v0.0.0-20200918101923-1e4c94603efe/go.mod h1:NI6xOQGuTnLXeHW8Z2glKSFhF7X+YxlAlqlBMaK0zEM=
 github.com/openshift/machine-api-operator v0.0.0-20190312153711-9650e16c9880/go.mod h1:7HeAh0v04zQn1L+4ItUjvpBQYsm2Nf81WaZLiXTcnkc=
 github.com/openshift/machine-api-operator v0.2.1-0.20191128180243-986b771e661d/go.mod h1:9qQPF00anuIsc6RiHYfHE0+cZZImbvFNLln0NRBVVMg=
 github.com/openshift/machine-api-operator v0.2.1-0.20200402110321-4f3602b96da3/go.mod h1:46g2eLjzAcaNURYDvhGu0GhyjKzOlCPqixEo68lFBLs=
@@ -1478,6 +1477,7 @@ github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uY
 github.com/rickb777/date v1.12.5-0.20200422084442-6300e543c4d9/go.mod h1:L8WrssTzvgYw34/Ppa0JpJfI7KKXZ2cVGI6Djt0brUU=
 github.com/rickb777/plural v1.2.0/go.mod h1:UdpyWFCGbo3mvK3f/PfZOAOrkjzJlYN/sD46XNWJ+Es=
 github.com/robfig/cron v0.0.0-20170526150127-736158dc09e1/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
+github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -1906,7 +1906,6 @@ golang.org/x/net v0.0.0-20200222125558-5a598a2470a0/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200421231249-e086a090c8fd/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200501053045-e0ff5e5a1de5/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
@@ -2469,7 +2468,6 @@ k8s.io/kube-aggregator v0.0.0-20190404125450-f5e124c822d6/go.mod h1:8sbzT4QQKDEm
 k8s.io/kube-aggregator v0.17.3/go.mod h1:1dMwMFQbmH76RKF0614L7dNenMl3dwnUJuOOyZ3GMXA=
 k8s.io/kube-aggregator v0.18.0-beta.2/go.mod h1:O3Td9mheraINbLHH4pzoFP2gRzG0Wk1COqzdSL4rBPk=
 k8s.io/kube-aggregator v0.18.0-rc.1/go.mod h1:35N7x/aAF8C5rEU78J+3pJ/k9v/8LypeWbzqBAEWA1I=
-k8s.io/kube-aggregator v0.18.2/go.mod h1:ijq6FnNUoKinA6kKbkN6svdTacSoQVNtKqmQ1+XJEYQ=
 k8s.io/kube-aggregator v0.19.0 h1:rL4fsftMaqkKjaibArYDaBeqN41CHaJzgRJjUB9IrIg=
 k8s.io/kube-aggregator v0.19.0/go.mod h1:1Ln45PQggFAG8xOqWPIYMxUq8WNtpPnYsbUJ39DpF/A=
 k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
@@ -2548,6 +2546,7 @@ sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WG
 sigs.k8s.io/controller-tools v0.3.1-0.20200617211605-651903477185/go.mod h1:JuPG+FXjAeZL7eGmTuXUJduEMlI2/kGqb0rUGlVi+Yo=
 sigs.k8s.io/controller-tools v0.4.0 h1:9zIdrc6q9RKke8+DnVPVBVZ+cfF9L0TwM01cxNnklYo=
 sigs.k8s.io/controller-tools v0.4.0/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
+sigs.k8s.io/kube-storage-version-migrator v0.0.3/go.mod h1:mXfSLkx9xbJHQsgNDDUZK/iQTs2tMbx/hsJlWe6Fthw=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190302045857-e85c7b244fd2/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=

--- a/pkg/gcpclient/mock/client_generated.go
+++ b/pkg/gcpclient/mock/client_generated.go
@@ -7,8 +7,8 @@ package mock
 import (
 	gomock "github.com/golang/mock/gomock"
 	gcpclient "github.com/openshift/hive/pkg/gcpclient"
-	v1 "google.golang.org/api/compute/v1"
-	v10 "google.golang.org/api/dns/v1"
+	compute "google.golang.org/api/compute/v1"
+	dns "google.golang.org/api/dns/v1"
 	reflect "reflect"
 )
 
@@ -36,10 +36,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // ListManagedZones mocks base method
-func (m *MockClient) ListManagedZones(opts gcpclient.ListManagedZonesOptions) (*v10.ManagedZonesListResponse, error) {
+func (m *MockClient) ListManagedZones(opts gcpclient.ListManagedZonesOptions) (*dns.ManagedZonesListResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListManagedZones", opts)
-	ret0, _ := ret[0].(*v10.ManagedZonesListResponse)
+	ret0, _ := ret[0].(*dns.ManagedZonesListResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -51,10 +51,10 @@ func (mr *MockClientMockRecorder) ListManagedZones(opts interface{}) *gomock.Cal
 }
 
 // ListResourceRecordSets mocks base method
-func (m *MockClient) ListResourceRecordSets(managedZone string, opts gcpclient.ListResourceRecordSetsOptions) (*v10.ResourceRecordSetsListResponse, error) {
+func (m *MockClient) ListResourceRecordSets(managedZone string, opts gcpclient.ListResourceRecordSetsOptions) (*dns.ResourceRecordSetsListResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResourceRecordSets", managedZone, opts)
-	ret0, _ := ret[0].(*v10.ResourceRecordSetsListResponse)
+	ret0, _ := ret[0].(*dns.ResourceRecordSetsListResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -66,7 +66,7 @@ func (mr *MockClientMockRecorder) ListResourceRecordSets(managedZone, opts inter
 }
 
 // AddResourceRecordSet mocks base method
-func (m *MockClient) AddResourceRecordSet(managedZone string, recordSet *v10.ResourceRecordSet) error {
+func (m *MockClient) AddResourceRecordSet(managedZone string, recordSet *dns.ResourceRecordSet) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddResourceRecordSet", managedZone, recordSet)
 	ret0, _ := ret[0].(error)
@@ -80,7 +80,7 @@ func (mr *MockClientMockRecorder) AddResourceRecordSet(managedZone, recordSet in
 }
 
 // DeleteResourceRecordSet mocks base method
-func (m *MockClient) DeleteResourceRecordSet(managedZone string, recordSet *v10.ResourceRecordSet) error {
+func (m *MockClient) DeleteResourceRecordSet(managedZone string, recordSet *dns.ResourceRecordSet) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteResourceRecordSet", managedZone, recordSet)
 	ret0, _ := ret[0].(error)
@@ -94,7 +94,7 @@ func (mr *MockClientMockRecorder) DeleteResourceRecordSet(managedZone, recordSet
 }
 
 // DeleteResourceRecordSets mocks base method
-func (m *MockClient) DeleteResourceRecordSets(managedZone string, recordSet []*v10.ResourceRecordSet) error {
+func (m *MockClient) DeleteResourceRecordSets(managedZone string, recordSet []*dns.ResourceRecordSet) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteResourceRecordSets", managedZone, recordSet)
 	ret0, _ := ret[0].(error)
@@ -108,7 +108,7 @@ func (mr *MockClientMockRecorder) DeleteResourceRecordSets(managedZone, recordSe
 }
 
 // UpdateResourceRecordSet mocks base method
-func (m *MockClient) UpdateResourceRecordSet(managedZone string, addRecordSet, removeRecordSet *v10.ResourceRecordSet) error {
+func (m *MockClient) UpdateResourceRecordSet(managedZone string, addRecordSet, removeRecordSet *dns.ResourceRecordSet) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateResourceRecordSet", managedZone, addRecordSet, removeRecordSet)
 	ret0, _ := ret[0].(error)
@@ -122,10 +122,10 @@ func (mr *MockClientMockRecorder) UpdateResourceRecordSet(managedZone, addRecord
 }
 
 // GetManagedZone mocks base method
-func (m *MockClient) GetManagedZone(managedZone string) (*v10.ManagedZone, error) {
+func (m *MockClient) GetManagedZone(managedZone string) (*dns.ManagedZone, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetManagedZone", managedZone)
-	ret0, _ := ret[0].(*v10.ManagedZone)
+	ret0, _ := ret[0].(*dns.ManagedZone)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -137,10 +137,10 @@ func (mr *MockClientMockRecorder) GetManagedZone(managedZone interface{}) *gomoc
 }
 
 // CreateManagedZone mocks base method
-func (m *MockClient) CreateManagedZone(managedZone *v10.ManagedZone) (*v10.ManagedZone, error) {
+func (m *MockClient) CreateManagedZone(managedZone *dns.ManagedZone) (*dns.ManagedZone, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateManagedZone", managedZone)
-	ret0, _ := ret[0].(*v10.ManagedZone)
+	ret0, _ := ret[0].(*dns.ManagedZone)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -166,10 +166,10 @@ func (mr *MockClientMockRecorder) DeleteManagedZone(managedZone interface{}) *go
 }
 
 // ListComputeZones mocks base method
-func (m *MockClient) ListComputeZones(arg0 gcpclient.ListComputeZonesOptions) (*v1.ZoneList, error) {
+func (m *MockClient) ListComputeZones(arg0 gcpclient.ListComputeZonesOptions) (*compute.ZoneList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListComputeZones", arg0)
-	ret0, _ := ret[0].(*v1.ZoneList)
+	ret0, _ := ret[0].(*compute.ZoneList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -181,10 +181,10 @@ func (mr *MockClientMockRecorder) ListComputeZones(arg0 interface{}) *gomock.Cal
 }
 
 // ListComputeImages mocks base method
-func (m *MockClient) ListComputeImages(arg0 gcpclient.ListComputeImagesOptions) (*v1.ImageList, error) {
+func (m *MockClient) ListComputeImages(arg0 gcpclient.ListComputeImagesOptions) (*compute.ImageList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListComputeImages", arg0)
-	ret0, _ := ret[0].(*v1.ImageList)
+	ret0, _ := ret[0].(*compute.ImageList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -196,7 +196,7 @@ func (mr *MockClientMockRecorder) ListComputeImages(arg0 interface{}) *gomock.Ca
 }
 
 // ListComputeInstances mocks base method
-func (m *MockClient) ListComputeInstances(arg0 gcpclient.ListComputeInstancesOptions, arg1 func(*v1.InstanceAggregatedList) error) error {
+func (m *MockClient) ListComputeInstances(arg0 gcpclient.ListComputeInstancesOptions, arg1 func(*compute.InstanceAggregatedList) error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListComputeInstances", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -210,7 +210,7 @@ func (mr *MockClientMockRecorder) ListComputeInstances(arg0, arg1 interface{}) *
 }
 
 // StopInstance mocks base method
-func (m *MockClient) StopInstance(arg0 *v1.Instance) error {
+func (m *MockClient) StopInstance(arg0 *compute.Instance) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopInstance", arg0)
 	ret0, _ := ret[0].(error)
@@ -224,7 +224,7 @@ func (mr *MockClientMockRecorder) StopInstance(arg0 interface{}) *gomock.Call {
 }
 
 // StartInstance mocks base method
-func (m *MockClient) StartInstance(arg0 *v1.Instance) error {
+func (m *MockClient) StartInstance(arg0 *compute.Instance) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0)
 	ret0, _ := ret[0].(error)

--- a/vendor/github.com/openshift/build-machinery-go/go.mod
+++ b/vendor/github.com/openshift/build-machinery-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/openshift/build-machinery-go
+
+go 1.13

--- a/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/lib/golang.mk
@@ -17,7 +17,7 @@ GOFMT_FLAGS ?=-s -l
 GOLINT ?=golint
 
 go_version :=$(shell $(GO) version | sed -E -e 's/.*go([0-9]+.[0-9]+.[0-9]+).*/\1/')
-GO_REQUIRED_MIN_VERSION ?=1.13.4
+GO_REQUIRED_MIN_VERSION ?=1.14.4
 ifneq "$(GO_REQUIRED_MIN_VERSION)" ""
 $(call require_minimal_version,$(GO),GO_REQUIRED_MIN_VERSION,$(go_version))
 endif

--- a/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
@@ -6,6 +6,7 @@ clean-binaries
 help
 image-ocp-openshift-apiserver-operator
 images
+telepresence
 test
 test-unit
 update

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/controller-gen.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/controller-gen.mk
@@ -1,6 +1,6 @@
 self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
 
-CONTROLLER_GEN_VERSION ?=v0.2.1-37-ga3cca5d
+CONTROLLER_GEN_VERSION ?=v0.2.5
 CONTROLLER_GEN ?=$(PERMANENT_TMP_GOPATH)/bin/controller-gen
 controller_gen_dir :=$(dir $(CONTROLLER_GEN))
 

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/crd-schema-gen.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/crd-schema-gen.mk
@@ -2,8 +2,16 @@ self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
 
 # $1 - crd file
 # $2 - patch file
-define patch-crd
+define patch-crd-yq
 	$(YQ) m -i -x '$(1)' '$(2)'
+
+endef
+
+# $1 - crd file
+# $2 - patch file
+define patch-crd-yaml-patch
+	$(YAML_PATCH) -o '$(2)' < '$(1)' > '$(1).patched'
+    mv '$(1).patched' '$(1)'
 
 endef
 
@@ -22,7 +30,8 @@ define run-crd-gen
 		schemapatch:manifests="$(2)" \
 		paths="$(subst $(empty) ,;,$(1))" \
 		output:dir="$(3)"
-	$$(foreach p,$$(wildcard $(2)/*.crd.yaml-merge-patch),$$(call patch-crd,$$(subst $(2),$(3),$$(basename $$(p))).yaml,$$(p)))
+	$$(foreach p,$$(wildcard $(2)/*.crd.yaml-merge-patch),$$(call patch-crd-yq,$$(subst $(2),$(3),$$(basename $$(p))).yaml,$$(p)))
+	$$(foreach p,$$(wildcard $(2)/*.crd.yaml-patch),$$(call patch-crd-yaml-patch,$$(subst $(2),$(3),$$(basename $$(p))).yaml,$$(p)))
 endef
 
 
@@ -32,7 +41,7 @@ endef
 # $4 - output
 define add-crd-gen-internal
 
-update-codegen-crds-$(1): ensure-controller-gen ensure-yq
+update-codegen-crds-$(1): ensure-controller-gen ensure-yq ensure-yaml-patch
 	$(call run-crd-gen,$(2),$(3),$(4))
 .PHONY: update-codegen-crds-$(1)
 
@@ -40,9 +49,9 @@ update-codegen-crds: update-codegen-crds-$(1)
 .PHONY: update-codegen-crds
 
 verify-codegen-crds-$(1): VERIFY_CODEGEN_CRD_TMP_DIR:=$$(shell mktemp -d)
-verify-codegen-crds-$(1): ensure-controller-gen ensure-yq
+verify-codegen-crds-$(1): ensure-controller-gen ensure-yq ensure-yaml-patch
 	$(call run-crd-gen,$(2),$(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR))
-	$$(foreach p,$$(wildcard $(3)/*.crd.yaml),$$(call diff-file,$$(p),$$(subst $(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR),$$(p))))
+	$$(foreach p,$$(wildcard $(3)/*crd.yaml),$$(call diff-file,$$(p),$$(subst $(3),$$(VERIFY_CODEGEN_CRD_TMP_DIR),$$(p))))
 .PHONY: verify-codegen-crds-$(1)
 
 verify-codegen-crds: verify-codegen-crds-$(1)
@@ -77,4 +86,5 @@ include $(addprefix $(self_dir), \
 	../../lib/tmp.mk \
 	../../targets/openshift/controller-gen.mk \
 	../../targets/openshift/yq.mk \
+    ../../targets/openshift/yaml-patch.mk \
 )

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/telepresence.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/telepresence.mk
@@ -1,0 +1,12 @@
+self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+scripts_dir :=$(shell realpath $(self_dir)../../../../scripts)
+
+telepresence:
+	$(info Running operator locally against a remote cluster using telepresence (https://telepresence.io))
+	$(info )
+	$(info To override the operator log level, set TP_VERBOSITY=<log level>)
+	$(info To debug the operator, set TP_DEBUG=y (requires the delve debugger))
+	$(info See the run-telepresence.sh script for more usage and configuration details)
+	$(info )
+	bash $(scripts_dir)/run-telepresence.sh
+.PHONY: telepresence

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yaml-patch.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yaml-patch.mk
@@ -1,0 +1,32 @@
+self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+
+YAML_PATCH ?=$(PERMANENT_TMP_GOPATH)/bin/yaml-patch
+yaml_patch_dir :=$(dir $(YAML_PATCH))
+
+
+ensure-yaml-patch:
+ifeq "" "$(wildcard $(YAML_PATCH))"
+	$(info Installing yaml-patch into '$(YAML_PATCH)')
+	mkdir -p '$(yaml_patch_dir)'
+	curl -s -f -L https://github.com/krishicks/yaml-patch/releases/download/v0.0.10/yaml_patch_$(GOHOSTOS) -o '$(YAML_PATCH)'
+	chmod +x '$(YAML_PATCH)';
+else
+	$(info Using existing yaml-patch from "$(YAML_PATCH)")
+endif
+.PHONY: ensure-yaml-patch
+
+clean-yaml-patch:
+	$(RM) '$(YAML_PATCH)'
+	if [ -d '$(yaml_patch_dir)' ]; then rmdir --ignore-fail-on-non-empty -p '$(yaml_patch_dir)'; fi
+.PHONY: clean-yaml-patch
+
+clean: clean-yaml-patch
+
+
+# We need to be careful to expand all the paths before any include is done
+# or self_dir could be modified for the next include by the included file.
+# Also doing this at the end of the file allows us to use self_dir before it could be modified.
+include $(addprefix $(self_dir), \
+	../../lib/golang.mk \
+	../../lib/tmp.mk \
+)

--- a/vendor/github.com/openshift/build-machinery-go/scripts/run-telepresence.sh
+++ b/vendor/github.com/openshift/build-machinery-go/scripts/run-telepresence.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script executes telepresence against an operator deployment.
+#
+#   KUBECONFIG=... TP_DEPLOYMENT_YAML=... TP_CMD_PATH=... run-telepresence.sh
+#
+# The script is parameterized by env vars prefixed with 'TP_'.
+#
+# Dependencies:
+#
+# - oc
+# - jq (fedora: dnf install jq; macos: brew install jq)
+# - telepresence (https://www.telepresence.io/reference/install)
+#   - >= 0.105 is compatible with OCP
+# - delve (go get github.com/go-delve/delve/cmd/dlv)
+
+KUBECONFIG="${KUBECONFIG:-}"
+if [[ "${KUBECONFIG}" == "" ]]; then
+  >&2 echo "KUBECONFIG is not set"
+  exit 1
+fi
+
+# The yaml defining the operator's deployment resource. Will be parsed
+# for configuration like resource name, namespace, and command.
+TP_DEPLOYMENT_YAML="${TP_DEPLOYMENT_YAML:-}"
+if [[ ! "${TP_DEPLOYMENT_YAML}" ]]; then
+  >&2 echo "TP_DEPLOYMENT_YAML is not set"
+  exit 1
+fi
+
+# The path to the golang package to run or debug
+# (e.g. `/my/project/cmd/operator`)
+TP_CMD_PATH="${TP_CMD_PATH:-}"
+if [[ ! "${TP_CMD_PATH}" ]]; then
+  >&2 echo "TP_CMD_PATH is not set"
+  exit 1
+fi
+
+# By default the operator will be run via 'go run'. Providing TP_DEBUG=y
+# will run `dlv debug` instead.
+TP_DEBUG="${TP_DEBUG:-}"
+
+# Whether to add an entry in /etc/hosts for the api server host. This
+# is necessary if targeting a cluster deployed in aws.
+TP_ADD_AWS_HOST_ENTRY="${TP_ADD_AWS_HOST_ENTRY:-y}"
+
+# The arguments for the command that will be executed will be parsed
+# from the deployment by default, but can be overridden by setting
+# this var. The name of the command itself is implicitly determined by
+# `go run` or `dlv debug` from TP_CMD_PATH.
+TP_CMD_ARGS="${TP_CMD_ARGS:-}"
+
+# Will add a -v=<value> argument to the command to set the logging
+# verbosity. If a verbosity argument was already supplied, this value
+# will override it.
+TP_VERBOSITY="${TP_VERBOSITY:-}"
+
+# The command telepresence should run in the local deployment
+# environment. By default it will run or debug the operator but it can
+# be useful to run a shell (e.g. `bash`) for troubleshooting.
+TP_RUN_CMD="${TP_RUN_CMD:-}"
+if [[ ! "${TP_RUN_CMD}" ]]; then
+  # Default to a recursive call
+  TP_RUN_CMD="${0}"
+  if [[ ! -x "${TP_RUN_CMD}" ]]; then
+    # Prefix the recursive call with bash if the script is not
+    # executable as will be the case when build-machinery-go is
+    # vendored.
+    TP_RUN_CMD="bash ${TP_RUN_CMD}"
+  fi
+fi
+
+# Whether this script should run telepresence or is being run by
+# telepresence. Used as an internal control var, not necessary to set
+# manually.
+_TP_INTERNAL_RUN="${_TP_INTERNAL_RUN:-}"
+
+# Some operators (e.g. auth operator) specify build flags to generate
+# different binaries for ocp or okd.
+TP_BUILD_FLAGS="${TP_BUILD_FLAGS:-}"
+
+# Simplify querying the deployment yaml with jq
+function jq_deployment () {
+  local jq_arg="${1}"
+  cat "${TP_DEPLOYMENT_YAML}"\
+    | python -c 'import json, sys, yaml ; y=yaml.safe_load(sys.stdin.read()) ; print(json.dumps(y))'\
+    | jq -r "${jq_arg}"
+}
+
+NAMESPACE="$(jq_deployment '.metadata.namespace')"
+NAME="$(jq_deployment '.metadata.name')"
+
+# If not provided, the lock configmap will be defaulted to the name of
+# the deployment suffixed by `-lock`.
+TP_LOCK_CONFIGMAP="${TP_LOCK_CONFIGMAP:-${NAME}-lock}"
+
+if [ "${_TP_INTERNAL_RUN}" ]; then
+  # Delete the leader election lock to ensure that the local process
+  # becomes the leader as quickly as possible.
+  oc delete configmap "${TP_LOCK_CONFIGMAP}" --namespace "${NAMESPACE}" --ignore-not-found=true
+
+  if [[ ! "${TP_CMD_ARGS}" ]]; then
+    # Parse the arguments from the deployment
+    TP_CMD_ARGS="$(jq_deployment '.spec.template.spec.containers[0].command[1:] | join(" ")' )"
+    TP_CMD_ARGS+=" $(jq_deployment '.spec.template.spec.containers[0].args | join(" ")' )"
+  fi
+
+  if [[ "${TP_VERBOSITY}" ]]; then
+    # Setting log level last ensures that any existing -v argument will be overridden.
+    TP_CMD_ARGS+=" -v=${TP_VERBOSITY}"
+  fi
+
+  pushd "${TP_CMD_PATH}" > /dev/null
+    if [[ "${TP_DEBUG}" ]]; then
+      if [[ "${TP_BUILD_FLAGS}" ]]; then
+        TP_BUILD_FLAGS="--build-flags=${TP_BUILD_FLAGS}"
+      fi
+      dlv debug ${TP_BUILD_FLAGS} -- ${TP_CMD_ARGS}
+    else
+      go run ${TP_BUILD_FLAGS} . ${TP_CMD_ARGS}
+    fi
+  popd > /dev/null
+else
+  if [[ "${TP_ADD_AWS_HOST_ENTRY}" ]]; then
+    # Add an entry in /etc/hosts for the api endpoint in the configured
+    # KUBECONFIG (which is assumed to have at most one server).
+    #
+    # This supports using telepresence with kube clusters running in
+    # aws. telepresence will proxy dns requests to the cluster and will
+    # return an internal aws address for the api endpoint otherwise.
+    SERVER_HOST="$(grep server "${KUBECONFIG}" | sed -e 's+    server: https://\(.*\):.*+\1+')"
+    SERVER_IP="$(dig "${SERVER_HOST}" +short | head -n 1)"
+    ENTRY="${SERVER_IP} ${SERVER_HOST}"
+    if ! grep "${ENTRY}" /etc/hosts > /dev/null; then
+      >&2 echo "Attempting to add '${ENTRY}' to /etc/hosts to ensure access to an aws cluster. This requires sudo."
+      >&2 echo "If this cluster is not in aws, specify TP_ADD_AWS_HOST_ENTRY="
+      grep -q "${SERVER_HOST}" /etc/hosts && \
+        (cp -f /etc/hosts /tmp/etc-hosts && \
+           sed -i 's+.*'"${SERVER_HOST}"'$+'"${ENTRY}"'+' /tmp/etc-hosts && \
+           sudo cp /tmp/etc-hosts /etc/hosts)\
+          || echo "${ENTRY}" | sudo tee -a /etc/hosts > /dev/null
+    fi
+  fi
+
+  # Ensure pod volumes are symlinked to the expected location
+  if [[ ! -L '/var/run/configmaps' ]]; then
+     >&2 echo "Attempting to symlink /tmp/tel_root/var/run/configmaps to /var/run/configmaps. This requires sudo."
+     sudo ln -s /tmp/tel_root/var/run/configmaps /var/run/configmaps
+  fi
+  if [[ ! -L '/var/run/secrets' ]]; then
+    >&2 echo "Attempting to symlink /tmp/tel_root/var/run/secrets to /var/run/secrets. This requires sudo."
+    sudo ln -s /tmp/tel_root/var/run/secrets /var/run/secrets
+  fi
+
+  KIND="$(jq_deployment '.kind')"
+  GROUP="$(jq_deployment '.apiVersion')"
+
+  # Ensure the operator is not managed by CVO
+  oc patch clusterversion/version --type='merge' -p "$(cat <<- EOF
+spec:
+  overrides:
+  - group: ${GROUP}
+    kind: ${KIND}
+    name: ${NAME}
+    namespace: ${NAMESPACE}
+    unmanaged: true
+EOF
+)"
+
+  # Ensure the operator is managed again on shutdown
+  function cleanup {
+    oc patch clusterversion/version --type='merge' -p "$(cat <<- EOF
+spec:
+  overrides:
+  - group: ${GROUP}
+    kind: ${KIND}
+    name: ${NAME}
+    namespace: ${NAMESPACE}
+    unmanaged: false
+EOF
+)"
+  }
+  trap cleanup EXIT
+
+  # Ensure that traffic for all machines in the cluster is also
+  # proxied so that the local operator will be able to access them.
+  ALSO_PROXY="$(oc get machines -A -o json | jq -jr '.items[] | .status.addresses[0].address | @text "--also-proxy=\(.) "')"
+
+  TELEPRESENCE_USE_OCP_IMAGE=NO _TP_INTERNAL_RUN=y telepresence --namespace="${NAMESPACE}"\
+    --swap-deployment "${NAME}" ${ALSO_PROXY} --mount=/tmp/tel_root --run ${TP_RUN_CMD}
+fi

--- a/vendor/github.com/openshift/library-go/pkg/controller/fileobserver/observer.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/fileobserver/observer.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 type Observer interface {

--- a/vendor/github.com/openshift/library-go/pkg/controller/fileobserver/observer_polling.go
+++ b/vendor/github.com/openshift/library-go/pkg/controller/fileobserver/observer_polling.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 type pollingObserver struct {

--- a/vendor/github.com/openshift/library-go/pkg/operator/events/recorder.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/events/recorder.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_in_memory.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_in_memory.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 type inMemoryEventRecorder struct {

--- a/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_logging.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_logging.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 type LoggingEventRecorder struct {

--- a/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_upstream.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_upstream.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 )
 
 // NewKubeRecorder returns new event recorder with tweaked correlator options.

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/generic_config_merger.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/generic_config_merger.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strings"
 
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/yaml"
 
 	corev1 "k8s.io/api/core/v1"

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/apiextensions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/apiextensions.go
@@ -27,7 +27,7 @@ func ReadCustomResourceDefinitionV1Beta1OrDie(objBytes []byte) *apiextensionsv1b
 }
 
 func ReadCustomResourceDefinitionV1OrDie(objBytes []byte) *apiextensionsv1.CustomResourceDefinition {
-	requiredObj, err := runtime.Decode(apiExtensionsCodecs.UniversalDecoder(apiextensionsv1beta1.SchemeGroupVersion), objBytes)
+	requiredObj, err := runtime.Decode(apiExtensionsCodecs.UniversalDecoder(apiextensionsv1.SchemeGroupVersion), objBytes)
 	if err != nil {
 		panic(err)
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/credentialsrequest.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceread/credentialsrequest.go
@@ -1,0 +1,14 @@
+package resourceread
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func ReadCredentialRequestsOrDie(objBytes []byte) *unstructured.Unstructured {
+	udi, _, err := scheme.Codecs.UniversalDecoder().Decode(objBytes, nil, &unstructured.Unstructured{})
+	if err != nil {
+		panic(err)
+	}
+	return udi.(*unstructured.Unstructured)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,7 @@
 # cloud.google.com/go v0.57.0
 cloud.google.com/go/compute/metadata
 # github.com/Azure/azure-sdk-for-go v43.2.0+incompatible
+## explicit
 github.com/Azure/azure-sdk-for-go/profiles/latest/dns/mgmt/dns
 github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute
 github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute
@@ -17,17 +18,20 @@ github.com/Azure/azure-sdk-for-go/version
 github.com/Azure/go-ansiterm
 github.com/Azure/go-ansiterm/winterm
 # github.com/Azure/go-autorest/autorest v0.10.0 => github.com/tombuildsstuff/go-autorest/autorest v0.10.1-0.20200416184303-d4e299a3c04a
+## explicit
 github.com/Azure/go-autorest/autorest
 github.com/Azure/go-autorest/autorest/azure
 # github.com/Azure/go-autorest/autorest/adal v0.8.2
 github.com/Azure/go-autorest/autorest/adal
 # github.com/Azure/go-autorest/autorest/azure/auth v0.4.1 => github.com/tombuildsstuff/go-autorest/autorest/azure/auth v0.4.3-0.20200416184303-d4e299a3c04a
+## explicit
 github.com/Azure/go-autorest/autorest/azure/auth
 # github.com/Azure/go-autorest/autorest/azure/cli v0.3.1
 github.com/Azure/go-autorest/autorest/azure/cli
 # github.com/Azure/go-autorest/autorest/date v0.2.0
 github.com/Azure/go-autorest/autorest/date
 # github.com/Azure/go-autorest/autorest/to v0.3.1-0.20191028180845-3492b2aff503
+## explicit
 github.com/Azure/go-autorest/autorest/to
 # github.com/Azure/go-autorest/autorest/validation v0.2.1-0.20191028180845-3492b2aff503
 github.com/Azure/go-autorest/autorest/validation
@@ -50,6 +54,7 @@ github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc
 # github.com/aws/aws-sdk-go v1.32.3
+## explicit
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/arn
 github.com/aws/aws-sdk-go/aws/awserr
@@ -112,6 +117,7 @@ github.com/beorn7/perks/quantile
 # github.com/blang/semver v3.5.1+incompatible
 github.com/blang/semver
 # github.com/blang/semver/v4 v4.0.0
+## explicit
 github.com/blang/semver/v4
 # github.com/bombsimon/wsl/v3 v3.0.0
 github.com/bombsimon/wsl/v3
@@ -142,6 +148,7 @@ github.com/docker/spdystream/spdy
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
 # github.com/evanphx/json-patch v4.9.0+incompatible
+## explicit
 github.com/evanphx/json-patch
 # github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d
 github.com/exponent-io/jsonpath
@@ -152,8 +159,10 @@ github.com/fatih/color
 # github.com/fsnotify/fsnotify v1.4.9
 github.com/fsnotify/fsnotify
 # github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
+## explicit
 github.com/ghodss/yaml
 # github.com/go-bindata/go-bindata v3.1.2+incompatible
+## explicit
 github.com/go-bindata/go-bindata
 github.com/go-bindata/go-bindata/go-bindata
 # github.com/go-critic/go-critic v0.4.1
@@ -163,6 +172,7 @@ github.com/go-critic/go-critic/checkers/internal/lintutil
 github.com/go-lintpack/lintpack
 github.com/go-lintpack/lintpack/astwalk
 # github.com/go-logr/logr v0.2.1-0.20200730175230-ee2de8da5be6
+## explicit
 github.com/go-logr/logr
 # github.com/go-openapi/jsonpointer v0.19.3
 github.com/go-openapi/jsonpointer
@@ -207,6 +217,7 @@ github.com/gogo/protobuf/sortkeys
 # github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 github.com/golang/groupcache/lru
 # github.com/golang/mock v1.4.4
+## explicit
 github.com/golang/mock/gomock
 github.com/golang/mock/mockgen
 github.com/golang/mock/mockgen/model
@@ -239,6 +250,7 @@ github.com/golangci/gocyclo/pkg/gocyclo
 github.com/golangci/gofmt/gofmt
 github.com/golangci/gofmt/goimports
 # github.com/golangci/golangci-lint v1.26.0
+## explicit
 github.com/golangci/golangci-lint/cmd/golangci-lint
 github.com/golangci/golangci-lint/internal/cache
 github.com/golangci/golangci-lint/internal/errorutil
@@ -289,6 +301,7 @@ github.com/google/go-cmp/cmp/internal/value
 # github.com/google/gofuzz v1.1.0
 github.com/google/gofuzz
 # github.com/google/uuid v1.1.1
+## explicit
 github.com/google/uuid
 # github.com/googleapis/gax-go/v2 v2.0.5
 github.com/googleapis/gax-go/v2
@@ -357,6 +370,7 @@ github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
 # github.com/heptio/velero v1.0.0
+## explicit
 github.com/heptio/velero/pkg/apis/velero/v1
 # github.com/imdario/mergo v0.3.9
 github.com/imdario/mergo
@@ -369,8 +383,10 @@ github.com/jirfag/go-printf-func-name/pkg/analyzer
 # github.com/jmespath/go-jmespath v0.3.0
 github.com/jmespath/go-jmespath
 # github.com/jonboulle/clockwork v0.1.0
+## explicit
 github.com/jonboulle/clockwork
 # github.com/json-iterator/go v1.1.10
+## explicit
 github.com/json-iterator/go
 # github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 github.com/kballard/go-shellquote
@@ -402,6 +418,7 @@ github.com/metal3-io/baremetal-operator/pkg/apis/metal3/v1alpha1
 # github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
 github.com/mgutz/ansi
 # github.com/miekg/dns v1.1.22
+## explicit
 github.com/miekg/dns
 # github.com/mitchellh/go-homedir v1.1.0
 github.com/mitchellh/go-homedir
@@ -415,6 +432,7 @@ github.com/moby/term/windows
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
+## explicit
 github.com/modern-go/reflect2
 # github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 github.com/munnerz/goautoneg
@@ -437,6 +455,7 @@ github.com/nxadm/tail/util
 github.com/nxadm/tail/watch
 github.com/nxadm/tail/winfile
 # github.com/onsi/ginkgo v1.12.1
+## explicit
 github.com/onsi/ginkgo
 github.com/onsi/ginkgo/config
 github.com/onsi/ginkgo/internal/codelocation
@@ -456,6 +475,7 @@ github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable
 github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty
 github.com/onsi/ginkgo/types
 # github.com/onsi/gomega v1.10.1
+## explicit
 github.com/onsi/gomega
 github.com/onsi/gomega/format
 github.com/onsi/gomega/gbytes
@@ -471,6 +491,7 @@ github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
 # github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
+## explicit
 github.com/openshift/api/apps/v1
 github.com/openshift/api/authorization/v1
 github.com/openshift/api/config/v1
@@ -480,7 +501,8 @@ github.com/openshift/api/image/v1
 github.com/openshift/api/operator/v1
 github.com/openshift/api/pkg/serialization
 github.com/openshift/api/route/v1
-# github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc
+# github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7
+## explicit
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make
 github.com/openshift/build-machinery-go/make/lib
@@ -494,23 +516,29 @@ github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1
 github.com/openshift/cloud-credential-operator/pkg/aws
 github.com/openshift/cloud-credential-operator/version
 # github.com/openshift/cluster-api v0.0.0-20191129101638-b09907ac6668
+## explicit
 github.com/openshift/cluster-api/pkg/apis/machine/common
 github.com/openshift/cluster-api/pkg/apis/machine/v1beta1
 # github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20200120152131-1b09fd9e7156
+## explicit
 github.com/openshift/cluster-api-provider-gcp/pkg/apis
 github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1
 # github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20200504092944-27473ea1ae43
+## explicit
 github.com/openshift/cluster-api-provider-ovirt/pkg/apis
 github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1
 # github.com/openshift/cluster-autoscaler-operator v0.0.0-20190521201101-62768a6ba480
+## explicit
 github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1
 github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1beta1
 # github.com/openshift/generic-admission-server v1.14.1-0.20200903115324-4ddcdd976480
+## explicit
 github.com/openshift/generic-admission-server/pkg/apiserver
 github.com/openshift/generic-admission-server/pkg/cmd
 github.com/openshift/generic-admission-server/pkg/cmd/server
 github.com/openshift/generic-admission-server/pkg/registry/admissionreview
 # github.com/openshift/installer v0.9.0-master.0.20200817183917-ab4e753ff30b
+## explicit
 github.com/openshift/installer/data
 github.com/openshift/installer/pkg/asset/installconfig/aws
 github.com/openshift/installer/pkg/asset/installconfig/azure
@@ -545,13 +573,15 @@ github.com/openshift/installer/pkg/types/ovirt/validation
 github.com/openshift/installer/pkg/types/vsphere
 github.com/openshift/installer/pkg/validate
 github.com/openshift/installer/pkg/version
-# github.com/openshift/library-go v0.0.0-20200429122220-9e6c27e916a0
+# github.com/openshift/library-go v0.0.0-20200918101923-1e4c94603efe
+## explicit
 github.com/openshift/library-go/pkg/controller
 github.com/openshift/library-go/pkg/controller/fileobserver
 github.com/openshift/library-go/pkg/operator/events
 github.com/openshift/library-go/pkg/operator/resource/resourcemerge
 github.com/openshift/library-go/pkg/operator/resource/resourceread
 # github.com/openshift/machine-api-operator v0.2.1-0.20200429102619-d36974451290
+## explicit
 github.com/openshift/machine-api-operator/pkg/apis/machine
 github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1
 github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider
@@ -565,10 +595,12 @@ github.com/pelletier/go-toml
 # github.com/peterbourgon/diskv v2.0.1+incompatible
 github.com/peterbourgon/diskv
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.7.1
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
@@ -596,6 +628,7 @@ github.com/shurcooL/httpfs/vfsutil
 # github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd
 github.com/shurcooL/vfsgen
 # github.com/sirupsen/logrus v1.6.0
+## explicit
 github.com/sirupsen/logrus
 # github.com/sourcegraph/go-diff v0.5.1
 github.com/sourcegraph/go-diff/diff
@@ -605,16 +638,19 @@ github.com/spf13/afero/mem
 # github.com/spf13/cast v1.3.0
 github.com/spf13/cast
 # github.com/spf13/cobra v1.0.0
+## explicit
 github.com/spf13/cobra
 # github.com/spf13/jwalterweatherman v1.0.0
 github.com/spf13/jwalterweatherman
 # github.com/spf13/pflag v1.0.5
+## explicit
 github.com/spf13/pflag
 # github.com/spf13/viper v1.6.1
 github.com/spf13/viper
 # github.com/stretchr/objx v0.2.0
 github.com/stretchr/objx
 # github.com/stretchr/testify v1.5.1
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/mock
 github.com/stretchr/testify/require
@@ -724,14 +760,17 @@ golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/lint v0.0.0-20200302205851-738671d3881b
+## explicit
 golang.org/x/lint
 golang.org/x/lint/golint
 # golang.org/x/mod v0.3.0
+## explicit
 golang.org/x/mod/internal/lazyregexp
 golang.org/x/mod/modfile
 golang.org/x/mod/module
 golang.org/x/mod/semver
 # golang.org/x/net v0.0.0-20200707034311-ab3426394381
+## explicit
 golang.org/x/net/bpf
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
@@ -750,6 +789,7 @@ golang.org/x/net/ipv6
 golang.org/x/net/trace
 golang.org/x/net/websocket
 # golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+## explicit
 golang.org/x/oauth2
 golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
@@ -785,6 +825,7 @@ golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 golang.org/x/text/width
 # golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+## explicit
 golang.org/x/time/rate
 # golang.org/x/tools v0.0.0-20200616195046-dc31b401abb5
 golang.org/x/tools/go/analysis
@@ -854,6 +895,7 @@ golang.org/x/xerrors/internal
 # gomodules.xyz/jsonpatch/v2 v2.0.1
 gomodules.xyz/jsonpatch/v2
 # google.golang.org/api v0.25.0
+## explicit
 google.golang.org/api/cloudresourcemanager/v1
 google.golang.org/api/compute/v1
 google.golang.org/api/dns/v1
@@ -963,12 +1005,14 @@ gopkg.in/AlecAivazis/survey.v1/terminal
 # gopkg.in/inf.v0 v0.9.1
 gopkg.in/inf.v0
 # gopkg.in/ini.v1 v1.51.0
+## explicit
 gopkg.in/ini.v1
 # gopkg.in/natefinch/lumberjack.v2 v2.0.0
 gopkg.in/natefinch/lumberjack.v2
 # gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 gopkg.in/tomb.v1
 # gopkg.in/yaml.v2 v2.3.0
+## explicit
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20190905181640-827449938966
 gopkg.in/yaml.v3
@@ -1002,6 +1046,7 @@ honnef.co/go/tools/stylecheck
 honnef.co/go/tools/unused
 honnef.co/go/tools/version
 # k8s.io/api v0.19.0
+## explicit
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
@@ -1047,6 +1092,7 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apiextensions-apiserver v0.19.0
+## explicit
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
@@ -1055,6 +1101,7 @@ k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1
 # k8s.io/apimachinery v0.19.0
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -1236,6 +1283,7 @@ k8s.io/apiserver/plugin/pkg/audit/webhook
 k8s.io/apiserver/plugin/pkg/authenticator/token/webhook
 k8s.io/apiserver/plugin/pkg/authorizer/webhook
 # k8s.io/cli-runtime v0.19.0
+## explicit
 k8s.io/cli-runtime/pkg/genericclioptions
 k8s.io/cli-runtime/pkg/kustomize
 k8s.io/cli-runtime/pkg/kustomize/k8sdeps
@@ -1249,6 +1297,7 @@ k8s.io/cli-runtime/pkg/kustomize/k8sdeps/validator
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
 # k8s.io/client-go v12.0.0+incompatible => k8s.io/client-go v0.19.0
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/cached/disk
 k8s.io/client-go/discovery/fake
@@ -1480,8 +1529,10 @@ k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
 # k8s.io/cluster-registry v0.0.6
+## explicit
 k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1
 # k8s.io/code-generator v0.19.0
+## explicit
 k8s.io/code-generator
 k8s.io/code-generator/cmd/client-gen
 k8s.io/code-generator/cmd/client-gen/args
@@ -1536,10 +1587,12 @@ k8s.io/gengo/namer
 k8s.io/gengo/parser
 k8s.io/gengo/types
 # k8s.io/klog v1.0.0
+## explicit
 k8s.io/klog
 # k8s.io/klog/v2 v2.3.0
 k8s.io/klog/v2
 # k8s.io/kube-aggregator v0.19.0
+## explicit
 k8s.io/kube-aggregator/pkg/apis/apiregistration
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1
@@ -1558,6 +1611,7 @@ k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/util/proto/validation
 k8s.io/kube-openapi/pkg/util/sets
 # k8s.io/kubectl v0.19.0
+## explicit
 k8s.io/kubectl/pkg/apps
 k8s.io/kubectl/pkg/cmd/apply
 k8s.io/kubectl/pkg/cmd/delete
@@ -1590,6 +1644,7 @@ k8s.io/kubectl/pkg/util/templates
 k8s.io/kubectl/pkg/util/term
 k8s.io/kubectl/pkg/validation
 # k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+## explicit
 k8s.io/utils/buffer
 k8s.io/utils/exec
 k8s.io/utils/integer
@@ -1607,14 +1662,18 @@ mvdan.cc/unparam/check
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
 # sigs.k8s.io/cluster-api-provider-aws v0.0.0 => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200506073438-9d49428ff837
+## explicit
 sigs.k8s.io/cluster-api-provider-aws/pkg/apis
 sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1beta1
 # sigs.k8s.io/cluster-api-provider-azure v0.0.0 => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20200120114645-8a9592f1f87b
+## explicit
 sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1beta1
 # sigs.k8s.io/cluster-api-provider-openstack v0.0.0 => github.com/openshift/cluster-api-provider-openstack v0.0.0-20200526112135-319a35b2e38e
+## explicit
 sigs.k8s.io/cluster-api-provider-openstack/pkg/apis
 sigs.k8s.io/cluster-api-provider-openstack/pkg/apis/openstackproviderconfig/v1alpha1
 # sigs.k8s.io/controller-runtime v0.6.2
+## explicit
 sigs.k8s.io/controller-runtime/pkg/cache
 sigs.k8s.io/controller-runtime/pkg/cache/internal
 sigs.k8s.io/controller-runtime/pkg/client
@@ -1655,6 +1714,7 @@ sigs.k8s.io/controller-runtime/pkg/webhook/admission
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/certwatcher
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 # sigs.k8s.io/controller-tools v0.4.0
+## explicit
 sigs.k8s.io/controller-tools/cmd/controller-gen
 sigs.k8s.io/controller-tools/pkg/crd
 sigs.k8s.io/controller-tools/pkg/crd/markers
@@ -1699,6 +1759,19 @@ sigs.k8s.io/structured-merge-diff/v4/schema
 sigs.k8s.io/structured-merge-diff/v4/typed
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml
 # sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4
 sourcegraph.com/sqs/pbtypes
+# github.com/Azure/go-autorest => github.com/tombuildsstuff/go-autorest v14.0.1-0.20200416184303-d4e299a3c04a+incompatible
+# github.com/Azure/go-autorest/autorest => github.com/tombuildsstuff/go-autorest/autorest v0.10.1-0.20200416184303-d4e299a3c04a
+# github.com/Azure/go-autorest/autorest/azure/auth => github.com/tombuildsstuff/go-autorest/autorest/azure/auth v0.4.3-0.20200416184303-d4e299a3c04a
+# github.com/metal3-io/baremetal-operator => github.com/openshift/baremetal-operator v0.0.0-20200715132148-0f91f62a41fe
+# github.com/metal3-io/cluster-api-provider-baremetal => github.com/openshift/cluster-api-provider-baremetal v0.0.0-20190821174549-a2a477909c1d
+# github.com/terraform-providers/terraform-provider-aws => github.com/openshift/terraform-provider-aws v1.60.1-0.20200630224953-76d1fb4e5699
+# github.com/terraform-providers/terraform-provider-azurerm => github.com/openshift/terraform-provider-azurerm v1.40.1-0.20200707062554-97ea089cc12a
+# github.com/terraform-providers/terraform-provider-ignition/v2 => github.com/community-terraform-providers/terraform-provider-ignition/v2 v2.1.0
+# sigs.k8s.io/cluster-api-provider-aws => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200506073438-9d49428ff837
+# sigs.k8s.io/cluster-api-provider-azure => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20200120114645-8a9592f1f87b
+# sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.0.0-20200526112135-319a35b2e38e
+# k8s.io/client-go => k8s.io/client-go v0.19.0


### PR DESCRIPTION
The version of github.com/openshift/library-go that Hive is using has a dependency on bitbucket.com/ww/goautoneg, which is dead. The latest version of library-go uses github.com/munnerz/goautoneg instead.

This is intended to fix problems when running `test verfiy`, which tries to download the goautoneg module.
```
Generating deepcopy funcs
F0918 16:15:47.256381   19839 main.go:82] Error: Failed making a parser: unable to add directory "github.com/openshift/hive/pkg/apis/hive/v1": unable to import "github.com/openshift/hive/pkg/apis/hive/v1": go/build: importGo github.com/openshift/hive/pkg/apis/hive/v1: exit status 1
go: github.com/openshift/installer@v0.9.0-master.0.20200817183917-ab4e753ff30b requires
	github.com/openshift/library-go@v0.0.0-20200324092245-db2a8546af81 requires
	bitbucket.org/ww/goautoneg@v0.0.0-20120707110453-75cd24fc2f2c: reading https://api.bitbucket.org/2.0/repositories/ww/goautoneg?fields=scm: 404 Not Found
```

/assign @dgoodwin 
/cc @akhil-rane 