### PR TITLE
makefile: use earlier version of controller-gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 .PHONY: all
 all: vendor update test build
 
+# Force build-machinery-go to grab an earlier version of controller-gen. The newer version adds annotations on pod
+# specs that will cause the CRDs to fail validation. The fix for that requires the CRDs to use v1, but we still need
+# to support users that are running kube versions that only have v1beta1.
+CONTROLLER_GEN_VERSION ?=v0.2.1-37-ga3cca5d
+
 # Include the library makefile
 include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	golang.mk \

--- a/config/crds/hive.openshift.io_checkpoints.yaml
+++ b/config/crds/hive.openshift.io_checkpoints.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: checkpoints.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterclaims.yaml
+++ b/config/crds/hive.openshift.io_clusterclaims.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clusterclaims.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clusterdeployments.hive.openshift.io
 spec:
@@ -659,13 +657,9 @@ spec:
                                   optional for env vars'
                                 type: string
                               divisor:
-                                anyOf:
-                                - type: integer
-                                - type: string
                                 description: Specifies the output format of the exposed
                                   resources, defaults to "1"
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
+                                type: string
                               resource:
                                 description: 'Required: resource to select'
                                 type: string

--- a/config/crds/hive.openshift.io_clusterdeprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterdeprovisions.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clusterdeprovisions.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterimagesets.yaml
+++ b/config/crds/hive.openshift.io_clusterimagesets.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clusterimagesets.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clusterpools.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterprovisions.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clusterprovisions.hive.openshift.io
 spec:
@@ -813,13 +811,9 @@ spec:
                                         optional for env vars'
                                       type: string
                                     divisor:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
                                       description: Specifies the output format of
                                         the exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
+                                      type: string
                                     resource:
                                       description: 'Required: resource to select'
                                       type: string
@@ -968,12 +962,11 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
+                                    - type: integer
                                     description: Name or number of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
                                   scheme:
                                     description: Scheme to use for connecting to the
                                       host. Defaults to HTTP.
@@ -992,12 +985,11 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
+                                    - type: integer
                                     description: Number or name of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
@@ -1066,12 +1058,11 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
+                                    - type: integer
                                     description: Name or number of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
                                   scheme:
                                     description: Scheme to use for connecting to the
                                       host. Defaults to HTTP.
@@ -1090,12 +1081,11 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
+                                    - type: integer
                                     description: Number or name of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
@@ -1160,12 +1150,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -1202,12 +1191,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -1266,10 +1254,6 @@ spec:
                           - containerPort
                           type: object
                         type: array
-                        x-kubernetes-list-map-keys:
-                        - containerPort
-                        - protocol
-                        x-kubernetes-list-type: map
                       readinessProbe:
                         description: 'Periodic probe of container service readiness.
                           Container will be removed from service endpoints if the
@@ -1329,12 +1313,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -1371,12 +1354,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -1393,21 +1375,13 @@ spec:
                         properties:
                           limits:
                             additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
+                              type: string
                             description: 'Limits describes the maximum amount of compute
                               resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                           requests:
                             additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
+                              type: string
                             description: 'Requests describes the minimum amount of
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
@@ -1631,12 +1605,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -1673,12 +1646,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -1973,13 +1945,9 @@ spec:
                                         optional for env vars'
                                       type: string
                                     divisor:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
                                       description: Specifies the output format of
                                         the exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
+                                      type: string
                                     resource:
                                       description: 'Required: resource to select'
                                       type: string
@@ -2124,12 +2092,11 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
+                                    - type: integer
                                     description: Name or number of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
                                   scheme:
                                     description: Scheme to use for connecting to the
                                       host. Defaults to HTTP.
@@ -2148,12 +2115,11 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
+                                    - type: integer
                                     description: Number or name of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
@@ -2222,12 +2188,11 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
+                                    - type: integer
                                     description: Name or number of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
                                   scheme:
                                     description: Scheme to use for connecting to the
                                       host. Defaults to HTTP.
@@ -2246,12 +2211,11 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
+                                    - type: integer
                                     description: Number or name of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
@@ -2314,12 +2278,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -2356,12 +2319,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -2471,12 +2433,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -2513,12 +2474,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -2536,21 +2496,13 @@ spec:
                         properties:
                           limits:
                             additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
+                              type: string
                             description: 'Limits describes the maximum amount of compute
                               resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                           requests:
                             additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
+                              type: string
                             description: 'Requests describes the minimum amount of
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
@@ -2765,12 +2717,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -2807,12 +2758,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -3114,13 +3064,9 @@ spec:
                                         optional for env vars'
                                       type: string
                                     divisor:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
                                       description: Specifies the output format of
                                         the exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
+                                      type: string
                                     resource:
                                       description: 'Required: resource to select'
                                       type: string
@@ -3269,12 +3215,11 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
+                                    - type: integer
                                     description: Name or number of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
                                   scheme:
                                     description: Scheme to use for connecting to the
                                       host. Defaults to HTTP.
@@ -3293,12 +3238,11 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
+                                    - type: integer
                                     description: Number or name of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
@@ -3367,12 +3311,11 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
+                                    - type: integer
                                     description: Name or number of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
                                   scheme:
                                     description: Scheme to use for connecting to the
                                       host. Defaults to HTTP.
@@ -3391,12 +3334,11 @@ spec:
                                     type: string
                                   port:
                                     anyOf:
-                                    - type: integer
                                     - type: string
+                                    - type: integer
                                     description: Number or name of the port to access
                                       on the container. Number must be in the range
                                       1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
                                 required:
                                 - port
                                 type: object
@@ -3461,12 +3403,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -3503,12 +3444,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -3567,10 +3507,6 @@ spec:
                           - containerPort
                           type: object
                         type: array
-                        x-kubernetes-list-map-keys:
-                        - containerPort
-                        - protocol
-                        x-kubernetes-list-type: map
                       readinessProbe:
                         description: 'Periodic probe of container service readiness.
                           Container will be removed from service endpoints if the
@@ -3630,12 +3566,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -3672,12 +3607,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -3694,21 +3628,13 @@ spec:
                         properties:
                           limits:
                             additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
+                              type: string
                             description: 'Limits describes the maximum amount of compute
                               resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
                           requests:
                             additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
+                              type: string
                             description: 'Requests describes the minimum amount of
                               compute resources required. If Requests is omitted for
                               a container, it defaults to Limits if that is explicitly
@@ -3932,12 +3858,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Name or number of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                               scheme:
                                 description: Scheme to use for connecting to the host.
                                   Defaults to HTTP.
@@ -3974,12 +3899,11 @@ spec:
                                 type: string
                               port:
                                 anyOf:
-                                - type: integer
                                 - type: string
+                                - type: integer
                                 description: Number or name of the port to access
                                   on the container. Number must be in the range 1
                                   to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
                             required:
                             - port
                             type: object
@@ -4117,11 +4041,7 @@ spec:
                   type: object
                 overhead:
                   additionalProperties:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
+                    type: string
                   description: 'Overhead represents the resource overhead associated
                     with running a pod for a given RuntimeClass. This field will be
                     autopopulated at admission time by the RuntimeClass admission
@@ -4526,10 +4446,6 @@ spec:
                     - whenUnsatisfiable
                     type: object
                   type: array
-                  x-kubernetes-list-map-keys:
-                  - topologyKey
-                  - whenUnsatisfiable
-                  x-kubernetes-list-type: map
                 volumes:
                   description: 'List of volumes that can be mounted by containers
                     belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
@@ -4875,13 +4791,9 @@ spec:
                                         optional for env vars'
                                       type: string
                                     divisor:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
                                       description: Specifies the output format of
                                         the exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
+                                      type: string
                                     resource:
                                       description: 'Required: resource to select'
                                       type: string
@@ -4904,9 +4816,6 @@ spec:
                               (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                             type: string
                           sizeLimit:
-                            anyOf:
-                            - type: integer
-                            - type: string
                             description: 'Total amount of local storage required for
                               this EmptyDir volume. The size limit is also applicable
                               for memory medium. The maximum usage on memory medium
@@ -4914,8 +4823,7 @@ spec:
                               specified here and the sum of memory limits of all containers
                               in a pod. The default is nil which means that the limit
                               is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
+                            type: string
                         type: object
                       ephemeral:
                         description: "Ephemeral represents a volume that is handled
@@ -5028,22 +4936,14 @@ spec:
                                     properties:
                                       limits:
                                         additionalProperties:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
+                                          type: string
                                         description: 'Limits describes the maximum
                                           amount of compute resources allowed. More
                                           info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
+                                          type: string
                                         description: 'Requests describes the minimum
                                           amount of compute resources required. If
                                           Requests is omitted for a container, it
@@ -5601,14 +5501,10 @@ spec:
                                                   for volumes, optional for env vars'
                                                 type: string
                                               divisor:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
                                                 description: Specifies the output
                                                   format of the exposed resources,
                                                   defaults to "1"
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
+                                                type: string
                                               resource:
                                                 description: 'Required: resource to
                                                   select'

--- a/config/crds/hive.openshift.io_clusterrelocates.yaml
+++ b/config/crds/hive.openshift.io_clusterrelocates.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clusterrelocates.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterstates.yaml
+++ b/config/crds/hive.openshift.io_clusterstates.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clusterstates.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_dnszones.yaml
+++ b/config/crds/hive.openshift.io_dnszones.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: dnszones.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: hiveconfigs.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_machinepoolnameleases.yaml
+++ b/config/crds/hive.openshift.io_machinepoolnameleases.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: machinepoolnameleases.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: machinepools.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_selectorsyncidentityproviders.yaml
+++ b/config/crds/hive.openshift.io_selectorsyncidentityproviders.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: selectorsyncidentityproviders.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_selectorsyncsets.yaml
+++ b/config/crds/hive.openshift.io_selectorsyncsets.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: selectorsyncsets.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_syncidentityproviders.yaml
+++ b/config/crds/hive.openshift.io_syncidentityproviders.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: syncidentityproviders.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_syncsets.yaml
+++ b/config/crds/hive.openshift.io_syncsets.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: syncsets.hive.openshift.io
 spec:

--- a/config/crds/hiveinternal.openshift.io_clustersyncleases.yaml
+++ b/config/crds/hiveinternal.openshift.io_clustersyncleases.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clustersyncleases.hiveinternal.openshift.io
 spec:

--- a/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
+++ b/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
@@ -1,8 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
   creationTimestamp: null
   name: clustersyncs.hiveinternal.openshift.io
 spec:

--- a/pkg/gcpclient/mock/client_generated.go
+++ b/pkg/gcpclient/mock/client_generated.go
@@ -7,8 +7,8 @@ package mock
 import (
 	gomock "github.com/golang/mock/gomock"
 	gcpclient "github.com/openshift/hive/pkg/gcpclient"
-	compute "google.golang.org/api/compute/v1"
-	dns "google.golang.org/api/dns/v1"
+	v1 "google.golang.org/api/compute/v1"
+	v10 "google.golang.org/api/dns/v1"
 	reflect "reflect"
 )
 
@@ -36,10 +36,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // ListManagedZones mocks base method
-func (m *MockClient) ListManagedZones(opts gcpclient.ListManagedZonesOptions) (*dns.ManagedZonesListResponse, error) {
+func (m *MockClient) ListManagedZones(opts gcpclient.ListManagedZonesOptions) (*v10.ManagedZonesListResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListManagedZones", opts)
-	ret0, _ := ret[0].(*dns.ManagedZonesListResponse)
+	ret0, _ := ret[0].(*v10.ManagedZonesListResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -51,10 +51,10 @@ func (mr *MockClientMockRecorder) ListManagedZones(opts interface{}) *gomock.Cal
 }
 
 // ListResourceRecordSets mocks base method
-func (m *MockClient) ListResourceRecordSets(managedZone string, opts gcpclient.ListResourceRecordSetsOptions) (*dns.ResourceRecordSetsListResponse, error) {
+func (m *MockClient) ListResourceRecordSets(managedZone string, opts gcpclient.ListResourceRecordSetsOptions) (*v10.ResourceRecordSetsListResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResourceRecordSets", managedZone, opts)
-	ret0, _ := ret[0].(*dns.ResourceRecordSetsListResponse)
+	ret0, _ := ret[0].(*v10.ResourceRecordSetsListResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -66,7 +66,7 @@ func (mr *MockClientMockRecorder) ListResourceRecordSets(managedZone, opts inter
 }
 
 // AddResourceRecordSet mocks base method
-func (m *MockClient) AddResourceRecordSet(managedZone string, recordSet *dns.ResourceRecordSet) error {
+func (m *MockClient) AddResourceRecordSet(managedZone string, recordSet *v10.ResourceRecordSet) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddResourceRecordSet", managedZone, recordSet)
 	ret0, _ := ret[0].(error)
@@ -80,7 +80,7 @@ func (mr *MockClientMockRecorder) AddResourceRecordSet(managedZone, recordSet in
 }
 
 // DeleteResourceRecordSet mocks base method
-func (m *MockClient) DeleteResourceRecordSet(managedZone string, recordSet *dns.ResourceRecordSet) error {
+func (m *MockClient) DeleteResourceRecordSet(managedZone string, recordSet *v10.ResourceRecordSet) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteResourceRecordSet", managedZone, recordSet)
 	ret0, _ := ret[0].(error)
@@ -94,7 +94,7 @@ func (mr *MockClientMockRecorder) DeleteResourceRecordSet(managedZone, recordSet
 }
 
 // DeleteResourceRecordSets mocks base method
-func (m *MockClient) DeleteResourceRecordSets(managedZone string, recordSet []*dns.ResourceRecordSet) error {
+func (m *MockClient) DeleteResourceRecordSets(managedZone string, recordSet []*v10.ResourceRecordSet) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteResourceRecordSets", managedZone, recordSet)
 	ret0, _ := ret[0].(error)
@@ -108,7 +108,7 @@ func (mr *MockClientMockRecorder) DeleteResourceRecordSets(managedZone, recordSe
 }
 
 // UpdateResourceRecordSet mocks base method
-func (m *MockClient) UpdateResourceRecordSet(managedZone string, addRecordSet, removeRecordSet *dns.ResourceRecordSet) error {
+func (m *MockClient) UpdateResourceRecordSet(managedZone string, addRecordSet, removeRecordSet *v10.ResourceRecordSet) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateResourceRecordSet", managedZone, addRecordSet, removeRecordSet)
 	ret0, _ := ret[0].(error)
@@ -122,10 +122,10 @@ func (mr *MockClientMockRecorder) UpdateResourceRecordSet(managedZone, addRecord
 }
 
 // GetManagedZone mocks base method
-func (m *MockClient) GetManagedZone(managedZone string) (*dns.ManagedZone, error) {
+func (m *MockClient) GetManagedZone(managedZone string) (*v10.ManagedZone, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetManagedZone", managedZone)
-	ret0, _ := ret[0].(*dns.ManagedZone)
+	ret0, _ := ret[0].(*v10.ManagedZone)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -137,10 +137,10 @@ func (mr *MockClientMockRecorder) GetManagedZone(managedZone interface{}) *gomoc
 }
 
 // CreateManagedZone mocks base method
-func (m *MockClient) CreateManagedZone(managedZone *dns.ManagedZone) (*dns.ManagedZone, error) {
+func (m *MockClient) CreateManagedZone(managedZone *v10.ManagedZone) (*v10.ManagedZone, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateManagedZone", managedZone)
-	ret0, _ := ret[0].(*dns.ManagedZone)
+	ret0, _ := ret[0].(*v10.ManagedZone)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -166,10 +166,10 @@ func (mr *MockClientMockRecorder) DeleteManagedZone(managedZone interface{}) *go
 }
 
 // ListComputeZones mocks base method
-func (m *MockClient) ListComputeZones(arg0 gcpclient.ListComputeZonesOptions) (*compute.ZoneList, error) {
+func (m *MockClient) ListComputeZones(arg0 gcpclient.ListComputeZonesOptions) (*v1.ZoneList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListComputeZones", arg0)
-	ret0, _ := ret[0].(*compute.ZoneList)
+	ret0, _ := ret[0].(*v1.ZoneList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -181,10 +181,10 @@ func (mr *MockClientMockRecorder) ListComputeZones(arg0 interface{}) *gomock.Cal
 }
 
 // ListComputeImages mocks base method
-func (m *MockClient) ListComputeImages(arg0 gcpclient.ListComputeImagesOptions) (*compute.ImageList, error) {
+func (m *MockClient) ListComputeImages(arg0 gcpclient.ListComputeImagesOptions) (*v1.ImageList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListComputeImages", arg0)
-	ret0, _ := ret[0].(*compute.ImageList)
+	ret0, _ := ret[0].(*v1.ImageList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -196,7 +196,7 @@ func (mr *MockClientMockRecorder) ListComputeImages(arg0 interface{}) *gomock.Ca
 }
 
 // ListComputeInstances mocks base method
-func (m *MockClient) ListComputeInstances(arg0 gcpclient.ListComputeInstancesOptions, arg1 func(*compute.InstanceAggregatedList) error) error {
+func (m *MockClient) ListComputeInstances(arg0 gcpclient.ListComputeInstancesOptions, arg1 func(*v1.InstanceAggregatedList) error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListComputeInstances", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -210,7 +210,7 @@ func (mr *MockClientMockRecorder) ListComputeInstances(arg0, arg1 interface{}) *
 }
 
 // StopInstance mocks base method
-func (m *MockClient) StopInstance(arg0 *compute.Instance) error {
+func (m *MockClient) StopInstance(arg0 *v1.Instance) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StopInstance", arg0)
 	ret0, _ := ret[0].(error)
@@ -224,7 +224,7 @@ func (mr *MockClientMockRecorder) StopInstance(arg0 interface{}) *gomock.Call {
 }
 
 // StartInstance mocks base method
-func (m *MockClient) StartInstance(arg0 *compute.Instance) error {
+func (m *MockClient) StartInstance(arg0 *v1.Instance) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartInstance", arg0)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
Force build-machinery-go to grab an earlier version of controller-gen. The newer version adds annotations on pod specs that will cause the CRDs to fail validation. The fix for that requires the CRDs to use v1, but we still need to support users that are running kube versions that only have v1beta1.

https://issues.redhat.com/browse/CO-1193

/assign @dgoodwin 
/cc @abutcher 