### PR TITLE
Configurable Clusterpool Initial Machinesets

### DIFF
--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -52,12 +52,8 @@ spec:
         spec:
           description: ClusterPoolSpec defines the desired state of the ClusterPool.
           properties:
-            baseDomain:
-              description: BaseDomain is the base domain to use for all clusters created
-                in this pool.
-              type: string
-            controlPlaneMachinePool:
-              description: ControlPlaneMachineConfig allows defining a machinepool
+            ControlPlaneMachinePoolPlatform:
+              description: ControlPlaneMachinePoolPlatform allows defining a machinepool
                 declaration for control plane nodes
               properties:
                 aws:
@@ -311,6 +307,10 @@ spec:
                       type: object
                   type: object
               type: object
+            baseDomain:
+              description: BaseDomain is the base domain to use for all clusters created
+                in this pool.
+              type: string
             imageSetRef:
               description: ImageSetRef is a reference to a ClusterImageSet. The release
                 image specified in the ClusterImageSet will be used by clusters created
@@ -570,8 +570,8 @@ spec:
               minimum: 0
               type: integer
             workerMachinePool:
-              description: WorkerMachinePool allows defining a machinepool declaration
-                for new worker nodes
+              description: WorkerMachinePoolPlatform allows defining a machinepool
+                declaration for new worker nodes
               properties:
                 aws:
                   description: AWS is the configuration used when installing on AWS.

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -56,6 +56,261 @@ spec:
               description: BaseDomain is the base domain to use for all clusters created
                 in this pool.
               type: string
+            controlPlaneMachinePool:
+              description: ControlPlaneMachineConfig allows defining a machinepool
+                declaration for control plane nodes
+              properties:
+                aws:
+                  description: AWS is the configuration used when installing on AWS.
+                  properties:
+                    amiID:
+                      description: AMIID is the AMI that should be used to boot the
+                        ec2 instance. If set, the AMI should belong to the same region
+                        as the cluster.
+                      type: string
+                    rootVolume:
+                      description: EC2RootVolume defines the root volume for EC2 instances
+                        in the machine pool.
+                      properties:
+                        iops:
+                          description: IOPS defines the amount of provisioned IOPS.
+                            This is only valid for type io1.
+                          minimum: 0
+                          type: integer
+                        kmsKeyARN:
+                          description: The KMS key that will be used to encrypt the
+                            EBS volume. If no key is provided the default KMS key
+                            for the account will be used. https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetEbsDefaultKmsKeyId.html
+                          type: string
+                        size:
+                          description: Size defines the size of the volume in gibibytes
+                            (GiB).
+                          minimum: 0
+                          type: integer
+                        type:
+                          description: Type defines the type of the volume.
+                          type: string
+                      required:
+                      - size
+                      - type
+                      type: object
+                    type:
+                      description: InstanceType defines the ec2 instance type. eg.
+                        m4-large
+                      type: string
+                    zones:
+                      description: Zones is list of availability zones that can be
+                        used.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                azure:
+                  description: Azure is the configuration used when installing on
+                    Azure.
+                  properties:
+                    osDisk:
+                      description: OSDisk defines the storage for instance.
+                      properties:
+                        diskSizeGB:
+                          description: DiskSizeGB defines the size of disk in GB.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        diskType:
+                          description: DiskType defines the type of disk. The valid
+                            values are Standard_LRS, Premium_LRS, StandardSSD_LRS
+                            For control plane nodes, the valid values are Premium_LRS
+                            and StandardSSD_LRS. Default is Premium_LRS
+                          enum:
+                          - Standard_LRS
+                          - Premium_LRS
+                          - StandardSSD_LRS
+                          type: string
+                      required:
+                      - diskSizeGB
+                      type: object
+                    type:
+                      description: InstanceType defines the azure instance type. eg.
+                        Standard_DS_V2
+                      type: string
+                    zones:
+                      description: Zones is list of availability zones that can be
+                        used. eg. ["1", "2", "3"]
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                baremetal:
+                  description: BareMetal is the configuration used when installing
+                    on bare metal.
+                  type: object
+                gcp:
+                  description: GCP is the configuration used when installing on GCP
+                  properties:
+                    osDisk:
+                      description: OSDisk defines the storage for instance.
+                      properties:
+                        DiskSizeGB:
+                          description: DiskSizeGB defines the size of disk in GB.
+                          format: int64
+                          maximum: 65536
+                          minimum: 16
+                          type: integer
+                        DiskType:
+                          description: DiskType defines the type of disk. The valid
+                            values are pd-standard and pd-ssd For control plane nodes,
+                            the valid value is pd-ssd.
+                          enum:
+                          - pd-ssd
+                          - pd-standard
+                          type: string
+                      required:
+                      - DiskSizeGB
+                      type: object
+                    type:
+                      description: InstanceType defines the GCP instance type. eg.
+                        n1-standard-4
+                      type: string
+                    zones:
+                      description: Zones is list of availability zones that can be
+                        used.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                libvirt:
+                  description: Libvirt is the configuration used when installing on
+                    libvirt.
+                  type: object
+                openstack:
+                  description: OpenStack is the configuration used when installing
+                    on OpenStack.
+                  properties:
+                    additionalNetworkIDs:
+                      description: AdditionalNetworkIDs contains IDs of additional
+                        networks for machines, where each ID is presented in UUID
+                        v4 format. Allowed address pairs won't be created for the
+                        additional networks.
+                      items:
+                        type: string
+                      type: array
+                    additionalSecurityGroupIDs:
+                      description: AdditionalSecurityGroupIDs contains IDs of additional
+                        security groups for machines, where each ID is presented in
+                        UUID v4 format.
+                      items:
+                        type: string
+                      type: array
+                    rootVolume:
+                      description: RootVolume defines the root volume for instances
+                        in the machine pool. The instances use ephemeral disks if
+                        not set.
+                      properties:
+                        size:
+                          description: Size defines the size of the volume in gibibytes
+                            (GiB). Required
+                          type: integer
+                        type:
+                          description: Type defines the type of the volume. Required
+                          type: string
+                      required:
+                      - size
+                      - type
+                      type: object
+                    type:
+                      description: FlavorName defines the OpenStack Nova flavor. eg.
+                        m1.large
+                      type: string
+                    zones:
+                      description: Zones is the list of availability zones where the
+                        instances should be deployed. If no zones are provided, all
+                        instances will be deployed on OpenStack Nova default availability
+                        zone
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - type
+                  type: object
+                ovirt:
+                  description: Ovirt is the configuration used when installing on
+                    oVirt.
+                  properties:
+                    cpu:
+                      description: CPU defines the VM CPU.
+                      properties:
+                        cores:
+                          description: Cores is the number of cores per socket. Total
+                            CPUs is (Sockets * Cores)
+                          format: int32
+                          type: integer
+                        sockets:
+                          description: Sockets is the number of sockets for a VM.
+                            Total CPUs is (Sockets * Cores)
+                          format: int32
+                          type: integer
+                      required:
+                      - cores
+                      - sockets
+                      type: object
+                    instanceTypeID:
+                      description: InstanceTypeID defines the VM instance type and
+                        overrides the hardware parameters of the created VM, including
+                        cpu and memory. If InstanceTypeID is passed, all memory and
+                        cpu variables will be ignored.
+                      type: string
+                    memoryMB:
+                      description: MemoryMB is the size of a VM's memory in MiBs.
+                      format: int32
+                      type: integer
+                    osDisk:
+                      description: OSDisk is the the root disk of the node.
+                      properties:
+                        sizeGB:
+                          description: SizeGB size of the bootable disk in GiB.
+                          format: int64
+                          type: integer
+                      required:
+                      - sizeGB
+                      type: object
+                    vmType:
+                      description: VMType defines the workload type of the VM.
+                      enum:
+                      - ""
+                      - desktop
+                      - server
+                      - high_performance
+                      type: string
+                  type: object
+                vsphere:
+                  description: VSphere is the configuration used when installing on
+                    vSphere.
+                  properties:
+                    coresPerSocket:
+                      description: NumCoresPerSocket is the number of cores per socket
+                        in a vm. The number of vCPUs on the vm will be NumCPUs/NumCoresPerSocket.
+                      format: int32
+                      type: integer
+                    cpus:
+                      description: NumCPUs is the total number of virtual processor
+                        cores to assign a vm.
+                      format: int32
+                      type: integer
+                    memoryMB:
+                      description: Memory is the size of a VM's memory in MB.
+                      format: int64
+                      type: integer
+                    osDisk:
+                      description: OSDisk defines the storage for instance.
+                      properties:
+                        diskSizeGB:
+                          description: DiskSizeGB defines the size of disk in GB.
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
+              type: object
             imageSetRef:
               description: ImageSetRef is a reference to a ClusterImageSet. The release
                 image specified in the ClusterImageSet will be used by clusters created
@@ -314,6 +569,261 @@ spec:
               format: int32
               minimum: 0
               type: integer
+            workerMachinePool:
+              description: WorkerMachinePool allows defining a machinepool declaration
+                for new worker nodes
+              properties:
+                aws:
+                  description: AWS is the configuration used when installing on AWS.
+                  properties:
+                    amiID:
+                      description: AMIID is the AMI that should be used to boot the
+                        ec2 instance. If set, the AMI should belong to the same region
+                        as the cluster.
+                      type: string
+                    rootVolume:
+                      description: EC2RootVolume defines the root volume for EC2 instances
+                        in the machine pool.
+                      properties:
+                        iops:
+                          description: IOPS defines the amount of provisioned IOPS.
+                            This is only valid for type io1.
+                          minimum: 0
+                          type: integer
+                        kmsKeyARN:
+                          description: The KMS key that will be used to encrypt the
+                            EBS volume. If no key is provided the default KMS key
+                            for the account will be used. https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetEbsDefaultKmsKeyId.html
+                          type: string
+                        size:
+                          description: Size defines the size of the volume in gibibytes
+                            (GiB).
+                          minimum: 0
+                          type: integer
+                        type:
+                          description: Type defines the type of the volume.
+                          type: string
+                      required:
+                      - size
+                      - type
+                      type: object
+                    type:
+                      description: InstanceType defines the ec2 instance type. eg.
+                        m4-large
+                      type: string
+                    zones:
+                      description: Zones is list of availability zones that can be
+                        used.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                azure:
+                  description: Azure is the configuration used when installing on
+                    Azure.
+                  properties:
+                    osDisk:
+                      description: OSDisk defines the storage for instance.
+                      properties:
+                        diskSizeGB:
+                          description: DiskSizeGB defines the size of disk in GB.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        diskType:
+                          description: DiskType defines the type of disk. The valid
+                            values are Standard_LRS, Premium_LRS, StandardSSD_LRS
+                            For control plane nodes, the valid values are Premium_LRS
+                            and StandardSSD_LRS. Default is Premium_LRS
+                          enum:
+                          - Standard_LRS
+                          - Premium_LRS
+                          - StandardSSD_LRS
+                          type: string
+                      required:
+                      - diskSizeGB
+                      type: object
+                    type:
+                      description: InstanceType defines the azure instance type. eg.
+                        Standard_DS_V2
+                      type: string
+                    zones:
+                      description: Zones is list of availability zones that can be
+                        used. eg. ["1", "2", "3"]
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                baremetal:
+                  description: BareMetal is the configuration used when installing
+                    on bare metal.
+                  type: object
+                gcp:
+                  description: GCP is the configuration used when installing on GCP
+                  properties:
+                    osDisk:
+                      description: OSDisk defines the storage for instance.
+                      properties:
+                        DiskSizeGB:
+                          description: DiskSizeGB defines the size of disk in GB.
+                          format: int64
+                          maximum: 65536
+                          minimum: 16
+                          type: integer
+                        DiskType:
+                          description: DiskType defines the type of disk. The valid
+                            values are pd-standard and pd-ssd For control plane nodes,
+                            the valid value is pd-ssd.
+                          enum:
+                          - pd-ssd
+                          - pd-standard
+                          type: string
+                      required:
+                      - DiskSizeGB
+                      type: object
+                    type:
+                      description: InstanceType defines the GCP instance type. eg.
+                        n1-standard-4
+                      type: string
+                    zones:
+                      description: Zones is list of availability zones that can be
+                        used.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                libvirt:
+                  description: Libvirt is the configuration used when installing on
+                    libvirt.
+                  type: object
+                openstack:
+                  description: OpenStack is the configuration used when installing
+                    on OpenStack.
+                  properties:
+                    additionalNetworkIDs:
+                      description: AdditionalNetworkIDs contains IDs of additional
+                        networks for machines, where each ID is presented in UUID
+                        v4 format. Allowed address pairs won't be created for the
+                        additional networks.
+                      items:
+                        type: string
+                      type: array
+                    additionalSecurityGroupIDs:
+                      description: AdditionalSecurityGroupIDs contains IDs of additional
+                        security groups for machines, where each ID is presented in
+                        UUID v4 format.
+                      items:
+                        type: string
+                      type: array
+                    rootVolume:
+                      description: RootVolume defines the root volume for instances
+                        in the machine pool. The instances use ephemeral disks if
+                        not set.
+                      properties:
+                        size:
+                          description: Size defines the size of the volume in gibibytes
+                            (GiB). Required
+                          type: integer
+                        type:
+                          description: Type defines the type of the volume. Required
+                          type: string
+                      required:
+                      - size
+                      - type
+                      type: object
+                    type:
+                      description: FlavorName defines the OpenStack Nova flavor. eg.
+                        m1.large
+                      type: string
+                    zones:
+                      description: Zones is the list of availability zones where the
+                        instances should be deployed. If no zones are provided, all
+                        instances will be deployed on OpenStack Nova default availability
+                        zone
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - type
+                  type: object
+                ovirt:
+                  description: Ovirt is the configuration used when installing on
+                    oVirt.
+                  properties:
+                    cpu:
+                      description: CPU defines the VM CPU.
+                      properties:
+                        cores:
+                          description: Cores is the number of cores per socket. Total
+                            CPUs is (Sockets * Cores)
+                          format: int32
+                          type: integer
+                        sockets:
+                          description: Sockets is the number of sockets for a VM.
+                            Total CPUs is (Sockets * Cores)
+                          format: int32
+                          type: integer
+                      required:
+                      - cores
+                      - sockets
+                      type: object
+                    instanceTypeID:
+                      description: InstanceTypeID defines the VM instance type and
+                        overrides the hardware parameters of the created VM, including
+                        cpu and memory. If InstanceTypeID is passed, all memory and
+                        cpu variables will be ignored.
+                      type: string
+                    memoryMB:
+                      description: MemoryMB is the size of a VM's memory in MiBs.
+                      format: int32
+                      type: integer
+                    osDisk:
+                      description: OSDisk is the the root disk of the node.
+                      properties:
+                        sizeGB:
+                          description: SizeGB size of the bootable disk in GiB.
+                          format: int64
+                          type: integer
+                      required:
+                      - sizeGB
+                      type: object
+                    vmType:
+                      description: VMType defines the workload type of the VM.
+                      enum:
+                      - ""
+                      - desktop
+                      - server
+                      - high_performance
+                      type: string
+                  type: object
+                vsphere:
+                  description: VSphere is the configuration used when installing on
+                    vSphere.
+                  properties:
+                    coresPerSocket:
+                      description: NumCoresPerSocket is the number of cores per socket
+                        in a vm. The number of vCPUs on the vm will be NumCPUs/NumCoresPerSocket.
+                      format: int32
+                      type: integer
+                    cpus:
+                      description: NumCPUs is the total number of virtual processor
+                        cores to assign a vm.
+                      format: int32
+                      type: integer
+                    memoryMB:
+                      description: Memory is the size of a VM's memory in MB.
+                      format: int64
+                      type: integer
+                    osDisk:
+                      description: OSDisk defines the storage for instance.
+                      properties:
+                        diskSizeGB:
+                          description: DiskSizeGB defines the size of disk in GB.
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
+              type: object
           required:
           - baseDomain
           - imageSetRef

--- a/pkg/apis/hive/v1/clusterpool_types.go
+++ b/pkg/apis/hive/v1/clusterpool_types.go
@@ -37,11 +37,11 @@ type ClusterPoolSpec struct {
 
 	// WorkerMachinePoolPlatform allows defining a machinepool declaration for new worker nodes
 	// +optional
-	WorkerMachinePoolPlatform installertypes.MachinePoolPlatform `json:"workerMachinePool,omitempty"`
+	WorkerMachinePoolPlatform *installertypes.MachinePoolPlatform `json:"workerMachinePool,omitempty"`
 
 	// ControlPlaneMachinePoolPlatform allows defining a machinepool declaration for control plane nodes
 	// +optional
-	ControlPlaneMachinePoolPlatform installertypes.MachinePoolPlatform `json:"ControlPlaneMachinePoolPlatform,omitempty"`
+	ControlPlaneMachinePoolPlatform *installertypes.MachinePoolPlatform `json:"ControlPlaneMachinePoolPlatform,omitempty"`
 }
 
 // ClusterPoolStatus defines the observed state of ClusterPool

--- a/pkg/apis/hive/v1/clusterpool_types.go
+++ b/pkg/apis/hive/v1/clusterpool_types.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	installertypes "github.com/openshift/installer/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -33,6 +34,14 @@ type ClusterPoolSpec struct {
 	// claimed will not be affected when this value is modified.
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
+
+	// WorkerMachinePool allows defining a machinepool declaration for new worker nodes
+	// +optional
+	WorkerMachinePool installertypes.MachinePoolPlatform `json:"workerMachinePool,omitempty"`
+
+	// ControlPlaneMachineConfig allows defining a machinepool declaration for control plane nodes
+	// +optional
+	ControlPlaneMachinePool installertypes.MachinePoolPlatform `json:"controlPlaneMachinePool,omitempty"`
 }
 
 // ClusterPoolStatus defines the observed state of ClusterPool

--- a/pkg/apis/hive/v1/clusterpool_types.go
+++ b/pkg/apis/hive/v1/clusterpool_types.go
@@ -35,13 +35,13 @@ type ClusterPoolSpec struct {
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 
-	// WorkerMachinePool allows defining a machinepool declaration for new worker nodes
+	// WorkerMachinePoolPlatform allows defining a machinepool declaration for new worker nodes
 	// +optional
-	WorkerMachinePool installertypes.MachinePoolPlatform `json:"workerMachinePool,omitempty"`
+	WorkerMachinePoolPlatform installertypes.MachinePoolPlatform `json:"workerMachinePool,omitempty"`
 
-	// ControlPlaneMachineConfig allows defining a machinepool declaration for control plane nodes
+	// ControlPlaneMachinePoolPlatform allows defining a machinepool declaration for control plane nodes
 	// +optional
-	ControlPlaneMachinePool installertypes.MachinePoolPlatform `json:"controlPlaneMachinePool,omitempty"`
+	ControlPlaneMachinePoolPlatform installertypes.MachinePoolPlatform `json:"ControlPlaneMachinePoolPlatform,omitempty"`
 }
 
 // ClusterPoolStatus defines the observed state of ClusterPool

--- a/pkg/clusterresource/aws.go
+++ b/pkg/clusterresource/aws.go
@@ -109,14 +109,14 @@ func (p *AWSCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installertype
 	}
 
 	// Use supplied machinepool configuration if possible
-	if (o.ControlPlaneMachinePool != installertypes.MachinePoolPlatform{}) {
-		ic.ControlPlane.Platform.AWS = o.ControlPlaneMachinePool.AWS
+	if (o.ControlPlaneMachinePoolPlatform != installertypes.MachinePoolPlatform{}) {
+		ic.ControlPlane.Platform.AWS = o.ControlPlaneMachinePoolPlatform.AWS
 	} else {
 		ic.ControlPlane.Platform.AWS = mpp
 	}
 
-	if (o.WorkerMachinePool != installertypes.MachinePoolPlatform{}) {
-		ic.Compute[0].Platform.AWS = o.WorkerMachinePool.AWS
+	if (o.WorkerMachinePoolPlatform != installertypes.MachinePoolPlatform{}) {
+		ic.Compute[0].Platform.AWS = o.WorkerMachinePoolPlatform.AWS
 	} else {
 		ic.Compute[0].Platform.AWS = mpp
 	}

--- a/pkg/clusterresource/aws.go
+++ b/pkg/clusterresource/aws.go
@@ -109,13 +109,13 @@ func (p *AWSCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installertype
 	}
 
 	// Use supplied machinepool configuration if possible
-	if (o.ControlPlaneMachinePoolPlatform != installertypes.MachinePoolPlatform{}) {
+	if (o.ControlPlaneMachinePoolPlatform != nil) {
 		ic.ControlPlane.Platform.AWS = o.ControlPlaneMachinePoolPlatform.AWS
 	} else {
 		ic.ControlPlane.Platform.AWS = mpp
 	}
 
-	if (o.WorkerMachinePoolPlatform != installertypes.MachinePoolPlatform{}) {
+	if (o.WorkerMachinePoolPlatform != nil) {
 		ic.Compute[0].Platform.AWS = o.WorkerMachinePoolPlatform.AWS
 	} else {
 		ic.Compute[0].Platform.AWS = mpp

--- a/pkg/clusterresource/aws.go
+++ b/pkg/clusterresource/aws.go
@@ -98,7 +98,7 @@ func (p *AWSCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installertype
 		},
 	}
 
-	// Used for both control plane and workers.
+	// Default configuration
 	mpp := &awsinstallertypes.MachinePool{
 		InstanceType: awsInstanceType,
 		EC2RootVolume: awsinstallertypes.EC2RootVolume{
@@ -107,9 +107,19 @@ func (p *AWSCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installertype
 			Type: volumeType,
 		},
 	}
-	ic.ControlPlane.Platform.AWS = mpp
-	ic.Compute[0].Platform.AWS = mpp
 
+	// Use supplied machinepool configuration if possible
+	if (o.ControlPlaneMachinePool != installertypes.MachinePoolPlatform{}) {
+		ic.ControlPlane.Platform.AWS = o.ControlPlaneMachinePool.AWS
+	} else {
+		ic.ControlPlane.Platform.AWS = mpp
+	}
+
+	if (o.WorkerMachinePool != installertypes.MachinePoolPlatform{}) {
+		ic.Compute[0].Platform.AWS = o.WorkerMachinePool.AWS
+	} else {
+		ic.Compute[0].Platform.AWS = mpp
+	}
 }
 
 func (p *AWSCloudBuilder) CredsSecretName(o *Builder) string {

--- a/pkg/clusterresource/azure.go
+++ b/pkg/clusterresource/azure.go
@@ -96,13 +96,13 @@ func (p *AzureCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installerty
 	mpp := &azureinstallertypes.MachinePool{}
 
 	// Use supplied machinepool configuration if possible
-	if (o.ControlPlaneMachinePoolPlatform != installertypes.MachinePoolPlatform{}) {
+	if (o.ControlPlaneMachinePoolPlatform != nil) {
 		ic.ControlPlane.Platform.Azure = o.ControlPlaneMachinePoolPlatform.Azure
 	} else {
 		ic.ControlPlane.Platform.Azure = mpp
 	}
 
-	if (o.WorkerMachinePoolPlatform != installertypes.MachinePoolPlatform{}) {
+	if (o.WorkerMachinePoolPlatform != nil) {
 		ic.Compute[0].Platform.Azure = o.WorkerMachinePoolPlatform.Azure
 	} else {
 		ic.Compute[0].Platform.Azure = mpp

--- a/pkg/clusterresource/azure.go
+++ b/pkg/clusterresource/azure.go
@@ -96,14 +96,14 @@ func (p *AzureCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installerty
 	mpp := &azureinstallertypes.MachinePool{}
 
 	// Use supplied machinepool configuration if possible
-	if (o.ControlPlaneMachinePool != installertypes.MachinePoolPlatform{}) {
-		ic.ControlPlane.Platform.Azure = o.ControlPlaneMachinePool.Azure
+	if (o.ControlPlaneMachinePoolPlatform != installertypes.MachinePoolPlatform{}) {
+		ic.ControlPlane.Platform.Azure = o.ControlPlaneMachinePoolPlatform.Azure
 	} else {
 		ic.ControlPlane.Platform.Azure = mpp
 	}
 
-	if (o.WorkerMachinePool != installertypes.MachinePoolPlatform{}) {
-		ic.Compute[0].Platform.Azure = o.WorkerMachinePool.Azure
+	if (o.WorkerMachinePoolPlatform != installertypes.MachinePoolPlatform{}) {
+		ic.Compute[0].Platform.Azure = o.WorkerMachinePoolPlatform.Azure
 	} else {
 		ic.Compute[0].Platform.Azure = mpp
 	}

--- a/pkg/clusterresource/azure.go
+++ b/pkg/clusterresource/azure.go
@@ -92,10 +92,22 @@ func (p *AzureCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installerty
 		},
 	}
 
-	// Used for both control plane and workers.
+	// Default configuration
 	mpp := &azureinstallertypes.MachinePool{}
-	ic.ControlPlane.Platform.Azure = mpp
-	ic.Compute[0].Platform.Azure = mpp
+
+	// Use supplied machinepool configuration if possible
+	if (o.ControlPlaneMachinePool != installertypes.MachinePoolPlatform{}) {
+		ic.ControlPlane.Platform.Azure = o.ControlPlaneMachinePool.Azure
+	} else {
+		ic.ControlPlane.Platform.Azure = mpp
+	}
+
+	if (o.WorkerMachinePool != installertypes.MachinePoolPlatform{}) {
+		ic.Compute[0].Platform.Azure = o.WorkerMachinePool.Azure
+	} else {
+		ic.Compute[0].Platform.Azure = mpp
+	}
+
 }
 
 func (p *AzureCloudBuilder) CredsSecretName(o *Builder) string {

--- a/pkg/clusterresource/builder.go
+++ b/pkg/clusterresource/builder.go
@@ -120,10 +120,10 @@ type Builder struct {
 	AdditionalTrustBundle string
 
 	// Allows passing in specifications for the machinepool that is created for the workers
-	WorkerMachinePoolPlatform installertypes.MachinePoolPlatform
+	WorkerMachinePoolPlatform *installertypes.MachinePoolPlatform
 
 	// Allows passing in specifications for the machinepool that is created for the control plane
-	ControlPlaneMachinePoolPlatform installertypes.MachinePoolPlatform
+	ControlPlaneMachinePoolPlatform *installertypes.MachinePoolPlatform
 }
 
 // Validate ensures that the builder's fields are logically configured and usable to generate the cluster resources.

--- a/pkg/clusterresource/builder.go
+++ b/pkg/clusterresource/builder.go
@@ -120,10 +120,10 @@ type Builder struct {
 	AdditionalTrustBundle string
 
 	// Allows passing in specifications for the machinepool that is created for the workers
-	WorkerMachinePool installertypes.MachinePoolPlatform
+	WorkerMachinePoolPlatform installertypes.MachinePoolPlatform
 
 	// Allows passing in specifications for the machinepool that is created for the control plane
-	ControlPlaneMachinePool installertypes.MachinePoolPlatform
+	ControlPlaneMachinePoolPlatform installertypes.MachinePoolPlatform
 }
 
 // Validate ensures that the builder's fields are logically configured and usable to generate the cluster resources.

--- a/pkg/clusterresource/builder.go
+++ b/pkg/clusterresource/builder.go
@@ -118,6 +118,12 @@ type Builder struct {
 	// AdditionalTrustBundle is a PEM-encoded X.509 certificate bundle
 	// that will be added to the nodes' trusted certificate store.
 	AdditionalTrustBundle string
+
+	// Allows passing in specifications for the machinepool that is created for the workers
+	WorkerMachinePool installertypes.MachinePoolPlatform
+
+	// Allows passing in specifications for the machinepool that is created for the control plane
+	ControlPlaneMachinePool installertypes.MachinePoolPlatform
 }
 
 // Validate ensures that the builder's fields are logically configured and usable to generate the cluster resources.
@@ -371,6 +377,7 @@ func (o *Builder) generateInstallConfigSecret() (*corev1.Secret, error) {
 }
 
 func (o *Builder) generateMachinePool() *hivev1.MachinePool {
+	// HK TODO Handle machinepool input
 	mp := &hivev1.MachinePool{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "MachinePool",

--- a/pkg/clusterresource/gcp.go
+++ b/pkg/clusterresource/gcp.go
@@ -93,12 +93,23 @@ func (p *GCPCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installertype
 		},
 	}
 
-	// Used for both control plane and workers.
+	// Default configuration
 	mpp := &installergcp.MachinePool{
 		InstanceType: gcpInstanceType,
 	}
-	ic.ControlPlane.Platform.GCP = mpp
-	ic.Compute[0].Platform.GCP = mpp
+
+	// Use supplied machinepool configuration if possible
+	if (o.ControlPlaneMachinePool != installertypes.MachinePoolPlatform{}) {
+		ic.ControlPlane.Platform.GCP = o.ControlPlaneMachinePool.GCP
+	} else {
+		ic.ControlPlane.Platform.GCP = mpp
+	}
+
+	if (o.WorkerMachinePool != installertypes.MachinePoolPlatform{}) {
+		ic.Compute[0].Platform.GCP = o.WorkerMachinePool.GCP
+	} else {
+		ic.Compute[0].Platform.GCP = mpp
+	}
 }
 
 func (p *GCPCloudBuilder) CredsSecretName(o *Builder) string {

--- a/pkg/clusterresource/gcp.go
+++ b/pkg/clusterresource/gcp.go
@@ -99,14 +99,14 @@ func (p *GCPCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installertype
 	}
 
 	// Use supplied machinepool configuration if possible
-	if (o.ControlPlaneMachinePool != installertypes.MachinePoolPlatform{}) {
-		ic.ControlPlane.Platform.GCP = o.ControlPlaneMachinePool.GCP
+	if (o.ControlPlaneMachinePoolPlatform != installertypes.MachinePoolPlatform{}) {
+		ic.ControlPlane.Platform.GCP = o.ControlPlaneMachinePoolPlatform.GCP
 	} else {
 		ic.ControlPlane.Platform.GCP = mpp
 	}
 
-	if (o.WorkerMachinePool != installertypes.MachinePoolPlatform{}) {
-		ic.Compute[0].Platform.GCP = o.WorkerMachinePool.GCP
+	if (o.WorkerMachinePoolPlatform != installertypes.MachinePoolPlatform{}) {
+		ic.Compute[0].Platform.GCP = o.WorkerMachinePoolPlatform.GCP
 	} else {
 		ic.Compute[0].Platform.GCP = mpp
 	}

--- a/pkg/clusterresource/gcp.go
+++ b/pkg/clusterresource/gcp.go
@@ -99,13 +99,13 @@ func (p *GCPCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installertype
 	}
 
 	// Use supplied machinepool configuration if possible
-	if (o.ControlPlaneMachinePoolPlatform != installertypes.MachinePoolPlatform{}) {
+	if (o.ControlPlaneMachinePoolPlatform != nil) {
 		ic.ControlPlane.Platform.GCP = o.ControlPlaneMachinePoolPlatform.GCP
 	} else {
 		ic.ControlPlane.Platform.GCP = mpp
 	}
 
-	if (o.WorkerMachinePoolPlatform != installertypes.MachinePoolPlatform{}) {
+	if (o.WorkerMachinePoolPlatform != nil) {
 		ic.Compute[0].Platform.GCP = o.WorkerMachinePoolPlatform.GCP
 	} else {
 		ic.Compute[0].Platform.GCP = mpp

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -298,15 +298,17 @@ func (r *ReconcileClusterPool) createCluster(
 
 	// We will use this unique random namespace name for our cluster name.
 	builder := &clusterresource.Builder{
-		Name:             ns.Name,
-		Namespace:        ns.Name,
-		BaseDomain:       clp.Spec.BaseDomain,
-		ImageSet:         clp.Spec.ImageSetRef.Name,
-		WorkerNodesCount: int64(3),
-		MachineNetwork:   "10.0.0.0/16",
-		PullSecret:       pullSecret,
-		CloudBuilder:     cloudBuilder,
-		Labels:           clp.Spec.Labels,
+		Name:                    ns.Name,
+		Namespace:               ns.Name,
+		BaseDomain:              clp.Spec.BaseDomain,
+		ImageSet:                clp.Spec.ImageSetRef.Name,
+		WorkerNodesCount:        int64(3),
+		MachineNetwork:          "10.0.0.0/16",
+		PullSecret:              pullSecret,
+		CloudBuilder:            cloudBuilder,
+		Labels:                  clp.Spec.Labels,
+		ControlPlaneMachinePool: clp.Spec.ControlPlaneMachinePool,
+		WorkerMachinePool:       clp.Spec.WorkerMachinePool,
 	}
 
 	objs, err := builder.Build()

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -307,8 +307,8 @@ func (r *ReconcileClusterPool) createCluster(
 		PullSecret:              pullSecret,
 		CloudBuilder:            cloudBuilder,
 		Labels:                  clp.Spec.Labels,
-		ControlPlaneMachinePool: clp.Spec.ControlPlaneMachinePool,
-		WorkerMachinePool:       clp.Spec.WorkerMachinePool,
+		ControlPlaneMachinePoolPlatform: clp.Spec.ControlPlaneMachinePoolPlatform,
+		WorkerMachinePoolPlatform:       clp.Spec.WorkerMachinePoolPlatform,
 	}
 
 	objs, err := builder.Build()


### PR DESCRIPTION
This is a proposal to allow customizing the controlplane and worker machines in a clusterpools `install-config.yaml`, addressing #1178 

It allows this through defining an optional `spec.controlPlaneMachinePool` and/or `spec.workerMachinePool` which will override the default values in the 

Example:
```yaml
kind: ClusterPool
metadata:
  name: hktest
  namespace: hive
spec:
  controlPlaneMachinePool:
    aws:
      type: m5.xlarge
      rootVolume:
        size: 128
        iops: 200
        type: gp2
  workerMachinePool:
    aws:
      type: m5.xlarge
      rootVolume:
        size: 128
        iops: 200
        type: gp2
  platform:
    aws:
      credentialsSecretRef:
        name: global-aws-creds
      region: eu-west-1
```

Initially support only added to AWS, Azure and GCP.

Hacked together with little hands-on experience with Go. Expecting things to be missing and sub-optimal, but it does compile and produce the desired result.