### PR TITLE
vsphere creds checking

### DIFF
--- a/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -316,6 +316,9 @@ const (
 
 	// ProvisionStoppedCondition is set when cluster provisioning is stopped
 	ProvisionStoppedCondition ClusterDeploymentConditionType = "ProvisionStopped"
+
+	// AuthenticationFailureCondition is true when platform credentials cannot be used because of authentication failure
+	AuthenticationFailureClusterDeploymentCondition ClusterDeploymentConditionType = "AuthenticationFailure"
 )
 
 // AllClusterDeploymentConditions is a slice containing all condition types. This can be used for dealing with

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -6,6 +6,14 @@ import (
 )
 
 const (
+	PlatformAWS       = "aws"
+	PlatformAzure     = "azure"
+	PlatformBaremetal = "baremetal"
+	PlatformGCP       = "gcp"
+	PlatformOpenStack = "openstack"
+	PlatformUnknown   = "unknown"
+	PlatformVSphere   = "vsphere"
+
 	mergedPullSecretSuffix = "merged-pull-secret"
 
 	// VeleroBackupEnvVar is the name of the environment variable used to tell the controller manager to enable velero backup integration.

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -57,6 +57,9 @@ const (
 	defaultRequeueTime = 10 * time.Second
 	maxProvisions      = 3
 
+	platformAuthFailureResason = "PlatformAuthError"
+	platformAuthSuccessReason  = "PlatformAuthWorking"
+
 	clusterImageSetNotFoundReason = "ClusterImageSetNotFound"
 	clusterImageSetFoundReason    = "ClusterImageSetFound"
 
@@ -71,14 +74,7 @@ const (
 	deleteAfterAnnotation    = "hive.openshift.io/delete-after" // contains a duration after which the cluster should be cleaned up.
 	tryInstallOnceAnnotation = "hive.openshift.io/try-install-once"
 
-	platformAWS       = "aws"
-	platformAzure     = "azure"
-	platformGCP       = "gcp"
-	platformOpenStack = "openstack"
-	platformVSphere   = "vsphere"
-	platformBaremetal = "baremetal"
-	platformUnknown   = "unknown"
-	regionUnknown     = "unknown"
+	regionUnknown = "unknown"
 )
 
 var (
@@ -163,10 +159,11 @@ func Add(mgr manager.Manager) error {
 // NewReconciler returns a new reconcile.Reconciler
 func NewReconciler(mgr manager.Manager, logger log.FieldLogger, rateLimiter flowcontrol.RateLimiter) reconcile.Reconciler {
 	r := &ReconcileClusterDeployment{
-		Client:       controllerutils.NewClientWithMetricsOrDie(mgr, ControllerName, &rateLimiter),
-		scheme:       mgr.GetScheme(),
-		logger:       logger,
-		expectations: controllerutils.NewExpectations(logger),
+		Client:                                  controllerutils.NewClientWithMetricsOrDie(mgr, ControllerName, &rateLimiter),
+		scheme:                                  mgr.GetScheme(),
+		logger:                                  logger,
+		expectations:                            controllerutils.NewExpectations(logger),
+		validateCredentialsForClusterDeployment: controllerutils.ValidateCredentialsForClusterDeployment,
 	}
 	r.remoteClusterAPIClientBuilder = func(cd *hivev1.ClusterDeployment) remoteclient.Builder {
 		return remoteclient.NewBuilder(r.Client, cd, ControllerName)
@@ -274,6 +271,10 @@ type ReconcileClusterDeployment struct {
 	// remoteClusterAPIClientBuilder is a function pointer to the function that gets a builder for building a client
 	// for the remote cluster's API server
 	remoteClusterAPIClientBuilder func(cd *hivev1.ClusterDeployment) remoteclient.Builder
+
+	// validateCredentialsForClusterDeployment is what this controller will call to validate
+	// that the platform creds are good (used for testing)
+	validateCredentialsForClusterDeployment func(client.Client, *hivev1.ClusterDeployment, log.FieldLogger) (bool, error)
 
 	protectedDelete bool
 }
@@ -580,6 +581,26 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 			result = &reconcile.Result{}
 		}
 		return *result, err
+	}
+
+	// Sanity check the platform/cloud credentials.
+	validCreds, err := r.validatePlatformCreds(cd, cdLog)
+	if err != nil {
+		cdLog.WithError(err).Error("errored validating platform credentials")
+		return reconcile.Result{}, err
+	}
+	// Make sure the condition is set properly.
+	changed, err := r.setAuthenticationFailure(cd, validCreds, cdLog)
+	if changed || err != nil {
+		return reconcile.Result{}, err
+	}
+
+	// If the platform credentials are no good, do not bother with ClusterProvision objects
+	authCondition := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.AuthenticationFailureClusterDeploymentCondition)
+	if authCondition != nil && authCondition.Status == corev1.ConditionTrue {
+		cdLog.Info("Skipping provision while platform credentials authentication is failing.")
+		// Periodically retry???
+		return reconcile.Result{}, nil
 	}
 
 	imageSet, err := r.getClusterImageSet(cd, cdLog)
@@ -1270,6 +1291,36 @@ func (r *ReconcileClusterDeployment) setDNSNotReadyCondition(cd *hivev1.ClusterD
 	cd.Status.Conditions = conditions
 	cdLog.Debugf("setting DNSNotReadyCondition to %v", status)
 	return r.Status().Update(context.TODO(), cd)
+}
+
+func (r *ReconcileClusterDeployment) setAuthenticationFailure(cd *hivev1.ClusterDeployment, authWorking bool, cdLog log.FieldLogger) (bool, error) {
+
+	var status corev1.ConditionStatus
+	var reason, message string
+
+	if authWorking {
+		status = corev1.ConditionFalse
+		reason = platformAuthSuccessReason
+		message = "Platform credentails passed authentication check"
+	} else {
+		status = corev1.ConditionTrue
+		reason = platformAuthFailureResason
+		message = "Platform credentials failed authentication check"
+	}
+
+	conditions, changed := controllerutils.SetClusterDeploymentConditionWithChangeCheck(
+		cd.Status.Conditions,
+		hivev1.AuthenticationFailureClusterDeploymentCondition,
+		status,
+		reason,
+		message,
+		controllerutils.UpdateConditionIfReasonOrMessageChange)
+	if !changed {
+		return false, nil
+	}
+	cd.Status.Conditions = conditions
+
+	return changed, r.Status().Update(context.TODO(), cd)
 }
 
 func (r *ReconcileClusterDeployment) setInstallLaunchErrorCondition(cd *hivev1.ClusterDeployment, status corev1.ConditionStatus, reason string, message string, cdLog log.FieldLogger) error {
@@ -2113,6 +2164,11 @@ func (r *ReconcileClusterDeployment) deleteOldFailedProvisions(provs []*hivev1.C
 	}
 }
 
+// validatePlatformCreds ensure the platform/cloud credentials are at least good enough to authenticate with
+func (r *ReconcileClusterDeployment) validatePlatformCreds(cd *hivev1.ClusterDeployment, logger log.FieldLogger) (bool, error) {
+	return r.validateCredentialsForClusterDeployment(r.Client, cd, logger)
+}
+
 // checkForFailedSync returns true if it finds that the ClusterSync has the Failed condition set
 func checkForFailedSync(clusterSync *hiveintv1alpha1.ClusterSync) bool {
 	for _, cond := range clusterSync.Status.Conditions {
@@ -2213,19 +2269,19 @@ func (r *ReconcileClusterDeployment) addOwnershipToSecret(cd *hivev1.ClusterDepl
 func getClusterPlatform(cd *hivev1.ClusterDeployment) string {
 	switch {
 	case cd.Spec.Platform.AWS != nil:
-		return platformAWS
+		return constants.PlatformAWS
 	case cd.Spec.Platform.Azure != nil:
-		return platformAzure
+		return constants.PlatformAzure
 	case cd.Spec.Platform.GCP != nil:
-		return platformGCP
+		return constants.PlatformGCP
 	case cd.Spec.Platform.OpenStack != nil:
-		return platformOpenStack
+		return constants.PlatformOpenStack
 	case cd.Spec.Platform.VSphere != nil:
-		return platformVSphere
+		return constants.PlatformVSphere
 	case cd.Spec.Platform.BareMetal != nil:
-		return platformBaremetal
+		return constants.PlatformBaremetal
 	}
-	return platformUnknown
+	return constants.PlatformUnknown
 }
 
 // getClusterRegion returns the region of a given ClusterDeployment

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -1509,6 +1509,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 			platformCredentialsValidation: func(client.Client, *hivev1.ClusterDeployment, log.FieldLogger) (bool, error) {
 				return false, nil
 			},
+			expectErr: true,
 			validate: func(c client.Client, t *testing.T) {
 				cd := getCD(c)
 				require.NotNil(t, cd, "could not get ClusterDeployment")
@@ -1525,7 +1526,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 						{
 							Status:  corev1.ConditionTrue,
 							Type:    hivev1.AuthenticationFailureClusterDeploymentCondition,
-							Reason:  platformAuthFailureResason,
+							Reason:  platformAuthFailureReason,
 							Message: "Platform credentials failed authentication check",
 						},
 					}
@@ -1535,6 +1536,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 			platformCredentialsValidation: func(client.Client, *hivev1.ClusterDeployment, log.FieldLogger) (bool, error) {
 				return false, nil
 			},
+			expectErr: true,
 			validate: func(c client.Client, t *testing.T) {
 				cd := getCD(c)
 				require.NotNil(t, cd, "could not get ClusterDeployment")

--- a/pkg/controller/metrics/provision_underway_collector.go
+++ b/pkg/controller/metrics/provision_underway_collector.go
@@ -21,6 +21,7 @@ var (
 		hivev1.DNSNotReadyCondition,
 		hivev1.InstallLaunchErrorCondition,
 		hivev1.ProvisionFailedCondition,
+		hivev1.AuthenticationFailureClusterDeploymentCondition,
 	}
 )
 

--- a/pkg/controller/utils/credentials.go
+++ b/pkg/controller/utils/credentials.go
@@ -32,7 +32,8 @@ func ValidateCredentialsForClusterDeployment(kubeClient client.Client, cd *hivev
 		}
 		return validateVSphereCredentials(cd.Spec.Platform.VSphere.VCenter,
 			string(secret.Data[constants.UsernameSecretKey]),
-			string(secret.Data[constants.PasswordSecretKey]))
+			string(secret.Data[constants.PasswordSecretKey]),
+			logger)
 	default:
 		// If we have no platform-specific credentials verification
 		// assume the creds are valid.
@@ -41,9 +42,9 @@ func ValidateCredentialsForClusterDeployment(kubeClient client.Client, cd *hivev
 	}
 }
 
-func validateVSphereCredentials(vcenter, username, password string) (bool, error) {
-
+func validateVSphereCredentials(vcenter, username, password string, logger log.FieldLogger) (bool, error) {
 	_, _, err := vsphere.CreateVSphereClients(context.TODO(), vcenter, username, password)
+	logger.WithError(err).Warn("failed to validate VSphere credentials")
 	return err == nil, nil
 }
 

--- a/pkg/controller/utils/credentials.go
+++ b/pkg/controller/utils/credentials.go
@@ -1,0 +1,67 @@
+package utils
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/installer/pkg/types/vsphere"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
+)
+
+// ValidateCredentialsForClusterDeployment will attempt to verify that the platform/cloud credentials
+// for the given ClusterDeployment are valid.
+// Note: It simply checks that the username/password (or equivalent) can authenticate,
+// not that the credentials have any specific permissions.
+func ValidateCredentialsForClusterDeployment(kubeClient client.Client, cd *hivev1.ClusterDeployment, logger log.FieldLogger) (bool, error) {
+	secret := &corev1.Secret{}
+
+	switch getClusterPlatform(cd) {
+	case constants.PlatformVSphere:
+		secretKey := types.NamespacedName{Name: cd.Spec.Platform.VSphere.CredentialsSecretRef.Name, Namespace: cd.Namespace}
+		if err := kubeClient.Get(context.TODO(), secretKey, secret); err != nil {
+			logger.WithError(err).Error("failed to read in ClusterDeployment's platform creds")
+			return false, err
+		}
+		return validateVSphereCredentials(cd.Spec.Platform.VSphere.VCenter,
+			string(secret.Data[constants.UsernameSecretKey]),
+			string(secret.Data[constants.PasswordSecretKey]))
+	default:
+		// If we have no platform-specific credentials verification
+		// assume the creds are valid.
+		return true, nil
+
+	}
+}
+
+func validateVSphereCredentials(vcenter, username, password string) (bool, error) {
+
+	_, _, err := vsphere.CreateVSphereClients(context.TODO(), vcenter, username, password)
+	return err == nil, nil
+}
+
+// getClusterPlatform returns the platform of a given ClusterDeployment
+func getClusterPlatform(cd *hivev1.ClusterDeployment) string {
+	switch {
+	case cd.Spec.Platform.AWS != nil:
+		return constants.PlatformAWS
+	case cd.Spec.Platform.Azure != nil:
+		return constants.PlatformAzure
+	case cd.Spec.Platform.GCP != nil:
+		return constants.PlatformGCP
+	case cd.Spec.Platform.OpenStack != nil:
+		return constants.PlatformOpenStack
+	case cd.Spec.Platform.VSphere != nil:
+		return constants.PlatformVSphere
+	case cd.Spec.Platform.BareMetal != nil:
+		return constants.PlatformBaremetal
+	}
+	return constants.PlatformUnknown
+}


### PR DESCRIPTION
Fix the immediate problem where passing bad credentials for a vSphere installation means that deleting the ClusterDeployment doesn't get deleted (b/c the deprovision fails (b/c of the bad creds)).

Test the creds, and set a condition so that we can avoid ever even creating a ClusterProvision when we detect bad credentials. This means deprovision works b/c the provision was never attempted. Right now we only check vSphere credentials, but more platforms can (and should) be added.

Add test cases to validate this.