### PR TITLE
Fix stalled leader election after Deployment updates

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -7,8 +7,6 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -159,6 +157,10 @@ func newRootCommand() *cobra.Command {
 			log.Info("Starting /healthz and /readyz endpoints")
 			go http.ListenAndServe(":8080", nil)
 
+			// use a Go context so we can tell the leaderelection code when we want to step down
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
 			run := func(ctx context.Context) {
 				// Create a new Cmd to provide shared dependencies and start components
 				mgr, err := manager.New(cfg, manager.Options{
@@ -214,27 +216,17 @@ func newRootCommand() *cobra.Command {
 				log.Info("Starting the Cmd.")
 
 				// Start the Cmd
-				log.Fatal(mgr.Start(signals.SetupSignalHandler()))
+				err = mgr.Start(signals.SetupSignalHandler())
+				if err != nil {
+					log.WithError(err).Error("error running manager")
+				}
+				// Canceling the leader election context
+				cancel()
 			}
 
 			// Leader election code based on:
 			// https://github.com/kubernetes/kubernetes/blob/f7e3bcdec2e090b7361a61e21c20b3dbbb41b7f0/staging/src/k8s.io/client-go/examples/leader-election/main.go#L92-L154
 			// This gives us ReleaseOnCancel which is not presently exposed in controller-runtime.
-
-			// use a Go context so we can tell the leaderelection code when we want to step down
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			// listen for interrupts or the Linux SIGTERM signal and cancel
-			// our context, which the leader election code will observe and
-			// step down
-			ch := make(chan os.Signal, 1)
-			signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
-			go func() {
-				<-ch
-				log.Info("received termination, signaling shutdown")
-				cancel()
-			}()
 
 			id := uuid.New().String()
 			leLog := log.WithField("id", id)

--- a/config/controllers/deployment.yaml
+++ b/config/controllers/deployment.yaml
@@ -13,6 +13,8 @@ spec:
       controller-tools.k8s.io: "1.0"
   replicas: 1
   revisionHistoryLimit: 4
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/config/operator/operator_deployment.yaml
+++ b/config/operator/operator_deployment.yaml
@@ -18,6 +18,8 @@ spec:
       controller-tools.k8s.io: "1.0"
   replicas: 1
   revisionHistoryLimit: 4
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -643,6 +643,8 @@ spec:
       controller-tools.k8s.io: "1.0"
   replicas: 1
   revisionHistoryLimit: 4
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
With the current Deployment strategy of rolling update, a new pod is brought up
before the old is terminated. The new pod leader election has already determined
someone else is leader before the old releases it's lock, and will wait the full
renew interval of 270 seconds before checking again.

To fix we switch to the recreate strategy which will delete the old pod first,
then create the new. This seems the desired strategy for leader election based
operators.