### PR TITLE
clusterpool: include deleting claimed clusters for max concurrent

### DIFF
--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -85,8 +85,8 @@ spec:
               type: object
             maxConcurrent:
               description: MaxConcurrent is the maximum number of clusters that will
-                be provisioned or deprovisioned at an time. By default there is no
-                limit.
+                be provisioned or deprovisioned at an time. This includes the claimed
+                clusters being deprovisioned. By default there is no limit.
               format: int32
               type: integer
             maxSize:

--- a/pkg/apis/hive/v1/clusterpool_types.go
+++ b/pkg/apis/hive/v1/clusterpool_types.go
@@ -27,7 +27,8 @@ type ClusterPoolSpec struct {
 	// +optional
 	MaxSize *int32 `json:"maxSize,omitempty"`
 
-	// MaxConcurrent is the maximum number of clusters that will be provisioned or deprovisioned at an time.
+	// MaxConcurrent is the maximum number of clusters that will be provisioned or deprovisioned at an time. This includes the
+	// claimed clusters being deprovisioned.
 	// By default there is no limit.
 	// +optional
 	MaxConcurrent *int32 `json:"maxConcurrent,omitempty"`

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -306,6 +306,11 @@ const (
 	// SyncSetMetricsGroupAnnotation can be applied to non-selector SyncSets to make them part of a
 	// group for which first applied metrics can be reported
 	SyncSetMetricsGroupAnnotation = "hive.openshift.io/syncset-metrics-group"
+
+	// ClusterClaimRemoveClusterAnnotation is used by the cluster claim controller to mark that the cluster
+	// that are previously claimed is no longer required and therefore should be removed/deprovisioned and removed
+	// from the pool.
+	ClusterClaimRemoveClusterAnnotation = "hive.openshift.io/remove-claimed-cluster-from-pool"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/pkg/controller/clusterclaim/clusterclaim_controller.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/resource"
@@ -306,10 +307,15 @@ func (r *ReconcileClusterClaim) cleanupResources(claim *hivev1.ClusterClaim, log
 	}
 
 	// Delete ClusterDeployment
-	if cd.DeletionTimestamp == nil {
+	_, toRemove := cd.Annotations[constants.ClusterClaimRemoveClusterAnnotation]
+	if cd.DeletionTimestamp == nil && !toRemove {
 		logger.Info("deleting clusterDeployment")
-		if err := r.Delete(context.Background(), cd); err != nil {
-			logger.WithError(err).Log(controllerutils.LogLevel(err), "error deleting ClusterDeployment")
+		if cd.Annotations == nil {
+			cd.Annotations = map[string]string{}
+		}
+		cd.Annotations[constants.ClusterClaimRemoveClusterAnnotation] = ""
+		if err := r.Update(context.Background(), cd); err != nil {
+			logger.WithError(err).Log(controllerutils.LogLevel(err), "error updating ClusterDeployment to mark it for deletion")
 			return err
 		}
 	}

--- a/pkg/controller/clusterclaim/clusterclaim_controller.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller.go
@@ -307,13 +307,13 @@ func (r *ReconcileClusterClaim) cleanupResources(claim *hivev1.ClusterClaim, log
 	}
 
 	// Delete ClusterDeployment
-	_, toRemove := cd.Annotations[constants.ClusterClaimRemoveClusterAnnotation]
+	toRemove := controllerutils.IsClaimedClusterMarkedForRemoval(cd)
 	if cd.DeletionTimestamp == nil && !toRemove {
 		logger.Info("deleting clusterDeployment")
 		if cd.Annotations == nil {
 			cd.Annotations = map[string]string{}
 		}
-		cd.Annotations[constants.ClusterClaimRemoveClusterAnnotation] = ""
+		cd.Annotations[constants.ClusterClaimRemoveClusterAnnotation] = "true"
 		if err := r.Update(context.Background(), cd); err != nil {
 			logger.WithError(err).Log(controllerutils.LogLevel(err), "error updating ClusterDeployment to mark it for deletion")
 			return err

--- a/pkg/controller/clusterclaim/clusterclaim_controller_test.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
 	testclaim "github.com/openshift/hive/pkg/test/clusterclaim"
 	testcd "github.com/openshift/hive/pkg/test/clusterdeployment"
 	testgeneric "github.com/openshift/hive/pkg/test/generic"
@@ -552,7 +553,8 @@ func TestReconcileClusterClaim(t *testing.T) {
 					assert.NotEqual(t, claimName, cd.Spec.ClusterPoolRef.ClaimName, "expected ClusterDeployment to not be claimed by ClusterClaim")
 				}
 				if isAssignedCD {
-					assignedClusterDeploymentExists = true
+					_, toRemove := cd.Annotations[constants.ClusterClaimRemoveClusterAnnotation]
+					assignedClusterDeploymentExists = !toRemove
 					if test.expectHibernating {
 						assert.Equal(t, hivev1.HibernatingClusterPowerState, cd.Spec.PowerState, "expected ClusterDeployment to be hibernating")
 					} else {

--- a/pkg/controller/clusterclaim/clusterclaim_controller_test.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller_test.go
@@ -19,7 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
-	"github.com/openshift/hive/pkg/constants"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	testclaim "github.com/openshift/hive/pkg/test/clusterclaim"
 	testcd "github.com/openshift/hive/pkg/test/clusterdeployment"
 	testgeneric "github.com/openshift/hive/pkg/test/generic"
@@ -553,7 +553,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 					assert.NotEqual(t, claimName, cd.Spec.ClusterPoolRef.ClaimName, "expected ClusterDeployment to not be claimed by ClusterClaim")
 				}
 				if isAssignedCD {
-					_, toRemove := cd.Annotations[constants.ClusterClaimRemoveClusterAnnotation]
+					toRemove := controllerutils.IsClaimedClusterMarkedForRemoval(&cd)
 					assignedClusterDeploymentExists = !toRemove
 					if test.expectHibernating {
 						assert.Equal(t, hivev1.HibernatingClusterPowerState, cd.Spec.PowerState, "expected ClusterDeployment to be hibernating")

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -246,7 +246,7 @@ func (r *ReconcileClusterPool) Reconcile(request reconcile.Request) (reconcile.R
 	var toRemoveClaimedCDs []*hivev1.ClusterDeployment
 	numberOfDeletingClaimedCDs := 0
 	for _, cd := range claimedCDs {
-		_, toRemove := cd.Annotations[constants.ClusterClaimRemoveClusterAnnotation]
+		toRemove := controllerutils.IsClaimedClusterMarkedForRemoval(cd)
 		switch {
 		case cd.DeletionTimestamp != nil:
 			numberOfDeletingClaimedCDs++

--- a/pkg/controller/clusterpool/clusterpool_controller_test.go
+++ b/pkg/controller/clusterpool/clusterpool_controller_test.go
@@ -664,7 +664,7 @@ func TestReconcileClusterPool(t *testing.T) {
 				unclaimedCDBuilder("c2").Build(testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").
-					GenericOptions(testgeneric.Deleted(), testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					GenericOptions(testgeneric.Deleted(), testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(
 						testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "test-claim"),
 					),
@@ -681,7 +681,7 @@ func TestReconcileClusterPool(t *testing.T) {
 				unclaimedCDBuilder("c2").Build(testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").
-					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(
 						testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "test-claim"),
 					),
@@ -699,7 +699,7 @@ func TestReconcileClusterPool(t *testing.T) {
 				unclaimedCDBuilder("c2").Build(),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").
-					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(
 						testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "test-claim"),
 					),
@@ -716,7 +716,7 @@ func TestReconcileClusterPool(t *testing.T) {
 				unclaimedCDBuilder("c2").GenericOptions(testgeneric.Deleted()).Build(testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").
-					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(
 						testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "test-claim"),
 					),
@@ -733,7 +733,7 @@ func TestReconcileClusterPool(t *testing.T) {
 				unclaimedCDBuilder("c2").GenericOptions(testgeneric.Deleted()).Build(testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").
-					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(
 						testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "test-claim"),
 					),
@@ -750,7 +750,7 @@ func TestReconcileClusterPool(t *testing.T) {
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").
-					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(
 						testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "test-claim"),
 					),
@@ -767,12 +767,12 @@ func TestReconcileClusterPool(t *testing.T) {
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(testcd.Installed()),
 				cdBuilder("c4").
-					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(
 						testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "test-claim"),
 					),
 				cdBuilder("c5").
-					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(
 						testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "test-claim"),
 					),
@@ -789,12 +789,12 @@ func TestReconcileClusterPool(t *testing.T) {
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").
-					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(
 						testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "test-claim"),
 					),
 				cdBuilder("c5").
-					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(
 						testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "test-claim"),
 					),
@@ -812,7 +812,7 @@ func TestReconcileClusterPool(t *testing.T) {
 				unclaimedCDBuilder("c2").Build(testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").
-					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(
 						testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "test-claim"),
 					),
@@ -830,12 +830,12 @@ func TestReconcileClusterPool(t *testing.T) {
 				unclaimedCDBuilder("c2").Build(testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(testcd.Installed()),
 				cdBuilder("c4").
-					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(
 						testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "test-claim"),
 					),
 				cdBuilder("c5").
-					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(
 						testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "test-claim"),
 					),
@@ -853,12 +853,12 @@ func TestReconcileClusterPool(t *testing.T) {
 				unclaimedCDBuilder("c2").Build(testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").
-					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(
 						testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "test-claim"),
 					),
 				cdBuilder("c5").
-					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(
 						testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "test-claim"),
 					),

--- a/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller.go
+++ b/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller.go
@@ -194,7 +194,7 @@ func (r *ReconcileClusterPoolNamespace) cleanupPreviouslyClaimedClusterDeploymen
 		if cdList.Items[idx].DeletionTimestamp != nil {
 			continue
 		}
-		if _, ok := cdList.Items[idx].Annotations[constants.ClusterClaimRemoveClusterAnnotation]; !ok {
+		if !controllerutils.IsClaimedClusterMarkedForRemoval(&cdList.Items[idx]) {
 			continue
 		}
 		someCleanupDone = true

--- a/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller.go
+++ b/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller.go
@@ -147,6 +147,18 @@ func (r *ReconcileClusterPoolNamespace) Reconcile(request reconcile.Request) (re
 		return reconcile.Result{}, nil
 	}
 
+	someCleanupDone, err := r.cleanupPreviouslyClaimedClusterDeployments(cdList, logger)
+	switch {
+	case someCleanupDone && err != nil:
+		logger.WithError(err).Log(controllerutils.LogLevel(err), "error cleaning up some clusters")
+		return reconcile.Result{RequeueAfter: durationBetweenDeletingClusterDeploymentChecks}, err
+	case err != nil:
+		logger.WithError(err).Log(controllerutils.LogLevel(err), "error cleaning up some clusters")
+		return reconcile.Result{}, err
+	case someCleanupDone:
+		return reconcile.Result{RequeueAfter: durationBetweenDeletingClusterDeploymentChecks}, nil
+	}
+
 	// If all of the ClusterDeployments have been deleted, then we need to due a Requeue After since the watch will
 	// not trigger when the ClusterDeployment is finally removed from storage.
 	for _, cd := range cdList.Items {
@@ -158,4 +170,48 @@ func (r *ReconcileClusterPoolNamespace) Reconcile(request reconcile.Request) (re
 
 	logger.Debug("all ClusterDeployments deleted; waiting longer for ClusterDeployments to be removed from storage")
 	return reconcile.Result{RequeueAfter: durationBetweenDeletingClusterDeploymentChecks}, nil
+}
+
+func (r *ReconcileClusterPoolNamespace) cleanupPreviouslyClaimedClusterDeployments(cdList *hivev1.ClusterDeploymentList, logger log.FieldLogger) (bool, error) {
+	poolKey := clusterPoolKey(&cdList.Items[0])
+	if poolKey == nil {
+		// since clusterpool creates a namespace for hosting clusterdeployments
+		// it is safe to assume that either all clusterdeployments are of a pool
+		// or none are.
+		return false, nil
+	}
+
+	clp := &hivev1.ClusterPool{}
+	err := r.Get(context.TODO(), *poolKey, clp)
+	if !apierrors.IsNotFound(err) {
+		// we only care about cleaning up when the pool no longer exists.
+		return false, nil
+	}
+
+	logger.Info("pool not found so start cleanup of previously claimed but not required anymore clusters.")
+	someCleanupDone := false
+	for idx := range cdList.Items {
+		if cdList.Items[idx].DeletionTimestamp != nil {
+			continue
+		}
+		if _, ok := cdList.Items[idx].Annotations[constants.ClusterClaimRemoveClusterAnnotation]; !ok {
+			continue
+		}
+		someCleanupDone = true
+
+		logger := logger.WithField("cluster", cdList.Items[idx].Name)
+		logger.Info("deleting cluster deployment for previous claim")
+		if err := r.Client.Delete(context.Background(), &cdList.Items[idx]); err != nil {
+			logger.WithError(err).Error("error deleting cluster deployment")
+			return someCleanupDone, err
+		}
+	}
+	return someCleanupDone, nil
+}
+
+func clusterPoolKey(cd *hivev1.ClusterDeployment) *types.NamespacedName {
+	if cd.Spec.ClusterPoolRef == nil {
+		return nil
+	}
+	return &types.NamespacedName{Namespace: cd.Spec.ClusterPoolRef.Namespace, Name: cd.Spec.ClusterPoolRef.PoolName}
 }

--- a/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller_test.go
+++ b/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller_test.go
@@ -96,7 +96,7 @@ func TestReconcileClusterPoolNamespace_Reconcile_Movement(t *testing.T) {
 			resources: []runtime.Object{
 				poolBuilder.Build(),
 				testcd.FullBuilder(namespaceName, "test-cd", scheme).
-					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(testcd.WithClusterPoolReference("test-pool-namespace", "test-cluster-pool", "test-claim")),
 				testcd.FullBuilder(namespaceName, "test-cd-2", scheme).
 					Build(testcd.WithClusterPoolReference("test-pool-namespace", "test-cluster-pool", "test-claim-2")),
@@ -109,7 +109,7 @@ func TestReconcileClusterPoolNamespace_Reconcile_Movement(t *testing.T) {
 			namespaceBuilder: namespaceBuilder,
 			resources: []runtime.Object{
 				testcd.FullBuilder(namespaceName, "test-cd", scheme).
-					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(testcd.WithClusterPoolReference("test-pool-namespace", "test-cluster-pool", "test-claim")),
 				testcd.FullBuilder(namespaceName, "test-cd-2", scheme).
 					Build(testcd.WithClusterPoolReference("test-pool-namespace", "test-cluster-pool", "test-claim-2")),
@@ -133,7 +133,7 @@ func TestReconcileClusterPoolNamespace_Reconcile_Movement(t *testing.T) {
 			namespaceBuilder: namespaceBuilder,
 			resources: []runtime.Object{
 				testcd.FullBuilder(namespaceName, "test-cd", scheme).
-					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, ""), testgeneric.Deleted()).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true"), testgeneric.Deleted()).
 					Build(testcd.WithClusterPoolReference("test-pool-namespace", "test-cluster-pool", "test-claim")),
 				testcd.FullBuilder(namespaceName, "test-cd-2", scheme).
 					GenericOptions(testgeneric.Deleted()).
@@ -275,7 +275,7 @@ func Test_cleanupPreviouslyClaimedClusterDeployments(t *testing.T) {
 		name: "no cleanup as cluster pool exists with marked for removal clusters",
 		resources: []runtime.Object{
 			poolBuilder.Build(),
-			cdBuilderWithPool("cd1", "test-cluster-pool").GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).Build(),
+			cdBuilderWithPool("cd1", "test-cluster-pool").GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).Build(),
 			cdBuilderWithPool("cd2", "test-cluster-pool").Build(),
 		},
 		expectedErr:      "",
@@ -302,7 +302,7 @@ func Test_cleanupPreviouslyClaimedClusterDeployments(t *testing.T) {
 	}, {
 		name: "no cleanup as clusters marked for removal already deleted",
 		resources: []runtime.Object{
-			cdBuilderWithPool("cd1", "test-cluster-pool").GenericOptions(testgeneric.Deleted(), testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).Build(),
+			cdBuilderWithPool("cd1", "test-cluster-pool").GenericOptions(testgeneric.Deleted(), testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).Build(),
 			cdBuilderWithPool("cd2", "test-cluster-pool").Build(),
 		},
 		expectedErr:      "",
@@ -311,7 +311,7 @@ func Test_cleanupPreviouslyClaimedClusterDeployments(t *testing.T) {
 	}, {
 		name: "some cleanup",
 		resources: []runtime.Object{
-			cdBuilderWithPool("cd1", "test-cluster-pool").GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).Build(),
+			cdBuilderWithPool("cd1", "test-cluster-pool").GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).Build(),
 			cdBuilderWithPool("cd2", "test-cluster-pool").Build(),
 		},
 		expectedErr:      "",
@@ -320,8 +320,8 @@ func Test_cleanupPreviouslyClaimedClusterDeployments(t *testing.T) {
 	}, {
 		name: "some cleanup 2",
 		resources: []runtime.Object{
-			cdBuilderWithPool("cd1", "test-cluster-pool").GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).Build(),
-			cdBuilderWithPool("cd2", "test-cluster-pool").GenericOptions(testgeneric.Deleted(), testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).Build(),
+			cdBuilderWithPool("cd1", "test-cluster-pool").GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).Build(),
+			cdBuilderWithPool("cd2", "test-cluster-pool").GenericOptions(testgeneric.Deleted(), testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).Build(),
 		},
 		expectedErr:      "",
 		expectedCleanup:  true,
@@ -329,10 +329,10 @@ func Test_cleanupPreviouslyClaimedClusterDeployments(t *testing.T) {
 	}, {
 		name: "some cleanup 3",
 		resources: []runtime.Object{
-			cdBuilderWithPool("cd1", "test-cluster-pool").GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).Build(),
+			cdBuilderWithPool("cd1", "test-cluster-pool").GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).Build(),
 			cdBuilderWithPool("cd2", "test-cluster-pool").Build(),
-			cdBuilderWithPool("cd3", "test-cluster-pool").GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).Build(),
-			cdBuilderWithPool("cd4", "test-cluster-pool").GenericOptions(testgeneric.Deleted(), testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).Build(),
+			cdBuilderWithPool("cd3", "test-cluster-pool").GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).Build(),
+			cdBuilderWithPool("cd4", "test-cluster-pool").GenericOptions(testgeneric.Deleted(), testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).Build(),
 		},
 		expectedErr:      "",
 		expectedCleanup:  true,

--- a/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller_test.go
+++ b/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller_test.go
@@ -18,6 +18,7 @@ import (
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
 	testcd "github.com/openshift/hive/pkg/test/clusterdeployment"
+	testcp "github.com/openshift/hive/pkg/test/clusterpool"
 	testgeneric "github.com/openshift/hive/pkg/test/generic"
 	testnamespace "github.com/openshift/hive/pkg/test/namespace"
 )
@@ -40,6 +41,13 @@ func TestReconcileClusterPoolNamespace_Reconcile_Movement(t *testing.T) {
 	namespaceBuilder := namespaceWithoutLabelBuilder.GenericOptions(
 		testgeneric.WithLabel(constants.ClusterPoolNameLabel, "test-cluster-pool"),
 	)
+
+	poolBuilder := testcp.FullBuilder("test-pool-namespace", "test-cluster-pool", scheme).
+		Options(
+			testcp.ForAWS("aws-creds", "us-east-1"),
+			testcp.WithBaseDomain("test-domain"),
+			testcp.WithImageSet("test-image-set"),
+		)
 
 	validateNoRequeueAfter := func(t *testing.T, requeueAfter time.Duration, startTime, endTime time.Time) {
 		assert.Zero(t, requeueAfter, "unexpected non-zero requeue after")
@@ -72,7 +80,70 @@ func TestReconcileClusterPoolNamespace_Reconcile_Movement(t *testing.T) {
 			validateRequeueAfter: validateNoRequeueAfter,
 		},
 		{
+			name:             "non-deleted clusterdeployment with existing pool",
+			namespaceBuilder: namespaceBuilder,
+			resources: []runtime.Object{
+				poolBuilder.Build(),
+				testcd.FullBuilder(namespaceName, "test-cd", scheme).
+					Build(testcd.WithClusterPoolReference("test-pool-namespace", "test-cluster-pool", "test-claim")),
+			},
+			expectDeleted:        false,
+			validateRequeueAfter: validateNoRequeueAfter,
+		},
+		{
+			name:             "non-deleted clusterdeployment with existing pool 2",
+			namespaceBuilder: namespaceBuilder,
+			resources: []runtime.Object{
+				poolBuilder.Build(),
+				testcd.FullBuilder(namespaceName, "test-cd", scheme).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					Build(testcd.WithClusterPoolReference("test-pool-namespace", "test-cluster-pool", "test-claim")),
+				testcd.FullBuilder(namespaceName, "test-cd-2", scheme).
+					Build(testcd.WithClusterPoolReference("test-pool-namespace", "test-cluster-pool", "test-claim-2")),
+			},
+			expectDeleted:        false,
+			validateRequeueAfter: validateNoRequeueAfter,
+		},
+		{
+			name:             "non-deleted clusterdeployment with no pool",
+			namespaceBuilder: namespaceBuilder,
+			resources: []runtime.Object{
+				testcd.FullBuilder(namespaceName, "test-cd", scheme).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).
+					Build(testcd.WithClusterPoolReference("test-pool-namespace", "test-cluster-pool", "test-claim")),
+				testcd.FullBuilder(namespaceName, "test-cd-2", scheme).
+					Build(testcd.WithClusterPoolReference("test-pool-namespace", "test-cluster-pool", "test-claim-2")),
+			},
+			expectDeleted:        false,
+			validateRequeueAfter: validateWaitForCDGoneRequeueAfter,
+		},
+		{
 			name:             "deleted clusterdeployment",
+			namespaceBuilder: namespaceBuilder,
+			resources: []runtime.Object{
+				testcd.FullBuilder(namespaceName, "test-cd", scheme).
+					GenericOptions(testgeneric.Deleted()).
+					Build(),
+			},
+			expectDeleted:        false,
+			validateRequeueAfter: validateWaitForCDGoneRequeueAfter,
+		},
+		{
+			name:             "deleted clusterdeployment with no pool",
+			namespaceBuilder: namespaceBuilder,
+			resources: []runtime.Object{
+				testcd.FullBuilder(namespaceName, "test-cd", scheme).
+					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, ""), testgeneric.Deleted()).
+					Build(testcd.WithClusterPoolReference("test-pool-namespace", "test-cluster-pool", "test-claim")),
+				testcd.FullBuilder(namespaceName, "test-cd-2", scheme).
+					GenericOptions(testgeneric.Deleted()).
+					Build(testcd.WithClusterPoolReference("test-pool-namespace", "test-cluster-pool", "test-claim-2")),
+			},
+			expectDeleted:        false,
+			validateRequeueAfter: validateWaitForCDGoneRequeueAfter,
+		},
+		{
+			name:             "deleted clusterdeployment with exist",
 			namespaceBuilder: namespaceBuilder,
 			resources: []runtime.Object{
 				testcd.FullBuilder(namespaceName, "test-cd", scheme).
@@ -150,6 +221,146 @@ func TestReconcileClusterPoolNamespace_Reconcile_Movement(t *testing.T) {
 			assert.Equal(t, tc.expectDeleted, apierrors.IsNotFound(err), "unexpected state of namespace existence")
 
 			tc.validateRequeueAfter(t, result.RequeueAfter, startTime, endTime)
+		})
+	}
+}
+
+func Test_cleanupPreviouslyClaimedClusterDeployments(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.DebugLevel)
+	scheme := runtime.NewScheme()
+	hivev1.AddToScheme(scheme)
+
+	poolBuilder := testcp.FullBuilder("test-namespace", "test-cluster-pool", scheme).
+		Options(
+			testcp.ForAWS("aws-creds", "us-east-1"),
+			testcp.WithBaseDomain("test-domain"),
+			testcp.WithImageSet("test-image-set"),
+		)
+	cdBuilder := func(name string) testcd.Builder {
+		return testcd.FullBuilder(name, name, scheme).Options(
+			testcd.WithPowerState(hivev1.HibernatingClusterPowerState),
+		)
+	}
+	cdBuilderWithPool := func(name, pool string) testcd.Builder {
+		return cdBuilder(name).Options(testcd.WithClusterPoolReference("test-namespace", pool, "test-claim"))
+	}
+
+	cases := []struct {
+		name             string
+		resources        []runtime.Object
+		expectedErr      string
+		expectedCleanup  bool
+		expectedClusters int
+	}{{
+		name: "no cleanup as clusterdeployment not for pool",
+		resources: []runtime.Object{
+			cdBuilder("cd1").Build(),
+			cdBuilder("cd2").Build(),
+		},
+		expectedErr:      "",
+		expectedCleanup:  false,
+		expectedClusters: 2,
+	}, {
+		name: "no cleanup as cluster pool exists",
+		resources: []runtime.Object{
+			poolBuilder.Build(),
+			cdBuilderWithPool("cd1", "test-cluster-pool").Build(),
+			cdBuilderWithPool("cd2", "test-cluster-pool").Build(),
+		},
+		expectedErr:      "",
+		expectedCleanup:  false,
+		expectedClusters: 2,
+	}, {
+		name: "no cleanup as cluster pool exists with marked for removal clusters",
+		resources: []runtime.Object{
+			poolBuilder.Build(),
+			cdBuilderWithPool("cd1", "test-cluster-pool").GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).Build(),
+			cdBuilderWithPool("cd2", "test-cluster-pool").Build(),
+		},
+		expectedErr:      "",
+		expectedCleanup:  false,
+		expectedClusters: 2,
+	}, {
+		name: "no cleanup as all clusters already deleted",
+		resources: []runtime.Object{
+			cdBuilderWithPool("cd1", "test-cluster-pool").GenericOptions(testgeneric.Deleted()).Build(),
+			cdBuilderWithPool("cd2", "test-cluster-pool").GenericOptions(testgeneric.Deleted()).Build(),
+		},
+		expectedErr:      "",
+		expectedCleanup:  false,
+		expectedClusters: 2,
+	}, {
+		name: "no cleanup as no clusters marked for removal",
+		resources: []runtime.Object{
+			cdBuilderWithPool("cd1", "test-cluster-pool").Build(),
+			cdBuilderWithPool("cd2", "test-cluster-pool").Build(),
+		},
+		expectedErr:      "",
+		expectedCleanup:  false,
+		expectedClusters: 2,
+	}, {
+		name: "no cleanup as clusters marked for removal already deleted",
+		resources: []runtime.Object{
+			cdBuilderWithPool("cd1", "test-cluster-pool").GenericOptions(testgeneric.Deleted(), testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).Build(),
+			cdBuilderWithPool("cd2", "test-cluster-pool").Build(),
+		},
+		expectedErr:      "",
+		expectedCleanup:  false,
+		expectedClusters: 2,
+	}, {
+		name: "some cleanup",
+		resources: []runtime.Object{
+			cdBuilderWithPool("cd1", "test-cluster-pool").GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).Build(),
+			cdBuilderWithPool("cd2", "test-cluster-pool").Build(),
+		},
+		expectedErr:      "",
+		expectedCleanup:  true,
+		expectedClusters: 1,
+	}, {
+		name: "some cleanup 2",
+		resources: []runtime.Object{
+			cdBuilderWithPool("cd1", "test-cluster-pool").GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).Build(),
+			cdBuilderWithPool("cd2", "test-cluster-pool").GenericOptions(testgeneric.Deleted(), testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).Build(),
+		},
+		expectedErr:      "",
+		expectedCleanup:  true,
+		expectedClusters: 1,
+	}, {
+		name: "some cleanup 3",
+		resources: []runtime.Object{
+			cdBuilderWithPool("cd1", "test-cluster-pool").GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).Build(),
+			cdBuilderWithPool("cd2", "test-cluster-pool").Build(),
+			cdBuilderWithPool("cd3", "test-cluster-pool").GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).Build(),
+			cdBuilderWithPool("cd4", "test-cluster-pool").GenericOptions(testgeneric.Deleted(), testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "")).Build(),
+		},
+		expectedErr:      "",
+		expectedCleanup:  true,
+		expectedClusters: 2,
+	}}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			c := fake.NewFakeClientWithScheme(scheme, test.resources...)
+			reconciler := &ReconcileClusterPoolNamespace{
+				Client: c,
+				logger: logger,
+			}
+			cds := &hivev1.ClusterDeploymentList{}
+			err := c.List(context.Background(), cds)
+			require.NoError(t, err)
+
+			cleanup, err := reconciler.cleanupPreviouslyClaimedClusterDeployments(cds, logger)
+			if test.expectedErr != "" {
+				assert.Regexp(t, test.expectedErr, err)
+			}
+			assert.Equal(t, test.expectedCleanup, cleanup)
+
+			cds = &hivev1.ClusterDeploymentList{}
+			err = c.List(context.Background(), cds)
+			require.NoError(t, err)
+
+			assert.Len(t, cds.Items, test.expectedClusters)
 		})
 	}
 }

--- a/pkg/controller/utils/clusterclaim.go
+++ b/pkg/controller/utils/clusterclaim.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"strconv"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
+)
+
+// IsClaimedClusterMarkedForRemoval returns true when hive.openshift.io/remove-claimed-cluster-from-pool
+// annotation is set to true value in the clusterdeployment
+func IsClaimedClusterMarkedForRemoval(cd *hivev1.ClusterDeployment) bool {
+	toRemove := false
+	if v, ok := cd.Annotations[constants.ClusterClaimRemoveClusterAnnotation]; ok && v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			toRemove = b
+		}
+	}
+	return toRemove
+}


### PR DESCRIPTION
The cluster pool 's max concurrent will include the deleting claimed clsuters. This is
to make sure cluster pool actions are safe and under limits as specified by the admin.

previously the claimed clusters from a pool, were deleted out band directly by the clusterclaim
controller when the claim was deleted. This made controlling the max concurrent provision/
deprovision difficult because 2 controllers are making the same decision making independently.
To enforce the max concurrent for pool, all the actions of cluster provision/deprovision had to
be moved to clusterpool controller so that it can ensure the max concurrent limit.

Thefore, the clusterclaim controller now annotates the clusterdeployment that it should be removed
when the claim is deleted, it still removes all the other claim specific resources from the the
namespace like rolebindings etc, and removes the finalizer. The clusterpool controller removes
this previously claimed cluster whenever there is budget to do so.

Since clusters in a pool that have been claimed can live after the cluster pool has been deleted,
we need to make sure these clusters are also cleaned up when the claims are deleted. To fulfil that
the clusterpoolnamespace controller will cleanup up all clusters that belonged to a clusterpool that
no longer exists and have been annotated by the claim as safe to remove.

xref: https://issues.redhat.com/browse/CO-1278

/assign @dgoodwin 
/cc @abutcher 