### PR TITLE
Improve ClusterClaim Wait Experience

### DIFF
--- a/config/crds/hive.openshift.io_clusterclaims.yaml
+++ b/config/crds/hive.openshift.io_clusterclaims.yaml
@@ -43,8 +43,10 @@ spec:
               type: string
             namespace:
               description: Namespace is the namespace containing the ClusterDeployment
-                of the claimed cluster. This field will be set by the ClusterPool
-                when the claim is assigned a cluster.
+                (name will match the namespace) of the claimed cluster. This field
+                will be set as soon as a suitable cluster can be found, however that
+                cluster may still be resuming and not yet ready for use. Wait for
+                the ClusterRunning condition to be true to avoid this issue.
               type: string
             subjects:
               description: Subjects hold references to which to authorize access to

--- a/pkg/apis/hive/v1/clusterclaim_types.go
+++ b/pkg/apis/hive/v1/clusterclaim_types.go
@@ -15,8 +15,9 @@ type ClusterClaimSpec struct {
 	// +optional
 	Subjects []rbacv1.Subject `json:"subjects,omitempty"`
 
-	// Namespace is the namespace containing the ClusterDeployment of the claimed cluster.
-	// This field will be set by the ClusterPool when the claim is assigned a cluster.
+	// Namespace is the namespace containing the ClusterDeployment (name will match the namespace) of the claimed cluster.
+	// This field will be set as soon as a suitable cluster can be found, however that cluster may still be
+	// resuming and not yet ready for use. Wait for the ClusterRunning condition to be true to avoid this issue.
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 
@@ -61,6 +62,8 @@ const (
 	ClusterClaimPendingCondition ClusterClaimConditionType = "Pending"
 	// ClusterClaimClusterDeletedCondition is set when the cluster assigned to the claim has been deleted.
 	ClusterClaimClusterDeletedCondition ClusterClaimConditionType = "ClusterDeleted"
+	// ClusterRunningCondition is true when a claimed cluster is running and ready for use.
+	ClusterRunningCondition ClusterClaimConditionType = "ClusterRunning"
 )
 
 // +genclient


### PR DESCRIPTION
Previously claim.spec.namespace is set as soon as a cluster is assigned to the claim, but the user then needs to wait for the cluster to wake from hibernation and be fully running before it can be used.

This change adds a new ClusterClaim condition, ClusterRunning, which will be True when the cluster is ready to be used, and can be waited for with `oc wait --for=condition=ClusterRunning --timeout=600s ClusterClaim myclaim`.

/assign @abhinavdahiya 
/cc @suhanime 