### PR TITLE
Add support for editing Labels and Taints on MachinePools

### DIFF
--- a/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook.go
+++ b/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook.go
@@ -224,8 +224,6 @@ func validateMachinePoolUpdate(old, new *hivev1.MachinePool) field.ErrorList {
 	specPath := field.NewPath("spec")
 	allErrs = append(allErrs, validation.ValidateImmutableField(new.Spec.ClusterDeploymentRef, old.Spec.ClusterDeploymentRef, specPath.Child("clusterDeploymentRef"))...)
 	allErrs = append(allErrs, validation.ValidateImmutableField(new.Spec.Name, old.Spec.Name, specPath.Child("name"))...)
-	allErrs = append(allErrs, validation.ValidateImmutableField(new.Spec.Labels, old.Spec.Labels, specPath.Child("labels"))...)
-	allErrs = append(allErrs, validation.ValidateImmutableField(new.Spec.Taints, old.Spec.Taints, specPath.Child("taints"))...)
 	allErrs = append(allErrs, validation.ValidateImmutableField(new.Spec.Platform, old.Spec.Platform, specPath.Child("platform"))...)
 	return allErrs
 }

--- a/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook_test.go
+++ b/pkg/apis/hive/v1/validating-webhooks/machinepool_validating_admission_hook_test.go
@@ -502,6 +502,16 @@ func Test_MachinePoolAdmission_Validate_Update(t *testing.T) {
 			}(),
 		},
 		{
+			name: "replicas changed",
+			old:  testMachinePool(),
+			new: func() *hivev1.MachinePool {
+				pool := testMachinePool()
+				pool.Spec.Replicas = pointer.Int64Ptr(5)
+				return pool
+			}(),
+			expectAllowed: true,
+		},
+		{
 			name: "labels changed",
 			old:  testMachinePool(),
 			new: func() *hivev1.MachinePool {
@@ -509,6 +519,7 @@ func Test_MachinePoolAdmission_Validate_Update(t *testing.T) {
 				pool.Spec.Labels = map[string]string{"new-label-key": "new-label-value"}
 				return pool
 			}(),
+			expectAllowed: true,
 		},
 		{
 			name: "taints changed",
@@ -522,6 +533,7 @@ func Test_MachinePoolAdmission_Validate_Update(t *testing.T) {
 				}}
 				return pool
 			}(),
+			expectAllowed: true,
 		},
 		{
 			name: "platform changed",


### PR DESCRIPTION
This PR ensures that editing 'labels' and 'taints' on MachinePools gets
reflected in the underlying MachineSet created. Currently, both 'labels' and
'taints' fields are validated as immutable fields by hive admission webhook
and hence cannot be updated. Changing it to treat them as mutable.

jira: https://issues.redhat.com/browse/CO-1265