### PR TITLE
CO-1107: Wait to Hibernate ClusterPool Clusters until SyncSets Applied

### DIFF
--- a/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -360,6 +360,9 @@ const (
 	// FailedToStartHibernationReason is used when there was an error starting machines
 	// to leave hibernation
 	FailedToStartHibernationReason = "FailedToStart"
+	// SyncSetsNotAppliedReason is used as the reason when SyncSets have not yet been applied
+	// for the cluster based on ClusterSync.Status.FirstSucessTime
+	SyncSetsNotAppliedReason = "SyncSetsNotApplied"
 )
 
 // +genclient

--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -374,7 +374,7 @@ func (r *ReconcileClusterSync) Reconcile(request reconcile.Request) (reconcile.R
 
 	// Set clusterSync.Status.FirstSyncSetsSuccessTime
 	syncStatuses := append(syncStatusesForSyncSets, syncStatusesForSelectorSyncSets...)
-	if len(syncStatuses) > 0 && clusterSync.Status.FirstSuccessTime == nil {
+	if clusterSync.Status.FirstSuccessTime == nil {
 		r.setFirstSuccessTime(syncStatuses, cd, clusterSync, logger)
 	}
 
@@ -948,6 +948,11 @@ func (r *ReconcileClusterSync) setFirstSuccessTime(syncStatuses []hiveintv1alpha
 		if status.FirstSuccessTime.Time.After(lastSuccessTime.Time) {
 			lastSuccessTime = status.FirstSuccessTime
 		}
+	}
+	// When len(syncStatuses) == 0, meaning there are no syncsets which apply to the cluster, we will use now as the last success time
+	if len(syncStatuses) == 0 {
+		now := metav1.Now()
+		lastSuccessTime = &now
 	}
 	clusterSync.Status.FirstSuccessTime = lastSuccessTime
 	allSyncSetsAppliedDuration := lastSuccessTime.Time.Sub(cd.Status.InstalledTimestamp.Time)

--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/workqueue"
 
@@ -25,6 +26,7 @@ import (
 	machineapi "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	hiveintv1alpha1 "github.com/openshift/hive/pkg/apis/hiveinternal/v1alpha1"
 	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
@@ -48,6 +50,10 @@ const (
 	// avoid a false positive when the node status is checked too
 	// soon after the cluster is ready
 	nodeCheckWaitTime = 4 * time.Minute
+
+	// hibernateAfterSyncSetsNotApplied is the amount of time to wait
+	// before hibernating when SyncSets have not been applied
+	hibernateAfterSyncSetsNotApplied = 10 * time.Minute
 )
 
 var (
@@ -157,16 +163,23 @@ func (r *hibernationReconciler) Reconcile(request reconcile.Request) (result rec
 	shouldHibernate := cd.Spec.PowerState == hivev1.HibernatingClusterPowerState
 	hibernatingCondition := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ClusterHibernatingCondition)
 
-	// Signal a problem if we should be hibernating or have requested hibernate after and the cluster does not support it.
+	// Signal a problem if we should be hibernating or have requested hibernate after and the cluster does not support it or
+	// SyncSets have not yet been applied.
 	if shouldHibernate || cd.Spec.HibernateAfter != nil {
-		if supported, msg := r.canHibernate(cd); !supported {
+		if supported, msg := r.hibernationSupported(cd); !supported {
 			return r.setHibernatingCondition(cd, hivev1.UnsupportedHibernationReason, msg, corev1.ConditionFalse, cdLog)
+		}
+		if syncSetsApplied, msg := r.syncSetsApplied(cd); !syncSetsApplied {
+			// Allow hibernation if hibernateAfterSyncSetsNotApplied duration has passed since cluster installed and syncsets still not applied
+			if cd.Status.InstalledTimestamp != nil && time.Now().Sub(cd.Status.InstalledTimestamp.Time) < hibernateAfterSyncSetsNotApplied {
+				return r.setHibernatingCondition(cd, hivev1.SyncSetsNotAppliedReason, msg, corev1.ConditionFalse, cdLog)
+			}
 		}
 	}
 
 	// Clear any lingering unsupported hibernation condition
 	if hibernatingCondition != nil && hibernatingCondition.Reason == hivev1.UnsupportedHibernationReason {
-		if supported, msg := r.canHibernate(cd); supported {
+		if supported, msg := r.hibernationSupported(cd); supported {
 			return r.setHibernatingCondition(cd, hivev1.RunningHibernationReason, msg, corev1.ConditionFalse, cdLog)
 		}
 	}
@@ -323,7 +336,7 @@ func (r *hibernationReconciler) checkClusterResumed(cd *hivev1.ClusterDeployment
 	return r.setHibernatingCondition(cd, hivev1.RunningHibernationReason, "All machines are started and nodes are ready", corev1.ConditionFalse, logger)
 }
 
-func (r *hibernationReconciler) setHibernatingCondition(cd *hivev1.ClusterDeployment, reason, message string, status corev1.ConditionStatus, logger log.FieldLogger) (reconcile.Result, error) {
+func (r *hibernationReconciler) setHibernatingCondition(cd *hivev1.ClusterDeployment, reason, message string, status corev1.ConditionStatus, logger log.FieldLogger) (result reconcile.Result, returnErr error) {
 	changed := false
 	if status == corev1.ConditionFalse && controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ClusterHibernatingCondition) == nil {
 		now := metav1.Now()
@@ -346,12 +359,23 @@ func (r *hibernationReconciler) setHibernatingCondition(cd *hivev1.ClusterDeploy
 			controllerutils.UpdateConditionIfReasonOrMessageChange,
 		)
 	}
+
+	if reason == hivev1.SyncSetsNotAppliedReason {
+		defer func() {
+			expiry := cd.Status.InstalledTimestamp.Time.Add(hibernateAfterSyncSetsNotApplied)
+			requeueAfter := time.Until(expiry)
+			logger.Infof("cluster will reconcile due to syncsets not applied in: %v", requeueAfter)
+			result.RequeueAfter = requeueAfter
+			result.Requeue = true
+		}()
+	}
+
 	if changed {
 		if err := r.Status().Update(context.TODO(), cd); err != nil {
 			logger.WithError(err).Log(controllerutils.LogLevel(err), "Failed to update hibernating condition")
 			return reconcile.Result{}, errors.Wrap(err, "failed to update hibernating condition")
 		}
-		logger.Info("Hibernating condition updated on cluster deployment.")
+		logger.WithField("reason", reason).Info("Hibernating condition updated on cluster deployment.")
 	}
 	return reconcile.Result{}, nil
 }
@@ -365,7 +389,7 @@ func (r *hibernationReconciler) getActuator(cd *hivev1.ClusterDeployment) Hibern
 	return nil
 }
 
-func (r *hibernationReconciler) canHibernate(cd *hivev1.ClusterDeployment) (bool, string) {
+func (r *hibernationReconciler) hibernationSupported(cd *hivev1.ClusterDeployment) (bool, string) {
 	if r.getActuator(cd) == nil {
 		return false, "Unsupported platform: no actuator to handle it"
 	}
@@ -381,6 +405,18 @@ func (r *hibernationReconciler) canHibernate(cd *hivev1.ClusterDeployment) (bool
 		return false, fmt.Sprintf("Unsupported version, need version %s or greater", minimumClusterVersion.String())
 	}
 	return true, "Hibernation capable"
+}
+
+func (r *hibernationReconciler) syncSetsApplied(cd *hivev1.ClusterDeployment) (bool, string) {
+	clusterSync := &hiveintv1alpha1.ClusterSync{}
+	err := r.Get(context.Background(), types.NamespacedName{Namespace: cd.Namespace, Name: cd.Name}, clusterSync)
+	if err != nil {
+		return false, fmt.Sprintf("could not get ClusterSync: %v", err)
+	}
+	if clusterSync.Status.FirstSuccessTime == nil {
+		return false, "Cluster SyncSets have not been applied"
+	}
+	return true, ""
 }
 
 func (r *hibernationReconciler) nodesReady(cd *hivev1.ClusterDeployment, remoteClient client.Client, logger log.FieldLogger) (bool, error) {

--- a/pkg/controller/hibernation/hibernation_controller_test.go
+++ b/pkg/controller/hibernation/hibernation_controller_test.go
@@ -464,6 +464,17 @@ func TestHibernateAfter(t *testing.T) {
 			).Build(),
 			expectedPowerState: hivev1.HibernatingClusterPowerState,
 		},
+		{
+			name: "cluster due for hibernate, syncsets successfully applied",
+			cd: cdBuilder.Build(
+				testcd.WithHibernateAfter(8*time.Hour),
+				testcd.WithCondition(hibernatingCondition(corev1.ConditionFalse, hivev1.RunningHibernationReason, 9*time.Hour)),
+				testcd.InstalledTimestamp(time.Now().Add(-10*time.Hour))),
+			cs: csBuilder.Options(
+				testcs.WithFirstSuccessTime(time.Now()),
+			).Build(),
+			expectedPowerState: hivev1.HibernatingClusterPowerState,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/test/clustersync/clustersync.go
+++ b/pkg/test/clustersync/clustersync.go
@@ -1,6 +1,9 @@
 package clusterSync
 
 import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	hiveinternalv1alpha1 "github.com/openshift/hive/pkg/apis/hiveinternal/v1alpha1"
@@ -93,5 +96,17 @@ func WithCondition(cond hiveinternalv1alpha1.ClusterSyncCondition) Option {
 			}
 		}
 		clusterSync.Status.Conditions = append(clusterSync.Status.Conditions, cond)
+	}
+}
+
+func WithFirstSuccessTime(firstSuccessTime time.Time) Option {
+	return func(clusterSync *hiveinternalv1alpha1.ClusterSync) {
+		clusterSync.Status.FirstSuccessTime = &metav1.Time{Time: firstSuccessTime}
+	}
+}
+
+func WithNoFirstSuccessTime() Option {
+	return func(clusterSync *hiveinternalv1alpha1.ClusterSync) {
+		clusterSync.Status.FirstSuccessTime = nil
 	}
 }


### PR DESCRIPTION
*  Set a `ClusterSync.Status.FirstSuccessTime` of `time.Now()` when there are no `SyncStatuses` found for `ClusterSync`. This means there are no `SyncSets` to apply.
* Determine if `SyncSets` have been applied in hibernation controller
  * If no `ClusterSync.Status.FirstSuccessTime` has been set for 10 minutes since `ClusterDeployment.Status.InstalledTimestamp`, hibernate anyway.
  * If 10 minutes have not passed since install and `ClusterSync.Status.FirstSuccessTime` is unset, requeue `ClusterDeployment` for time remaining to meet 10 minutes since cluster was installed.

/assign @dgoodwin 
/cc @akhil-rane 
