### PR TITLE
clusterpool: allow setting max size and max concurrent actions

### DIFF
--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -75,6 +75,18 @@ spec:
                 for the pool. ClusterDeployments that have already been claimed will
                 not be affected when this value is modified.
               type: object
+            maxConcurrent:
+              description: MaxConcurrent is the maximum number of clusters that will
+                be provisioned or deprovisioned at an time. By default there is no
+                limit.
+              format: int32
+              type: integer
+            maxSize:
+              description: MaxSize is the maximum number of clusters that will be
+                provisioned including clusters that have been claimed and ones waiting
+                to be used. By default there is no limit.
+              format: int32
+              type: integer
             platform:
               description: Platform encompasses the desired platform for the cluster.
               properties:

--- a/pkg/apis/hive/v1/clusterpool_types.go
+++ b/pkg/apis/hive/v1/clusterpool_types.go
@@ -21,6 +21,17 @@ type ClusterPoolSpec struct {
 	// +required
 	Size int32 `json:"size"`
 
+	// MaxSize is the maximum number of clusters that will be provisioned including clusters that have been claimed
+	// and ones waiting to be used.
+	// By default there is no limit.
+	// +optional
+	MaxSize *int32 `json:"maxSize,omitempty"`
+
+	// MaxConcurrent is the maximum number of clusters that will be provisioned or deprovisioned at an time.
+	// By default there is no limit.
+	// +optional
+	MaxConcurrent *int32 `json:"maxConcurrent,omitempty"`
+
 	// BaseDomain is the base domain to use for all clusters created in this pool.
 	// +required
 	BaseDomain string `json:"baseDomain"`
@@ -72,9 +83,12 @@ type ClusterPoolCondition struct {
 type ClusterPoolConditionType string
 
 const (
-	// ClusterPoolMissingDependentsCondition is set when a cluster pool is missing dependencies required to create a
+	// ClusterPoolMissingDependenciesCondition is set when a cluster pool is missing dependencies required to create a
 	// cluster. Dependencies include resources such as the ClusterImageSet and the credentials Secret.
 	ClusterPoolMissingDependenciesCondition ClusterPoolConditionType = "MissingDependencies"
+	// ClusterPoolCapacityAvailableCondition is set to provide information on whether the cluster pool has capacity
+	// available to create more clusters for the pool.
+	ClusterPoolCapacityAvailableCondition ClusterPoolConditionType = "CapacityAvailable"
 )
 
 // +genclient

--- a/pkg/apis/hive/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/hive/v1/zz_generated.deepcopy.go
@@ -1078,6 +1078,16 @@ func (in *ClusterPoolSpec) DeepCopyInto(out *ClusterPoolSpec) {
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
+	if in.MaxSize != nil {
+		in, out := &in.MaxSize, &out.MaxSize
+		*out = new(int32)
+		**out = **in
+	}
+	if in.MaxConcurrent != nil {
+		in, out := &in.MaxConcurrent, &out.MaxConcurrent
+		*out = new(int32)
+		**out = **in
+	}
 	out.ImageSetRef = in.ImageSetRef
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -237,7 +237,7 @@ func (r *ReconcileClusterPool) Reconcile(request reconcile.Request) (reconcile.R
 	}
 
 	// Find all ClusterDeployments from this pool:
-	poolCDs, err := r.getAllUnclaimedClusterDeployments(clp, logger)
+	claimedCDs, unClaminedCDs, err := r.getAllClusterDeploymentsForPool(clp, logger)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -245,7 +245,7 @@ func (r *ReconcileClusterPool) Reconcile(request reconcile.Request) (reconcile.R
 	var installingCDs []*hivev1.ClusterDeployment
 	var readyCDs []*hivev1.ClusterDeployment
 	numberOfDeletingCDs := 0
-	for _, cd := range poolCDs {
+	for _, cd := range unClaminedCDs {
 		switch {
 		case cd.DeletionTimestamp != nil:
 			numberOfDeletingCDs++
@@ -259,7 +259,7 @@ func (r *ReconcileClusterPool) Reconcile(request reconcile.Request) (reconcile.R
 	logger.WithFields(log.Fields{
 		"installing": len(installingCDs),
 		"deleting":   numberOfDeletingCDs,
-		"total":      len(poolCDs),
+		"total":      len(unClaminedCDs),
 		"ready":      len(readyCDs),
 	}).Debug("found clusters for ClusterPool")
 
@@ -271,6 +271,22 @@ func (r *ReconcileClusterPool) Reconcile(request reconcile.Request) (reconcile.R
 			logger.WithError(err).Log(controllerutils.LogLevel(err), "could not update ClusterPool status")
 			return reconcile.Result{}, errors.Wrap(err, "could not update ClusterPool status")
 		}
+	}
+
+	hasAvailableCapacity := true
+	if clp.Spec.MaxSize != nil {
+		hasAvailableCapacity = clp.Status.Size+int32(len(claimedCDs)) < *clp.Spec.MaxSize
+		if !hasAvailableCapacity {
+			logger.WithFields(log.Fields{
+				"ClusterPoolSize": clp.Status.Size,
+				"ClaimedSize":     len(claimedCDs),
+				"Capacity":        *clp.Spec.MaxSize,
+			}).Info("Cannot add more clusters because no capacity available.")
+		}
+	}
+	if err := r.setAvailableCapacityCondition(clp, hasAvailableCapacity, logger); err != nil {
+		logger.WithError(err).Error("error setting CapacityAvailable condition")
+		return reconcile.Result{}, err
 	}
 
 	pendingClaims, err := r.getAllPendingClusterClaims(clp, logger)
@@ -288,14 +304,44 @@ func (r *ReconcileClusterPool) Reconcile(request reconcile.Request) (reconcile.R
 	}
 
 	switch drift := reserveSize - int(clp.Spec.Size); {
+	// activity quota exceeded, so no action
+	case clp.Spec.MaxConcurrent != nil && int(*clp.Spec.MaxConcurrent)-len(installingCDs)-numberOfDeletingCDs <= 0:
+		logger.WithFields(log.Fields{
+			"MaxConcurrent": *clp.Spec.MaxConcurrent,
+			"Current":       len(installingCDs) + numberOfDeletingCDs,
+		}).Info("Cannot create/delete clusters as max concurrent quota exceeded.")
 	// If too many, delete some.
 	case drift > 0:
-		if err := r.deleteExcessClusters(installingCDs, readyCDs, drift, logger); err != nil {
+		toDel := drift
+		if clp.Spec.MaxConcurrent != nil {
+			availableActivity := int(*clp.Spec.MaxConcurrent) - len(installingCDs) - numberOfDeletingCDs
+			if toDel > availableActivity {
+				toDel = availableActivity
+			}
+		}
+		if err := r.deleteExcessClusters(installingCDs, readyCDs, toDel, logger); err != nil {
 			return reconcile.Result{}, err
 		}
 	// If too few, create new InstallConfig and ClusterDeployment.
 	case drift < 0:
-		if err := r.addClusters(clp, -drift, logger); err != nil {
+		toAdd := -drift
+		if !hasAvailableCapacity {
+			break
+		}
+		if clp.Spec.MaxSize != nil {
+			availableCapacity := int(*clp.Spec.MaxSize) - int(clp.Status.Size) - len(claimedCDs)
+			log.Info(availableCapacity)
+			if toAdd > availableCapacity {
+				toAdd = availableCapacity
+			}
+		}
+		if clp.Spec.MaxConcurrent != nil {
+			availableActivity := int(*clp.Spec.MaxConcurrent) - len(installingCDs) - numberOfDeletingCDs
+			if toAdd > availableActivity {
+				toAdd = availableActivity
+			}
+		}
+		if err := r.addClusters(clp, toAdd, logger); err != nil {
 			log.WithError(err).Error("error adding clusters")
 			return reconcile.Result{}, err
 		}
@@ -565,11 +611,11 @@ func (r *ReconcileClusterPool) reconcileDeletedPool(pool *hivev1.ClusterPool, lo
 	if !controllerutils.HasFinalizer(pool, finalizer) {
 		return nil
 	}
-	poolCDs, err := r.getAllUnclaimedClusterDeployments(pool, logger)
+	_, unClaimedCDs, err := r.getAllClusterDeploymentsForPool(pool, logger)
 	if err != nil {
 		return err
 	}
-	for _, cd := range poolCDs {
+	for _, cd := range unClaimedCDs {
 		if cd.DeletionTimestamp != nil {
 			continue
 		}
@@ -586,19 +632,24 @@ func (r *ReconcileClusterPool) reconcileDeletedPool(pool *hivev1.ClusterPool, lo
 	return nil
 }
 
-func (r *ReconcileClusterPool) getAllUnclaimedClusterDeployments(pool *hivev1.ClusterPool, logger log.FieldLogger) ([]*hivev1.ClusterDeployment, error) {
+func (r *ReconcileClusterPool) getAllClusterDeploymentsForPool(pool *hivev1.ClusterPool, logger log.FieldLogger) (claimed, unclaimed []*hivev1.ClusterDeployment, err error) {
 	cdList := &hivev1.ClusterDeploymentList{}
 	if err := r.Client.List(context.Background(), cdList); err != nil {
 		logger.WithError(err).Error("error listing ClusterDeployments")
-		return nil, err
+		return nil, nil, err
 	}
-	var poolCDs []*hivev1.ClusterDeployment
 	for i, cd := range cdList.Items {
-		if refInCD := cd.Spec.ClusterPoolRef; refInCD != nil && *refInCD == poolReference(pool) {
-			poolCDs = append(poolCDs, &cdList.Items[i])
+		if refInCD := cd.Spec.ClusterPoolRef; refInCD != nil {
+			if refInCD.Namespace == pool.Namespace && refInCD.PoolName == pool.Name {
+				if len(refInCD.ClaimName) > 0 {
+					claimed = append(claimed, &cdList.Items[i])
+				} else {
+					unclaimed = append(unclaimed, &cdList.Items[i])
+				}
+			}
 		}
 	}
-	return poolCDs, nil
+	return claimed, unclaimed, nil
 }
 
 func poolReference(pool *hivev1.ClusterPool) hivev1.ClusterPoolReference {
@@ -645,6 +696,35 @@ func (r *ReconcileClusterPool) setMissingDependenciesCondition(pool *hivev1.Clus
 		if err := r.Status().Update(context.Background(), pool); err != nil {
 			logger.WithError(err).Log(controllerutils.LogLevel(err), "could not update ClusterPool conditions")
 			return fmt.Errorf("could not update ClusterPool conditions: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *ReconcileClusterPool) setAvailableCapacityCondition(pool *hivev1.ClusterPool, available bool, logger log.FieldLogger) error {
+	status := corev1.ConditionTrue
+	reason := "Available"
+	message := "There is capacity to add more clusters to the pool."
+	updateConditionCheck := controllerutils.UpdateConditionNever
+	if !available {
+		status = corev1.ConditionFalse
+		reason = "MaxCapacity"
+		message = fmt.Sprintf("Pool is at maximum capacity of %d waiting and claimed clusters.", *pool.Spec.MaxSize)
+		updateConditionCheck = controllerutils.UpdateConditionIfReasonOrMessageChange
+	}
+	conds, changed := controllerutils.SetClusterPoolConditionWithChangeCheck(
+		pool.Status.Conditions,
+		hivev1.ClusterPoolCapacityAvailableCondition,
+		status,
+		reason,
+		message,
+		updateConditionCheck,
+	)
+	if changed {
+		pool.Status.Conditions = conds
+		if err := r.Status().Update(context.Background(), pool); err != nil {
+			logger.WithError(err).Log(controllerutils.LogLevel(err), "could not update ClusterPool conditions")
+			return errors.Wrap(err, "could not update ClusterPool conditions")
 		}
 	}
 	return nil

--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -214,20 +214,22 @@ func SetClusterPoolConditionWithChangeCheck(
 	now := metav1.Now()
 	existingCondition := FindClusterPoolCondition(conditions, conditionType)
 	if existingCondition == nil {
-		if status == corev1.ConditionTrue {
-			conditions = append(
-				conditions,
-				hivev1.ClusterPoolCondition{
-					Type:               conditionType,
-					Status:             status,
-					Reason:             reason,
-					Message:            message,
-					LastTransitionTime: now,
-					LastProbeTime:      now,
-				},
-			)
-			changed = true
-		}
+		// Deviating from other setter methods we use due to latest API conventions in Kube. They clarify that a
+		// True condition is not necessarily an abnormal state, and that conditions should be set asap even if Unknown.
+		// Previously we would not bother setting the condition if the status was false. With ClusterClaim we are
+		// beginning to adhere to these guidelines.
+		conditions = append(
+			conditions,
+			hivev1.ClusterPoolCondition{
+				Type:               conditionType,
+				Status:             status,
+				Reason:             reason,
+				Message:            message,
+				LastTransitionTime: now,
+				LastProbeTime:      now,
+			},
+		)
+		changed = true
 	} else {
 		if shouldUpdateCondition(
 			existingCondition.Status, existingCondition.Reason, existingCondition.Message,

--- a/pkg/test/clusterpool/clusterpool.go
+++ b/pkg/test/clusterpool/clusterpool.go
@@ -3,6 +3,7 @@ package clusterpool
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	hivev1aws "github.com/openshift/hive/pkg/apis/hive/v1/aws"
@@ -109,6 +110,18 @@ func WithBaseDomain(baseDomain string) Option {
 func WithImageSet(clusterImageSetName string) Option {
 	return func(clusterPool *hivev1.ClusterPool) {
 		clusterPool.Spec.ImageSetRef = hivev1.ClusterImageSetReference{Name: clusterImageSetName}
+	}
+}
+
+func WithMaxSize(size int) Option {
+	return func(clusterPool *hivev1.ClusterPool) {
+		clusterPool.Spec.MaxSize = pointer.Int32Ptr(int32(size))
+	}
+}
+
+func WithMaxConcurrent(size int) Option {
+	return func(clusterPool *hivev1.ClusterPool) {
+		clusterPool.Spec.MaxConcurrent = pointer.Int32Ptr(int32(size))
 	}
 }
 


### PR DESCRIPTION
xref: https://issues.redhat.com/browse/CO-1278

Today the cluster pool keeps creating clusters to match `.spec.size` as ready clusters
are claimed by users. This is usually not possible as the secret used by the cluster pool usually
maps to an account in cloud that has limits/quotas and therefore there is need to allow admin
to set a limit on the maximum number of clusters created by a pool (already claimed + unclaimed).
The new field `.spec.maxSize` allows the admin to set this limit on maximum number of clusters
that are created for a pool. This includes the already claimed clusters, clusters ready to be claimed and
clusters that being provisioned, and does not include clusters are being deleted.
NOTE: when unset, this implies Inf capacity.

Similar to quotas in accounts, most cloud providers have API quotas that limit number of cloud API interactions
over a period of time. An close approximation of this can be made in terms of number of clusters being brought
up/down as these are periods of high cloud API interactions. So if the admin can define a limit on the
number of UP/DOWN activity that can happen for a pool, it allows the admin to prevent rate limiting.
The new field `.spec.maxConcurrent` specifies the maximum number of cluster create/delete can be in progress at
a given instant.
NOTE: when unset, this implies Inf concurrent limit.