### PR TITLE
Refine ClusterDeployment printcolumns.

### DIFF
--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -5,20 +5,26 @@ metadata:
   name: clusterdeployments.hive.openshift.io
 spec:
   additionalPrinterColumns:
-  - JSONPath: .spec.clusterName
-    name: ClusterName
+  - JSONPath: .metadata.labels.hive\.openshift\.io/cluster-platform
+    name: Platform
+    type: string
+  - JSONPath: .metadata.labels.hive\.openshift\.io/cluster-region
+    name: Region
     type: string
   - JSONPath: .metadata.labels.hive\.openshift\.io/cluster-type
     name: ClusterType
-    type: string
-  - JSONPath: .spec.baseDomain
-    name: BaseDomain
     type: string
   - JSONPath: .spec.installed
     name: Installed
     type: boolean
   - JSONPath: .spec.clusterMetadata.infraID
     name: InfraID
+    type: string
+  - JSONPath: .metadata.labels.hive\.openshift\.io/version-major-minor-patch
+    name: Version
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Hibernating')].reason
+    name: PowerState
     type: string
   - JSONPath: .metadata.creationTimestamp
     name: Age

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -97,7 +97,7 @@ function teardown() {
         fi
 
         # This is here for backup. The test-e2e-destroycluster test
-        # should normally delete the clusterdeployemnt. Only if the 
+        # should normally delete the clusterdeployemnt. Only if the
         # test fails before then, this will ensure we at least attempt
         # to delete the cluster.
 	echo "Deleting ClusterDeployment ${CLUSTER_NAME}"
@@ -193,7 +193,7 @@ while [ $i -le ${max_tries} ]; do
 
   GET_BY_SHORT_NAME=$(oc get cd)
 
-  if echo "${GET_BY_SHORT_NAME}" | grep 'BASEDOMAIN' ; then
+  if echo "${GET_BY_SHORT_NAME}" | grep 'INFRAID' ; then
     echo "Success"
     break
   else

--- a/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -370,11 +370,13 @@ const (
 // ClusterDeployment is the Schema for the clusterdeployments API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="ClusterName",type="string",JSONPath=".spec.clusterName"
+// +kubebuilder:printcolumn:name="Platform",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/cluster-platform"
+// +kubebuilder:printcolumn:name="Region",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/cluster-region"
 // +kubebuilder:printcolumn:name="ClusterType",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/cluster-type"
-// +kubebuilder:printcolumn:name="BaseDomain",type="string",JSONPath=".spec.baseDomain"
 // +kubebuilder:printcolumn:name="Installed",type="boolean",JSONPath=".spec.installed"
 // +kubebuilder:printcolumn:name="InfraID",type="string",JSONPath=".spec.clusterMetadata.infraID"
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/version-major-minor-patch"
+// +kubebuilder:printcolumn:name="PowerState",type="string",JSONPath=".status.conditions[?(@.type=='Hibernating')].reason"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=clusterdeployments,shortName=cd,scope=Namespaced
 type ClusterDeployment struct {


### PR DESCRIPTION
Drop ClusterName, it's virtually always identical to the
ClusterDeployment.Name.

Drop BaseDomain, doesn't seem useful.

Add Platform, Region, OpenShift version, and the observed power state
from the Hibernating condition.