### PR TITLE
types: add status sub-resource to syncsets

### DIFF
--- a/config/crds/hive.openshift.io_selectorsyncsets.yaml
+++ b/config/crds/hive.openshift.io_selectorsyncsets.yaml
@@ -13,6 +13,8 @@ spec:
     - sss
     singular: selectorsyncset
   scope: Cluster
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: SelectorSyncSet is the Schema for the SelectorSyncSet API

--- a/config/crds/hive.openshift.io_syncsets.yaml
+++ b/config/crds/hive.openshift.io_syncsets.yaml
@@ -13,6 +13,8 @@ spec:
     - ss
     singular: syncset
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: SyncSet is the Schema for the SyncSet API

--- a/pkg/apis/hive/v1/syncset_types.go
+++ b/pkg/apis/hive/v1/syncset_types.go
@@ -273,6 +273,7 @@ type SelectorSyncSetStatus struct {
 
 // SelectorSyncSet is the Schema for the SelectorSyncSet API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:path=selectorsyncsets,shortName=sss,scope=Cluster
 type SelectorSyncSet struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -287,6 +288,7 @@ type SelectorSyncSet struct {
 
 // SyncSet is the Schema for the SyncSet API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:path=syncsets,shortName=ss,scope=Namespaced
 type SyncSet struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
Add a status sub-resource to the SyncSet and SelectorSyncSet types. With older versions of kubernetes (1.11 as an example), the CRD strategy will not update the generation of the resource if the CRD does not have a status sub-resource.

See https://github.com/kubernetes/kubernetes/blob/v1.11.0/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/strategy.go#L90

https://issues.redhat.com/browse/CO-1191

/assign @abutcher 
/cc @dgoodwin 