### PR TITLE
Major improvement for syncset apply performance and simulated scale testing.

### DIFF
--- a/contrib/pkg/adm/managedns/enable.go
+++ b/contrib/pkg/adm/managedns/enable.go
@@ -374,8 +374,7 @@ func (o *Options) getResourceHelper() (resource.Helper, error) {
 		log.WithError(err).Error("Cannot get client config")
 		return nil, err
 	}
-	helper := resource.NewHelperFromRESTConfig(cfg, log.WithField("command", "adm manage-dns enable"))
-	return helper, nil
+	return resource.NewHelperFromRESTConfig(cfg, log.WithField("command", "adm manage-dns enable"))
 }
 
 func (o *Options) setupLocalClients() error {

--- a/contrib/pkg/testresource/command.go
+++ b/contrib/pkg/testresource/command.go
@@ -56,7 +56,11 @@ func newApplyCommand() *cobra.Command {
 			}
 			content := mustRead(args[0])
 			kubeconfig := mustRead(kubeconfigPath)
-			helper := resource.NewHelper(kubeconfig, log.WithField("cmd", "apply"))
+			helper, err := resource.NewHelper(kubeconfig, log.WithField("cmd", "apply"))
+			if err != nil {
+				fmt.Printf("Error creating resource helper: %v\n", err)
+				return
+			}
 			info, err := helper.Info(content)
 			if err != nil {
 				fmt.Printf("Error obtaining info: %v\n", err)
@@ -124,8 +128,12 @@ func newPatchCommand() *cobra.Command {
 			}
 			content := mustRead(args[0])
 			kubeconfig := mustRead(kubeconfigPath)
-			helper := resource.NewHelper(kubeconfig, log.WithField("cmd", "patch"))
-			err := helper.Patch(types.NamespacedName{Name: name, Namespace: namespace}, kind, apiVersion, content, patchTypeStr)
+			helper, err := resource.NewHelper(kubeconfig, log.WithField("cmd", "patch"))
+			if err != nil {
+				fmt.Printf("Error creating resource helper: %v\n", err)
+				return
+			}
+			err = helper.Patch(types.NamespacedName{Name: name, Namespace: namespace}, kind, apiVersion, content, patchTypeStr)
 			if err != nil {
 				fmt.Printf("Error: %v\n", err)
 				return

--- a/contrib/pkg/utils/generic.go
+++ b/contrib/pkg/utils/generic.go
@@ -42,8 +42,7 @@ func GetResourceHelper(logger log.FieldLogger) (resource.Helper, error) {
 		logger.WithError(err).Error("Cannot get client config")
 		return nil, err
 	}
-	helper := resource.NewHelperFromRESTConfig(cfg, logger)
-	return helper, nil
+	return resource.NewHelperFromRESTConfig(cfg, logger)
 }
 
 func DefaultNamespace() (string, error) {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -294,6 +294,10 @@ const (
 	// InstallLogsAWSS3BucketEnvVar is the environment variable specifying the S3 bucket to use.
 	InstallLogsAWSS3BucketEnvVar = "HIVE_INSTALL_LOGS_AWS_S3_BUCKET"
 
+	// HiveSyncSetsFakeApplyEnvVar is set to true by the hive-operator when a developer has configured HiveConfig to
+	// fake out all apply operations for simulated scale testing.
+	HiveSyncSetsFakeApplyEnvVar = "HIVE_SYNCSETS_FAKE_APPLY"
+
 	// ReconcileIDLen is the length of the random strings we generate for contextual loggers in controller
 	// Reconcile functions.
 	ReconcileIDLen = 8

--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -149,7 +149,7 @@ func NewReconciler(mgr manager.Manager, rateLimiter flowcontrol.RateLimiter) (*R
 }
 
 func resourceHelperBuilderFunc(restConfig *rest.Config, logger log.FieldLogger) (resource.Helper, error) {
-	return resource.NewHelperFromRESTConfig(restConfig, logger), nil
+	return resource.NewHelperFromRESTConfig(restConfig, logger)
 }
 
 // AddToManager adds a new Controller to mgr with r as the reconcile.Reconciler

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller.go
@@ -75,7 +75,11 @@ func Add(mgr manager.Manager) error {
 // NewReconciler returns a new reconcile.Reconciler
 func NewReconciler(mgr manager.Manager, rateLimiter flowcontrol.RateLimiter) reconcile.Reconciler {
 	logger := log.WithField("controller", ControllerName)
-	helper := resource.NewHelperWithMetricsFromRESTConfig(mgr.GetConfig(), ControllerName, logger)
+	helper, err := resource.NewHelperWithMetricsFromRESTConfig(mgr.GetConfig(), ControllerName, logger)
+	if err != nil {
+		// Hard exit if we can't create this controller
+		logger.WithError(err).Fatal("unable to create resource helper")
+	}
 	r := &ReconcileControlPlaneCerts{
 		Client:  controllerutils.NewClientWithMetricsOrDie(mgr, ControllerName, &rateLimiter),
 		scheme:  mgr.GetScheme(),

--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -76,7 +76,11 @@ func Add(mgr manager.Manager) error {
 // NewReconciler returns a new reconcile.Reconciler
 func NewReconciler(mgr manager.Manager, rateLimiter flowcontrol.RateLimiter) reconcile.Reconciler {
 	logger := log.WithField("controller", ControllerName)
-	helper := resource.NewHelperWithMetricsFromRESTConfig(mgr.GetConfig(), ControllerName, logger)
+	helper, err := resource.NewHelperWithMetricsFromRESTConfig(mgr.GetConfig(), ControllerName, logger)
+	if err != nil {
+		// Hard exit if we can't create this controller
+		logger.WithError(err).Fatal("unable to create resource helper")
+	}
 	return &ReconcileRemoteClusterIngress{
 		Client:  controllerutils.NewClientWithMetricsOrDie(mgr, ControllerName, &rateLimiter),
 		scheme:  mgr.GetScheme(),

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -50,6 +50,12 @@ const (
 	// hiveConfigHashAnnotation is annotation on hivedeployment that contains
 	// the hash of the contents of the hive-controllers-config configmap
 	hiveConfigHashAnnotation = "hive.openshift.io/hiveconfig-hash"
+
+	// fakeAppliesAnnotation is an annotation which can be added to HiveConfig indicating that
+	// Hive should be configured to completely fake all "apply" operations to target clusters.
+	// This is used for scale testing simulations where we want to adopt one cluster thousands
+	// of times, but not overwhelm it with requests.
+	fakeAppliesAnnotation = "hive.openshift.io/fake-applies"
 )
 
 func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper, instance *hivev1.HiveConfig, recorder events.Recorder, mdConfigMap *corev1.ConfigMap) error {
@@ -162,6 +168,21 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 				Value: instance.Spec.Backup.Velero.Namespace,
 			}
 			hiveContainer.Env = append(hiveContainer.Env, tmpEnvVar)
+		}
+	}
+
+	if _, ok := instance.Annotations[fakeAppliesAnnotation]; ok {
+		fakeApplies, err := strconv.ParseBool(instance.Annotations[fakeAppliesAnnotation])
+		if err != nil {
+			hLog.WithError(err).Errorf("unable to parse %s as a boolean", fakeAppliesAnnotation)
+			return err
+		}
+		if fakeApplies {
+			hLog.Warnf("%s specified, configuring hive to fake all resource helper apply/delete operations", fakeAppliesAnnotation)
+			hiveContainer.Env = append(hiveContainer.Env, corev1.EnvVar{
+				Name:  hiveconstants.HiveSyncSetsFakeApplyEnvVar,
+				Value: "true",
+			})
 		}
 	}
 

--- a/pkg/operator/hive/hive_controller.go
+++ b/pkg/operator/hive/hive_controller.go
@@ -320,7 +320,12 @@ func (r *ReconcileHiveConfig) Reconcile(request reconcile.Request) (reconcile.Re
 		}
 	}
 
-	h := resource.NewHelperFromRESTConfig(r.restConfig, hLog)
+	h, err := resource.NewHelperFromRESTConfig(r.restConfig, hLog)
+	if err != nil {
+		hLog.WithError(err).Error("error creating resource helper")
+		r.updateHiveConfigStatus(origHiveConfig, instance, hLog, false)
+		return reconcile.Result{}, err
+	}
 
 	managedDomainsConfigMap, err := r.configureManagedDomains(hLog, instance)
 	if err != nil {

--- a/pkg/resource/apply.go
+++ b/pkg/resource/apply.go
@@ -235,7 +235,8 @@ func (r *helper) setupApplyCommand(f cmdutil.Factory, obj []byte, ioStreams gene
 		return nil, nil, err
 	}
 	o.DeleteOptions = o.DeleteFlags.ToOptions(dynamicClient, o.IOStreams)
-	o.OpenAPISchema, _ = f.OpenAPISchema()
+	// Re-use the openAPISchema that should have been initialized in the constructor.
+	o.OpenAPISchema = r.openAPISchema
 	o.Validator, err = f.Validator(false)
 	if err != nil {
 		r.logger.WithError(err).Error("cannot obtain schema to validate objects from factory")

--- a/test/integration/resource/apply_test.go
+++ b/test/integration/resource/apply_test.go
@@ -118,9 +118,12 @@ func TestApply(t *testing.T) {
 				}
 				var h resource.Helper
 				if clientConfig == "kubeconfig" {
-					h = resource.NewHelper(kubeconfig, logger)
+					h, err = resource.NewHelper(kubeconfig, logger)
 				} else {
-					h = resource.NewHelperFromRESTConfig(cfg, logger)
+					h, err = resource.NewHelperFromRESTConfig(cfg, logger)
+				}
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
 				}
 				accessor := meta.NewAccessor()
 				for _, obj := range test.existing {

--- a/test/integration/resource/createonly_test.go
+++ b/test/integration/resource/createonly_test.go
@@ -88,9 +88,12 @@ func TestCreateOnly(t *testing.T) {
 				}
 				var h resource.Helper
 				if clientConfig == "kubeconfig" {
-					h = resource.NewHelper(kubeconfig, logger)
+					h, err = resource.NewHelper(kubeconfig, logger)
 				} else {
-					h = resource.NewHelperFromRESTConfig(cfg, logger)
+					h, err = resource.NewHelperFromRESTConfig(cfg, logger)
+				}
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
 				}
 				accessor := meta.NewAccessor()
 				for _, obj := range test.existing {

--- a/test/integration/resource/createupdate_test.go
+++ b/test/integration/resource/createupdate_test.go
@@ -103,9 +103,12 @@ func TestCreateOrUpdate(t *testing.T) {
 				}
 				var h resource.Helper
 				if clientConfig == "kubeconfig" {
-					h = resource.NewHelper(kubeconfig, logger)
+					h, err = resource.NewHelper(kubeconfig, logger)
 				} else {
-					h = resource.NewHelperFromRESTConfig(cfg, logger)
+					h, err = resource.NewHelperFromRESTConfig(cfg, logger)
+				}
+				if err != nil {
+					t.Fatalf("unexpected err: %v", err)
 				}
 				accessor := meta.NewAccessor()
 				for _, obj := range test.existing {

--- a/test/integration/resource/info_test.go
+++ b/test/integration/resource/info_test.go
@@ -21,7 +21,8 @@ func TestInfo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	h := resource.NewHelper(kubeconfig, logger)
+	h, err := resource.NewHelper(kubeconfig, logger)
+	require.NoError(t, err)
 	i, err := h.Info([]byte(`apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/test/integration/resource/patch_test.go
+++ b/test/integration/resource/patch_test.go
@@ -73,7 +73,11 @@ func TestPatch(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected err: %v", err)
 			}
-			h := resource.NewHelper(kubeconfig, logger)
+			h, err := resource.NewHelper(kubeconfig, logger)
+			if err != nil {
+				t.Errorf("unexpected err creating resource Helper: %v", err)
+				return
+			}
 			err = h.Patch(types.NamespacedName{Namespace: namespace.Name, Name: cm.Name}, "ConfigMap", "v1", []byte(test.patch), test.patchType)
 			if err != nil {
 				t.Errorf("unexpected error calling patch: %v", err)


### PR DESCRIPTION
Adds a new developer annotation that can be applied to HiveConfig, hive.openshift.io/fake-applies: true, which will configure hive to fake out all Apply operations (SyncSets) to remote clusters. This is for simulated scale testing and allows us to use one spoke cluster and adopt it thousands of times. 

Commit still included for Greg's original work in this area in case we ever want to reference or use it, his solution uses a nodejs server which we tell to wait a specified ms before returning. In my testing a Sleep performs fairly similar, a little faster but I believe this is because we are double simulating requests in the nodejs approach, if we lookup real world data for the sleep array, then do an http request telling it to wait this time, it will be slower than the data we looked up. I believe Sleep is a reasonable simulation and much easier to commit in this fashion for re-use, however I wanted to keep the http request sim in the commit history.

Major fix in this PR is for performance, I found that we surprisingly still are doing OpenAPI schema builds on every single resource apply. We found this previously and it was the driver for moving to ClusterSync instead of SyncSetInstance controllers, however somewhere we missed this along the way. This operation took 3s when we first discovered it in the wild IIRC, and in my testing against one cluster it was taking 11s. Done 600 times, we can't complete a reconcile loop in less than an hour.

This fix moves the schema build up into the constructor for the resource apply Helper and then stores it as a field.
