### PR TITLE
OpenStackClusterDeprovision: fix optional certficate field marshalling

### DIFF
--- a/pkg/apis/hive/v1/clusterdeprovision_types.go
+++ b/pkg/apis/hive/v1/clusterdeprovision_types.go
@@ -77,7 +77,7 @@ type OpenStackClusterDeprovision struct {
 	// necessary for communicating with the OpenStack.
 	//
 	// +optional
-	CertificatesSecretRef *corev1.LocalObjectReference `json:"certificatesSecretRef"`
+	CertificatesSecretRef *corev1.LocalObjectReference `json:"certificatesSecretRef,omitempty"`
 }
 
 // VSphereClusterDeprovision contains VMware vSphere-specific configuration for a ClusterDeprovision


### PR DESCRIPTION
Since there was not omitempty on the new field added in
https://github.com/openshift/hive/pull/1196/files#diff-e993baf98b3c3bef0bc8ca5fe256449adb63079a3267f02b6ea11a1e5ca90d9eR80 a new object would created for clusterdeprovision with `null` value for the field
causing validation errors like

```
Invalid value: "null": spec.platform.openstack.certificatesSecretRef in body must be of type object: "null"
```

xref: https://issues.redhat.com/browse/CO-1303

/assign @abutcher 
/cc @dgoodwin 