### PR TITLE
change osd pipeline build to use quay

### DIFF
--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -24,7 +24,7 @@ REMOVED_VERSIONS=""
 if [[ "$REMOVE_UNDEPLOYED" == true ]]; then
     DEPLOYED_HASH=$(
         curl -s https://gitlab.cee.redhat.com/service/app-interface/-/raw/master/data/services/hive/cicd/ci-int/saas-hive.yaml | \
-            docker run --rm -i evns/yq -r '.resourceTemplates[]|select(.name="hive").targets[]|select(.namespace."$ref"=="/services/hive/namespaces/hive-production.yml").ref'
+            docker run --rm -i quay.io/openshift-hive/yq:latest -r '.resourceTemplates[]|select(.name="hive").targets[]|select(.namespace."$ref"=="/services/hive/namespaces/hive-production.yml").ref'
     )
 
     delete=false


### PR DESCRIPTION
dockerhub is adding rate limiting. Change our build to use
yq from quay.

Long term, it would be better to change the build to use
the app-interface graphql endpoint, but this will at least
make sure the builds don't stop working.

/assign @dgoodwin 
/cc @suhanime 