### PR TITLE
clusterpool: ensure clusterdeployments namespace has same rbac as cluster-pool-admin

### DIFF
--- a/config/controllers/hive_controllers_role.yaml
+++ b/config/controllers/hive_controllers_role.yaml
@@ -49,6 +49,7 @@ rules:
   - ""
   resources:
   - pods
+  - pods/log
   verbs:
   - get
   - list

--- a/config/rbac/hive_clusterpool_admin.yaml
+++ b/config/rbac/hive_clusterpool_admin.yaml
@@ -1,0 +1,48 @@
+# hive-cluster-pool-admin is a role intended for cluster pool administrators who need to be able to debug
+# cluster installations for the pool.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hive-cluster-pool-admin
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  - clusterprovisions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterpools
+  - clusterclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/docs/clusterpools.md
+++ b/docs/clusterpools.md
@@ -92,3 +92,23 @@ status:
     type: Pending
 ```
 
+## Managing admins for Cluster Pools
+
+Role bindings in the **namespace** of a `ClusterPool` that bind to the Cluster Role `hive-cluster-pool-admin`
+are used to provide the **subjects** same permission in the namespaces created for various clusterprovisions for the cluster pool.
+This allows operators to define adminstrators for a `ClusterPool` allowing them visibility to all the resources created for it. This is
+most useful to debug `ClusterProvisions` associated with the pool that have failed and therefore cannot be claimed.
+
+NOTE: You can only define such administrators for the entire namespace and not a specific `ClusterPool`.
+
+To make any `User` or `Group` `hive-cluster-pool-admin` for a namespace you can,
+
+```sh
+oc -n <namespace> adm policy add-role-to-group hive-cluster-pool-admin <user>
+```
+
+or,
+
+```sh
+oc -n <namespace> adm policy add-role-to-group hive-cluster-pool-admin <group>
+```

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -20,6 +20,7 @@
 // config/controllers/service.yaml
 // config/rbac/hive_admin_role.yaml
 // config/rbac/hive_admin_role_binding.yaml
+// config/rbac/hive_clusterpool_admin.yaml
 // config/rbac/hive_frontend_role.yaml
 // config/rbac/hive_frontend_role_binding.yaml
 // config/rbac/hive_frontend_serviceaccount.yaml
@@ -756,6 +757,7 @@ rules:
   - ""
   resources:
   - pods
+  - pods/log
   verbs:
   - get
   - list
@@ -1041,6 +1043,71 @@ func configRbacHive_admin_role_bindingYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "config/rbac/hive_admin_role_binding.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _configRbacHive_clusterpool_adminYaml = []byte(`# hive-cluster-pool-admin is a role intended for cluster pool administrators who need to be able to debug
+# cluster installations for the pool.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hive-cluster-pool-admin
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterdeployments
+  - clusterprovisions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - hive.openshift.io
+  resources:
+  - clusterpools
+  - clusterclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+`)
+
+func configRbacHive_clusterpool_adminYamlBytes() ([]byte, error) {
+	return _configRbacHive_clusterpool_adminYaml, nil
+}
+
+func configRbacHive_clusterpool_adminYaml() (*asset, error) {
+	bytes, err := configRbacHive_clusterpool_adminYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "config/rbac/hive_clusterpool_admin.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1485,6 +1552,7 @@ var _bindata = map[string]func() (*asset, error){
 	"config/controllers/service.yaml":                           configControllersServiceYaml,
 	"config/rbac/hive_admin_role.yaml":                          configRbacHive_admin_roleYaml,
 	"config/rbac/hive_admin_role_binding.yaml":                  configRbacHive_admin_role_bindingYaml,
+	"config/rbac/hive_clusterpool_admin.yaml":                   configRbacHive_clusterpool_adminYaml,
 	"config/rbac/hive_frontend_role.yaml":                       configRbacHive_frontend_roleYaml,
 	"config/rbac/hive_frontend_role_binding.yaml":               configRbacHive_frontend_role_bindingYaml,
 	"config/rbac/hive_frontend_serviceaccount.yaml":             configRbacHive_frontend_serviceaccountYaml,
@@ -1563,6 +1631,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"rbac": {nil, map[string]*bintree{
 			"hive_admin_role.yaml":              {configRbacHive_admin_roleYaml, map[string]*bintree{}},
 			"hive_admin_role_binding.yaml":      {configRbacHive_admin_role_bindingYaml, map[string]*bintree{}},
+			"hive_clusterpool_admin.yaml":       {configRbacHive_clusterpool_adminYaml, map[string]*bintree{}},
 			"hive_frontend_role.yaml":           {configRbacHive_frontend_roleYaml, map[string]*bintree{}},
 			"hive_frontend_role_binding.yaml":   {configRbacHive_frontend_role_bindingYaml, map[string]*bintree{}},
 			"hive_frontend_serviceaccount.yaml": {configRbacHive_frontend_serviceaccountYaml, map[string]*bintree{}},

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -300,6 +300,7 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 	openshiftSpecificAssets := []string{
 		"config/rbac/hive_admin_role.yaml",
 		"config/rbac/hive_reader_role.yaml",
+		"config/rbac/hive_clusterpool_admin.yaml",
 		"config/rbac/hive_admin_role_binding.yaml",
 		"config/rbac/hive_reader_role_binding.yaml",
 	}


### PR DESCRIPTION
xref: https://issues.redhat.com/browse/CO-1282

Any role bindings in the namespace of the clusterpool that refer the ClusterRole `hive-cluster-pool-admin`
will be used to provide the subjects the same permission in the namespaces created for various
clusterdeployments for the clusterpool.

The controller performs these additional actions for each reconcile,

- lists all the rolebindings in clusterpool's namespace that refer the ClusterRole `hive-cluster-pool-admin`
to collect all the subjects.
  This makes sure that no work needs to be done when there are such rolebindings. And since k8s ensures that a rolebinding
  cannot be created when the ref doesn't exist, this will ensure that only when the ClusterRole exists would the controller
  run the next steps.
- lists all the namespaces attached to the clusterpool by using the constants.ClusterPoolNameLabel label selector.
- creates/updates a rolebinding `hive-cluster-pool-admin-binding` in each namespace binding to the same ClusterRole.

The controller also adds new watchers,

- changes to rolebindings in the clusterdeployment namespace
- changes to any rolebindings with ref to ClusterRole `hive-cluster-pool-admin` triggers resync for all clusterpools
  in that namespace.

**NOTE**: the controller can only pass on the permissions that it has i.e. the current hive-cluster-pool-admin cluster role is a subset of the hive-controller's permission. If the controller permissions are less that what the hive-cluster-pool-admin cluster role, then when creating a rolebinding in the clusterdeployment namespace we see an error like 
```
time="2020-11-30T21:21:11.129Z" level=error msg="could not create rolebinding" clusterPool=default/adahiya-pool-1 controller=clusterpool error="rolebindings.rbac.authorization.k8s.io \"hive-cluster-pool-admin-binding\" is forbidden: user \"system:serviceaccount:hive:hive-controllers\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:hive\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"\"], Resources:[\"pods/log\"], Verbs:[\"get\" \"list\" \"watch\"]}\n{APIGroups:[\"apiextensions.k8s.io\"], Resources:[\"customresourcedefinitions\"], Verbs:[\"get\" \"list\" \"watch\"]}" reconcileID=gn7pt9sd rolebinding=adahiya-pool-1-kpkbg/hive-cluster-pool-admin-binding
```
