### PR TITLE
Fix control plane cert patching for new clusters.

### DIFF
--- a/pkg/controller/controlplanecerts/controlplanecerts_controller.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller.go
@@ -363,7 +363,7 @@ func (r *ReconcileControlPlaneCerts) getServingCertificatesJSONPatch(cd *hivev1.
 			additional.Domain, remoteSecretName(bundle.CertificateSecretRef.Name, cd)))
 	}
 
-	var kubeAPIServerNamedCertsTemplate = `[ { "op": "replace", "path": "/spec/servingCerts/namedCertificates", "value": [ %s ] } ]`
+	var kubeAPIServerNamedCertsTemplate = `[ { "op": "add", "path": "/spec/servingCerts", "value": {} }, { "op": "add", "path": "/spec/servingCerts/namedCertificates", "value": [  ] }, { "op": "replace", "path": "/spec/servingCerts/namedCertificates", "value": [ %s ] } ]`
 	namedCerts := buf.String()
 	return fmt.Sprintf(kubeAPIServerNamedCertsTemplate, namedCerts), nil
 

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
@@ -81,7 +81,7 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 				fakeClusterDeployment().defaultCert("default-cert", "default-secret").obj(),
 				fakeCertSecret("default-secret"),
 			},
-			expectedPatch:   `[ { "op": "replace", "path": "/spec/servingCerts/namedCertificates", "value": [  { "names": [ "test-api-url" ], "servingCertificate": { "name": "fake-cluster-default-secret" } } ] } ]`,
+			expectedPatch:   `[ { "op": "add", "path": "/spec/servingCerts", "value": {} }, { "op": "add", "path": "/spec/servingCerts/namedCertificates", "value": [  ] }, { "op": "replace", "path": "/spec/servingCerts/namedCertificates", "value": [  { "names": [ "test-api-url" ], "servingCertificate": { "name": "fake-cluster-default-secret" } } ] } ]`,
 			expectedSecrets: []string{"default-secret"},
 		},
 		{
@@ -93,7 +93,7 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 				fakeCertSecret("secret1"),
 				fakeCertSecret("secret2"),
 			},
-			expectedPatch:   `[ { "op": "replace", "path": "/spec/servingCerts/namedCertificates", "value": [  { "names": [ "foo.com" ], "servingCertificate": { "name": "fake-cluster-secret1" } }, { "names": [ "bar.com" ], "servingCertificate": { "name": "fake-cluster-secret2" } } ] } ]`,
+			expectedPatch:   `[ { "op": "add", "path": "/spec/servingCerts", "value": {} }, { "op": "add", "path": "/spec/servingCerts/namedCertificates", "value": [  ] }, { "op": "replace", "path": "/spec/servingCerts/namedCertificates", "value": [  { "names": [ "foo.com" ], "servingCertificate": { "name": "fake-cluster-secret1" } }, { "names": [ "bar.com" ], "servingCertificate": { "name": "fake-cluster-secret2" } } ] } ]`,
 			expectedSecrets: []string{"secret1", "secret2"},
 		},
 		{
@@ -108,7 +108,7 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 				fakeCertSecret("secret1"),
 				fakeCertSecret("secret2"),
 			},
-			expectedPatch:   `[ { "op": "replace", "path": "/spec/servingCerts/namedCertificates", "value": [  { "names": [ "test-api-url" ], "servingCertificate": { "name": "fake-cluster-secret0" } }, { "names": [ "foo.com" ], "servingCertificate": { "name": "fake-cluster-secret1" } }, { "names": [ "bar.com" ], "servingCertificate": { "name": "fake-cluster-secret2" } } ] } ]`,
+			expectedPatch:   `[ { "op": "add", "path": "/spec/servingCerts", "value": {} }, { "op": "add", "path": "/spec/servingCerts/namedCertificates", "value": [  ] }, { "op": "replace", "path": "/spec/servingCerts/namedCertificates", "value": [  { "names": [ "test-api-url" ], "servingCertificate": { "name": "fake-cluster-secret0" } }, { "names": [ "foo.com" ], "servingCertificate": { "name": "fake-cluster-secret1" } }, { "names": [ "bar.com" ], "servingCertificate": { "name": "fake-cluster-secret2" } } ] } ]`,
 			expectedSecrets: []string{"secret0", "secret1", "secret2"},
 		},
 		{
@@ -130,7 +130,7 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 				fakeClusterDeployment().obj(),
 				fakeSyncSet(),
 			},
-			expectedPatch: `[ { "op": "replace", "path": "/spec/servingCerts/namedCertificates", "value": [  ] } ]`,
+			expectedPatch: `[ { "op": "add", "path": "/spec/servingCerts", "value": {} }, { "op": "add", "path": "/spec/servingCerts/namedCertificates", "value": [  ] }, { "op": "replace", "path": "/spec/servingCerts/namedCertificates", "value": [  ] } ]`,
 		},
 		{
 			name: "existing not found condition changed to false",


### PR DESCRIPTION
Recent change was not tested with new clusters as all eyes were on
making sure we rolled out for existing clusters smoothly.

JSON patches will not apply if the json sections referenced do not yet
exist.

This change adds two new directions to the json patch to ensure that the
two parent sections for what we need to patch exist. Because these are
all within the same json patch, they do not modify the resource. (which
they would if we applied each individually)

Because we need to ensure the .spec.serviceCerts node exists (by inserting
an empty node followed by then adding the list of certs), we still
effictively own everything underneath .spec.serviceCerts and will stomp
any non-hive changes when reconciling the control plane certs.