### PR TITLE
Revert "Merge pull request #1154 from joelddiaz/azure-resource-groups"

### DIFF
--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -385,13 +385,6 @@ spec:
                       description: Region specifies the Azure region where the cluster
                         will be created.
                       type: string
-                    resourceGroupName:
-                      description: ResourceGroupName specifies the name of the Azure
-                        resource group containing the custer. This must match the
-                        name of the Azure resource group specified in the InstallConfig.
-                        If the name of the Azure resource group is omitted from the
-                        InstallConfig, then it must be omitted here as well.
-                      type: string
                   required:
                   - credentialsSecretRef
                   - region

--- a/config/crds/hive.openshift.io_clusterdeprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterdeprovisions.yaml
@@ -89,13 +89,6 @@ spec:
                             TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
                       type: object
-                    resourceGroupName:
-                      description: ResourceGroupName is used to indicate that the
-                        cluster was installed into an already-existing Azure resource
-                        group (instead of having the installer create the resource
-                        group based on the cluster name). This will be used to indicate
-                        to the uninstall process where it should clean up.
-                      type: string
                   type: object
                 gcp:
                   description: GCP contains GCP-specific deprovision settings

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -125,13 +125,6 @@ spec:
                       description: Region specifies the Azure region where the cluster
                         will be created.
                       type: string
-                    resourceGroupName:
-                      description: ResourceGroupName specifies the name of the Azure
-                        resource group containing the custer. This must match the
-                        name of the Azure resource group specified in the InstallConfig.
-                        If the name of the Azure resource group is omitted from the
-                        InstallConfig, then it must be omitted here as well.
-                      type: string
                   required:
                   - credentialsSecretRef
                   - region

--- a/pkg/apis/hive/v1/azure/platform.go
+++ b/pkg/apis/hive/v1/azure/platform.go
@@ -18,12 +18,6 @@ type Platform struct {
 
 	// BaseDomainResourceGroupName specifies the resource group where the azure DNS zone for the base domain is found
 	BaseDomainResourceGroupName string `json:"baseDomainResourceGroupName,omitempty"`
-
-	// ResourceGroupName specifies the name of the Azure resource group containing the custer.
-	// This must match the name of the Azure resource group specified in the InstallConfig.
-	// If the name of the Azure resource group is omitted from the InstallConfig, then it must be
-	// omitted here as well.
-	ResourceGroupName string `json:"resourceGroupName,omitempty"`
 }
 
 //SetBaseDomain parses the baseDomainID and sets the related fields on azure.Platform

--- a/pkg/apis/hive/v1/clusterdeprovision_types.go
+++ b/pkg/apis/hive/v1/clusterdeprovision_types.go
@@ -57,10 +57,6 @@ type AWSClusterDeprovision struct {
 type AzureClusterDeprovision struct {
 	// CredentialsSecretRef is the Azure account credentials to use for deprovisioning the cluster
 	CredentialsSecretRef *corev1.LocalObjectReference `json:"credentialsSecretRef,omitempty"`
-	// ResourceGroupName is used to indicate that the cluster was installed into an already-existing
-	// Azure resource group (instead of having the installer create the resource group based on the
-	// cluster name). This will be used to indicate to the uninstall process where it should clean up.
-	ResourceGroupName string `json:"resourceGroupName,omitempty"`
 }
 
 // GCPClusterDeprovision contains GCP-specific configuration for a ClusterDeprovision

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -1811,7 +1811,6 @@ func generateDeprovision(cd *hivev1.ClusterDeployment) (*hivev1.ClusterDeprovisi
 	case cd.Spec.Platform.Azure != nil:
 		req.Spec.Platform.Azure = &hivev1.AzureClusterDeprovision{
 			CredentialsSecretRef: &cd.Spec.Platform.Azure.CredentialsSecretRef,
-			ResourceGroupName:    cd.Spec.Platform.Azure.ResourceGroupName,
 		}
 	case cd.Spec.Platform.GCP != nil:
 		req.Spec.Platform.GCP = &hivev1.GCPClusterDeprovision{

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller_test.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller_test.go
@@ -222,28 +222,6 @@ func TestClusterDeprovisionReconcile(t *testing.T) {
 				validateNoJobExists(t, c)
 			},
 		},
-		{
-			name: "create uninstall job with Azure resource group param",
-			deprovision: func() *hivev1.ClusterDeprovision {
-				deprov := testClusterDeprovision()
-				deprov.Spec.Platform.AWS = nil
-				deprov.Spec.Platform.Azure = &hivev1.AzureClusterDeprovision{
-					CredentialsSecretRef: &corev1.LocalObjectReference{
-						Name: "azure-creds",
-					},
-					ResourceGroupName: "manual-resourcegroup",
-				}
-				return deprov
-			}(),
-			deployment: testDeletedClusterDeployment(),
-			validate: func(t *testing.T, c client.Client) {
-				job := validateJobExists(t, c)
-				cliArgs := job.Spec.Template.Spec.Containers[0].Args
-
-				assert.Contains(t, cliArgs, "--resource-group", "expected the --resource-group param to be included in the deprovision")
-				assert.Contains(t, cliArgs, "manual-resourcegroup", "expected name of the Azure resource group to be included in the params")
-			},
-		},
 	}
 
 	for _, test := range tests {
@@ -366,7 +344,7 @@ func validateNoJobExists(t *testing.T, c client.Client) {
 	}
 }
 
-func validateJobExists(t *testing.T, c client.Client) *batchv1.Job {
+func validateJobExists(t *testing.T, c client.Client) {
 	job := &batchv1.Job{}
 	err := c.Get(context.TODO(), types.NamespacedName{Namespace: testNamespace, Name: testName + "-uninstall"}, job)
 	if err != nil {
@@ -376,8 +354,6 @@ func validateJobExists(t *testing.T, c client.Client) *batchv1.Job {
 	require.NotNil(t, job, "expected job")
 	assert.Equal(t, testClusterDeprovision().Name, job.Labels[constants.ClusterDeprovisionNameLabel], "incorrect cluster deprovision name label")
 	assert.Equal(t, constants.JobTypeDeprovision, job.Labels[constants.JobTypeLabel], "incorrect job type label")
-
-	return job
 }
 
 func validateNotCompleted(t *testing.T, c client.Client) {

--- a/pkg/controller/hibernation/azure_actuator.go
+++ b/pkg/controller/hibernation/azure_actuator.go
@@ -187,12 +187,8 @@ func azureMachinePowerState(vm compute.VirtualMachine) string {
 }
 
 func clusterDeploymentResourceGroup(cd *hivev1.ClusterDeployment) string {
-	// For the case where a specific resource group is specified (eg the cluster was installed
-	// into a pre-existing resource group), use it.
-	if cd.Spec.Platform.Azure != nil && cd.Spec.Platform.Azure.ResourceGroupName != "" {
-		return cd.Spec.Platform.Azure.ResourceGroupName
-	}
-
+	// TODO: Fix this to use explicit resource group name when we
+	// collect that from the installer.
 	if cd.Spec.ClusterMetadata == nil {
 		return ""
 	}

--- a/pkg/controller/hibernation/azure_actuator_test.go
+++ b/pkg/controller/hibernation/azure_actuator_test.go
@@ -27,12 +27,6 @@ const (
 	azureTestResourceGroup = "test-infra-id-rg"
 )
 
-type azureInstanceGroup struct {
-	state             string
-	count             int
-	resourceGroupName string
-}
-
 func TestAzureCanHandle(t *testing.T) {
 	cd := testcd.BasicBuilder().Options(func(cd *hivev1.ClusterDeployment) {
 		cd.Spec.Platform.Azure = &hivev1azure.Platform{}
@@ -46,140 +40,60 @@ func TestAzureCanHandle(t *testing.T) {
 
 func TestAzureStopAndStartMachines(t *testing.T) {
 	tests := []struct {
-		name              string
-		testFunc          string
-		instances         []azureInstanceGroup
-		setupClient       func(*testing.T, *mockazureclient.MockClient)
-		clusterDeployment *hivev1.ClusterDeployment
+		name        string
+		testFunc    string
+		instances   map[string]int
+		setupClient func(*testing.T, *mockazureclient.MockClient)
 	}{
 		{
-			name:     "stop no running instances",
-			testFunc: "StopMachines",
-			instances: []azureInstanceGroup{
-				newDefaultAzureInstanceGroup("deallocated", 2),
-				newDefaultAzureInstanceGroup("deallocating", 2),
-				newDefaultAzureInstanceGroup("stopped", 2),
-			},
+			name:      "stop no running instances",
+			testFunc:  "StopMachines",
+			instances: map[string]int{"deallocated": 2, "deallocating": 2, "stopped": 1},
 		},
 		{
-			name:     "stop running instances",
-			testFunc: "StopMachines",
-			instances: []azureInstanceGroup{
-				newDefaultAzureInstanceGroup("deallocated", 2),
-				newDefaultAzureInstanceGroup("running", 2),
-			},
+			name:      "stop running instances",
+			testFunc:  "StopMachines",
+			instances: map[string]int{"deallocated": 2, "running": 2},
 			setupClient: func(t *testing.T, c *mockazureclient.MockClient) {
-				setupAzureDeallocateCalls(c, []azureInstanceGroup{
-					newDefaultAzureInstanceGroup("running", 2),
-				})
+				setupAzureDeallocateCalls(c, map[string]int{"running": 2})
 			},
 		},
 		{
-			name:     "stop pending and running instances",
-			testFunc: "StopMachines",
-			instances: []azureInstanceGroup{
-				newDefaultAzureInstanceGroup("deallocating", 3),
-				newDefaultAzureInstanceGroup("deallocated", 4),
-				newDefaultAzureInstanceGroup("starting", 1),
-				newDefaultAzureInstanceGroup("running", 3),
-			},
+			name:      "stop pending and running instances",
+			testFunc:  "StopMachines",
+			instances: map[string]int{"deallocating": 3, "deallocated": 4, "starting": 1, "running": 3},
 			setupClient: func(t *testing.T, c *mockazureclient.MockClient) {
-				setupAzureDeallocateCalls(c, []azureInstanceGroup{
-					newDefaultAzureInstanceGroup("starting", 1),
-					newDefaultAzureInstanceGroup("running", 3),
-				})
+				setupAzureDeallocateCalls(c, map[string]int{"starting": 1, "running": 3})
 			},
 		},
 		{
-			name:     "start no stopped instances",
-			testFunc: "StartMachines",
-			instances: []azureInstanceGroup{
-				newDefaultAzureInstanceGroup("starting", 4),
-				newDefaultAzureInstanceGroup("running", 3),
-			},
+			name:      "start no stopped instances",
+			testFunc:  "StartMachines",
+			instances: map[string]int{"starting": 4, "running": 3},
 		},
 		{
-			name:     "start stopped instances",
-			testFunc: "StartMachines",
-			instances: []azureInstanceGroup{
-				newDefaultAzureInstanceGroup("deallocated", 3),
-				newDefaultAzureInstanceGroup("running", 3),
-			},
+			name:      "start stopped instances",
+			testFunc:  "StartMachines",
+			instances: map[string]int{"deallocated": 3, "running": 3},
 			setupClient: func(t *testing.T, c *mockazureclient.MockClient) {
-				setupAzureStartCalls(c, []azureInstanceGroup{
-					newDefaultAzureInstanceGroup("deallocated", 3),
-				})
+				setupAzureStartCalls(c, map[string]int{"deallocated": 3})
 			},
 		},
 		{
-			name:     "start stopped and stopping instances",
-			testFunc: "StartMachines",
-			instances: []azureInstanceGroup{
-				newDefaultAzureInstanceGroup("deallocated", 3),
-				newDefaultAzureInstanceGroup("deallocating", 1),
-				newDefaultAzureInstanceGroup("starting", 3),
-			},
+			name:      "start stopped and stopping instances",
+			testFunc:  "StartMachines",
+			instances: map[string]int{"deallocated": 3, "deallocating": 1, "starting": 3},
 			setupClient: func(t *testing.T, c *mockazureclient.MockClient) {
-				setupAzureStartCalls(c, []azureInstanceGroup{
-					newDefaultAzureInstanceGroup("deallocated", 3),
-					newDefaultAzureInstanceGroup("deallocating", 1),
-				})
+				setupAzureStartCalls(c, map[string]int{"deallocated": 3, "deallocating": 1})
 			},
-		},
-		{
-			name:     "use resource group name on start",
-			testFunc: "StartMachines",
-			instances: []azureInstanceGroup{
-				newAzureInstanceGroup("stopped", 3, "manual-resourcegroup"),
-			},
-			setupClient: func(t *testing.T, c *mockazureclient.MockClient) {
-				setupAzureStartCalls(c, []azureInstanceGroup{
-					newAzureInstanceGroup("stopped", 3, "manual-resourcegroup"),
-				})
-			},
-			clusterDeployment: func() *hivev1.ClusterDeployment {
-				cd := testAzureClusterDeployment()
-				cd.Spec.Platform.Azure = &hivev1azure.Platform{
-					ResourceGroupName: "manual-resourcegroup",
-				}
-				return cd
-			}(),
-		},
-		{
-			name:     "use resource group name on stop",
-			testFunc: "StopMachines",
-			instances: []azureInstanceGroup{
-				newAzureInstanceGroup("running", 3, "manual-resourcegroup"),
-			},
-			setupClient: func(t *testing.T, c *mockazureclient.MockClient) {
-				setupAzureDeallocateCalls(c, []azureInstanceGroup{
-					newAzureInstanceGroup("running", 3, "manual-resourcegroup"),
-				})
-			},
-			clusterDeployment: func() *hivev1.ClusterDeployment {
-				cd := testAzureClusterDeployment()
-				cd.Spec.Platform.Azure = &hivev1azure.Platform{
-					ResourceGroupName: "manual-resourcegroup",
-				}
-				return cd
-			}(),
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
 			azureClient := mockazureclient.NewMockClient(ctrl)
-
-			cd := testAzureClusterDeployment()
-			if test.clusterDeployment != nil {
-				cd = test.clusterDeployment
-			}
-
 			setupAzureClientInstances(azureClient, test.instances)
-
 			if test.setupClient != nil {
 				test.setupClient(t, azureClient)
 			}
@@ -187,9 +101,9 @@ func TestAzureStopAndStartMachines(t *testing.T) {
 			var err error
 			switch test.testFunc {
 			case "StopMachines":
-				err = actuator.StopMachines(cd, nil, log.New())
+				err = actuator.StopMachines(testAzureClusterDeployment(), nil, log.New())
 			case "StartMachines":
-				err = actuator.StartMachines(cd, nil, log.New())
+				err = actuator.StartMachines(testAzureClusterDeployment(), nil, log.New())
 			default:
 				t.Fatal("Invalid function to test")
 			}
@@ -200,139 +114,55 @@ func TestAzureStopAndStartMachines(t *testing.T) {
 
 func TestAzureMachinesStoppedAndRunning(t *testing.T) {
 	tests := []struct {
-		name              string
-		testFunc          string
-		expected          bool
-		instances         []azureInstanceGroup
-		instanceSetup     func(*mockazureclient.MockClient, []azureInstanceGroup)
-		setupClient       func(*testing.T, *mockazureclient.MockClient)
-		clusterDeployment *hivev1.ClusterDeployment
+		name        string
+		testFunc    string
+		expected    bool
+		instances   map[string]int
+		setupClient func(*testing.T, *mockazureclient.MockClient)
 	}{
 		{
-			name:     "Stopped - All machines stopped",
-			testFunc: "MachinesStopped",
-			expected: true,
-			instances: []azureInstanceGroup{
-				newDefaultAzureInstanceGroup("deallocated", 3),
-				newDefaultAzureInstanceGroup("stopped", 2),
-			},
+			name:      "Stopped - All machines stopped",
+			testFunc:  "MachinesStopped",
+			expected:  true,
+			instances: map[string]int{"deallocated": 3, "stopped": 2},
 		},
 		{
-			name:     "Stopped - Some machines starting",
-			testFunc: "MachinesStopped",
-			expected: false,
-			instances: []azureInstanceGroup{
-				newDefaultAzureInstanceGroup("deallocated", 3),
-				newDefaultAzureInstanceGroup("stopped", 2),
-				newDefaultAzureInstanceGroup("starting", 2),
-			},
+			name:      "Stopped - Some machines starting",
+			testFunc:  "MachinesStopped",
+			expected:  false,
+			instances: map[string]int{"deallocated": 3, "stopped": 2, "starting": 2},
 		},
 		{
-			name:     "Stopped - machines running",
-			testFunc: "MachinesStopped",
-			expected: false,
-			instances: []azureInstanceGroup{
-				newDefaultAzureInstanceGroup("running", 3),
-				newDefaultAzureInstanceGroup("deallocated", 2),
-			},
+			name:      "Stopped - machines running",
+			testFunc:  "MachinesStopped",
+			expected:  false,
+			instances: map[string]int{"running": 3, "deallocated": 2},
 		},
 		{
-			name:     "Running - All machines running",
-			testFunc: "MachinesRunning",
-			expected: true,
-			instances: []azureInstanceGroup{
-				newDefaultAzureInstanceGroup("running", 3),
-			},
+			name:      "Running - All machines running",
+			testFunc:  "MachinesRunning",
+			expected:  true,
+			instances: map[string]int{"running": 3},
 		},
 		{
-			name:     "Running - Some machines starting",
-			testFunc: "MachinesRunning",
-			expected: false,
-			instances: []azureInstanceGroup{
-				newDefaultAzureInstanceGroup("running", 3),
-				newDefaultAzureInstanceGroup("starting", 1),
-			},
+			name:      "Running - Some machines starting",
+			testFunc:  "MachinesRunning",
+			expected:  false,
+			instances: map[string]int{"running": 3, "starting": 1},
 		},
 		{
-			name:     "Running - Some machines deallocated or deallocating",
-			testFunc: "MachinesRunning",
-			expected: false,
-			instances: []azureInstanceGroup{
-				newDefaultAzureInstanceGroup("running", 3),
-				newDefaultAzureInstanceGroup("deallocated", 2),
-				newDefaultAzureInstanceGroup("stopped", 1),
-				newDefaultAzureInstanceGroup("deallocating", 3),
-			},
-		},
-		{
-			name:     "Stopped - mixed with other resource groups",
-			testFunc: "MachinesRunning",
-			expected: false,
-			instances: []azureInstanceGroup{
-				newDefaultAzureInstanceGroup("running", 3),
-				newAzureInstanceGroup("stopped", 4, "manual-resourcegroup"),
-			},
-			clusterDeployment: func() *hivev1.ClusterDeployment {
-				cd := testClusterDeployment()
-				cd.Spec.Platform.Azure = &hivev1azure.Platform{
-					ResourceGroupName: "manual-resourcegroup",
-				}
-				return cd
-			}(),
-		},
-		{
-			name:     "Half Running - mixed with other resource groups",
-			testFunc: "MachinesRunning",
-			expected: false,
-			instances: []azureInstanceGroup{
-				newDefaultAzureInstanceGroup("running", 3),
-				newAzureInstanceGroup("stopped", 4, "manual-resourcegroup"),
-				newAzureInstanceGroup("running", 3, "manual-resourcegroup"),
-			},
-			clusterDeployment: func() *hivev1.ClusterDeployment {
-				cd := testClusterDeployment()
-				cd.Spec.Platform.Azure = &hivev1azure.Platform{
-					ResourceGroupName: "manual-resourcegroup",
-				}
-				return cd
-			}(),
-		},
-		{
-			name:     "Fully Running - mixed with other resource groups",
-			testFunc: "MachinesRunning",
-			expected: true,
-			instances: []azureInstanceGroup{
-				newDefaultAzureInstanceGroup("running", 3),
-				newAzureInstanceGroup("running", 4, "manual-resourcegroup"),
-				newAzureInstanceGroup("stopped", 3, "other-resourcegroup"),
-			},
-			clusterDeployment: func() *hivev1.ClusterDeployment {
-				cd := testClusterDeployment()
-				cd.Spec.Platform.Azure = &hivev1azure.Platform{
-					ResourceGroupName: "manual-resourcegroup",
-				}
-				return cd
-			}(),
+			name:      "Running - Some machines deallocated or deallocating",
+			testFunc:  "MachinesRunning",
+			expected:  false,
+			instances: map[string]int{"running": 3, "deallocated": 2, "stopped": 1, "deallocating": 3},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
-			cd := testAzureClusterDeployment()
-			if test.clusterDeployment != nil {
-				cd = test.clusterDeployment
-			}
-
 			azureClient := mockazureclient.NewMockClient(ctrl)
-			if test.instanceSetup != nil {
-				test.instanceSetup(azureClient, test.instances)
-			} else {
-				setupAzureClientInstances(azureClient, test.instances)
-			}
-
+			setupAzureClientInstances(azureClient, test.instances)
 			if test.setupClient != nil {
 				test.setupClient(t, azureClient)
 			}
@@ -341,9 +171,9 @@ func TestAzureMachinesStoppedAndRunning(t *testing.T) {
 			var result bool
 			switch test.testFunc {
 			case "MachinesStopped":
-				result, err = actuator.MachinesStopped(cd, nil, log.New())
+				result, err = actuator.MachinesStopped(testAzureClusterDeployment(), nil, log.New())
 			case "MachinesRunning":
-				result, err = actuator.MachinesRunning(cd, nil, log.New())
+				result, err = actuator.MachinesRunning(testAzureClusterDeployment(), nil, log.New())
 			default:
 				t.Fatal("Invalid function to test")
 			}
@@ -371,21 +201,19 @@ func testAzureActuator(azureClient azureclient.Client) *azureActuator {
 	}
 }
 
-func setupAzureClientInstances(client *mockazureclient.MockClient, instances []azureInstanceGroup) {
+func setupAzureClientInstances(client *mockazureclient.MockClient, instances map[string]int) {
 	vms := []compute.VirtualMachine{}
-
-	for _, azInstance := range instances {
-		for i := 0; i < azInstance.count; i++ {
-			name := fmt.Sprintf("%s-%d", azInstance.state, i)
+	for state, count := range instances {
+		for i := 0; i < count; i++ {
+			name := fmt.Sprintf("%s-%d", state, i)
 			instanceViewStatus := []compute.InstanceViewStatus{
 				{
-					Code: pointer.StringPtr("PowerState/" + azInstance.state),
+					Code: pointer.StringPtr("PowerState/" + state),
 				},
 			}
-
 			vms = append(vms, compute.VirtualMachine{
 				Name: pointer.StringPtr(name),
-				ID:   pointer.StringPtr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s", azureTestSubscription, azInstance.resourceGroupName, name)),
+				ID:   pointer.StringPtr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s", azureTestSubscription, azureTestResourceGroup, name)),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					InstanceView: &compute.VirtualMachineInstanceView{
 						Statuses: &instanceViewStatus,
@@ -404,26 +232,18 @@ func setupAzureClientInstances(client *mockazureclient.MockClient, instances []a
 	client.EXPECT().ListAllVirtualMachines(gomock.Any(), "true").Times(1).Return(result, nil)
 }
 
-func setupAzureDeallocateCalls(client *mockazureclient.MockClient, instances []azureInstanceGroup) {
-	for _, azInstances := range instances {
-		for i := 0; i < azInstances.count; i++ {
-			client.EXPECT().DeallocateVirtualMachine(gomock.Any(), azInstances.resourceGroupName, fmt.Sprintf("%s-%d", azInstances.state, i)).Times(1)
+func setupAzureDeallocateCalls(client *mockazureclient.MockClient, instances map[string]int) {
+	for state, count := range instances {
+		for i := 0; i < count; i++ {
+			client.EXPECT().DeallocateVirtualMachine(gomock.Any(), azureTestResourceGroup, fmt.Sprintf("%s-%d", state, i)).Times(1)
 		}
 	}
 }
 
-func setupAzureStartCalls(client *mockazureclient.MockClient, instances []azureInstanceGroup) {
-	for _, azInstances := range instances {
-		for i := 0; i < azInstances.count; i++ {
-			client.EXPECT().StartVirtualMachine(gomock.Any(), azInstances.resourceGroupName, fmt.Sprintf("%s-%d", azInstances.state, i)).Times(1)
+func setupAzureStartCalls(client *mockazureclient.MockClient, instances map[string]int) {
+	for state, count := range instances {
+		for i := 0; i < count; i++ {
+			client.EXPECT().StartVirtualMachine(gomock.Any(), azureTestResourceGroup, fmt.Sprintf("%s-%d", state, i)).Times(1)
 		}
 	}
-}
-
-func newDefaultAzureInstanceGroup(state string, count int) azureInstanceGroup {
-	return newAzureInstanceGroup(state, count, azureTestResourceGroup)
-}
-
-func newAzureInstanceGroup(state string, count int, resourceGroupName string) azureInstanceGroup {
-	return azureInstanceGroup{state: state, count: count, resourceGroupName: resourceGroupName}
 }

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -586,10 +586,6 @@ func completeAzureDeprovisionJob(req *hivev1.ClusterDeprovision, job *batchv1.Jo
 			VolumeMounts: volumeMounts,
 		},
 	}
-	if req.Spec.Platform.Azure.ResourceGroupName != "" {
-		containers[0].Args = append(containers[0].Args, "--resource-group", req.Spec.Platform.Azure.ResourceGroupName)
-	}
-
 	job.Spec.Template.Spec.Containers = containers
 	job.Spec.Template.Spec.Volumes = volumes
 


### PR DESCRIPTION
This reverts commit 34d28c1d6e001687fae2d0fc3ac722fe173f0c8c, reversing
changes made to 54442c3959748609d63aeacdba010b86a97e7a5e.

The bring-your-own-resource-group introduces a behavior when we hit an error during installation that causes the pre-made resource group to be deleted (that's how the uninstall process works). So any future installation attempt will fail b/c that resource group no longer exists.

This behavior doesn't map to the kind of retry loops that are implemented in hive, so we will not be supporting this BYO-resource-group.