### PR TITLE
Multiple changes to improve insight into clustersync performance.

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -293,6 +293,10 @@ const (
 
 	// InstallLogsAWSS3BucketEnvVar is the environment variable specifying the S3 bucket to use.
 	InstallLogsAWSS3BucketEnvVar = "HIVE_INSTALL_LOGS_AWS_S3_BUCKET"
+
+	// ReconcileIDLen is the length of the random strings we generate for contextual loggers in controller
+	// Reconcile functions.
+	ReconcileIDLen = 8
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/pkg/controller/clusterclaim/clusterclaim_controller.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller.go
@@ -159,13 +159,10 @@ type ReconcileClusterClaim struct {
 
 // Reconcile reconciles a ClusterClaim.
 func (r *ReconcileClusterClaim) Reconcile(request reconcile.Request) (result reconcile.Result, returnErr error) {
-	start := time.Now()
-	logger := r.logger.WithField("clusterClaim", request.NamespacedName)
-
+	logger := controllerutils.BuildControllerLogger(ControllerName, "clusterClaim", request.NamespacedName)
 	logger.Infof("reconciling cluster claim")
-	defer func() {
-		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, logger)
-	}()
+	recobsrv := hivemetrics.NewReconcileObserver(ControllerName, logger)
+	defer recobsrv.ObserveControllerReconcileTime()
 
 	// Fetch the ClusterClaim instance
 	claim := &hivev1.ClusterClaim{}

--- a/pkg/controller/clusterclaim/clusterclaim_controller.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller.go
@@ -164,9 +164,7 @@ func (r *ReconcileClusterClaim) Reconcile(request reconcile.Request) (result rec
 
 	logger.Infof("reconciling cluster claim")
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		logger.WithField("elapsed", dur).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, logger)
 	}()
 
 	// Fetch the ClusterClaim instance

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -280,18 +280,10 @@ type ReconcileClusterDeployment struct {
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
 //
 func (r *ReconcileClusterDeployment) Reconcile(request reconcile.Request) (result reconcile.Result, returnErr error) {
-	start := time.Now()
-	cdLog := r.logger.WithFields(log.Fields{
-		"controller":        ControllerName,
-		"clusterDeployment": request.Name,
-		"namespace":         request.Namespace,
-	})
-
-	// For logging, we need to see when the reconciliation loop starts and ends.
+	cdLog := controllerutils.BuildControllerLogger(ControllerName, "clusterDeployment", request.NamespacedName)
 	cdLog.Info("reconciling cluster deployment")
-	defer func() {
-		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, cdLog)
-	}()
+	recobsrv := hivemetrics.NewReconcileObserver(ControllerName, cdLog)
+	defer recobsrv.ObserveControllerReconcileTime()
 
 	// Fetch the ClusterDeployment instance
 	cd := &hivev1.ClusterDeployment{}

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -290,9 +290,7 @@ func (r *ReconcileClusterDeployment) Reconcile(request reconcile.Request) (resul
 	// For logging, we need to see when the reconciliation loop starts and ends.
 	cdLog.Info("reconciling cluster deployment")
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		cdLog.WithField("elapsed", dur).WithField("result", result).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, cdLog)
 	}()
 
 	// Fetch the ClusterDeployment instance

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
@@ -157,9 +157,7 @@ func (r *ReconcileClusterDeprovision) Reconcile(request reconcile.Request) (reco
 	// For logging, we need to see when the reconciliation loop starts and ends.
 	rLog.Info("reconciling cluster deprovision request")
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		rLog.WithField("elapsed", dur).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, rLog)
 	}()
 
 	// Fetch the ClusterDeprovision instance

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -133,9 +133,7 @@ func (r *ReconcileClusterPool) Reconcile(request reconcile.Request) (reconcile.R
 
 	logger.Infof("reconciling cluster pool")
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		logger.WithField("elapsed", dur).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, logger)
 	}()
 
 	// Fetch the ClusterPool instance

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -128,13 +127,10 @@ type ReconcileClusterPool struct {
 // Reconcile reads the state of the ClusterPool, checks if we currently have enough ClusterDeployments waiting, and
 // attempts to reach the desired state if not.
 func (r *ReconcileClusterPool) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	start := time.Now()
-	logger := r.logger.WithField("clusterPool", request.Name)
-
+	logger := controllerutils.BuildControllerLogger(ControllerName, "clusterPool", request.NamespacedName)
 	logger.Infof("reconciling cluster pool")
-	defer func() {
-		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, logger)
-	}()
+	recobsrv := hivemetrics.NewReconcileObserver(ControllerName, logger)
+	defer recobsrv.ObserveControllerReconcileTime()
 
 	// Fetch the ClusterPool instance
 	clp := &hivev1.ClusterPool{}

--- a/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller.go
+++ b/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller.go
@@ -103,13 +103,10 @@ type ReconcileClusterPoolNamespace struct {
 
 // Reconcile deletes a Namespace if it no longer contains any ClusterDeployments.
 func (r *ReconcileClusterPoolNamespace) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	start := time.Now()
-	logger := r.logger.WithField("namespace", request.Name)
-
+	logger := controllerutils.BuildControllerLogger(ControllerName, "namespace", request.NamespacedName)
 	logger.Info("reconciling namespace")
-	defer func() {
-		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, logger)
-	}()
+	recobsrv := hivemetrics.NewReconcileObserver(ControllerName, logger)
+	defer recobsrv.ObserveControllerReconcileTime()
 
 	// Fetch the Namespace instance
 	namespace := &corev1.Namespace{}

--- a/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller.go
+++ b/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller.go
@@ -108,9 +108,7 @@ func (r *ReconcileClusterPoolNamespace) Reconcile(request reconcile.Request) (re
 
 	logger.Info("reconciling namespace")
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		logger.WithField("elapsed", dur).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, logger)
 	}()
 
 	// Fetch the Namespace instance

--- a/pkg/controller/clusterprovision/clusterprovision_controller.go
+++ b/pkg/controller/clusterprovision/clusterprovision_controller.go
@@ -151,9 +151,7 @@ func (r *ReconcileClusterProvision) Reconcile(request reconcile.Request) (reconc
 	// For logging, we need to see when the reconciliation loop starts and ends.
 	pLog.Info("reconciling cluster provision")
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		pLog.WithField("elapsed", dur).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, pLog)
 	}()
 
 	// Fetch the ClusterProvision instance

--- a/pkg/controller/clusterrelocate/clusterrelocate_controller.go
+++ b/pkg/controller/clusterrelocate/clusterrelocate_controller.go
@@ -162,9 +162,7 @@ func (r *ReconcileClusterRelocate) Reconcile(request reconcile.Request) (reconci
 	// For logging, we need to see when the reconciliation loop starts and ends.
 	logger.Info("reconciling cluster deployment")
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		logger.WithField("elapsed", dur).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, logger)
 	}()
 
 	// Fetch the ClusterDeployment instance

--- a/pkg/controller/clusterstate/clusterstate_controller.go
+++ b/pkg/controller/clusterstate/clusterstate_controller.go
@@ -101,17 +101,10 @@ type ReconcileClusterState struct {
 
 // Reconcile ensures that a given ClusterState resource exists and reflects the state of cluster operators from its target cluster
 func (r *ReconcileClusterState) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	start := time.Now()
-	logger := r.logger.WithFields(log.Fields{
-		"controller":        ControllerName,
-		"clusterDeployment": request.NamespacedName.String(),
-	})
-
-	// For logging, we need to see when the reconciliation loop starts and ends.
+	logger := controllerutils.BuildControllerLogger(ControllerName, "clusterDeployment", request.NamespacedName)
 	logger.Info("reconciling cluster deployment")
-	defer func() {
-		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, logger)
-	}()
+	recobsrv := hivemetrics.NewReconcileObserver(ControllerName, logger)
+	defer recobsrv.ObserveControllerReconcileTime()
 
 	// Fetch the ClusterDeployment instance
 	cd := &hivev1.ClusterDeployment{}

--- a/pkg/controller/clusterstate/clusterstate_controller.go
+++ b/pkg/controller/clusterstate/clusterstate_controller.go
@@ -110,9 +110,7 @@ func (r *ReconcileClusterState) Reconcile(request reconcile.Request) (reconcile.
 	// For logging, we need to see when the reconciliation loop starts and ends.
 	logger.Info("reconciling cluster deployment")
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		logger.WithField("elapsed", dur).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, logger)
 	}()
 
 	// Fetch the ClusterDeployment instance

--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/json"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/workqueue"
@@ -250,7 +251,10 @@ type ReconcileClusterSync struct {
 // applied or re-applied.
 func (r *ReconcileClusterSync) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	start := time.Now()
-	logger := r.logger.WithField("ClusterDeployment", request.NamespacedName)
+	logger := r.logger.WithFields(log.Fields{
+		"clusterDeployment": request.NamespacedName,
+		"reconcileID":       utilrand.String(8), // not a true UUID, just a short random string to help us search logs
+	})
 
 	logger.Infof("reconciling ClusterDeployment")
 	defer func() {

--- a/pkg/controller/clusterversion/clusterversion_controller.go
+++ b/pkg/controller/clusterversion/clusterversion_controller.go
@@ -3,7 +3,6 @@ package clusterversion
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/blang/semver/v4"
 	log "github.com/sirupsen/logrus"
@@ -94,17 +93,10 @@ type ReconcileClusterVersion struct {
 // Reconcile reads that state of the cluster for a ClusterDeployment object and syncs the remote ClusterVersion status
 // if the remote cluster is available.
 func (r *ReconcileClusterVersion) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	start := time.Now()
-	cdLog := log.WithFields(log.Fields{
-		"clusterDeployment": request.Name,
-		"namespace":         request.Namespace,
-		"controller":        ControllerName,
-	})
-
+	cdLog := controllerutils.BuildControllerLogger(ControllerName, "clusterDeployment", request.NamespacedName)
 	cdLog.Info("reconciling cluster deployment")
-	defer func() {
-		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, cdLog)
-	}()
+	recobsrv := hivemetrics.NewReconcileObserver(ControllerName, cdLog)
+	defer recobsrv.ObserveControllerReconcileTime()
 
 	// Fetch the ClusterDeployment instance
 	cd := &hivev1.ClusterDeployment{}

--- a/pkg/controller/clusterversion/clusterversion_controller.go
+++ b/pkg/controller/clusterversion/clusterversion_controller.go
@@ -103,9 +103,7 @@ func (r *ReconcileClusterVersion) Reconcile(request reconcile.Request) (reconcil
 
 	cdLog.Info("reconciling cluster deployment")
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		cdLog.WithField("elapsed", dur).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, cdLog)
 	}()
 
 	// Fetch the ClusterDeployment instance

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller.go
@@ -118,17 +118,10 @@ type ReconcileControlPlaneCerts struct {
 // Reconcile reads that state of the cluster for a ClusterDeployment object and makes changes based on the state read
 // and what is in the ClusterDeployment.Spec
 func (r *ReconcileControlPlaneCerts) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	start := time.Now()
-	cdLog := log.WithFields(log.Fields{
-		"clusterDeployment": request.Name,
-		"namespace":         request.Namespace,
-		"controller":        ControllerName,
-	})
-
+	cdLog := controllerutils.BuildControllerLogger(ControllerName, "clusterDeployment", request.NamespacedName)
 	cdLog.Info("reconciling cluster deployment")
-	defer func() {
-		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, cdLog)
-	}()
+	recobsrv := hivemetrics.NewReconcileObserver(ControllerName, cdLog)
+	defer recobsrv.ObserveControllerReconcileTime()
 
 	// Fetch the ClusterDeployment instance
 	cd := &hivev1.ClusterDeployment{}

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller.go
@@ -127,9 +127,7 @@ func (r *ReconcileControlPlaneCerts) Reconcile(request reconcile.Request) (recon
 
 	cdLog.Info("reconciling cluster deployment")
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		cdLog.WithField("elapsed", dur).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, cdLog)
 	}()
 
 	// Fetch the ClusterDeployment instance

--- a/pkg/controller/dnsendpoint/dnsendpoint_controller.go
+++ b/pkg/controller/dnsendpoint/dnsendpoint_controller.go
@@ -3,7 +3,6 @@ package dnsendpoint
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -166,17 +165,10 @@ type ReconcileDNSEndpoint struct {
 // Reconcile reads that state of the cluster for a DNSEndpoint object and makes changes based on the state read
 // and what is in the DNSEndpoint.Spec
 func (r *ReconcileDNSEndpoint) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	start := time.Now()
-	dnsLog := r.logger.WithFields(log.Fields{
-		"dnszone":   request.Name,
-		"namespace": request.Namespace,
-	})
-
-	// For logging, we need to see when the reconciliation loop starts and ends.
+	dnsLog := controllerutils.BuildControllerLogger(ControllerName, "dnsZone", request.NamespacedName)
 	dnsLog.Info("reconciling dns endpoint")
-	defer func() {
-		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, dnsLog)
-	}()
+	recobsrv := hivemetrics.NewReconcileObserver(ControllerName, dnsLog)
+	defer recobsrv.ObserveControllerReconcileTime()
 
 	// Fetch the DNSZone object
 	instance := &hivev1.DNSZone{}

--- a/pkg/controller/dnsendpoint/dnsendpoint_controller.go
+++ b/pkg/controller/dnsendpoint/dnsendpoint_controller.go
@@ -175,9 +175,7 @@ func (r *ReconcileDNSEndpoint) Reconcile(request reconcile.Request) (reconcile.R
 	// For logging, we need to see when the reconciliation loop starts and ends.
 	dnsLog.Info("reconciling dns endpoint")
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		dnsLog.WithField("elapsed", dur).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, dnsLog)
 	}()
 
 	// Fetch the DNSZone object

--- a/pkg/controller/dnszone/dnszone_controller.go
+++ b/pkg/controller/dnszone/dnszone_controller.go
@@ -127,18 +127,10 @@ type ReconcileDNSZone struct {
 // Reconcile reads that state of the cluster for a DNSZone object and makes changes based on the state read
 // and what is in the DNSZone.Spec
 func (r *ReconcileDNSZone) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	start := time.Now()
-	dnsLog := r.logger.WithFields(log.Fields{
-		"controller": ControllerName,
-		"dnszone":    request.Name,
-		"namespace":  request.Namespace,
-	})
-
-	// For logging, we need to see when the reconciliation loop starts and ends.
+	dnsLog := controllerutils.BuildControllerLogger(ControllerName, "dnsZone", request.NamespacedName)
 	dnsLog.Info("reconciling dns zone")
-	defer func() {
-		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, dnsLog)
-	}()
+	recobsrv := hivemetrics.NewReconcileObserver(ControllerName, dnsLog)
+	defer recobsrv.ObserveControllerReconcileTime()
 
 	// Fetch the DNSZone object
 	desiredState := &hivev1.DNSZone{}

--- a/pkg/controller/dnszone/dnszone_controller.go
+++ b/pkg/controller/dnszone/dnszone_controller.go
@@ -137,9 +137,7 @@ func (r *ReconcileDNSZone) Reconcile(request reconcile.Request) (reconcile.Resul
 	// For logging, we need to see when the reconciliation loop starts and ends.
 	dnsLog.Info("reconciling dns zone")
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		dnsLog.WithField("elapsed", dur).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, dnsLog)
 	}()
 
 	// Fetch the DNSZone object

--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -132,9 +132,7 @@ func (r *hibernationReconciler) Reconcile(request reconcile.Request) (result rec
 
 	cdLog.Info("reconciling cluster deployment")
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		cdLog.WithField("elapsed", dur).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, cdLog)
 	}()
 
 	// Fetch the ClusterDeployment instance

--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -124,16 +124,10 @@ func AddToManager(mgr manager.Manager, r *hibernationReconciler, concurrentRecon
 
 // Reconcile syncs a single ClusterDeployment
 func (r *hibernationReconciler) Reconcile(request reconcile.Request) (result reconcile.Result, returnErr error) {
-	start := time.Now()
-	cdLog := r.logger.WithFields(log.Fields{
-		"controller":        ControllerName,
-		"clusterDeployment": request.NamespacedName.String(),
-	})
-
+	cdLog := controllerutils.BuildControllerLogger(ControllerName, "clusterDeployment", request.NamespacedName)
 	cdLog.Info("reconciling cluster deployment")
-	defer func() {
-		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, cdLog)
-	}()
+	recobsrv := hivemetrics.NewReconcileObserver(ControllerName, cdLog)
+	defer recobsrv.ObserveControllerReconcileTime()
 
 	// Fetch the ClusterDeployment instance
 	cd := &hivev1.ClusterDeployment{}

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -614,9 +614,9 @@ func (ro *ReconcileObserver) ObserveControllerReconcileTime() {
 	// Add a log field to categorize request duration into buckets. We can't easily query > in Kibana in
 	// OpenShift deployments due to logging limitations, so these constant buckets give us a small number of
 	// constant search strings we can use to identify slow reconcile loops.
-	for _, millis := range elapsedDurationMillisBuckets {
-		if dur.Milliseconds() >= millis {
-			fields["elapsedMillisGT"] = millis
+	for _, bucket := range elapsedDurationBuckets {
+		if dur >= bucket {
+			fields["elapsedMillisGT"] = bucket.Milliseconds()
 			break
 		}
 	}
@@ -627,4 +627,4 @@ func (ro *ReconcileObserver) SetOutcome(outcome ReconcileOutcome) {
 	ro.outcome = outcome
 }
 
-var elapsedDurationMillisBuckets = []int64{120_000, 60_000, 30_000, 10_000, 5_000, 1_000, 0}
+var elapsedDurationBuckets = []time.Duration{2 * time.Minute, time.Minute, 30 * time.Second, 10 * time.Second, 5 * time.Second, time.Second, 0}

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -305,9 +305,6 @@ func (mc *Calculator) Start(stopCh <-chan struct{}) error {
 		}
 
 		mc.calculateSelectorSyncSetMetrics(mcLog)
-
-		elapsed := time.Since(start)
-		mcLog.WithField("elapsed", elapsed).Info("metrics calculation complete")
 	}, mc.Interval, stopCh)
 
 	return nil
@@ -598,5 +595,5 @@ func GetClusterDeploymentType(obj metav1.Object) string {
 func ObserveControllerReconcileTime(controller string, start time.Time, outcome ReconcileOutcome, logger log.FieldLogger) {
 	dur := time.Since(start)
 	metricControllerReconcileTime.WithLabelValues(controller, string(outcome)).Observe(dur.Seconds())
-	logger.WithFields(log.Fields{"elapsed": dur, "outcome": outcome}).Info("reconcile complete")
+	logger.WithFields(log.Fields{"elapsedMillis": dur.Milliseconds(), "outcome": outcome}).Info("reconcile complete")
 }

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -599,7 +599,7 @@ func ObserveControllerReconcileTime(controller string, start time.Time, outcome 
 	// Add a log field to categorize request duration into buckets. We can't easily query > in Kibana in
 	// OpenShift deployments due to logging limitations, so these constant buckets give us a small number of
 	// constant search strings we can use to identify slow reconcile loops.
-	for _, millis := range elapsedDurationBuckets {
+	for _, millis := range elapsedDurationMillisBuckets {
 		if dur.Milliseconds() >= millis {
 			fields["elapsedMillisGT"] = millis
 			break
@@ -608,4 +608,4 @@ func ObserveControllerReconcileTime(controller string, start time.Time, outcome 
 	logger.WithFields(fields).Info("reconcile complete")
 }
 
-var elapsedDurationBuckets = []int64{120000, 60000, 30000, 10000, 5000, 1000, 0}
+var elapsedDurationMillisBuckets = []int64{120_000, 60_000, 30_000, 10_000, 5_000, 1_000, 0}

--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -134,9 +134,7 @@ func (r *ReconcileRemoteClusterIngress) Reconcile(request reconcile.Request) (re
 	})
 	cdLog.Info("reconciling cluster deployment")
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		cdLog.WithField("elapsed", dur).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, cdLog)
 	}()
 
 	rContext := &reconcileContext{}

--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -127,15 +127,10 @@ type ReconcileRemoteClusterIngress struct {
 // any needed ClusterIngress objects up for syncing to the remote cluster.
 //
 func (r *ReconcileRemoteClusterIngress) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	start := time.Now()
-	cdLog := r.logger.WithFields(log.Fields{
-		"clusterDeployment": request.Name,
-		"namespace":         request.Namespace,
-	})
+	cdLog := controllerutils.BuildControllerLogger(ControllerName, "clusterDeployment", request.NamespacedName)
 	cdLog.Info("reconciling cluster deployment")
-	defer func() {
-		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, cdLog)
-	}()
+	recobsrv := hivemetrics.NewReconcileObserver(ControllerName, cdLog)
+	defer recobsrv.ObserveControllerReconcileTime()
 
 	rContext := &reconcileContext{}
 

--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -176,15 +175,10 @@ type ReconcileRemoteMachineSet struct {
 // Reconcile reads that state of the cluster for a MachinePool object and makes changes to the
 // remote cluster MachineSets based on the state read
 func (r *ReconcileRemoteMachineSet) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	start := time.Now()
-	logger := r.logger.WithFields(log.Fields{
-		"machinePool": request.Name,
-		"namespace":   request.Namespace,
-	})
+	logger := controllerutils.BuildControllerLogger(ControllerName, "machinePool", request.NamespacedName)
 	logger.Info("reconciling machine pool")
-	defer func() {
-		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, logger)
-	}()
+	recobsrv := hivemetrics.NewReconcileObserver(ControllerName, logger)
+	defer recobsrv.ObserveControllerReconcileTime()
 
 	// Fetch the MachinePool instance
 	pool := &hivev1.MachinePool{}

--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -182,11 +182,8 @@ func (r *ReconcileRemoteMachineSet) Reconcile(request reconcile.Request) (reconc
 		"namespace":   request.Namespace,
 	})
 	logger.Info("reconciling machine pool")
-
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		logger.WithField("elapsed", dur).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, logger)
 	}()
 
 	// Fetch the MachinePool instance

--- a/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
+++ b/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
@@ -6,15 +6,9 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"time"
 
-	openshiftapiv1 "github.com/openshift/api/config/v1"
-	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
-	"github.com/openshift/hive/pkg/constants"
-	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
-	controllerutils "github.com/openshift/hive/pkg/controller/utils"
-	k8slabels "github.com/openshift/hive/pkg/util/labels"
 	log "github.com/sirupsen/logrus"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/workqueue"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -31,7 +26,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	openshiftapiv1 "github.com/openshift/api/config/v1"
+
 	apihelpers "github.com/openshift/hive/pkg/apis/helpers"
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
+	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+	k8slabels "github.com/openshift/hive/pkg/util/labels"
 )
 
 const (
@@ -173,14 +175,10 @@ type identityProviderPatchSpec struct {
 // remote cluster MachineSets based on the state read and the worker machines defined in
 // ClusterDeployment.Spec.Config.Machines
 func (r *ReconcileSyncIdentityProviders) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	start := time.Now()
-	contextLogger := addReconcileRequestLoggerFields(r.logger, request)
-
-	// For logging, we need to see when the reconciliation loop starts and ends.
+	contextLogger := controllerutils.BuildControllerLogger(ControllerName, "clusterDeployment", request.NamespacedName)
 	contextLogger.Info("reconciling syncidentityproviders and clusterdeployments")
-	defer func() {
-		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, contextLogger)
-	}()
+	recobsrv := hivemetrics.NewReconcileObserver(ControllerName, contextLogger)
+	defer recobsrv.ObserveControllerReconcileTime()
 
 	// Fetch the ClusterDeployment instance
 	cd := &hivev1.ClusterDeployment{}
@@ -209,9 +207,7 @@ func (r *ReconcileSyncIdentityProviders) Reconcile(request reconcile.Request) (r
 		return reconcile.Result{}, nil
 	}
 
-	contextLogger = addClusterDeploymentLoggerFields(contextLogger, cd)
-
-	return reconcile.Result{}, r.syncIdentityProviders(cd)
+	return reconcile.Result{}, r.syncIdentityProviders(cd, contextLogger)
 }
 
 func (r *ReconcileSyncIdentityProviders) createSyncSetSpec(cd *hivev1.ClusterDeployment, idps []openshiftapiv1.IdentityProvider) (*hivev1.SyncSetSpec, error) {
@@ -251,10 +247,8 @@ func GenerateIdentityProviderSyncSetName(clusterDeploymentName string) string {
 	return apihelpers.GetResourceName(clusterDeploymentName, constants.IdentityProviderSuffix)
 }
 
-func (r *ReconcileSyncIdentityProviders) syncIdentityProviders(cd *hivev1.ClusterDeployment) error {
-	contextLogger := addClusterDeploymentLoggerFields(r.logger, cd)
-
-	idpsFromSSIDP, err := r.getRelatedSelectorSyncIdentityProviders(cd)
+func (r *ReconcileSyncIdentityProviders) syncIdentityProviders(cd *hivev1.ClusterDeployment, contextLogger *log.Entry) error {
+	idpsFromSSIDP, err := r.getRelatedSelectorSyncIdentityProviders(cd, contextLogger)
 	if err != nil {
 		return err
 	}
@@ -329,14 +323,12 @@ func (r *ReconcileSyncIdentityProviders) syncIdentityProviders(cd *hivev1.Cluste
 	return nil
 }
 
-func (r *ReconcileSyncIdentityProviders) getRelatedSelectorSyncIdentityProviders(cd *hivev1.ClusterDeployment) ([]openshiftapiv1.IdentityProvider, error) {
+func (r *ReconcileSyncIdentityProviders) getRelatedSelectorSyncIdentityProviders(cd *hivev1.ClusterDeployment, contextLogger *log.Entry) ([]openshiftapiv1.IdentityProvider, error) {
 	list := &hivev1.SelectorSyncIdentityProviderList{}
 	err := r.Client.List(context.TODO(), list)
 	if err != nil {
 		return nil, err
 	}
-
-	contextLogger := addClusterDeploymentLoggerFields(r.logger, cd)
 
 	cdLabelSet := labels.Set(cd.Labels)
 	var idps []openshiftapiv1.IdentityProvider
@@ -379,19 +371,6 @@ func (r *ReconcileSyncIdentityProviders) getRelatedSyncIdentityProviders(cd *hiv
 	idps = sortIdentityProviders(idps)
 
 	return idps, err
-}
-
-func addReconcileRequestLoggerFields(logger log.FieldLogger, request reconcile.Request) *log.Entry {
-	return logger.WithFields(log.Fields{
-		"NamespacedName": request.NamespacedName,
-	})
-}
-
-func addClusterDeploymentLoggerFields(logger log.FieldLogger, cd *hivev1.ClusterDeployment) *log.Entry {
-	return logger.WithFields(log.Fields{
-		"clusterDeployment": cd.Name,
-		"namespace":         cd.Namespace,
-	})
 }
 
 func addSelectorSyncIdentityProviderLoggerFields(logger log.FieldLogger, ssidp *hivev1.SelectorSyncIdentityProvider) *log.Entry {

--- a/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
+++ b/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
@@ -179,9 +179,7 @@ func (r *ReconcileSyncIdentityProviders) Reconcile(request reconcile.Request) (r
 	// For logging, we need to see when the reconciliation loop starts and ends.
 	contextLogger.Info("reconciling syncidentityproviders and clusterdeployments")
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		contextLogger.WithField("elapsed", dur).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, contextLogger)
 	}()
 
 	// Fetch the ClusterDeployment instance

--- a/pkg/controller/unreachable/unreachable_controller.go
+++ b/pkg/controller/unreachable/unreachable_controller.go
@@ -123,9 +123,7 @@ func (r *ReconcileRemoteMachineSet) Reconcile(request reconcile.Request) (reconc
 	// For logging, we need to see when the reconciliation loop starts and ends.
 	cdLog.Info("reconciling cluster deployment")
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		cdLog.WithField("elapsed", dur).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, cdLog)
 	}()
 
 	cd := &hivev1.ClusterDeployment{}

--- a/pkg/controller/unreachable/unreachable_controller.go
+++ b/pkg/controller/unreachable/unreachable_controller.go
@@ -113,18 +113,10 @@ type ReconcileRemoteMachineSet struct {
 
 // Reconcile checks if we can establish an API client connection to the remote cluster and maintains the unreachable condition as a result.
 func (r *ReconcileRemoteMachineSet) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	start := time.Now()
-	cdLog := log.WithFields(log.Fields{
-		"clusterDeployment": request.Name,
-		"namespace":         request.Namespace,
-		"controller":        ControllerName,
-	})
-
-	// For logging, we need to see when the reconciliation loop starts and ends.
+	cdLog := controllerutils.BuildControllerLogger(ControllerName, "clusterDeployment", request.NamespacedName)
 	cdLog.Info("reconciling cluster deployment")
-	defer func() {
-		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, cdLog)
-	}()
+	recobsrv := hivemetrics.NewReconcileObserver(ControllerName, cdLog)
+	defer recobsrv.ObserveControllerReconcileTime()
 
 	cd := &hivev1.ClusterDeployment{}
 	err := r.Get(context.TODO(), request.NamespacedName, cd)

--- a/pkg/controller/utils/clientwrapper.go
+++ b/pkg/controller/utils/clientwrapper.go
@@ -117,6 +117,15 @@ func (cmt *ControllerMetricsTripper) RoundTrip(req *http.Request) (*http.Respons
 	if err == nil && pathErr == nil {
 		metricKubeClientRequests.WithLabelValues(cmt.Controller.String(), req.Method, path, remoteStr, resp.Status).Inc()
 		metricKubeClientRequestSeconds.WithLabelValues(cmt.Controller.String(), req.Method, path, remoteStr, resp.Status).Observe(applyTime)
+		if applyTime >= 5.0 {
+			log.WithFields(log.Fields{
+				"controller": cmt.Controller.String(),
+				"method":     req.Method,
+				"path":       path,
+				"remote":     remoteStr,
+				"status":     resp.Status,
+			}).Warn("slow client request")
+		}
 	}
 
 	return resp, err

--- a/pkg/controller/utils/clientwrapper.go
+++ b/pkg/controller/utils/clientwrapper.go
@@ -28,8 +28,9 @@ var (
 		[]string{"controller", "method", "resource", "remote", "status"},
 	)
 	metricKubeClientRequestSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name: "hive_kube_client_request_seconds",
-		Help: "Length of time for kubernetes client requests.",
+		Name:    "hive_kube_client_request_seconds",
+		Help:    "Length of time for kubernetes client requests.",
+		Buckets: []float64{0.05, 0.1, 0.5, 1, 5, 10, 30, 60, 120},
 	},
 		[]string{"controller", "method", "resource", "remote", "status"},
 	)

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
@@ -319,4 +320,13 @@ func CopySecret(c client.Client, src, dest types.NamespacedName) error {
 	}
 
 	return nil
+}
+
+// BuildControllerLogger returns a logger for controllers with consistent fields.
+func BuildControllerLogger(controller hivev1.ControllerName, resource string, nsName types.NamespacedName) *log.Entry {
+	return log.WithFields(log.Fields{
+		"controller":  controller,
+		resource:      nsName.String(),
+		"reconcileID": utilrand.String(constants.ReconcileIDLen),
+	})
 }

--- a/pkg/controller/velerobackup/velerobackup_controller.go
+++ b/pkg/controller/velerobackup/velerobackup_controller.go
@@ -169,14 +169,10 @@ type ReconcileBackup struct {
 
 // Reconcile ensures that all Hive object changes have corresponding Velero backup objects.
 func (r *ReconcileBackup) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	start := time.Now()
-	nsLogger := r.logger.WithField("namespace", request.Namespace)
-
-	// For logging, we need to see when the reconciliation loop starts and ends.
+	nsLogger := controllerutils.BuildControllerLogger(ControllerName, "namespace", request.NamespacedName)
 	nsLogger.Info("reconciling backups and Hive object changes")
-	defer func() {
-		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, nsLogger)
-	}()
+	recobsrv := hivemetrics.NewReconcileObserver(ControllerName, nsLogger)
+	defer recobsrv.ObserveControllerReconcileTime()
 
 	cp, checkpointFound, err := r.getNamespaceCheckpoint(request.Namespace, nsLogger)
 	if err != nil {

--- a/pkg/controller/velerobackup/velerobackup_controller.go
+++ b/pkg/controller/velerobackup/velerobackup_controller.go
@@ -175,9 +175,7 @@ func (r *ReconcileBackup) Reconcile(request reconcile.Request) (reconcile.Result
 	// For logging, we need to see when the reconciliation loop starts and ends.
 	nsLogger.Info("reconciling backups and Hive object changes")
 	defer func() {
-		dur := time.Since(start)
-		hivemetrics.MetricControllerReconcileTime.WithLabelValues(ControllerName.String()).Observe(dur.Seconds())
-		nsLogger.WithField("elapsed", dur).Info("reconcile complete")
+		hivemetrics.ObserveControllerReconcileTime(ControllerName.String(), start, hivemetrics.ReconcileOutcomeUnspecified, nsLogger)
 	}()
 
 	cp, checkpointFound, err := r.getNamespaceCheckpoint(request.Namespace, nsLogger)


### PR DESCRIPTION
Use custom buckets for the kube client request histogram, previously capping at 10, we might be going well beyond that in some cases.

Add a reconcileID random string field to the logger in the cluster sync controller. Searching for "reconcile complete" will help us identify slow reconciles, and we can then walk back easily to search just for the log entries for that loop. Went with a random string 8 chars long instead of a full uuid just for brevity and log space, as a true globally unique ID is not really required here.

Add utility for controllers to log their elapsed time and report the metric. Will now log consistent elapsedMillis instead of a duration with varying units. We probably can't do greater than queries in kibana because of limitations in how openshift uses it, but it's still a good idea.

Add elapsedMillisGT categories to let us search logs for requests greater than one of the fixed limits. 

Log kube requests greater than 5 seconds as a warning. This appears quite rare from current metrics.

/assign @suhanime 
/cc @twiest @gregsheremeta 

Greg added you as well just in case you have thoughts.