### PR TITLE
Point installer to forked branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,3 +81,6 @@ replace (
 // needed because otherwise installer fetches a library-go version that requires bitbucket.com/ww/goautoneg which is dead
 // Tagged version fetches github.com/munnerz/goautoneg instead
 replace github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20200421122923-c1de486c7d47
+
+// Point installer to forked ocm-2.0 branch
+replace github.com/openshift/installer => github.com/openshift-hive/installer v0.9.0-master.0.20201105141806-0f6c9c7c1fcf

--- a/go.mod
+++ b/go.mod
@@ -77,3 +77,7 @@ replace (
 	sigs.k8s.io/cluster-api-provider-azure => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20200120114645-8a9592f1f87b // Pin OpenShift fork
 	sigs.k8s.io/cluster-api-provider-openstack => github.com/openshift/cluster-api-provider-openstack v0.0.0-20200526112135-319a35b2e38e // Pin OpenShift fork
 )
+
+// needed because otherwise installer fetches a library-go version that requires bitbucket.com/ww/goautoneg which is dead
+// Tagged version fetches github.com/munnerz/goautoneg instead
+replace github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20200421122923-c1de486c7d47

--- a/go.sum
+++ b/go.sum
@@ -1553,6 +1553,8 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/image-spec v1.0.2-0.20190823105129-775207bd45b6/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20191031171055-b133feaeeb2e/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
+github.com/openshift-hive/installer v0.9.0-master.0.20201105141806-0f6c9c7c1fcf h1:BF3j+zfJAoh9y2r5ZXZkixdZwGSGV1r8xonm+sKs62k=
+github.com/openshift-hive/installer v0.9.0-master.0.20201105141806-0f6c9c7c1fcf/go.mod h1:HsI5XXlg/GFalX4HwQ0jiNkRy2lgX7NjuuYcNOVdLKY=
 github.com/openshift-metal3/terraform-provider-ironic v0.2.1/go.mod h1:G79T6t60oBpYfZK/x960DRzYsNHdz5YVCHINx6QlmtU=
 github.com/openshift/api v0.0.0-20200320142426-0de0d539b0c3/go.mod h1:7k3+uZYOir97walbYUqApHUA2OPhkQpVJHt0n7GJ6P4=
 github.com/openshift/api v0.0.0-20200323095748-e7041f8762a3/go.mod h1:7k3+uZYOir97walbYUqApHUA2OPhkQpVJHt0n7GJ6P4=
@@ -1591,8 +1593,6 @@ github.com/openshift/cluster-autoscaler-operator v0.0.0-20190521201101-62768a6ba
 github.com/openshift/cluster-version-operator v3.11.1-0.20190629164025-08cac1c02538+incompatible/go.mod h1:0BbpR1mrN0F2ZRae5N1XHcytmkvVPaeKgSQwRRBWugc=
 github.com/openshift/generic-admission-server v1.14.0 h1:GAQy5JNVcbmUuIpPvLd39+2rPecxEm7WQ2sP7ACrse4=
 github.com/openshift/generic-admission-server v1.14.0/go.mod h1:GD9KN/W4KxqRQGVMbqQHpHzb2XcQVvLCaBaSciqXvfM=
-github.com/openshift/installer v0.9.0-master.0.20200603112517-20e472f69982 h1:R3sTUOUN4Z55RU59qXigFToSKmKxfliqd0Hz8PXdYS4=
-github.com/openshift/installer v0.9.0-master.0.20200603112517-20e472f69982/go.mod h1:HsI5XXlg/GFalX4HwQ0jiNkRy2lgX7NjuuYcNOVdLKY=
 github.com/openshift/library-go v0.0.0-20200421122923-c1de486c7d47 h1:DY2Tkjmfxkp6xscjKdODVfAY2+zsK/fG3sChzL941z4=
 github.com/openshift/library-go v0.0.0-20200421122923-c1de486c7d47/go.mod h1:CEI4oNUL/2Hext5N9Ut3lb5T3oUBSLcHKitn9NMnvHY=
 github.com/openshift/machine-api-operator v0.0.0-20190312153711-9650e16c9880/go.mod h1:7HeAh0v04zQn1L+4ItUjvpBQYsm2Nf81WaZLiXTcnkc=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-bitbucket.org/ww/goautoneg v0.0.0-20120707110453-75cd24fc2f2c/go.mod h1:1vhO7Mn/FZMgOgDVGLy5X1mE6rq1HbkBdkF/yj8zkcg=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.31.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -1558,7 +1557,7 @@ github.com/openshift-metal3/terraform-provider-ironic v0.2.1/go.mod h1:G79T6t60o
 github.com/openshift/api v0.0.0-20200320142426-0de0d539b0c3/go.mod h1:7k3+uZYOir97walbYUqApHUA2OPhkQpVJHt0n7GJ6P4=
 github.com/openshift/api v0.0.0-20200323095748-e7041f8762a3/go.mod h1:7k3+uZYOir97walbYUqApHUA2OPhkQpVJHt0n7GJ6P4=
 github.com/openshift/api v0.0.0-20200326152221-912866ddb162/go.mod h1:RKMJ5CBnljLfnej+BJ/xnOWc3kZDvJUaIAEq2oKSPtE=
-github.com/openshift/api v0.0.0-20200424083944-0422dc17083e/go.mod h1:VnbEzX8SAaRj7Yfl836NykdQIlbEjfL6/CD+AaJQg5Q=
+github.com/openshift/api v0.0.0-20200326160804-ecb9283fe820/go.mod h1:RKMJ5CBnljLfnej+BJ/xnOWc3kZDvJUaIAEq2oKSPtE=
 github.com/openshift/api v3.9.1-0.20190517100836-d5b34b957e91+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible h1:AvJ2SgJ7ekSlEL/wyeVMffxDkbKohp4JLge9wMtT23o=
 github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
@@ -1594,9 +1593,8 @@ github.com/openshift/generic-admission-server v1.14.0 h1:GAQy5JNVcbmUuIpPvLd39+2
 github.com/openshift/generic-admission-server v1.14.0/go.mod h1:GD9KN/W4KxqRQGVMbqQHpHzb2XcQVvLCaBaSciqXvfM=
 github.com/openshift/installer v0.9.0-master.0.20200603112517-20e472f69982 h1:R3sTUOUN4Z55RU59qXigFToSKmKxfliqd0Hz8PXdYS4=
 github.com/openshift/installer v0.9.0-master.0.20200603112517-20e472f69982/go.mod h1:HsI5XXlg/GFalX4HwQ0jiNkRy2lgX7NjuuYcNOVdLKY=
-github.com/openshift/library-go v0.0.0-20200324092245-db2a8546af81/go.mod h1:Qc5duoXHzAKyUfA0REIlG/rdfWzknOpp9SiDiyg5Y7A=
-github.com/openshift/library-go v0.0.0-20200429122220-9e6c27e916a0 h1:PWdXDFk+4DLTdoEc4G5v5YWvDaI098/Wvo6Y551A4sk=
-github.com/openshift/library-go v0.0.0-20200429122220-9e6c27e916a0/go.mod h1:2kWwXTkpoQJUN3jZ3QW88EIY1hdRMqxgRs2hheEW/pg=
+github.com/openshift/library-go v0.0.0-20200421122923-c1de486c7d47 h1:DY2Tkjmfxkp6xscjKdODVfAY2+zsK/fG3sChzL941z4=
+github.com/openshift/library-go v0.0.0-20200421122923-c1de486c7d47/go.mod h1:CEI4oNUL/2Hext5N9Ut3lb5T3oUBSLcHKitn9NMnvHY=
 github.com/openshift/machine-api-operator v0.0.0-20190312153711-9650e16c9880/go.mod h1:7HeAh0v04zQn1L+4ItUjvpBQYsm2Nf81WaZLiXTcnkc=
 github.com/openshift/machine-api-operator v0.2.1-0.20191128180243-986b771e661d/go.mod h1:9qQPF00anuIsc6RiHYfHE0+cZZImbvFNLln0NRBVVMg=
 github.com/openshift/machine-api-operator v0.2.1-0.20200402110321-4f3602b96da3/go.mod h1:46g2eLjzAcaNURYDvhGu0GhyjKzOlCPqixEo68lFBLs=
@@ -2485,7 +2483,6 @@ k8s.io/apiextensions-apiserver v0.0.0-20190918161926-8f644eb6e783/go.mod h1:xvae
 k8s.io/apiextensions-apiserver v0.0.0-20190918201827-3de75813f604/go.mod h1:7H8sjDlWQu89yWB3FhZfsLyRCRLuoXoCoY5qtwW1q6I=
 k8s.io/apiextensions-apiserver v0.0.0-20191121021419-88daf26ec3b8/go.mod h1:NMIy5Wa/or8CsLhYRleOp9CWAHVdcWpzT6Ufx1SNVjA=
 k8s.io/apiextensions-apiserver v0.17.0/go.mod h1:XiIFUakZywkUl54fVXa7QTEHcqQz9HG55nHd1DCoHj8=
-k8s.io/apiextensions-apiserver v0.18.0-beta.2/go.mod h1:Hnrg5jx8/PbxRbUoqDGxtQkULjwx8FDW4WYJaKNK+fk=
 k8s.io/apiextensions-apiserver v0.18.0/go.mod h1:18Cwn1Xws4xnWQNC00FLq1E350b9lUF+aOdIWDOZxgo=
 k8s.io/apiextensions-apiserver v0.18.2 h1:I4v3/jAuQC+89L3Z7dDgAiN4EOjN6sbm6iBqQwHTah8=
 k8s.io/apiextensions-apiserver v0.18.2/go.mod h1:q3faSnRGmYimiocj6cHQ1I3WpLqmDgJFlKL37fC4ZvY=
@@ -2500,12 +2497,10 @@ k8s.io/apimachinery v0.18.0-rc.1/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU
 k8s.io/apimachinery v0.18.0/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
 k8s.io/apimachinery v0.18.2 h1:44CmtbmkzVDAhCpRVSiP2R5PPrC2RtlIv/MoB8xpdRA=
 k8s.io/apimachinery v0.18.2/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
-k8s.io/apimachinery v0.18.3 h1:pOGcbVAhxADgUYnjS08EFXs9QMl8qaH5U4fr5LGUrSk=
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
 k8s.io/apiserver v0.0.0-20190918200908-1e17798da8c1/go.mod h1:4FuDU+iKPjdsdQSN3GsEKZLB/feQsj1y9dhhBDVV2Ns=
 k8s.io/apiserver v0.0.0-20191121020624-6eed2f5a3289/go.mod h1:7P+0qMKoaggchirHLUSCVD22ohdkjN19+qQOKcAdfbI=
 k8s.io/apiserver v0.17.0/go.mod h1:ABM+9x/prjINN6iiffRVNCBR2Wk7uY4z+EtEGZD48cg=
-k8s.io/apiserver v0.18.0-beta.2/go.mod h1:bnblMkMoCFnIfVnVftd0SXJPzyvrk3RtaqSbblphF/A=
 k8s.io/apiserver v0.18.0-rc.1/go.mod h1:RYE9w2Lijk1aWW3i3pS7kFGU0Afof+UDoOz1qW9aSYg=
 k8s.io/apiserver v0.18.0/go.mod h1:3S2O6FeBBd6XTo0njUrLxiqk8GNy6wWOftjhJcXYnjw=
 k8s.io/apiserver v0.18.2 h1:fwKxdTWwwYhxvtjo0UUfX+/fsitsNtfErPNegH2x9ic=
@@ -2532,7 +2527,6 @@ k8s.io/component-base v0.0.0-20190918160511-547f6c5d7090/go.mod h1:933PBGtQFJky3
 k8s.io/component-base v0.0.0-20190918200425-ed2f0867c778/go.mod h1:DFWQCXgXVLiWtzFaS17KxHdlUeUymP7FLxZSkmL9/jU=
 k8s.io/component-base v0.0.0-20191121020327-771114ba3383/go.mod h1:tv9ITs6VEFWkF+kHwY4GiFvDr9vUGKJ4X/8+Z+oqVLk=
 k8s.io/component-base v0.17.0/go.mod h1:rKuRAokNMY2nn2A6LP/MiwpoaMRHpfRnrPaUJJj1Yoc=
-k8s.io/component-base v0.18.0-beta.2/go.mod h1:HVk5FpRnyzQ/MjBr9//e/yEBjTVa2qjGXCTuUzcD7ks=
 k8s.io/component-base v0.18.0-rc.1/go.mod h1:NNlRaxZEdLqTs2+6yXiU2SHl8gKsbcy19Ii+Sfq53RM=
 k8s.io/component-base v0.18.0/go.mod h1:u3BCg0z1uskkzrnAKFzulmYaEpZF7XC9Pf/uFyb1v2c=
 k8s.io/component-base v0.18.2 h1:SJweNZAGcUvsypLGNPNGeJ9UgPZQ6+bW+gEHe8uyh/Y=
@@ -2552,8 +2546,8 @@ k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/kube-aggregator v0.0.0-20190404125450-f5e124c822d6/go.mod h1:8sbzT4QQKDEmSCIbfqjV0sd97GpUT7A4W626sBiYJmU=
-k8s.io/kube-aggregator v0.18.0-beta.2/go.mod h1:O3Td9mheraINbLHH4pzoFP2gRzG0Wk1COqzdSL4rBPk=
 k8s.io/kube-aggregator v0.18.0-rc.1/go.mod h1:35N7x/aAF8C5rEU78J+3pJ/k9v/8LypeWbzqBAEWA1I=
+k8s.io/kube-aggregator v0.18.0/go.mod h1:ateewQ5QbjMZF/dihEFXwaEwoA4v/mayRvzfmvb6eqI=
 k8s.io/kube-aggregator v0.18.2 h1:mgsze91nZC27HeJi8bLRyhLINQznEUy4SOTpbOhsZEM=
 k8s.io/kube-aggregator v0.18.2/go.mod h1:ijq6FnNUoKinA6kKbkN6svdTacSoQVNtKqmQ1+XJEYQ=
 k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c h1:/KUFqjjqAcY4Us6luF5RDNZ16KJtb49HfR3ZHB9qYXM=

--- a/vendor/github.com/openshift/library-go/pkg/operator/events/recorder.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/events/recorder.go
@@ -33,8 +33,6 @@ type Recorder interface {
 	// ComponentName returns the current source component name for the event.
 	// This allows to suffix the original component name with 'sub-component'.
 	ComponentName() string
-
-	Shutdown()
 }
 
 // podNameEnv is a name of environment variable inside container that specifies the name of the current replica set.
@@ -160,8 +158,6 @@ type recorder struct {
 func (r *recorder) ComponentName() string {
 	return r.sourceComponent
 }
-
-func (r *recorder) Shutdown() {}
 
 func (r *recorder) ForComponent(componentName string) Recorder {
 	newRecorderForComponent := *r

--- a/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_in_memory.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_in_memory.go
@@ -37,8 +37,6 @@ func (r *inMemoryEventRecorder) ComponentName() string {
 	return r.source
 }
 
-func (r *inMemoryEventRecorder) Shutdown() {}
-
 func (r *inMemoryEventRecorder) ForComponent(component string) Recorder {
 	r.Lock()
 	defer r.Unlock()

--- a/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_logging.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_logging.go
@@ -26,8 +26,6 @@ func (r *LoggingEventRecorder) ForComponent(component string) Recorder {
 	return &newRecorder
 }
 
-func (r *LoggingEventRecorder) Shutdown() {}
-
 func (r *LoggingEventRecorder) WithComponentSuffix(suffix string) Recorder {
 	return r.ForComponent(fmt.Sprintf("%s-%s", r.ComponentName(), suffix))
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_upstream.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/events/recorder_upstream.go
@@ -2,32 +2,22 @@ package events
 
 import (
 	"fmt"
-	"strings"
-	"sync"
+
+	"k8s.io/klog"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/component-base/metrics"
-	"k8s.io/component-base/metrics/legacyregistry"
-	"k8s.io/klog"
 )
 
-// NewKubeRecorder returns new event recorder with tweaked correlator options.
-func NewKubeRecorderWithOptions(client corev1client.EventInterface, options record.CorrelatorOptions, sourceComponentName string, involvedObjectRef *corev1.ObjectReference) Recorder {
+// NewKubeRecorder returns new event recorder.
+func NewKubeRecorder(client corev1client.EventInterface, sourceComponentName string, involvedObjectRef *corev1.ObjectReference) Recorder {
 	return (&upstreamRecorder{
 		client:            client,
 		component:         sourceComponentName,
 		involvedObjectRef: involvedObjectRef,
-		options:           options,
-		fallbackRecorder:  NewRecorder(client, sourceComponentName, involvedObjectRef),
 	}).ForComponent(sourceComponentName)
-}
-
-// NewKubeRecorder returns new event recorder with default correlator options.
-func NewKubeRecorder(client corev1client.EventInterface, sourceComponentName string, involvedObjectRef *corev1.ObjectReference) Recorder {
-	return NewKubeRecorderWithOptions(client, record.CorrelatorOptions{}, sourceComponentName, involvedObjectRef)
 }
 
 // upstreamRecorder is an implementation of Recorder interface.
@@ -37,83 +27,18 @@ type upstreamRecorder struct {
 	broadcaster       record.EventBroadcaster
 	eventRecorder     record.EventRecorder
 	involvedObjectRef *corev1.ObjectReference
-	options           record.CorrelatorOptions
-
-	// shuttingDown indicates that the broadcaster for this recorder is being shut down
-	shuttingDown  bool
-	shutdownMutex sync.RWMutex
-
-	// fallbackRecorder is used when the kube recorder is shutting down
-	// in that case we create the events directly.
-	fallbackRecorder Recorder
-}
-
-// RecommendedClusterSingletonCorrelatorOptions provides recommended event correlator options for components that produce
-// many events (like operators).
-func RecommendedClusterSingletonCorrelatorOptions() record.CorrelatorOptions {
-	return record.CorrelatorOptions{
-		BurstSize: 60,      // default: 25 (change allows a single source to send 50 events about object per minute)
-		QPS:       1. / 1., // default: 1/300 (change allows refill rate to 1 new event every 1s)
-		KeyFunc: func(event *corev1.Event) (aggregateKey string, localKey string) {
-			return strings.Join([]string{
-				event.Source.Component,
-				event.Source.Host,
-				event.InvolvedObject.Kind,
-				event.InvolvedObject.Namespace,
-				event.InvolvedObject.Name,
-				string(event.InvolvedObject.UID),
-				event.InvolvedObject.APIVersion,
-				event.Type,
-				event.Reason,
-				// By default, KeyFunc don't use message for aggregation, this cause events with different message, but same reason not be lost as "similar events".
-				event.Message,
-			}, ""), event.Message
-		},
-	}
-}
-
-var eventsCounterMetric = metrics.NewCounterVec(&metrics.CounterOpts{
-	Subsystem:      "event_recorder",
-	Name:           "total_events_count",
-	Help:           "Total count of events processed by this event recorder per involved object",
-	StabilityLevel: metrics.ALPHA,
-}, []string{"severity"})
-
-func init() {
-	(&sync.Once{}).Do(func() {
-		legacyregistry.MustRegister(eventsCounterMetric)
-	})
 }
 
 func (r *upstreamRecorder) ForComponent(componentName string) Recorder {
-	newRecorderForComponent := upstreamRecorder{
-		client:            r.client,
-		fallbackRecorder:  r.fallbackRecorder.WithComponentSuffix(componentName),
-		options:           r.options,
-		involvedObjectRef: r.involvedObjectRef,
-		shuttingDown:      r.shuttingDown,
-	}
-
-	// tweak the event correlator, so we don't loose important events.
-	broadcaster := record.NewBroadcasterWithCorrelatorOptions(r.options)
+	newRecorderForComponent := *r
+	broadcaster := record.NewBroadcaster()
 	broadcaster.StartLogging(klog.Infof)
 	broadcaster.StartRecordingToSink(&corev1client.EventSinkImpl{Interface: newRecorderForComponent.client})
 
 	newRecorderForComponent.eventRecorder = broadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: componentName})
-	newRecorderForComponent.broadcaster = broadcaster
 	newRecorderForComponent.component = componentName
 
 	return &newRecorderForComponent
-}
-
-func (r *upstreamRecorder) Shutdown() {
-	r.shutdownMutex.Lock()
-	r.shuttingDown = true
-	r.shutdownMutex.Unlock()
-	// Wait for broadcaster to flush events (this is blocking)
-	// TODO: There is still race condition in upstream that might cause panic() on events recorded after the shutdown
-	//       is called as the event recording is not-blocking (go routine based).
-	r.broadcaster.Shutdown()
 }
 
 func (r *upstreamRecorder) WithComponentSuffix(suffix string) Recorder {
@@ -134,33 +59,12 @@ func (r *upstreamRecorder) Warningf(reason, messageFmt string, args ...interface
 	r.Warning(reason, fmt.Sprintf(messageFmt, args...))
 }
 
-func (r *upstreamRecorder) incrementEventsCounter(severity string) {
-	if r.involvedObjectRef == nil {
-		return
-	}
-	eventsCounterMetric.WithLabelValues(severity).Inc()
-}
-
 // Event emits the normal type event.
 func (r *upstreamRecorder) Event(reason, message string) {
-	r.shutdownMutex.RLock()
-	defer r.shutdownMutex.RUnlock()
-	defer r.incrementEventsCounter(corev1.EventTypeNormal)
-	if r.shuttingDown {
-		r.fallbackRecorder.Event(reason, message)
-		return
-	}
 	r.eventRecorder.Event(r.involvedObjectRef, corev1.EventTypeNormal, reason, message)
 }
 
 // Warning emits the warning type event.
 func (r *upstreamRecorder) Warning(reason, message string) {
-	r.shutdownMutex.RLock()
-	defer r.shutdownMutex.RUnlock()
-	defer r.incrementEventsCounter(corev1.EventTypeWarning)
-	if r.shuttingDown {
-		r.fallbackRecorder.Warning(reason, message)
-		return
-	}
 	r.eventRecorder.Event(r.involvedObjectRef, corev1.EventTypeWarning, reason, message)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -489,7 +489,7 @@ github.com/openshift/generic-admission-server/pkg/apiserver
 github.com/openshift/generic-admission-server/pkg/cmd
 github.com/openshift/generic-admission-server/pkg/cmd/server
 github.com/openshift/generic-admission-server/pkg/registry/admissionreview
-# github.com/openshift/installer v0.9.0-master.0.20200603112517-20e472f69982
+# github.com/openshift/installer v0.9.0-master.0.20200603112517-20e472f69982 => github.com/openshift-hive/installer v0.9.0-master.0.20201105141806-0f6c9c7c1fcf
 github.com/openshift/installer/data
 github.com/openshift/installer/pkg/asset/installconfig/aws
 github.com/openshift/installer/pkg/asset/installconfig/azure

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -519,7 +519,7 @@ github.com/openshift/installer/pkg/types/openstack
 github.com/openshift/installer/pkg/types/ovirt
 github.com/openshift/installer/pkg/types/vsphere
 github.com/openshift/installer/pkg/version
-# github.com/openshift/library-go v0.0.0-20200429122220-9e6c27e916a0
+# github.com/openshift/library-go v0.0.0-20200429122220-9e6c27e916a0 => github.com/openshift/library-go v0.0.0-20200421122923-c1de486c7d47
 github.com/openshift/library-go/pkg/controller
 github.com/openshift/library-go/pkg/controller/fileobserver
 github.com/openshift/library-go/pkg/operator/events


### PR DESCRIPTION
This commit will point the installer to the ocm-2.0 branch of
openshift-hive/installer, which is a fork of installer repo.

It will also bring in the fixes for GCP and Azure deprovision bugs:
https://bugzilla.redhat.com/show_bug.cgi?id=1880132
https://bugzilla.redhat.com/show_bug.cgi?id=1888378

/assign @dgoodwin 
/cc @twiest 