### PR TITLE
Modify 'verify' target to execute 'go mod vendor'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,8 @@ crd: ensure-controller-gen ensure-yq
 	$(foreach p,$(wildcard ./config/crds/*.yaml),$(call strip-yaml-break,$(p)))
 update: crd
 
+verify: vendor
+
 .PHONY: verify-crd
 verify-crd: ensure-controller-gen ensure-yq
 	./hack/verify-crd.sh


### PR DESCRIPTION
Currently our CI tests do not run 'go mod vendor'
This commit ensures 'vendor' target in Makefile is ran on every PR in
order to check that all the packages vendored in are downloadable.