### PR TITLE
Patch APIServer config for certs instead of assuming full control.

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -268,6 +268,7 @@ Prerequisites:
 1. Ensure that the `hiveutil` binary is available (`make hiveutil`)
 2. Run: `hiveutil certificate create ${CLUSTER_NAME} --base-domain ${BASE_DOMAIN}`
    where CLUSTER_NAME is the name of your cluster and BASE_DOMAIN is the public DNS domain for your cluster (Defaults to `new-installer.openshift.com`)
+3. Follow the instructions in the output of the hiveutil certificate command. You will need to setup the letsencrypt CA as trusted one time only for your cluster.
 
 ### Using Generated Certificate
 
@@ -277,7 +278,7 @@ create a cluster that uses the certificate.
 NOTE: The cluster name and domain used to create the certificate must match the name and base domain of the cluster you create.
 
 Example:
-`hiveutil create-cluster mycluster --serving-cert=$HOME/mycluster.crt --serving-cert-key=$HOME/mycluster.key`
+`hiveutil create-cluster mycluster --serving-cert=$HOME/mycluster.crt --serving-cert-key=$HOME/mycluster.key` 
 
 
 ## Dependency management

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,7 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	configv1 "github.com/openshift/api/config/v1"
 	openshiftapiv1 "github.com/openshift/api/config/v1"
 
 	"github.com/openshift/hive/pkg/apis"
@@ -62,18 +62,18 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 	tests := []struct {
 		name     string
 		existing []runtime.Object
-		validate func(*testing.T, client.Client, []runtime.Object)
+
+		expectNoSyncSet        bool
+		expectedPatch          string
+		expectedSecrets        []string
+		expectedNotFoundStatus corev1.ConditionStatus
 	}{
 		{
 			name: "no control plane certs",
 			existing: []runtime.Object{
 				fakeClusterDeployment().obj(),
 			},
-			validate: func(t *testing.T, c client.Client, applied []runtime.Object) {
-				cd := getFakeClusterDeployment(t, c)
-				assert.Empty(t, applied, "no syncset should be applied")
-				assert.Len(t, cd.Status.Conditions, 1, "no conditions should be added")
-			},
+			expectNoSyncSet: true,
 		},
 		{
 			name: "default control plane certs",
@@ -81,18 +81,8 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 				fakeClusterDeployment().defaultCert("default-cert", "default-secret").obj(),
 				fakeCertSecret("default-secret"),
 			},
-			validate: func(t *testing.T, c client.Client, applied []runtime.Object) {
-				cd := getFakeClusterDeployment(t, c)
-				assert.Len(t, cd.Status.Conditions, 1, "no conditions should be added")
-
-				validateAppliedSyncSet(t, applied, additionalCert(fakeAPIURLDomain, "default-secret"))
-
-				ss := applied[0].(metav1.Object)
-				labels := ss.GetLabels()
-
-				assert.Equal(t, fakeClusterDeployment().obj().Name, labels[constants.ClusterDeploymentNameLabel], "incorrect cluster deployment name label")
-				assert.Equal(t, constants.SyncSetTypeControlPlaneCerts, labels[constants.SyncSetTypeLabel], "incorrect syncset type label")
-			},
+			expectedPatch:   `[ { "op": "replace", "path": "/spec/servingCerts/namedCertificates", "value": [  { "names": [ "test-api-url" ], "servingCertificate": { "name": "fake-cluster-default-secret" } } ] } ]`,
+			expectedSecrets: []string{"default-secret"},
 		},
 		{
 			name: "additional certs only",
@@ -103,11 +93,8 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 				fakeCertSecret("secret1"),
 				fakeCertSecret("secret2"),
 			},
-			validate: func(t *testing.T, c client.Client, applied []runtime.Object) {
-				cd := getFakeClusterDeployment(t, c)
-				assert.Len(t, cd.Status.Conditions, 1, "no conditions should be added")
-				validateAppliedSyncSet(t, applied, additionalCert("foo.com", "secret1"), additionalCert("bar.com", "secret2"))
-			},
+			expectedPatch:   `[ { "op": "replace", "path": "/spec/servingCerts/namedCertificates", "value": [  { "names": [ "foo.com" ], "servingCertificate": { "name": "fake-cluster-secret1" } }, { "names": [ "bar.com" ], "servingCertificate": { "name": "fake-cluster-secret2" } } ] } ]`,
+			expectedSecrets: []string{"secret1", "secret2"},
 		},
 		{
 			name: "default and additional certs",
@@ -121,12 +108,8 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 				fakeCertSecret("secret1"),
 				fakeCertSecret("secret2"),
 			},
-			validate: func(t *testing.T, c client.Client, applied []runtime.Object) {
-				cd := getFakeClusterDeployment(t, c)
-				assert.Len(t, cd.Status.Conditions, 1, "no conditions should be added")
-
-				validateAppliedSyncSet(t, applied, additionalCert(fakeAPIURLDomain, "secret0"), additionalCert("foo.com", "secret1"), additionalCert("bar.com", "secret2"))
-			},
+			expectedPatch:   `[ { "op": "replace", "path": "/spec/servingCerts/namedCertificates", "value": [  { "names": [ "test-api-url" ], "servingCertificate": { "name": "fake-cluster-secret0" } }, { "names": [ "foo.com" ], "servingCertificate": { "name": "fake-cluster-secret1" } }, { "names": [ "bar.com" ], "servingCertificate": { "name": "fake-cluster-secret2" } } ] } ]`,
+			expectedSecrets: []string{"secret0", "secret1", "secret2"},
 		},
 		{
 			name: "missing secret",
@@ -138,38 +121,26 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 				fakeCertSecret("secret0"),
 				fakeCertSecret("secret2"),
 			},
-			validate: func(t *testing.T, c client.Client, applied []runtime.Object) {
-				assert.Empty(t, applied)
-				cd := getFakeClusterDeployment(t, c)
-				assert.Equal(t, 2, len(cd.Status.Conditions), "unexpected number of conditions")
-				notFoundCondition := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ControlPlaneCertificateNotFoundCondition)
-				assert.NotNil(t, notFoundCondition, "expected a NotFound condition")
-				assert.Equal(t, notFoundCondition.Status, corev1.ConditionTrue, "expected NotFound condition to be True")
-			},
+			expectNoSyncSet:        true,
+			expectedNotFoundStatus: corev1.ConditionTrue,
 		},
 		{
-			name: "existing syncset, remove certs",
+			name: "existing syncset remove certs",
 			existing: []runtime.Object{
 				fakeClusterDeployment().obj(),
 				fakeSyncSet(),
 			},
-			validate: func(t *testing.T, c client.Client, applied []runtime.Object) {
-				validateAppliedSyncSet(t, applied)
-			},
+			expectedPatch: `[ { "op": "replace", "path": "/spec/servingCerts/namedCertificates", "value": [  ] } ]`,
 		},
 		{
-			name: "existing not found condition, change to false",
+			name: "existing not found condition changed to false",
 			existing: []runtime.Object{
-				fakeClusterDeployment().defaultCert("defaut", "test-secret").withNotFoundCondition().obj(),
+				fakeClusterDeployment().defaultCert("default", "test-secret").withNotFoundCondition().obj(),
 				fakeCertSecret("test-secret"),
 			},
-			validate: func(t *testing.T, c client.Client, applied []runtime.Object) {
-				cd := getFakeClusterDeployment(t, c)
-				assert.Equal(t, 2, len(cd.Status.Conditions), "unexpected number of conditions")
-				notFoundCondition := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ControlPlaneCertificateNotFoundCondition)
-				assert.NotNil(t, notFoundCondition, "expected a NotFound condition")
-				assert.Equal(t, string(corev1.ConditionFalse), string(notFoundCondition.Status), "unexpected NotFound status")
-			},
+			// no apply expected because we update the condition and return immediately, next reconcile would apply
+			expectNoSyncSet:        true,
+			expectedNotFoundStatus: corev1.ConditionFalse,
 		},
 	}
 
@@ -203,8 +174,44 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 
 			assert.Nil(t, err)
 
-			if test.validate != nil {
-				test.validate(t, fakeClient, applier.appliedObjects)
+			cd := getFakeClusterDeployment(t, fakeClient)
+
+			if test.expectNoSyncSet {
+				assert.Len(t, applier.appliedObjects, 0, "unexpected syncset apply")
+			} else {
+				require.Len(t, applier.appliedObjects, 1, "single apply expected")
+				require.IsType(t, &hivev1.SyncSet{}, applier.appliedObjects[0], "syncset apply expected")
+				ss := applier.appliedObjects[0].(*hivev1.SyncSet)
+
+				// Resources should have been removed from the SyncSet
+				assert.Equal(t, 0, len(ss.Spec.Resources))
+
+				// Expect our patch, plus one to force the kubeapiserver redeploy:
+				require.Equal(t, 2, len(ss.Spec.Patches))
+				assert.Equal(t, test.expectedPatch, ss.Spec.Patches[0].Patch)
+
+				secretMappings := ss.Spec.Secrets
+				require.Equal(t, len(test.expectedSecrets), len(secretMappings))
+
+				// Ensure there are no duplicate Secret names
+				names := secretNames(secretMappings)
+				assert.Equal(t, sets.NewString(names...).Len(), len(names), "duplicate secret names present")
+				for i, sn := range test.expectedSecrets {
+					assert.Equal(t, hivev1.SecretReference{Name: sn, Namespace: fakeNamespace}, ss.Spec.Secrets[i].SourceRef)
+				}
+
+				labels := ss.GetLabels()
+
+				assert.Equal(t, fakeClusterDeployment().obj().Name, labels[constants.ClusterDeploymentNameLabel], "incorrect cluster deployment name label")
+				assert.Equal(t, constants.SyncSetTypeControlPlaneCerts, labels[constants.SyncSetTypeLabel], "incorrect syncset type label")
+			}
+
+			notFoundCondition := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ControlPlaneCertificateNotFoundCondition)
+			if test.expectedNotFoundStatus != "" {
+				assert.NotNil(t, notFoundCondition, "expected a NotFound condition")
+				assert.Equal(t, test.expectedNotFoundStatus, notFoundCondition.Status, "unexpected NotFound status")
+			} else {
+				assert.Nil(t, notFoundCondition, "test did not specify an expectedNotFoundStatus but condition was present")
 			}
 
 		})
@@ -397,43 +404,11 @@ func additionalCert(domain, secret string) additionalCertSpec {
 	}
 }
 
-func validateAppliedSyncSet(t *testing.T, objs []runtime.Object, additional ...additionalCertSpec) {
-	assert.Len(t, objs, 1, "single syncset expected")
-	assert.IsType(t, &hivev1.SyncSet{}, objs[0], "syncset object expected")
-	ss := objs[0].(*hivev1.SyncSet)
-	secretMappings := ss.Spec.Secrets
-	var apiServerConfig *configv1.APIServer
-	for _, rr := range ss.Spec.Resources {
-		if config, ok := rr.Object.(*configv1.APIServer); ok {
-			apiServerConfig = config
-			continue
-		}
-		assert.Fail(t, "unexpected resource type", "syncset resource type: %T", rr.Object)
-	}
-	// Ensure there are no duplicate names
-	names := secretNames(secretMappings)
-	assert.Equal(t, sets.NewString(names...).Len(), len(names))
-
-	for i, c := range additional {
-		s := findSecret(secretMappings, c.secret)
-		assert.NotNil(t, s)
-		assert.Contains(t, apiServerConfig.Spec.ServingCerts.NamedCertificates[i].Names, c.domain)
-		assert.Equal(t, apiServerConfig.Spec.ServingCerts.NamedCertificates[i].ServingCertificate.Name, c.secret)
-	}
-	if len(additional) == 0 {
-		assert.Empty(t, apiServerConfig.Spec.ServingCerts.NamedCertificates)
-	}
-
-	// If not setting any secrets, ensure they're empty
-	if len(additional) == 0 {
-		assert.Empty(t, secretMappings)
-	}
-}
-
 func fakeSyncSet() *hivev1.SyncSet {
 	ss := &hivev1.SyncSet{}
 	ss.Namespace = fakeNamespace
 	ss.Name = GenerateControlPlaneCertsSyncSetName(fakeName)
+	// Simulated legacy resources, should be migrated to a patch after reconcile.
 	ss.Spec.Resources = []runtime.RawExtension{
 		{
 			Object: fakeCertSecret("foo1"),

--- a/pkg/resource/patch.go
+++ b/pkg/resource/patch.go
@@ -43,6 +43,9 @@ func (r *helper) Patch(name types.NamespacedName, kind, apiVersion string, patch
 			WithField("stderr", ioStreams.ErrOut.(*bytes.Buffer).String()).Warn("running the patch command failed")
 		return err
 	}
+	r.logger.
+		WithField("stdout", ioStreams.Out.(*bytes.Buffer).String()).
+		WithField("stderr", ioStreams.ErrOut.(*bytes.Buffer).String()).Info("patch command successful")
 	return nil
 }
 


### PR DESCRIPTION
To allow other callers to manage parts of the APIServer configuration
in-cluster, switch to patching in the certs we need instead of fully
managing the resource.

Refactors tests a bit to not rely on validation functions and instead
test most things consistently across every set of test inputs.