### PR TITLE
CO-1188: Changing resourceApplyMode on SSS doesn't update ClusterSync.

### DIFF
--- a/docs/syncset.md
+++ b/docs/syncset.md
@@ -154,3 +154,9 @@ To see details, run as below.
 ```sh
 oc get syncsetinstances <synsetinstance name> -o yaml
 ```
+
+## Changing ResourceApplyMode
+
+Changing the `resourceApplyMode` from `"Sync"` to `"Upsert"` will remove `SyncSet` resources tracked for deletion within the corresponding `ClusterSync` object. It is possible that the `ClusterSync` controller could process a resource removal and a `resourceApplyMode` change simultaneously and when this occurs resources no longer tracked in the `SyncSet` will be orphaned rather than deleted.
+
+Likewise, changing the `resourceApplyMode` from `"Upsert"` to `"Sync"` will add `SyncSet` resources to resources tracked for deletion within the corresponding `ClusterSync` object. When the `ClusterSync` controller processes a resource removal and a `resourceApplyMode` change simultaneously, resources removed will be orphaned rather than deleted.

--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -471,6 +471,10 @@ func (r *ReconcileClusterSync) applySyncSets(
 		if syncSet.GetSpec().ResourceApplyMode == hivev1.SyncResourceApplyMode {
 			newSyncStatus.ResourcesToDelete = resourcesApplied
 		}
+		if syncSet.GetSpec().ResourceApplyMode == hivev1.UpsertResourceApplyMode && len(oldSyncStatus.ResourcesToDelete) > 0 {
+			logger.Infof("resource apply mode is %v but there are resources to delete in clustersync status", hivev1.UpsertResourceApplyMode)
+			oldSyncStatus.ResourcesToDelete = nil
+		}
 		if err != nil {
 			newSyncStatus.Result = hiveintv1alpha1.FailureSyncSetResult
 			newSyncStatus.FailureMessage = err.Error()


### PR DESCRIPTION
Remove `ResourcesToDelete` in `SyncStatus` when `ResourceApplyMode` is `"Upsert"`.

/assign @staebler 
/cc @akhil-rane 

Create `SyncSet` containing two configmap resources with `resourceApplyMode: Sync`:
```yaml
---
apiVersion: hive.openshift.io/v1
kind: SyncSet
metadata:
  name: sample-configmap
spec:
  resourceApplyMode: Sync
  clusterDeploymentRefs:
  - name: abutcher
  resources:
  - apiVersion: v1
    kind: ConfigMap
    namespace: default
    metadata:
      name: sample-configmap-one
      namespace: default
    data:
      foo: bar
  - apiVersion: v1
    kind: ConfigMap
    namespace: default
    metadata:
      name: sample-configmap-two
      namespace: default
    data:
      foo: bar
```

Check that `resourcesToDelete` contains both configmap resources:

```
$ oc get clustersync abutcher -o jsonpath='{range .status.syncSets[0].resourcesToDelete[*]}{.name}{"\n"}{end}'
sample-configmap-one
sample-configmap-two
```

Change `resourceApplyMode` to `"Upsert"` and ensure `resourcesToDelete` is empty:

```
$ oc patch syncset sample-configmap --type=merge -p '{"spec":{"resourceApplyMode": "Upsert"}}'
syncset.hive.openshift.io/sample-configmap patched

$ oc get clustersync abutcher -o jsonpath='{ .status.syncSets[0] }'                  
map[firstSuccessTime:2020-10-21T16:59:12Z lastTransitionTime:2020-10-21T17:08:11Z name:sample-configmap observedGeneration:3 result:Success]
```

Change `resourceApplyMode` back to `"Sync"` and ensure `resourcesToDelete` contains both configmaps:

```
$ oc patch syncset sample-configmap --type=merge -p '{"spec":{"resourceApplyMode": "Sync"}}'  
syncset.hive.openshift.io/sample-configmap patched

$ oc get clustersync abutcher -o jsonpath='{range .status.syncSets[0].resourcesToDelete[*]}{.name}{"\n"}{end}'
sample-configmap-one
sample-configmap-two
```

---

Behavior regarding simultaneous updates documented in `SyncSet` docs.

Simultaneously change `resourceApplyMode` from `"Sync"` to `"Upsert"` and remove configmap `sample-configmap-two` from resources. `SyncSet` contains one resource and `sample-configmap-two` has been orphaned on the remote cluster rather than deleted.

```
$ oc patch syncset sample-configmap --type=merge -p '{"spec":{"resourceApplyMode": "Upsert", "resources": [{"apiVersion": "v1", "kind": "ConfigMap", "namespace": "default", "metadata": {"name": "sample-configmap-one", "namespace": "default"}, "data": {"foo": "bar"}}]}}'
syncset.hive.openshift.io/sample-configmap patched

$ oc get syncset sample-configmap -o jsonpath='{range .spec.resources[*]}{.metadata.name}{"\n"}{end}'
sample-configmap-one

$ oc get clustersync abutcher -o jsonpath='{.status.syncSets[0]}'                                             
map[firstSuccessTime:2020-10-21T17:14:32Z lastTransitionTime:2020-10-21T17:14:55Z name:sample-configmap observedGeneration:2 result:Success]

(remote) $ oc get configmap
NAME                   DATA   AGE
sample-configmap-one   1      25s
sample-configmap-two   1      25s
```

Simultaneously change `resourceApplyMode` from `"Upsert"` to `"Sync"` and remove configmap `sample-configmap-two` from resources. `Syncset` contains one resource, `resourcesToDelete` only contains `sample-configmap-one` and `sample-configmap-two` has been orphaned on the remote cluster rather than deleted.

```
$ oc patch syncset sample-configmap --type=merge -p '{"spec":{"resourceApplyMode": "Sync", "resources": [{"apiVersion": "v1", "kind": "ConfigMap", "namespace": "default", "metadata": {"name": "sample-configmap-one", "namespace": "default"}, "data": {"foo": "bar"}}]}}'
syncset.hive.openshift.io/sample-configmap patched

$ oc get syncset sample-configmap -o jsonpath='{range .spec.resources[*]}{.metadata.name}{"\n"}{end}'                                                      sample-configmap-one

$ oc get clustersync abutcher -o jsonpath='{range .status.syncSets[0].resourcesToDelete[*]}{.name}{"\n"}{end}'
sample-configmap-one

(remote) $ oc get configmap
NAME                   DATA   AGE
sample-configmap-one   1      3m24s
sample-configmap-two   1      3m24s
```