### PR TITLE
suport clusters installed into manually created Azure resource groups

### DIFF
--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -379,6 +379,13 @@ spec:
                       description: Region specifies the Azure region where the cluster
                         will be created.
                       type: string
+                    resourceGroupName:
+                      description: ResourceGroupName specifies the name of the Azure
+                        resource group containing the custer. This must match the
+                        name of the Azure resource group specified in the InstallConfig.
+                        If the name of the Azure resource group is omitted from the
+                        InstallConfig, then it must be omitted here as well.
+                      type: string
                   required:
                   - credentialsSecretRef
                   - region

--- a/config/crds/hive.openshift.io_clusterdeprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterdeprovisions.yaml
@@ -89,6 +89,13 @@ spec:
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                       type: object
+                    resourceGroupName:
+                      description: ResourceGroupName is used to indicate that the
+                        cluster was installed into an already-existing Azure resource
+                        group (instead of having the installer create the resource
+                        group based on the cluster name). This will be used to indicate
+                        to the uninstall process where it should clean up.
+                      type: string
                   type: object
                 gcp:
                   description: GCP contains GCP-specific deprovision settings

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -118,6 +118,13 @@ spec:
                       description: Region specifies the Azure region where the cluster
                         will be created.
                       type: string
+                    resourceGroupName:
+                      description: ResourceGroupName specifies the name of the Azure
+                        resource group containing the custer. This must match the
+                        name of the Azure resource group specified in the InstallConfig.
+                        If the name of the Azure resource group is omitted from the
+                        InstallConfig, then it must be omitted here as well.
+                      type: string
                   required:
                   - credentialsSecretRef
                   - region

--- a/contrib/pkg/deprovision/azure.go
+++ b/contrib/pkg/deprovision/azure.go
@@ -15,9 +15,15 @@ import (
 	azureutils "github.com/openshift/hive/contrib/pkg/utils/azure"
 )
 
+type azureParams struct {
+	logLevel      string
+	resourceGroup string
+}
+
 // NewDeprovisionAzureCommand is the entrypoint to create the azure deprovision subcommand
 func NewDeprovisionAzureCommand() *cobra.Command {
-	var logLevel string
+	var params azureParams
+
 	cmd := &cobra.Command{
 		Use:   "azure INFRAID",
 		Short: "Deprovision Azure assets (as created by openshift-installer)",
@@ -26,7 +32,7 @@ func NewDeprovisionAzureCommand() *cobra.Command {
 			if err := validate(); err != nil {
 				log.WithError(err).Fatal("Failed validating Azure credentials")
 			}
-			uninstaller, err := completeAzureUninstaller(logLevel, args)
+			uninstaller, err := completeAzureUninstaller(args, params)
 			if err != nil {
 				log.WithError(err).Error("Cannot complete command")
 				return
@@ -36,8 +42,12 @@ func NewDeprovisionAzureCommand() *cobra.Command {
 			}
 		},
 	}
+
 	flags := cmd.Flags()
-	flags.StringVar(&logLevel, "loglevel", "info", "log level, one of: debug, info, warn, error, fatal, panic")
+	flags.StringVar(&params.logLevel, "loglevel", "info", "log level, one of: debug, info, warn, error, fatal, panic")
+	// default of empty string for the resource group means the uninstall will look for a resource group
+	// matching the infra id.
+	flags.StringVar(&params.resourceGroup, "resource-group", "", "name of Azure resource group (if the installer didn't create one)")
 	return cmd
 }
 
@@ -50,10 +60,10 @@ func validate() error {
 	return nil
 }
 
-func completeAzureUninstaller(logLevel string, args []string) (providers.Destroyer, error) {
+func completeAzureUninstaller(args []string, params azureParams) (providers.Destroyer, error) {
 
 	// Set log level
-	level, err := log.ParseLevel(logLevel)
+	level, err := log.ParseLevel(params.logLevel)
 	if err != nil {
 		log.WithError(err).Error("cannot parse log level")
 		return nil, err
@@ -72,7 +82,8 @@ func completeAzureUninstaller(logLevel string, args []string) (providers.Destroy
 		InfraID: args[0],
 		ClusterPlatformMetadata: types.ClusterPlatformMetadata{
 			Azure: &installertypesazure.Metadata{
-				CloudName: installertypesazure.PublicCloud,
+				CloudName:         installertypesazure.PublicCloud,
+				ResourceGroupName: params.resourceGroup,
 			},
 		},
 	}

--- a/pkg/apis/hive/v1/azure/platform.go
+++ b/pkg/apis/hive/v1/azure/platform.go
@@ -18,6 +18,12 @@ type Platform struct {
 
 	// BaseDomainResourceGroupName specifies the resource group where the azure DNS zone for the base domain is found
 	BaseDomainResourceGroupName string `json:"baseDomainResourceGroupName,omitempty"`
+
+	// ResourceGroupName specifies the name of the Azure resource group containing the custer.
+	// This must match the name of the Azure resource group specified in the InstallConfig.
+	// If the name of the Azure resource group is omitted from the InstallConfig, then it must be
+	// omitted here as well.
+	ResourceGroupName string `json:"resourceGroupName,omitempty"`
 }
 
 //SetBaseDomain parses the baseDomainID and sets the related fields on azure.Platform

--- a/pkg/apis/hive/v1/clusterdeprovision_types.go
+++ b/pkg/apis/hive/v1/clusterdeprovision_types.go
@@ -57,6 +57,10 @@ type AWSClusterDeprovision struct {
 type AzureClusterDeprovision struct {
 	// CredentialsSecretRef is the Azure account credentials to use for deprovisioning the cluster
 	CredentialsSecretRef *corev1.LocalObjectReference `json:"credentialsSecretRef,omitempty"`
+	// ResourceGroupName is used to indicate that the cluster was installed into an already-existing
+	// Azure resource group (instead of having the installer create the resource group based on the
+	// cluster name). This will be used to indicate to the uninstall process where it should clean up.
+	ResourceGroupName string `json:"resourceGroupName,omitempty"`
 }
 
 // GCPClusterDeprovision contains GCP-specific configuration for a ClusterDeprovision

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -1718,6 +1718,7 @@ func generateDeprovision(cd *hivev1.ClusterDeployment) (*hivev1.ClusterDeprovisi
 	case cd.Spec.Platform.Azure != nil:
 		req.Spec.Platform.Azure = &hivev1.AzureClusterDeprovision{
 			CredentialsSecretRef: &cd.Spec.Platform.Azure.CredentialsSecretRef,
+			ResourceGroupName:    cd.Spec.Platform.Azure.ResourceGroupName,
 		}
 	case cd.Spec.Platform.GCP != nil:
 		req.Spec.Platform.GCP = &hivev1.GCPClusterDeprovision{

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openshift/hive/pkg/apis"
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	hivev1aws "github.com/openshift/hive/pkg/apis/hive/v1/aws"
+	hivev1azure "github.com/openshift/hive/pkg/apis/hive/v1/azure"
 	"github.com/openshift/hive/pkg/apis/hive/v1/baremetal"
 	hiveintv1alpha1 "github.com/openshift/hive/pkg/apis/hiveinternal/v1alpha1"
 	"github.com/openshift/hive/pkg/constants"
@@ -127,6 +128,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 		validate                func(client.Client, *testing.T)
 		reconcilerSetup         func(*ReconcileClusterDeployment)
 	}{
+
 		{
 			name: "Add finalizer",
 			existing: []runtime.Object{
@@ -1440,6 +1442,44 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				require.NotNil(t, cd, "could not get ClusterDeployment")
 				assertConditionStatus(t, cd, hivev1.InstallLaunchErrorCondition, corev1.ConditionTrue)
 				assertConditionReason(t, cd, hivev1.InstallLaunchErrorCondition, "PodInPendingPhase")
+			},
+		},
+		{
+			name: "set resourcegroupname for Azure deprovision",
+			existing: []runtime.Object{
+				func() *hivev1.ClusterDeployment {
+					cd := testClusterDeploymentWithProvision()
+					cd.Spec.Platform.AWS = nil
+					cd.Spec.Platform.Azure = &hivev1azure.Platform{
+						CredentialsSecretRef: corev1.LocalObjectReference{
+							Name: "azure-credentials",
+						},
+						Region:            "centralus",
+						ResourceGroupName: "manual-resourcegroup",
+					}
+					cd.Labels[hivev1.HiveClusterPlatformLabel] = "azure"
+					cd.Labels[hivev1.HiveClusterRegionLabel] = "centralus"
+
+					now := metav1.Now()
+					cd.DeletionTimestamp = &now
+
+					return cd
+				}(),
+				testSecret(corev1.SecretTypeDockerConfigJson, pullSecretSecret, corev1.DockerConfigJsonKey, "{}"),
+			},
+			validate: func(c client.Client, t *testing.T) {
+				cd := getCD(c)
+				require.NotNil(t, cd, "could not get ClusterDeployment")
+
+				deprovisionKey := types.NamespacedName{
+					Name:      cd.Name,
+					Namespace: cd.Namespace,
+				}
+				deprovision := &hivev1.ClusterDeprovision{}
+				err := c.Get(context.TODO(), deprovisionKey, deprovision)
+				require.NoError(t, err, "failed to get ClusterDeprovision")
+
+				assert.Equal(t, "manual-resourcegroup", deprovision.Spec.Platform.Azure.ResourceGroupName)
 			},
 		},
 	}

--- a/pkg/controller/hibernation/azure_actuator.go
+++ b/pkg/controller/hibernation/azure_actuator.go
@@ -187,8 +187,12 @@ func azureMachinePowerState(vm compute.VirtualMachine) string {
 }
 
 func clusterDeploymentResourceGroup(cd *hivev1.ClusterDeployment) string {
-	// TODO: Fix this to use explicit resource group name when we
-	// collect that from the installer.
+	// For the case where a specific resource group is specified (eg the cluster was installed
+	// into a pre-existing resource group), use it.
+	if cd.Spec.Platform.Azure != nil && cd.Spec.Platform.Azure.ResourceGroupName != "" {
+		return cd.Spec.Platform.Azure.ResourceGroupName
+	}
+
 	if cd.Spec.ClusterMetadata == nil {
 		return ""
 	}

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -582,6 +582,10 @@ func completeAzureDeprovisionJob(req *hivev1.ClusterDeprovision, job *batchv1.Jo
 			VolumeMounts: volumeMounts,
 		},
 	}
+	if req.Spec.Platform.Azure.ResourceGroupName != "" {
+		containers[0].Args = append(containers[0].Args, "--resource-group", req.Spec.Platform.Azure.ResourceGroupName)
+	}
+
 	job.Spec.Template.Spec.Containers = containers
 	job.Spec.Template.Spec.Volumes = volumes
 


### PR DESCRIPTION
New versions of the installer supports installing an Azure cluster into a pre-existing resource group.
The name of the resource group needs to be used when deprovisioning a cluster that was installed this way.

- [x] Update hiveutil with the new --resource-group param
- [x] Update clusterdeployment and clusterdeprovision types to hold this field
- [x] Update clusterdeployment controller to set the resourceGroupName field for the clusterdeprovision
- [x] Update deprovision job generator to pass the --resource-group param when it is set in the clusterdeprovision
- [x] Add test cases
- [x] Update hibernation controller to use the resourceGroupName to find instances