### PR TITLE
Support opt-in Non-Selector SyncSet first applied metrics

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -301,6 +301,10 @@ const (
 	// ReconcileIDLen is the length of the random strings we generate for contextual loggers in controller
 	// Reconcile functions.
 	ReconcileIDLen = 8
+
+	// SyncSetMetricsGroupAnnotation can be applied to non-selector SyncSets to make them part of a
+	// group for which first applied metrics can be reported
+	SyncSetMetricsGroupAnnotation = "hive.openshift.io/syncset-metrics-group"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller.go
@@ -263,8 +263,9 @@ func (r *ReconcileControlPlaneCerts) generateControlPlaneCertsSyncSet(cd *hivev1
 	cdLog.Debug("generating syncset for control plane secrets")
 	syncSet := &hivev1.SyncSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      GenerateControlPlaneCertsSyncSetName(cd.Name),
-			Namespace: cd.Namespace,
+			Name:        GenerateControlPlaneCertsSyncSetName(cd.Name),
+			Namespace:   cd.Namespace,
+			Annotations: map[string]string{constants.SyncSetMetricsGroupAnnotation: "cp-certs"},
 		},
 		Spec: hivev1.SyncSetSpec{
 			SyncSetCommonSpec: hivev1.SyncSetCommonSpec{

--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -279,8 +279,9 @@ func (r *ReconcileRemoteClusterIngress) syncSyncSet(rContext *reconcileContext, 
 	newSyncSetSpec := newSyncSetSpec(rContext.clusterDeployment, rawExtensions, secretMappings)
 	syncSet := &hivev1.SyncSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ssName,
-			Namespace: rContext.clusterDeployment.Namespace,
+			Name:        ssName,
+			Namespace:   rContext.clusterDeployment.Namespace,
+			Annotations: map[string]string{constants.SyncSetMetricsGroupAnnotation: "ingress"},
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "SyncSet",


### PR DESCRIPTION
This PR adds support to group non-selector syncsets using 'hive.openshift.io/syncset-metrics-group' 
annotation and report first applied metrics for each group.

jira: https://issues.redhat.com/browse/CO-1217