### PR TITLE
Set clusterSync.Status.FirstSyncSetsSuccessTime and add metric

### DIFF
--- a/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
+++ b/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
@@ -75,6 +75,11 @@ spec:
                 - type
                 type: object
               type: array
+            firstSyncSetsSuccessTime:
+              description: FirstSyncSetsSuccessTime is the time we first successfully
+                applied all (selector)syncsets to a cluster.
+              format: date-time
+              type: string
             selectorSyncSets:
               description: SelectorSyncSets is the sync status of all of the SelectorSyncSets
                 for the cluster.

--- a/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
+++ b/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
@@ -75,9 +75,9 @@ spec:
                 - type
                 type: object
               type: array
-            firstSyncSetsSuccessTime:
-              description: FirstSyncSetsSuccessTime is the time we first successfully
-                applied all (selector)syncsets to a cluster.
+            firstSuccessTime:
+              description: FirstSuccessTime is the time we first successfully applied
+                all (selector)syncsets to a cluster.
               format: date-time
               type: string
             selectorSyncSets:

--- a/pkg/apis/hiveinternal/v1alpha1/clustersync_types.go
+++ b/pkg/apis/hiveinternal/v1alpha1/clustersync_types.go
@@ -37,9 +37,9 @@ type ClusterSyncStatus struct {
 	// +optional
 	Conditions []ClusterSyncCondition `json:"conditions,omitempty"`
 
-	// FirstSyncSetsSuccessTime is the time we first successfully applied all (selector)syncsets to a cluster.
+	// FirstSuccessTime is the time we first successfully applied all (selector)syncsets to a cluster.
 	// +optional
-	FirstSyncSetsSuccessTime *metav1.Time `json:"firstSyncSetsSuccessTime,omitempty"`
+	FirstSuccessTime *metav1.Time `json:"firstSuccessTime,omitempty"`
 }
 
 // SyncStatus is the status of applying a specific SyncSet or SelectorSyncSet to the cluster.

--- a/pkg/apis/hiveinternal/v1alpha1/clustersync_types.go
+++ b/pkg/apis/hiveinternal/v1alpha1/clustersync_types.go
@@ -36,6 +36,10 @@ type ClusterSyncStatus struct {
 	// Conditions is a list of conditions associated with syncing to the cluster.
 	// +optional
 	Conditions []ClusterSyncCondition `json:"conditions,omitempty"`
+
+	// FirstSyncSetsSuccessTime is the time we first successfully applied all (selector)syncsets to a cluster.
+	// +optional
+	FirstSyncSetsSuccessTime *metav1.Time `json:"firstSyncSetsSuccessTime,omitempty"`
 }
 
 // SyncStatus is the status of applying a specific SyncSet or SelectorSyncSet to the cluster.

--- a/pkg/apis/hiveinternal/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/hiveinternal/v1alpha1/zz_generated.deepcopy.go
@@ -204,8 +204,8 @@ func (in *ClusterSyncStatus) DeepCopyInto(out *ClusterSyncStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.FirstSyncSetsSuccessTime != nil {
-		in, out := &in.FirstSyncSetsSuccessTime, &out.FirstSyncSetsSuccessTime
+	if in.FirstSuccessTime != nil {
+		in, out := &in.FirstSuccessTime, &out.FirstSuccessTime
 		*out = (*in).DeepCopy()
 	}
 	return

--- a/pkg/apis/hiveinternal/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/hiveinternal/v1alpha1/zz_generated.deepcopy.go
@@ -204,6 +204,10 @@ func (in *ClusterSyncStatus) DeepCopyInto(out *ClusterSyncStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.FirstSyncSetsSuccessTime != nil {
+		in, out := &in.FirstSyncSetsSuccessTime, &out.FirstSyncSetsSuccessTime
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -529,6 +529,16 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 	}
 
 	if cd.Spec.Installed {
+		// set installedTimestamp for adopted clusters
+		if cd.Status.InstalledTimestamp == nil {
+			now := metav1.Now()
+			cd.Status.InstalledTimestamp = &now
+			if err := r.Status().Update(context.TODO(), cd); err != nil {
+				cdLog.WithError(err).Log(controllerutils.LogLevel(err), "could not set cluster installed timestamp")
+				return reconcile.Result{Requeue: true}, nil
+			}
+		}
+
 		// update SyncSetFailedCondition status condition
 		cdLog.Info("Check if any syncsets Failed")
 		if err := r.setSyncSetFailedCondition(cd, cdLog); err != nil {

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -531,8 +531,7 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 	if cd.Spec.Installed {
 		// set installedTimestamp for adopted clusters
 		if cd.Status.InstalledTimestamp == nil {
-			now := metav1.Now()
-			cd.Status.InstalledTimestamp = &now
+			cd.Status.InstalledTimestamp = &cd.ObjectMeta.CreationTimestamp
 			if err := r.Status().Update(context.TODO(), cd); err != nil {
 				cdLog.WithError(err).Log(controllerutils.LogLevel(err), "could not set cluster installed timestamp")
 				return reconcile.Result{Requeue: true}, nil

--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -373,7 +373,7 @@ func (r *ReconcileClusterSync) Reconcile(request reconcile.Request) (reconcile.R
 
 	// Set clusterSync.Status.FirstSyncSetsSuccessTime
 	syncStatuses := append(syncStatusesForSyncSets, syncStatusesForSelectorSyncSets...)
-	if len(syncStatuses) > 0 && clusterSync.Status.FirstSuccessTime == nil && !selectorSyncSetsNeedRequeue && !syncSetsNeedRequeue {
+	if len(syncStatuses) > 0 && clusterSync.Status.FirstSuccessTime == nil {
 		r.setFirstSuccessTime(syncStatuses, cd, clusterSync, logger)
 	}
 
@@ -919,6 +919,9 @@ func getFailingSyncSets(syncStatuses []hiveintv1alpha1.SyncStatus) []string {
 }
 
 func (r *ReconcileClusterSync) setFirstSuccessTime(syncStatuses []hiveintv1alpha1.SyncStatus, cd *hivev1.ClusterDeployment, clusterSync *hiveintv1alpha1.ClusterSync, logger log.FieldLogger) {
+	if reflect.ValueOf(cd.Status.InstalledTimestamp).IsNil() {
+		return
+	}
 	lastSuccessTime := &metav1.Time{}
 	for _, status := range syncStatuses {
 		if status.FirstSuccessTime == nil {

--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -919,7 +919,7 @@ func getFailingSyncSets(syncStatuses []hiveintv1alpha1.SyncStatus) []string {
 }
 
 func (r *ReconcileClusterSync) setFirstSuccessTime(syncStatuses []hiveintv1alpha1.SyncStatus, cd *hivev1.ClusterDeployment, clusterSync *hiveintv1alpha1.ClusterSync, logger log.FieldLogger) {
-	if reflect.ValueOf(cd.Status.InstalledTimestamp).IsNil() {
+	if cd.Status.InstalledTimestamp == nil {
 		return
 	}
 	lastSuccessTime := &metav1.Time{}

--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -88,6 +88,14 @@ var (
 		},
 		[]string{"type", "result"},
 	)
+
+	metricTimeToApplySyncSets = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "hive_clustersync_time_to_apply_all_syncsets_seconds",
+			Help:    "Time between cluster install complete and all syncsets applied.",
+			Buckets: []float64{60, 300, 600, 1200, 1800, 2400, 3000, 3600},
+		},
+	)
 )
 
 func init() {
@@ -95,6 +103,7 @@ func init() {
 	metrics.Registry.MustRegister(metricTimeToApplySelectorSyncSet)
 	metrics.Registry.MustRegister(metricResourcesApplied)
 	metrics.Registry.MustRegister(metricTimeToApplySyncSetResource)
+	metrics.Registry.MustRegister(metricTimeToApplySyncSets)
 }
 
 // Add creates a new clustersync Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
@@ -361,6 +370,12 @@ func (r *ReconcileClusterSync) Reconcile(request reconcile.Request) (reconcile.R
 	clusterSync.Status.SelectorSyncSets = syncStatusesForSelectorSyncSets
 
 	setFailedCondition(clusterSync)
+
+	// Set clusterSync.Status.FirstSyncSetsSuccessTime
+	syncStatuses := append(syncStatusesForSyncSets, syncStatusesForSelectorSyncSets...)
+	if len(syncStatuses) > 0 && clusterSync.Status.FirstSyncSetsSuccessTime == nil {
+		r.setFirstSyncSetsSuccessTime(syncStatuses, cd, clusterSync, logger)
+	}
 
 	// Update the ClusterSync
 	if !reflect.DeepEqual(origStatus, &clusterSync.Status) {
@@ -901,6 +916,22 @@ func getFailingSyncSets(syncStatuses []hiveintv1alpha1.SyncStatus) []string {
 		}
 	}
 	return failures
+}
+
+func (r *ReconcileClusterSync) setFirstSyncSetsSuccessTime(syncStatuses []hiveintv1alpha1.SyncStatus, cd *hivev1.ClusterDeployment, clusterSync *hiveintv1alpha1.ClusterSync, logger log.FieldLogger) {
+	lastSuccessTime := &metav1.Time{}
+	for _, status := range syncStatuses {
+		if status.FirstSuccessTime == nil {
+			return
+		}
+		if status.FirstSuccessTime.Time.After(lastSuccessTime.Time) {
+			lastSuccessTime = status.FirstSuccessTime
+		}
+	}
+	clusterSync.Status.FirstSyncSetsSuccessTime = lastSuccessTime
+	allSyncSetsAppliedDuration := lastSuccessTime.Time.Sub(cd.Status.InstalledTimestamp.Time)
+	metricTimeToApplySyncSets.Observe(float64(allSyncSetsAppliedDuration.Seconds()))
+	return
 }
 
 func namesForFailureMessage(syncSetKind string, names []string) string {

--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -930,7 +930,7 @@ func (r *ReconcileClusterSync) setFirstSuccessTime(syncStatuses []hiveintv1alpha
 	}
 	clusterSync.Status.FirstSuccessTime = lastSuccessTime
 	allSyncSetsAppliedDuration := lastSuccessTime.Time.Sub(cd.Status.InstalledTimestamp.Time)
-	logger.Debugf("observed syncsets applied duration: %v seconds", allSyncSetsAppliedDuration.Seconds())
+	logger.Infof("observed syncsets applied duration: %v seconds", allSyncSetsAppliedDuration.Seconds())
 	metricTimeToApplySyncSets.Observe(float64(allSyncSetsAppliedDuration.Seconds()))
 	return
 }

--- a/pkg/controller/clustersync/clustersync_controller_test.go
+++ b/pkg/controller/clustersync/clustersync_controller_test.go
@@ -1733,7 +1733,7 @@ func TestReconcileClusterSync_FirstSuccessTime(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	scheme := newScheme()
-	cd := cdBuilder(scheme).Options(testcd.WithInstalledTimestamp(metav1.NewTime(timeInThePast.Time.Add(-time.Minute * 15).Truncate(time.Second)))).Build()
+	cd := cdBuilder(scheme).Options(testcd.InstalledTimestamp(timeInThePast.Time.Add(-time.Minute * 15).Truncate(time.Second))).Build()
 	resourceToApply := testConfigMap("dest-namespace", "dest-name")
 	syncSetNew := testsyncset.FullBuilder(testNamespace, "test-syncset-new", scheme).Build(
 		testsyncset.ForClusterDeployments(testCDName),
@@ -1780,7 +1780,7 @@ func TestReconcileClusterSync_NoFirstSuccessTimeSet(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	scheme := newScheme()
-	cd := cdBuilder(scheme).Options(testcd.WithInstalledTimestamp(metav1.NewTime(timeInThePast.Time.Add(-time.Minute * 15).Truncate(time.Second)))).Build()
+	cd := cdBuilder(scheme).Options(testcd.InstalledTimestamp(timeInThePast.Time.Add(-time.Minute * 15).Truncate(time.Second))).Build()
 	syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
 		testsyncset.ForClusterDeployments(testCDName),
 		testsyncset.WithGeneration(1),
@@ -1836,7 +1836,7 @@ func cdBuilder(scheme *runtime.Scheme) testcd.Builder {
 				Type:   hivev1.UnreachableCondition,
 				Status: corev1.ConditionFalse,
 			}),
-			testcd.WithInstalledTimestamp(metav1.Now()),
+			testcd.InstalledTimestamp(time.Now()),
 		)
 }
 

--- a/pkg/controller/clustersync/clustersync_controller_test.go
+++ b/pkg/controller/clustersync/clustersync_controller_test.go
@@ -1729,26 +1729,40 @@ func TestReconcileClusterSync_ConditionNotMutatedWhenMessageNotChanged(t *testin
 	assert.Equal(t, timeInThePast, cond.LastProbeTime, "expected no change in last probe time")
 }
 
-func TestReconcileClusterSync_FirstSyncSetsSuccessTime(t *testing.T) {
+func TestReconcileClusterSync_FirstSuccessTime(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	scheme := newScheme()
 	cd := cdBuilder(scheme).Options(testcd.WithInstalledTimestamp(metav1.NewTime(timeInThePast.Time.Add(-time.Minute * 15).Truncate(time.Second)))).Build()
 	resourceToApply := testConfigMap("dest-namespace", "dest-name")
-	syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
+	syncSetNew := testsyncset.FullBuilder(testNamespace, "test-syncset-new", scheme).Build(
 		testsyncset.ForClusterDeployments(testCDName),
 		testsyncset.WithGeneration(1),
 		testsyncset.WithResources(resourceToApply),
 	)
-	existingSyncStatus := buildSyncStatus("test-syncset",
+	syncSetOld := testsyncset.FullBuilder(testNamespace, "test-syncset-old", scheme).Build(
+		testsyncset.ForClusterDeployments(testCDName),
+		testsyncset.WithGeneration(1),
+		testsyncset.WithResources(resourceToApply),
+	)
+	oldFirstSuccessTime := metav1.NewTime(timeInThePast.Time.Add(time.Minute * 10).Truncate(time.Second))
+	existingOldSyncStatus := buildSyncStatus("test-syncset-old",
+		withTransitionInThePast(),
+		withFirstSuccessTime(oldFirstSuccessTime),
+	)
+	existingNewSyncStatus := buildSyncStatus("test-syncset-new",
 		withTransitionInThePast(),
 		withFirstSuccessTimeInThePast(),
 	)
-	clusterSync := clusterSyncBuilder(scheme).Build(testcs.WithSyncSetStatus(existingSyncStatus))
+	clusterSync := clusterSyncBuilder(scheme).Build(
+		testcs.WithSyncSetStatus(existingOldSyncStatus),
+		testcs.WithSyncSetStatus(existingNewSyncStatus),
+	)
 	syncLease := buildSyncLease(time.Now().Add(-time.Hour))
-	rt := newReconcileTest(t, mockCtrl, scheme, cd, syncSet, clusterSync, syncLease)
+	rt := newReconcileTest(t, mockCtrl, scheme, cd, syncSetOld, syncSetNew, clusterSync, syncLease)
 	rt.expectedSyncSetStatuses = []hiveintv1alpha1.SyncStatus{
-		buildSyncStatus("test-syncset", withTransitionInThePast(), withFirstSuccessTimeInThePast()),
+		buildSyncStatus("test-syncset-new", withTransitionInThePast(), withFirstSuccessTimeInThePast()),
+		buildSyncStatus("test-syncset-old", withTransitionInThePast(), withFirstSuccessTime(oldFirstSuccessTime)),
 	}
 	rt.expectUnchangedLeaseRenewTime = true
 	rt.run(t)
@@ -1758,7 +1772,49 @@ func TestReconcileClusterSync_FirstSyncSetsSuccessTime(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 		return
 	}
-	assert.Equal(t, *updatedClusterSync.Status.FirstSyncSetsSuccessTime, timeInThePast)
+	// ClusterSync.Status.FirstSuccessTime is the oldest SyncStatus.FirstSuccessTime
+	assert.Equal(t, oldFirstSuccessTime, *updatedClusterSync.Status.FirstSuccessTime)
+}
+
+func TestReconcileClusterSync_NoFirstSuccessTimeSet(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	scheme := newScheme()
+	cd := cdBuilder(scheme).Options(testcd.WithInstalledTimestamp(metav1.NewTime(timeInThePast.Time.Add(-time.Minute * 15).Truncate(time.Second)))).Build()
+	syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
+		testsyncset.ForClusterDeployments(testCDName),
+		testsyncset.WithGeneration(1),
+		testsyncset.WithResources(testConfigMap("dest-namespace", "dest-name")),
+	)
+	existingSyncStatus := buildSyncStatus("test-syncset",
+		withTransitionInThePast(),
+		withFailureResult("test apply error"),
+		withNoFirstSuccessTime(),
+	)
+	clusterSync := clusterSyncBuilder(scheme).Build(
+		testcs.WithSyncSetStatus(existingSyncStatus),
+	)
+	syncLease := buildSyncLease(time.Now().Add(-time.Hour))
+	rt := newReconcileTest(t, mockCtrl, scheme, cd, syncSet, clusterSync, syncLease)
+	rt.expectedSyncSetStatuses = []hiveintv1alpha1.SyncStatus{
+		buildSyncStatus("test-syncset",
+			withNoFirstSuccessTime(),
+			withFailureResult("failed to apply resource 0: test apply error")),
+	}
+	rt.mockResourceHelper.EXPECT().Apply(gomock.Any()).
+		Return(resource.ApplyResult(""), errors.New("test apply error")).Times(1)
+	rt.expectedFailedMessage = "SyncSet test-syncset is failing"
+	rt.expectUnchangedLeaseRenewTime = true
+	rt.expectRequeue = true
+	rt.run(t)
+	updatedClusterSync := &hiveintv1alpha1.ClusterSync{}
+	err := rt.c.Get(context.TODO(), client.ObjectKey{Name: testCDName, Namespace: testNamespace}, updatedClusterSync)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		return
+	}
+	// ClusterSync.Status.FirstSuccessTime remains unset
+	assert.Nil(t, updatedClusterSync.Status.FirstSuccessTime)
 }
 
 func newScheme() *runtime.Scheme {
@@ -1990,5 +2046,11 @@ func withNoFirstSuccessTime() syncStatusOption {
 func withFirstSuccessTimeInThePast() syncStatusOption {
 	return func(syncStatus *hiveintv1alpha1.SyncStatus) {
 		syncStatus.FirstSuccessTime = &timeInThePast
+	}
+}
+
+func withFirstSuccessTime(firstSuccessTime metav1.Time) syncStatusOption {
+	return func(syncStatus *hiveintv1alpha1.SyncStatus) {
+		syncStatus.FirstSuccessTime = &firstSuccessTime
 	}
 }

--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -103,6 +103,13 @@ func WithCondition(cond hivev1.ClusterDeploymentCondition) Option {
 	}
 }
 
+// WithInstalledTimestamp adds the specified InstalledTimestamp to ClusterDeployment.Status
+func WithInstalledTimestamp(timestamp metav1.Time) Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Status.InstalledTimestamp = &timestamp
+	}
+}
+
 func WithUnclaimedClusterPoolReference(namespace, poolName string) Option {
 	return WithClusterPoolReference(namespace, poolName, "")
 }

--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -103,13 +103,6 @@ func WithCondition(cond hivev1.ClusterDeploymentCondition) Option {
 	}
 }
 
-// WithInstalledTimestamp adds the specified InstalledTimestamp to ClusterDeployment.Status
-func WithInstalledTimestamp(timestamp metav1.Time) Option {
-	return func(clusterDeployment *hivev1.ClusterDeployment) {
-		clusterDeployment.Status.InstalledTimestamp = &timestamp
-	}
-}
-
 func WithUnclaimedClusterPoolReference(namespace, poolName string) Option {
 	return WithClusterPoolReference(namespace, poolName, "")
 }


### PR DESCRIPTION
`clusterSync.Status.FirstSyncSetsSuccessTime` represents the first time that all syncsets were successfully applied for a `ClusterSync`.

![graph](https://i.imgur.com/lTsikNm.png)

Debugging from an info log which has been removed:
```
time="2020-09-23T19:35:30.404Z" level=info msg="allSyncSetsAppliedDuration: 455.403955562" ClusterDeployment=default/abutcher-fake19 controller=clustersync
time="2020-09-23T19:37:11.989Z" level=info msg="allSyncSetsAppliedDuration: 72.989812565" ClusterDeployment=default/abutcher-fake20 controller=clustersync
time="2020-09-23T19:38:05.293Z" level=info msg="allSyncSetsAppliedDuration: 15.293506293" ClusterDeployment=default/abutcher-fake21 controller=clustersync
time="2020-09-23T19:38:13.863Z" level=info msg="allSyncSetsAppliedDuration: 14.863788385" ClusterDeployment=default/abutcher-fake22 controller=clustersync
time="2020-09-23T19:38:51.982Z" level=info msg="allSyncSetsAppliedDuration: 14.982687708" ClusterDeployment=default/abutcher-fake25 controller=clustersync
time="2020-09-23T19:38:56.619Z" level=info msg="allSyncSetsAppliedDuration: 23.619802815" ClusterDeployment=default/abutcher-fake23 controller=clustersync
time="2020-09-23T19:38:58.717Z" level=info msg="allSyncSetsAppliedDuration: 22.717619695" ClusterDeployment=default/abutcher-fake24 controller=clustersync
time="2020-09-23T19:40:01.149Z" level=info msg="allSyncSetsAppliedDuration: 13.149632688" ClusterDeployment=default/abutcher-fake26 controller=clustersync
time="2020-09-23T19:40:06.201Z" level=info msg="allSyncSetsAppliedDuration: 15.200993113" ClusterDeployment=default/abutcher-fake27 controller=clustersync
time="2020-09-23T19:40:08.346Z" level=info msg="allSyncSetsAppliedDuration: 15.346563830000001" ClusterDeployment=default/abutcher-fake28 controller=clustersync
time="2020-09-23T19:40:58.319Z" level=info msg="allSyncSetsAppliedDuration: 13.319778068" ClusterDeployment=default/abutcher-fake29 controller=clustersync
time="2020-09-23T19:41:00.516Z" level=info msg="allSyncSetsAppliedDuration: 12.516478762" ClusterDeployment=default/abutcher-fake30 controller=clustersync
time="2020-09-23T19:41:06.326Z" level=info msg="allSyncSetsAppliedDuration: 16.32694665" ClusterDeployment=default/abutcher-fake31 controller=clustersync
```

/assign @staebler 
/cc @dgoodwin 