### PR TITLE
Add dev prometheus config for scraping multiple pods.

### DIFF
--- a/config/prometheus/prometheus-configmap.yaml
+++ b/config/prometheus/prometheus-configmap.yaml
@@ -14,7 +14,24 @@ data:
         static_configs:
           - targets: ['localhost:9090']
 
-      - job_name: 'hive'
-        static_configs:
-          - targets: ['hive-controllers:2112']
+      - job_name: 'hive-controllers'
+        kubernetes_sd_configs:
+          - role: endpoints
+        relabel_configs:
+          - source_labels:
+              - __meta_kubernetes_namespace
+              - __meta_kubernetes_endpoints_name
+              - __meta_kubernetes_endpoint_port_name
+            action: keep
+            regex: hive;hive-controllers;metrics
 
+      - job_name: 'hive-clustersync'
+        kubernetes_sd_configs:
+          - role: endpoints
+        relabel_configs:
+          - source_labels:
+              - __meta_kubernetes_namespace
+              - __meta_kubernetes_endpoints_name
+              - __meta_kubernetes_endpoint_port_name
+            action: keep
+            regex: hive;hive-clustersync;metrics

--- a/config/prometheus/prometheus-deployment-with-pvc.yaml
+++ b/config/prometheus/prometheus-deployment-with-pvc.yaml
@@ -1,3 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: hive
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: hive
 ---
 apiVersion: "v1"
 kind: "PersistentVolumeClaim"
@@ -30,6 +65,7 @@ spec:
         app: prometheus
         purpose: example
     spec:
+      serviceAccountName: prometheus
       containers:
       - name: prometheus-example
         image: prom/prometheus

--- a/config/prometheus/prometheus-deployment.yaml
+++ b/config/prometheus/prometheus-deployment.yaml
@@ -1,3 +1,39 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: hive
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: hive
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -18,6 +54,7 @@ spec:
         app: prometheus
         purpose: example
     spec:
+      serviceAccountName: prometheus
       containers:
       - name: prometheus-example
         image: prom/prometheus


### PR DESCRIPTION
This is in preparation for the hive-clustersync pods that we expect to
soon be running, we no longer will have one pod to scrape by going to a
service, rather we'll want to scrape all pods by endpoints behind the
service.

Breaks out hive-controllers (name matches app-sre configuration,
although it doesn't matter as this is just dev prometheus setup for
scale testing), and adds hive-clustersync job. Both are capable of
scraping multiple pods, though this is not strictly relevant for
hive-controllers, it should work fine.