### PR TITLE
Add install failure details to provisioning underway metric

### DIFF
--- a/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -287,10 +287,6 @@ const (
 	// API URL override.
 	ActiveAPIURLOverrideCondition ClusterDeploymentConditionType = "ActiveAPIURLOverride"
 
-	// InstallFailingCondition indicates that a failure has been detected and we will attempt to offer some
-	// information as to why in the reason.
-	InstallFailingCondition ClusterDeploymentConditionType = "InstallFailing"
-
 	// DNSNotReadyCondition indicates that the the DNSZone object created for the clusterDeployment
 	// (ie manageDNS==true) has not yet indicated that the DNS zone is successfully responding to queries.
 	DNSNotReadyCondition ClusterDeploymentConditionType = "DNSNotReady"
@@ -324,7 +320,6 @@ var AllClusterDeploymentConditions = []ClusterDeploymentConditionType{
 	IngressCertificateNotFoundCondition,
 	UnreachableCondition,
 	ActiveAPIURLOverrideCondition,
-	InstallFailingCondition,
 	DNSNotReadyCondition,
 	ProvisionFailedCondition,
 	SyncSetFailedCondition,

--- a/pkg/controller/metrics/provision_underway_collector.go
+++ b/pkg/controller/metrics/provision_underway_collector.go
@@ -1,0 +1,96 @@
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+)
+
+var (
+	// ClusterDeployment conditions that could indicate provisioning problems with a cluster
+	provisioningDelayCondition = [...]hivev1.ClusterDeploymentConditionType{
+		hivev1.ProvisionFailedCondition,
+		hivev1.InstallLaunchErrorCondition,
+	}
+)
+
+// provisioning underway metrics collected through a custom prometheus collector
+type provisioningUnderwayCollector struct {
+	client client.Client
+
+	// metricClusterDeploymentProvisionUnderwaySeconds is a prometheus metric for the number of seconds
+	// between when a still provisioning cluster was created and now.
+	metricClusterDeploymentProvisionUnderwaySeconds *prometheus.Desc
+}
+
+// collects the metrics for provisioningUnderwayCollector
+func (cc provisioningUnderwayCollector) Collect(ch chan<- prometheus.Metric) {
+	ccLog := log.WithField("controller", "metrics")
+	ccLog.Info("calculating provisioning underway metrics across all ClusterDeployments")
+
+	// Load all ClusterDeployments so we can accumulate facts about them.
+	clusterDeployments := &hivev1.ClusterDeploymentList{}
+	err := cc.client.List(context.Background(), clusterDeployments)
+	if err != nil {
+		log.WithError(err).Error("error listing cluster deployments")
+		return
+	}
+	for _, cd := range clusterDeployments.Items {
+		if cd.DeletionTimestamp != nil {
+			continue
+		}
+		if cd.Spec.Installed {
+			continue
+		}
+
+		// Add install failure details for stuck provision
+		condition, reason := "Unknown", "Unknown"
+		for _, delayCondition := range provisioningDelayCondition {
+			if cdCondition := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions,
+				delayCondition); cdCondition != nil {
+				condition = string(delayCondition)
+				if cdCondition.Reason != "" {
+					reason = cdCondition.Reason
+				}
+				break
+			}
+		}
+
+		// For installing clusters we report the seconds since the cluster was created.
+		ch <- prometheus.MustNewConstMetric(
+			cc.metricClusterDeploymentProvisionUnderwaySeconds,
+			prometheus.GaugeValue,
+			time.Since(cd.CreationTimestamp.Time).Seconds(),
+			cd.Name,
+			cd.Namespace,
+			GetClusterDeploymentType(&cd),
+			condition,
+			reason,
+		)
+
+	}
+
+}
+
+func (cc provisioningUnderwayCollector) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(cc, ch)
+}
+
+func newProvisioningUnderwayCollector(client client.Client) prometheus.Collector {
+	return provisioningUnderwayCollector{
+		client: client,
+		metricClusterDeploymentProvisionUnderwaySeconds: prometheus.NewDesc(
+			"hive_cluster_deployment_provision_underway_seconds",
+			"Length of time a cluster has been provisioning.",
+			[]string{"cluster_deployment", "namespace", "cluster_type", "condition", "reason"},
+			nil,
+		),
+	}
+}


### PR DESCRIPTION
For a stuck provision, add the install failure details to the provision underway metric.

Relevant cluster deployment conditions are InstallFailing, ProvisionFailed and InstallLaunchError.
InstallFailing is not used anywhere currently and looks to be replaced by ProvisionFailed, hence it has been dropped.

/assign @dgoodwin 