### PR TITLE
Add two new GCP specific install failure search strings.

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -32,16 +32,6 @@ data:
       - "data.aws_route53_zone.public: no matching Route53Zone found"
       installFailingReason: NoMatchingRoute53Zone
       installFailingMessage: No matching Route53Zone found
-    - name: KubeAPIWaitTimeout
-      searchRegexStrings:
-      - "waiting for Kubernetes API: context deadline exceeded"
-      installFailingReason: KubeAPIWaitTimeout
-      installFailingMessage: Timeout waiting for the Kubernetes API to begin responding
-    - name: MonitoringOperatorStillUpdating
-      searchRegexStrings:
-      - "failed to initialize the cluster: Cluster operator monitoring is still updating"
-      installFailingReason: MonitoringOperatorStillUpdating
-      installFailingMessage: Timeout waiting for the monitoring operator to become ready
     - name: SimulatorThrottling
       searchRegexStrings:
       - "validate AWS credentials: checking install permissions: error simulating policy: Throttling: Rate exceeded"
@@ -52,12 +42,34 @@ data:
       - "Throttling: Rate exceeded"
       installFailingReason: AWSAPIRateLimitExceeded
       installFailingMessage: AWS API rate limit exceeded
+    # GCP Specific
+    - name: GCPInvalidProjectID
+      searchRegexStrings:
+      - "platform\.gcp\.project.* invalid project ID"
+      installFailingReason: GCPInvalidProjectID
+      installFailingMessage: Invalid GCP project ID
+    - name: GCPInstanceTypeNotFound
+      searchRegexStrings:
+      - "platform.gcp.type: Invalid value:.* instance type.* not found]"
+      installFailingReason: GCPInstanceTypeNotFound
+      installFailingMessage: GCP instance type not found
     # Bare Metal
     - name: LibvirtSSHKeyPermissionDenied
       searchRegexStrings:
       - "platform.baremetal.libvirtURI: Internal error: could not connect to libvirt: virError.Code=38, Domain=7, Message=.Cannot recv data: Permission denied"
       installFailingReason: LibvirtSSHKeyPermissionDenied
       installFailingMessage: "Permission denied connecting to libvirt host, check SSH key configuration and pass phrase"
+    # Generic OpenShift Install
+    - name: KubeAPIWaitTimeout
+      searchRegexStrings:
+      - "waiting for Kubernetes API: context deadline exceeded"
+      installFailingReason: KubeAPIWaitTimeout
+      installFailingMessage: Timeout waiting for the Kubernetes API to begin responding
+    - name: MonitoringOperatorStillUpdating
+      searchRegexStrings:
+      - "failed to initialize the cluster: Cluster operator monitoring is still updating"
+      installFailingReason: MonitoringOperatorStillUpdating
+      installFailingMessage: Timeout waiting for the monitoring operator to become ready
     # Processing stops at the first match, so this more generic
     # message about the connection failure must always come after the
     # more specific message for LibvirtSSHKeyPermissionDenied.

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -26,6 +26,7 @@ func init() {
 const (
 	dnsAlreadyExistsLog    = "blahblah\naws_route53_record.api_external: [ERR]: Error building changeset: InvalidChangeBatch: [Tried to create resource record set [name='api.jh-stg-2405-2.n6b3.s1.devshift.org.'type='A'] but it already exists]\n\nblahblah"
 	pendingVerificationLog = "blahblah\naws_instance.master.2: Error launching source instance: PendingVerification: Your request for accessing resources in this region is being validated, and you will not be able to launch additional resources in this region until the validation is complete. We will notify you by email once your request has been validated. While normally resolved within minutes, please allow up to 4 hours for this process to complete. If the issue still persists, please let us know by writing to awsa\n\nblahblah"
+	gcpInvalidProjectIDLog = "blahblah\ntime=\"2020-11-13T16:05:07Z\" level=fatal msg=\"failed to fetch Master Machines: failed to load asset \"Install Config\": platform.gcp.project: Invalid value: \"o-6b20f250\": invalid project ID\nblahblah"
 )
 
 func TestParseInstallLog(t *testing.T) {
@@ -47,6 +48,12 @@ func TestParseInstallLog(t *testing.T) {
 			log:            pointer.StringPtr(pendingVerificationLog),
 			existing:       []runtime.Object{buildRegexConfigMap()},
 			expectedReason: "PendingVerification",
+		},
+		{
+			name:           "Wildcard",
+			log:            pointer.StringPtr(gcpInvalidProjectIDLog),
+			existing:       []runtime.Object{buildRegexConfigMap()},
+			expectedReason: "GCPInvalidProjectID",
 		},
 		{
 			name:           "no log",
@@ -163,6 +170,11 @@ func buildRegexConfigMap() *corev1.ConfigMap {
   - "PendingVerification: Your request for accessing resources in this region is being validated"
   installFailingReason: PendingVerification
   installFailingMessage: Account pending verification for region
+- name: GCPInvalidProjectID
+  searchRegexStrings:
+  - "platform.gcp.project.* invalid project ID"
+  installFailingReason: GCPInvalidProjectID
+  installFailingMessage: Invalid GCP project ID
 `,
 		},
 	}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1350,16 +1350,6 @@ data:
       - "data.aws_route53_zone.public: no matching Route53Zone found"
       installFailingReason: NoMatchingRoute53Zone
       installFailingMessage: No matching Route53Zone found
-    - name: KubeAPIWaitTimeout
-      searchRegexStrings:
-      - "waiting for Kubernetes API: context deadline exceeded"
-      installFailingReason: KubeAPIWaitTimeout
-      installFailingMessage: Timeout waiting for the Kubernetes API to begin responding
-    - name: MonitoringOperatorStillUpdating
-      searchRegexStrings:
-      - "failed to initialize the cluster: Cluster operator monitoring is still updating"
-      installFailingReason: MonitoringOperatorStillUpdating
-      installFailingMessage: Timeout waiting for the monitoring operator to become ready
     - name: SimulatorThrottling
       searchRegexStrings:
       - "validate AWS credentials: checking install permissions: error simulating policy: Throttling: Rate exceeded"
@@ -1370,12 +1360,34 @@ data:
       - "Throttling: Rate exceeded"
       installFailingReason: AWSAPIRateLimitExceeded
       installFailingMessage: AWS API rate limit exceeded
+    # GCP Specific
+    - name: GCPInvalidProjectID
+      searchRegexStrings:
+      - "platform\.gcp\.project.* invalid project ID"
+      installFailingReason: GCPInvalidProjectID
+      installFailingMessage: Invalid GCP project ID
+    - name: GCPInstanceTypeNotFound
+      searchRegexStrings:
+      - "platform.gcp.type: Invalid value:.* instance type.* not found]"
+      installFailingReason: GCPInstanceTypeNotFound
+      installFailingMessage: GCP instance type not found
     # Bare Metal
     - name: LibvirtSSHKeyPermissionDenied
       searchRegexStrings:
       - "platform.baremetal.libvirtURI: Internal error: could not connect to libvirt: virError.Code=38, Domain=7, Message=.Cannot recv data: Permission denied"
       installFailingReason: LibvirtSSHKeyPermissionDenied
       installFailingMessage: "Permission denied connecting to libvirt host, check SSH key configuration and pass phrase"
+    # Generic OpenShift Install
+    - name: KubeAPIWaitTimeout
+      searchRegexStrings:
+      - "waiting for Kubernetes API: context deadline exceeded"
+      installFailingReason: KubeAPIWaitTimeout
+      installFailingMessage: Timeout waiting for the Kubernetes API to begin responding
+    - name: MonitoringOperatorStillUpdating
+      searchRegexStrings:
+      - "failed to initialize the cluster: Cluster operator monitoring is still updating"
+      installFailingReason: MonitoringOperatorStillUpdating
+      installFailingMessage: Timeout waiting for the monitoring operator to become ready
     # Processing stops at the first match, so this more generic
     # message about the connection failure must always come after the
     # more specific message for LibvirtSSHKeyPermissionDenied.


### PR DESCRIPTION
Will now set a provision failed condition reason for bad project IDs and
non-existent instance types on GCP. Both should flow out through the
alert as well.

/assign @abutcher 
/cc @twiest 