### PR TITLE
Store install logs in s3 compatible storage

### DIFF
--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -227,9 +227,9 @@ spec:
                       description: 'CredentialsSecretRef references a secret in the
                         TargetNamespace that will be used to authenticate with AWS
                         S3. It will need permission to upload logs to S3. Secret should
-                        have key named "cloud" that contains an AWS credentials formatted
-                        file. Example:   [default]   aws_access_key_id = minio   aws_secret_access_key
-                        = minio123'
+                        have keys named aws_access_key_id and aws_secret_access_key
+                        that contain the AWS credentials. Example Secret:   data:     aws_access_key_id:
+                        minio     aws_secret_access_key: minio123'
                       properties:
                         name:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -248,10 +248,8 @@ spec:
                   - credentialsSecretRef
                   type: object
                 skipGatherLogs:
-                  description: SkipGatherLogs disables functionality that attempts
-                    to gather full logs from the cluster if an installation fails
-                    for any reason. The logs will be stored in a persistent volume
-                    for up to 7 days.
+                  description: 'DEPRECATED: This flag is no longer respected and will
+                    be removed in the future.'
                   type: boolean
               type: object
             globalPullSecretRef:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,12 +2,42 @@
 
 ## Cluster Install Failure Logs
 
-In the event a cluster is brought up but overall installation fails, either during bootstrap or cluster initialization, Hive will attempt to gather logs from the cluster itself. These logs are stored in a persistent volume created for every install job. If the install succeeds on the first attempt, the persistent volume claim is immediately deleted. If the install has had any errors along the way, it will be preserved for 7 days and then removed.
+In the event a cluster is brought up but overall installation fails, either during bootstrap or cluster initialization, Hive will attempt to gather logs from the cluster itself. If configured, these logs are stored in an S3 compatible object store under a directory created for each cluster provision. If the install succeeds on the first attempt, then nothing will be stored. If the install has had any errors that cause an install log to be created, then it will uploaded to the configured object store.
 
-You can access these logs gathered from the cluster with the following script found in the hive.git repository:
+### One Time Setup
+
+In order for Hive to gather and upload install logs on cluster provision failure, the object store must have a place for Hive to store data and Hive must be configured with the object store information.
+
+Steps:
+1. Create a storage bucket (or the equivalent if using an S3 compatible service)
+1. Create a secret in the configured Hive namespace with credentials that can access the bucket.
+1. Configure Hive config with the following information:
+```yaml
+  spec:
+    failedProvisionConfig:
+      aws:
+        bucket: name_of_bucket_created_in_above_step
+        credentialsSecretRef:
+          name: name_of_secret_that_can_access_bucket
+        region: region_of_bucket_created_in_above_step
+```
+
+### Listing stored install logs directories
+
+The logs gathered from the cluster can be accessed with the `logextractor.sh` script found in the Hive git repository.
+
+In order to sync down the correct install logs, it is necessary to know which directory to sync. This can be determined by listing the install log directories with the following command:
 
 ```bash
-$ hack/logextractor.sh mycluster ./extracted-logs/
+$ hack/logextractor.sh ls
+```
+
+### Retrieving stored install logs for a specific cluster provision
+
+To sync down the desired install logs, run the following command using the directory name determined in the command above. In this example, `cluster1-6a85a345-namespace` is used as an example directory name:
+
+```bash
+$ hack/logextractor.sh sync cluster1-6a85a345-namespace /path/to/store/the/logs
 ```
 
 ## Deprovision

--- a/hack/logextractor.sh
+++ b/hack/logextractor.sh
@@ -1,85 +1,94 @@
-#!/bin/sh
-#
-# This script can be used to extract the failure cluster logs tarball from the PVC created for an install pod.
-# Note that there will only be failure logs if there was a failure installing and that the failure logs will
-# only be retained for 7 days after a successful install.
-#
-# Usage: ./logextractor.sh [CLUSTERDEPLOYMENT_NAMESPACE/]CLUSTER_DEPLOYMENT_NAME DEST_DIR
-#
+#!/bin/bash
 
-usage(){
-	echo $1
-	echo "Usage: $0 [CLUSTERDEPLOYMENT_NAMESPACE/]CLUSTERDEPLOYMENT_NAME DEST_DIR"
-	exit 1
-}
+# exit on error
+set -e
 
-# Get the name and namespace for the clusterdeployment.
-CD_NAME_ARG=${1}
-[ -z ${CD_NAME_ARG} ] && usage "missing ClusterDeployment name"
-CD_NAME_ARR=(${CD_NAME_ARG//// })
-case ${#CD_NAME_ARR[@]} in
-1)
-	CD_NAME=${CD_NAME_ARR[0]}
-	;;
-2)
-	CD_NAMESPACE=${CD_NAME_ARR[0]}
-	CD_NAME=${CD_NAME_ARR[1]}
-	;;
-*)
-	usage "Could not determine namespace and name of ClusterDeployment"
-	;;
-esac
-
-# Get the destination directory
-DEST_DIR=${2}
-[ -z ${DEST_DIR} ] && usage "missing destination directory"
-
-# Argument to supply to oc commands to provide the namespace. This is empty if
-# the user did not specify a namespace.
-NAMESPACE_ARG="${CD_NAMESPACE:+--namespace }${CD_NAMESPACE}"
-
-POD_NAME="hive-logextractor"
-PVC_NAME=$(oc get pvc ${NAMESPACE_ARG} -l hive.openshift.io/cluster-deployment-name=${CD_NAME} -o jsonpath="{.items[0].metadata.name}" 2> /dev/null)
-
-if [ -z "$PVC_NAME" ]
-then
-	echo "Could not find PVC for ClusterDeployment ${CD_NAME_ARG}."
-	echo "Either the installation has not yet started for the ClusterDeployment, the installation succeeded on the first attempt, or the successful installation was long enough ago that the PVC has already been cleaned up."
-	exit 1
+if [ $# -eq 0 ]; then
+  echo "Usage: $(basename $0) ls <extra options to append to aws command>"
+  echo "Usage: $(basename $0) sync <s3_log_dir> <extra options to append to aws command>"
+  echo
+  echo "ls lists the directories in s3 that contain install logs"
+  echo "sync downloads the specified files in the specified s3_log_dir"
+  echo
+  echo "Examples:"
+  echo "  # this lists all log directories in s3"
+  echo "  $(basename $0) ls"
+  echo
+  echo "  # this downloads all logs in cluster1-6a85a345-cd5 to /tmp/logs"
+  echo "  $(basename $0) sync cluster1-6a85a345-cd5 /tmp/logs"
+  echo
+  exit 5
 fi
 
-echo "Found PVC for cluster deployment: $PVC_NAME"
+hiveconfig=$(oc get hiveconfig hive -o json)
+if [ -z "$hiveconfig" ] ; then
+  echo "Error: Unable to retrieve hiveconfig."
+  exit 10
+fi
 
-echo "apiVersion: v1
-kind: Pod
-metadata:
-  name: $POD_NAME${CD_NAMESPACE:+
-  namespace: }${CD_NAMESPACE}
-spec:
-  volumes:
-  - name: logsvol
-    persistentVolumeClaim:
-      claimName: $PVC_NAME
-  containers:
-  - image: centos:7
-    command: ["/bin/sh"]
-    args: ["-c", "while true\; do sleep 100000000\; done"]
-    imagePullPolicy: Always
-    name: logextractor
-    resources: {}
-    volumeMounts:
-    - mountPath: "/logs"
-      name: logsvol
-    terminationMessagePath: /dev/termination-log
-    terminationMessagePolicy: File" | \
-oc apply -f -
+bucket=$(echo "$hiveconfig" | jq -r '.spec.failedProvisionConfig.aws.bucket')
+if [ -z "$bucket" ] ; then
+  echo "Error: Unable to determine S3 bucket from hiveconfig."
+  exit 10
+fi
 
-echo "waiting for $POD_NAME pod to be ready"
+region=$(echo "$hiveconfig" | jq -r '.spec.failedProvisionConfig.aws.region')
+if [ -z "$region" ] ; then
+  echo "Error: Unable to determine AWS region from hiveconfig."
+  exit 10
+fi
 
-oc wait --for=condition=Ready --timeout=120s ${NAMESPACE_ARG} pod/$POD_NAME
+secret_name=$(echo "$hiveconfig" | jq -r '.spec.failedProvisionConfig.aws.credentialsSecretRef.name')
+if [ -z "$secret_name" ] ; then
+  echo "Error: Unable to determine AWS credentials secret name from hiveconfig."
+  exit 10
+fi
 
-echo "copying logs to ${DEST_DIR}"
-oc cp ${NAMESPACE_ARG} $POD_NAME:/logs ${DEST_DIR}
+hive_ns=$(echo "$hiveconfig" | jq -r '.spec.targetNamespace')
+if [ -z "$hive_ns" ] ; then
+  echo "Error: Unable to determine hive namespace from hiveconfig."
+  exit 10
+fi
 
-echo "deleting logextractor pod"
-oc delete pod ${NAMESPACE_ARG} $POD_NAME
+
+credentials_secret=$(oc get secret -n "$hive_ns" -o json "$secret_name")
+if [ -z "$credentials_secret" ] ; then
+  echo "Error: Unable to retrieve credentials secret [$secret_name]."
+  exit 10
+fi
+
+AWS_ACCESS_KEY_ID=$(echo "$credentials_secret" | jq -r '.data.aws_access_key_id' | base64 -d)
+if [ -z "$AWS_ACCESS_KEY_ID" ] || [[ "$AWS_ACCESS_KEY_ID" != AKIA* ]] ; then
+  echo "Error: Unable to retrieve aws_access_key_id from secret [$secret_name] in the [$hive_ns] namespace."
+  exit 10
+fi
+
+AWS_SECRET_ACCESS_KEY=$(echo "$credentials_secret" | jq -r '.data.aws_secret_access_key' | base64 -d)
+if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+  echo "Error: Unable to retrieve aws_secret_access_key from secret [$secret_name] in the [$hive_ns] namespace."
+  exit 10
+fi
+
+
+subcmd=$1
+shift # dump the sub-command from args so we can pass the rest of the args to the aws command
+
+case $subcmd in
+  ls) echo
+      echo "Bucket [$bucket] contents:"
+      aws s3 ls "s3://${bucket}/" $@
+      echo
+      ;;
+  sync)
+      s3_log_dir="$1"
+      shift # dump the specified s3_log_dir so we can pass the rest of the args to the aws command
+      if [ -z "s3_log_dir" ]; then
+        echo "Error: s3_log_dir unspecified."
+        exit 10
+      fi
+      aws s3 sync "s3://${bucket}/${s3_log_dir}" $@
+      ;;
+  *) echo "Error: unknown subcommand [$subcmd]."
+     exit 20
+     ;;
+esac

--- a/pkg/apis/hive/v1/hiveconfig_types.go
+++ b/pkg/apis/hive/v1/hiveconfig_types.go
@@ -125,8 +125,9 @@ type VeleroBackupConfig struct {
 // FailedProvisionConfig contains settings to control behavior undertaken by Hive when an installation attempt fails.
 type FailedProvisionConfig struct {
 
-	// SkipGatherLogs disables functionality that attempts to gather full logs from the cluster if an installation
-	// fails for any reason. The logs will be stored in a persistent volume for up to 7 days.
+	// TODO: Figure out how to mark SkipGatherLogs as deprecated (more than just a comment)
+
+	// DEPRECATED: This flag is no longer respected and will be removed in the future.
 	SkipGatherLogs bool                      `json:"skipGatherLogs,omitempty"`
 	AWS            *FailedProvisionAWSConfig `json:"aws,omitempty"`
 }
@@ -159,11 +160,11 @@ type ManageDNSConfig struct {
 type FailedProvisionAWSConfig struct {
 	// CredentialsSecretRef references a secret in the TargetNamespace that will be used to authenticate with
 	// AWS S3. It will need permission to upload logs to S3.
-	// Secret should have key named "cloud" that contains an AWS credentials formatted file.
-	// Example:
-	//   [default]
-	//   aws_access_key_id = minio
-	//   aws_secret_access_key = minio123
+	// Secret should have keys named aws_access_key_id and aws_secret_access_key that contain the AWS credentials.
+	// Example Secret:
+	//   data:
+	//     aws_access_key_id: minio
+	//     aws_secret_access_key: minio123
 	CredentialsSecretRef corev1.LocalObjectReference `json:"credentialsSecretRef"`
 
 	// Region is the AWS region to use for S3 operations.

--- a/pkg/awsclient/mock/client_generated.go
+++ b/pkg/awsclient/mock/client_generated.go
@@ -12,6 +12,7 @@ import (
 	route53 "github.com/aws/aws-sdk-go/service/route53"
 	s3 "github.com/aws/aws-sdk-go/service/s3"
 	s3iface "github.com/aws/aws-sdk-go/service/s3/s3iface"
+	s3manager "github.com/aws/aws-sdk-go/service/s3/s3manager"
 	sts "github.com/aws/aws-sdk-go/service/sts"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
@@ -383,6 +384,36 @@ func (m *MockClient) ListBuckets(arg0 *s3.ListBucketsInput) (*s3.ListBucketsOutp
 func (mr *MockClientMockRecorder) ListBuckets(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListBuckets", reflect.TypeOf((*MockClient)(nil).ListBuckets), arg0)
+}
+
+// PutObject mocks base method
+func (m *MockClient) PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutObject", input)
+	ret0, _ := ret[0].(*s3.PutObjectOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PutObject indicates an expected call of PutObject
+func (mr *MockClientMockRecorder) PutObject(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutObject", reflect.TypeOf((*MockClient)(nil).PutObject), input)
+}
+
+// Upload mocks base method
+func (m *MockClient) Upload(arg0 *s3manager.UploadInput) (*s3manager.UploadOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Upload", arg0)
+	ret0, _ := ret[0].(*s3manager.UploadOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Upload indicates an expected call of Upload
+func (mr *MockClientMockRecorder) Upload(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*MockClient)(nil).Upload), arg0)
 }
 
 // GetS3API mocks base method

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -29,13 +29,6 @@ const (
 	// MinBackupPeriodSecondsEnvVar is the name of the environment variable used to tell the controller manager the minimum period of time between backups.
 	MinBackupPeriodSecondsEnvVar = "HIVE_MIN_BACKUP_PERIOD_SECONDS"
 
-	// SkipGatherLogsEnvVar is the environment variable which passes the configuration to disable
-	// log gathering on failed cluster installs. The value will be either "true" or "false".
-	// If unset "false" should be assumed. This variable is set by the operator depending on the
-	// value of the setting in HiveConfig, passed to the controllers deployment, as well as to
-	// install pods which do the actual log gathering.
-	SkipGatherLogsEnvVar = "SKIP_GATHER_LOGS"
-
 	// InstallJobLabel is the label used for artifacts specific to Hive cluster installations.
 	InstallJobLabel = "hive.openshift.io/install"
 
@@ -287,11 +280,11 @@ const (
 	// InstallLogsUploadProviderEnvVar is used to specify which object store provider is being used.
 	InstallLogsUploadProviderEnvVar = "HIVE_INSTALL_LOGS_UPLOAD_PROVIDER"
 
-	// InstallLogsCredentialsSecretRefEnvVar is the environment variable specifying what secret to use for storing logs.
-	InstallLogsCredentialsSecretRefEnvVar = "HIVE_INSTALL_LOGS_CREDENTIALS_SECRET"
-
 	// InstallLogsUploadProviderAWS is used to specify that AWS is the cloud provider to upload logs to.
 	InstallLogsUploadProviderAWS = "aws"
+
+	// InstallLogsCredentialsSecretRefEnvVar is the environment variable specifying what secret to use for storing logs.
+	InstallLogsCredentialsSecretRefEnvVar = "HIVE_INSTALL_LOGS_CREDENTIALS_SECRET"
 
 	// InstallLogsAWSRegionEnvVar is the environment variable specifying the region to use with S3
 	InstallLogsAWSRegionEnvVar = "HIVE_INSTALL_LOGS_AWS_REGION"

--- a/pkg/install/generate_test.go
+++ b/pkg/install/generate_test.go
@@ -102,8 +102,6 @@ func TestInstallerPodSpec(t *testing.T) {
 				test.provisionName,
 				test.releaseImage,
 				test.serviceAccountName,
-				test.pvcName,
-				test.skipGatherLogs,
 				test.extraEnvVars)
 
 			// Assert

--- a/pkg/installmanager/helper_test.go
+++ b/pkg/installmanager/helper_test.go
@@ -1,0 +1,48 @@
+package installmanager
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	mockaws "github.com/openshift/hive/pkg/awsclient/mock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakekubeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+)
+
+type mocks struct {
+	fakeKubeClient client.Client
+	mockCtrl       *gomock.Controller
+	mockAWSClient  *mockaws.MockClient
+}
+
+// setupDefaultMocks is an easy way to setup all of the default mocks
+func setupDefaultMocks(t *testing.T, initObjs ...runtime.Object) *mocks {
+	mocks := &mocks{
+		fakeKubeClient: fakekubeclient.NewFakeClient(initObjs...),
+		mockCtrl:       gomock.NewController(t),
+	}
+
+	mocks.mockAWSClient = mockaws.NewMockClient(mocks.mockCtrl)
+
+	return mocks
+}
+
+func testClusterProvision() *hivev1.ClusterProvision {
+	return &hivev1.ClusterProvision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testProvisionName,
+			Namespace: testNamespace,
+		},
+		Spec: hivev1.ClusterProvisionSpec{
+			ClusterDeploymentRef: corev1.LocalObjectReference{
+				Name: testDeploymentName,
+			},
+			Stage: hivev1.ClusterProvisionStageProvisioning,
+		},
+	}
+}

--- a/pkg/installmanager/loguploaderactuator.go
+++ b/pkg/installmanager/loguploaderactuator.go
@@ -1,0 +1,16 @@
+package installmanager
+
+import (
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// LogUploaderActuator interface is the interface that is used to add provider support for uploading logs.
+type LogUploaderActuator interface {
+	// IsConfigured returns true if the actuator can handle a particular case
+	IsConfigured() bool
+
+	// UploadLogs uploads installer logs to the provider's storage mechanism.
+	UploadLogs(clusterName string, clusterprovision *hivev1.ClusterProvision, c client.Client, log log.FieldLogger, filenames ...string) error
+}

--- a/pkg/installmanager/s3loguploaderactuator.go
+++ b/pkg/installmanager/s3loguploaderactuator.go
@@ -1,0 +1,104 @@
+package installmanager
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	awsclient "github.com/openshift/hive/pkg/awsclient"
+	"github.com/openshift/hive/pkg/constants"
+
+	"github.com/pkg/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+// Ensure s3LogUploaderActuator implements the Actuator interface. This will fail at compile time when false.
+var _ LogUploaderActuator = &s3LogUploaderActuator{}
+
+// s3LogUploaderActuator manages getting the desired state, getting the current state and reconciling the two.
+type s3LogUploaderActuator struct {
+	// awsClientFn is the function to build an AWS client, here for lazy loading the client.
+	awsClientFn func(client.Client, string, string, string, log.FieldLogger) (awsclient.Client, error)
+}
+
+// IsConfigured returns true if the actuator can handle a particular ClusterDeprovision
+func (a *s3LogUploaderActuator) IsConfigured() bool {
+	provider, foundProviderEnvVar := os.LookupEnv(constants.InstallLogsUploadProviderEnvVar)
+	if !foundProviderEnvVar {
+		log.Debug("Couldn't find install logs provider environment variable. Skipping.")
+		return false
+	}
+
+	return provider == constants.InstallLogsUploadProviderAWS
+}
+
+// UploadLogs uploads installer logs to the provider's storage mechanism.
+func (a *s3LogUploaderActuator) UploadLogs(clusterName string, clusterprovision *hivev1.ClusterProvision, c client.Client, log log.FieldLogger, filenames ...string) error {
+	secretName, foundSecretName := os.LookupEnv(constants.InstallLogsCredentialsSecretRefEnvVar)
+	if !foundSecretName {
+		return errors.New("couldn't find secret name in environment variable. Skipping upload")
+	}
+
+	region, foundRegionEnvVar := os.LookupEnv(constants.InstallLogsAWSRegionEnvVar)
+	if !foundRegionEnvVar {
+		return errors.New("couldn't find region in environment variable. Skipping upload")
+	}
+
+	bucket, foundBucketEnvVar := os.LookupEnv(constants.InstallLogsAWSS3BucketEnvVar)
+	if !foundBucketEnvVar {
+		return errors.New("couldn't find bucket in environment variable. Skipping upload")
+	}
+
+	awsc, err := a.awsClientFn(c, secretName, clusterprovision.Namespace, region, log)
+	if err != nil {
+		return err
+	}
+
+	retvalErrs := []error{}
+
+	folder := fmt.Sprintf("%v-%v", clusterName, clusterprovision.Namespace)
+
+	log.Infof("Uploading log(s) to S3: s3://%v/%v/", bucket, folder)
+
+	for _, filename := range filenames {
+		file, err := os.Open(filename)
+		if err != nil {
+			retvalErrs = append(retvalErrs, errors.Wrapf(err, "Failed opening log file: %v", filename))
+			continue
+		}
+		defer file.Close()
+
+		stat, err := file.Stat()
+		if err != nil {
+			retvalErrs = append(retvalErrs, errors.Wrapf(err, "Failed stat on log file: %v", filename))
+			continue
+		}
+
+		logkey := fmt.Sprintf("%v/%v-%v", folder, clusterprovision.Name, stat.Name())
+
+		_, err = awsc.Upload(&s3manager.UploadInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(logkey),
+			Body:   file,
+		})
+
+		if err != nil {
+			retvalErrs = append(retvalErrs, errors.Wrapf(err, "Failed uploading log file: %v", filename))
+		}
+	}
+
+	return utilerrors.NewAggregate(retvalErrs)
+}
+
+func getAWSClient(c client.Client, secretName, namespace, region string, logger log.FieldLogger) (awsclient.Client, error) {
+	awsClient, err := awsclient.NewClient(c, secretName, namespace, region)
+	if err != nil {
+		logger.WithError(err).Error("failed to get AWS client")
+	}
+	return awsClient, err
+}

--- a/pkg/installmanager/s3loguploaderactuator_test.go
+++ b/pkg/installmanager/s3loguploaderactuator_test.go
@@ -1,0 +1,95 @@
+package installmanager
+
+import (
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/openshift/hive/pkg/apis"
+	awsclient "github.com/openshift/hive/pkg/awsclient"
+	"github.com/openshift/hive/pkg/constants"
+)
+
+const (
+	awsSecretName = "awscreds"
+)
+
+func init() {
+	log.SetLevel(log.DebugLevel)
+}
+
+func TestUploadLogs(t *testing.T) {
+	apis.AddToScheme(scheme.Scheme)
+	tests := []struct {
+		name                    string
+		existing                []runtime.Object
+		putObjectError          error
+		setupPutObjectMock      bool
+		setupEnvVars            bool
+		expectedUploadLogsError bool
+	}{
+		{
+			name:                    "missing env vars",
+			existing:                []runtime.Object{},
+			expectedUploadLogsError: true,
+		},
+		{
+			name:               "successfully upload objects",
+			existing:           []runtime.Object{},
+			setupPutObjectMock: true,
+			setupEnvVars:       true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Arrange
+			mocks := setupDefaultMocks(t, test.existing...)
+
+			// This is necessary for the mocks to report failures like methods not being called an expected number of times.
+			defer mocks.mockCtrl.Finish()
+
+			// The aws actuator won't run without this set.
+			if test.setupEnvVars {
+				os.Setenv(constants.InstallLogsUploadProviderEnvVar, constants.InstallLogsUploadProviderAWS)
+				os.Setenv(constants.InstallLogsCredentialsSecretRefEnvVar, "notarealsecret")
+				os.Setenv(constants.InstallLogsAWSRegionEnvVar, "region1")
+				os.Setenv(constants.InstallLogsAWSS3BucketEnvVar, "bucket1")
+			}
+			if test.setupPutObjectMock {
+				mocks.mockAWSClient.EXPECT().
+					Upload(gomock.Any()).
+					Return(nil, test.putObjectError)
+			}
+
+			actuator := &s3LogUploaderActuator{awsClientFn: func(client.Client, string, string, string, log.FieldLogger) (awsclient.Client, error) {
+				return mocks.mockAWSClient, nil
+			}}
+			provision := testClusterProvision()
+
+			// Act
+			err := actuator.UploadLogs("notarealcluster", provision, mocks.fakeKubeClient, log.New(), "/etc/issue")
+
+			// Assert
+			if test.expectedUploadLogsError {
+				assert.Error(t, err, "Function didn't error as expected")
+			} else {
+				assert.NoError(t, err, "Function errored unexpectedly")
+			}
+
+			if test.setupEnvVars {
+				os.Unsetenv(constants.InstallLogsUploadProviderEnvVar)
+				os.Unsetenv(constants.InstallLogsCredentialsSecretRefEnvVar)
+				os.Unsetenv(constants.InstallLogsAWSRegionEnvVar)
+				os.Unsetenv(constants.InstallLogsAWSS3BucketEnvVar)
+			}
+		})
+	}
+}

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -103,13 +103,6 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 
 	hiveNSName := getHiveNamespace(instance)
 
-	// By default we will try to gather logs on failed installs:
-	logsEnvVar := corev1.EnvVar{
-		Name:  constants.SkipGatherLogsEnvVar,
-		Value: strconv.FormatBool(instance.Spec.FailedProvisionConfig.SkipGatherLogs),
-	}
-	hiveContainer.Env = append(hiveContainer.Env, logsEnvVar)
-
 	if instance.Spec.FailedProvisionConfig.AWS != nil {
 		awsSpec := instance.Spec.FailedProvisionConfig.AWS
 


### PR DESCRIPTION
- [x] Implement sending install logs to s3 storage on failure
- [x] Remove provisioning PV previously used to store install logs.
- [x] Add unit tests
- [x] Manually test bootstrap node failure

/assign @joelddiaz 
/cc @csrwng 