### PR TITLE
Fix regexes

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -45,7 +45,7 @@ data:
     # GCP Specific
     - name: GCPInvalidProjectID
       searchRegexStrings:
-      - "platform\.gcp\.project.* invalid project ID"
+      - "platform.gcp.project.* invalid project ID"
       installFailingReason: GCPInvalidProjectID
       installFailingMessage: Invalid GCP project ID
     - name: GCPInstanceTypeNotFound

--- a/pkg/controller/metrics/provision_underway_collector.go
+++ b/pkg/controller/metrics/provision_underway_collector.go
@@ -66,6 +66,12 @@ func (cc provisioningUnderwayCollector) Collect(ch chan<- prometheus.Metric) {
 			}
 		}
 
+		platform := cd.Labels[hivev1.HiveClusterPlatformLabel]
+		imageSet := "none"
+		if cd.Spec.Provisioning != nil && cd.Spec.Provisioning.ImageSetRef != nil {
+			imageSet = cd.Spec.Provisioning.ImageSetRef.Name
+		}
+
 		// For installing clusters we report the seconds since the cluster was created.
 		ch <- prometheus.MustNewConstMetric(
 			cc.metricClusterDeploymentProvisionUnderwaySeconds,
@@ -76,6 +82,8 @@ func (cc provisioningUnderwayCollector) Collect(ch chan<- prometheus.Metric) {
 			GetClusterDeploymentType(&cd),
 			condition,
 			reason,
+			platform,
+			imageSet,
 		)
 
 	}
@@ -92,7 +100,7 @@ func newProvisioningUnderwayCollector(client client.Client) prometheus.Collector
 		metricClusterDeploymentProvisionUnderwaySeconds: prometheus.NewDesc(
 			"hive_cluster_deployment_provision_underway_seconds",
 			"Length of time a cluster has been provisioning.",
-			[]string{"cluster_deployment", "namespace", "cluster_type", "condition", "reason"},
+			[]string{"cluster_deployment", "namespace", "cluster_type", "condition", "reason", "platform", "image_set"},
 			nil,
 		),
 	}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1363,7 +1363,7 @@ data:
     # GCP Specific
     - name: GCPInvalidProjectID
       searchRegexStrings:
-      - "platform\.gcp\.project.* invalid project ID"
+      - "platform.gcp.project.* invalid project ID"
       installFailingReason: GCPInvalidProjectID
       installFailingMessage: Invalid GCP project ID
     - name: GCPInstanceTypeNotFound


### PR DESCRIPTION
The escape chars in the install log regex configmap led to it being unparseable, so all attempts to parse install logs are presently failing in stage and prod.

Also added the cluster platform and imageset to the metric labels to help us identify when it's a failing 4.7 nightly on gcp, which is where all our failures seem to be right now.

/assign @suhanime 
/cc @akhil-rane 