### PR TITLE
allow skipping leader election

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -228,47 +228,51 @@ func newRootCommand() *cobra.Command {
 			// https://github.com/kubernetes/kubernetes/blob/f7e3bcdec2e090b7361a61e21c20b3dbbb41b7f0/staging/src/k8s.io/client-go/examples/leader-election/main.go#L92-L154
 			// This gives us ReleaseOnCancel which is not presently exposed in controller-runtime.
 
-			id := uuid.New().String()
-			leLog := log.WithField("id", id)
-			leLog.Info("generated leader election ID")
+			if os.Getenv("HIVE_SKIP_LEADER_ELECTION") != "" {
+				run(ctx)
+			} else {
+				id := uuid.New().String()
+				leLog := log.WithField("id", id)
+				leLog.Info("generated leader election ID")
 
-			lock := &resourcelock.ConfigMapLock{
-				ConfigMapMeta: metav1.ObjectMeta{
-					Namespace: hiveNSName,
-					Name:      leaderElectionConfigMap,
-				},
-				Client: kubernetes.NewForConfigOrDie(cfg).CoreV1(),
-				LockConfig: resourcelock.ResourceLockConfig{
-					Identity: id,
-				},
+				lock := &resourcelock.ConfigMapLock{
+					ConfigMapMeta: metav1.ObjectMeta{
+						Namespace: hiveNSName,
+						Name:      leaderElectionConfigMap,
+					},
+					Client: kubernetes.NewForConfigOrDie(cfg).CoreV1(),
+					LockConfig: resourcelock.ResourceLockConfig{
+						Identity: id,
+					},
+				}
+
+				// start the leader election code loop
+				leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+					Lock:            lock,
+					ReleaseOnCancel: true,
+					LeaseDuration:   leaseDuration,
+					RenewDeadline:   renewDeadline,
+					RetryPeriod:     retryPeriod,
+					Callbacks: leaderelection.LeaderCallbacks{
+						OnStartedLeading: func(ctx context.Context) {
+							run(ctx)
+						},
+						OnStoppedLeading: func() {
+							// we can do cleanup here if necessary
+							leLog.Infof("leader lost")
+							os.Exit(0)
+						},
+						OnNewLeader: func(identity string) {
+							if identity == id {
+								// We just became the leader
+								leLog.Info("became leader")
+								return
+							}
+							log.Infof("current leader: %s", identity)
+						},
+					},
+				})
 			}
-
-			// start the leader election code loop
-			leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
-				Lock:            lock,
-				ReleaseOnCancel: true,
-				LeaseDuration:   leaseDuration,
-				RenewDeadline:   renewDeadline,
-				RetryPeriod:     retryPeriod,
-				Callbacks: leaderelection.LeaderCallbacks{
-					OnStartedLeading: func(ctx context.Context) {
-						run(ctx)
-					},
-					OnStoppedLeading: func() {
-						// we can do cleanup here if necessary
-						leLog.Infof("leader lost")
-						os.Exit(0)
-					},
-					OnNewLeader: func(identity string) {
-						if identity == id {
-							// We just became the leader
-							leLog.Info("became leader")
-							return
-						}
-						log.Infof("current leader: %s", identity)
-					},
-				},
-			})
 		},
 	}
 


### PR DESCRIPTION
Allow skiping leader election to add some flexibility when developing on hive where we can simultaneously have hive running in a cluster (potentially with some controllers disabled), and running hive locally.