### PR TITLE
Add option to limit install attempts

### DIFF
--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -327,6 +327,11 @@ spec:
                 - name
                 type: object
               type: array
+            installAttemptsLimit:
+              description: InstallAttemptsLimit is the maximum number of times Hive
+                will attempt to install the cluster.
+              format: int32
+              type: integer
             installed:
               description: Installed is true if the cluster has been installed
               type: boolean

--- a/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -128,6 +128,10 @@ type ClusterDeploymentSpec struct {
 	// time since the cluster last came out of hibernation.
 	// +optional
 	HibernateAfter *metav1.Duration `json:"hibernateAfter,omitempty"`
+
+	// InstallAttemptsLimit is the maximum number of times Hive will attempt to install the cluster.
+	// +optional
+	InstallAttemptsLimit *int32 `json:"installAttemptsLimit,omitempty"`
 }
 
 // Provisioning contains settings used only for initial cluster provisioning.
@@ -313,6 +317,9 @@ const (
 
 	// DeprovisionLaunchErrorCondition is set when a cluster deprovision fails to launch.
 	DeprovisionLaunchErrorCondition ClusterDeploymentConditionType = "DeprovisionLaunchError"
+
+	// ProvisionStoppedCondition is set when cluster provisioning is stopped
+	ProvisionStoppedCondition ClusterDeploymentConditionType = "ProvisionStopped"
 )
 
 // AllClusterDeploymentConditions is a slice containing all condition types. This can be used for dealing with


### PR DESCRIPTION
This PR adds an option to limit the number of install restarts by setting a
value in the ClusterDeployment field `limitInstallRestarts`. Once this limit has
reached, `ProvisionStopped` error condition will be set in the status.