### PR TITLE
Allow public subnets in AWS MachinePool

### DIFF
--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -117,8 +117,10 @@ spec:
                       type: object
                     subnets:
                       description: Subnets is the list of subnets to which to attach
-                        the machines. There must be exactly one subnet for each availability
-                        zone used.
+                        the machines. There must be exactly one private subnet for
+                        each availability zone used. If public subnets are specified,
+                        there must be exactly one private and one public subnet specified
+                        for each availability zone.
                       items:
                         type: string
                       type: array

--- a/pkg/apis/hive/v1/aws/machinepool.go
+++ b/pkg/apis/hive/v1/aws/machinepool.go
@@ -7,7 +7,8 @@ type MachinePoolPlatform struct {
 	Zones []string `json:"zones,omitempty"`
 
 	// Subnets is the list of subnets to which to attach the machines.
-	// There must be exactly one subnet for each availability zone used.
+	// There must be exactly one private subnet for each availability zone used.
+	// If public subnets are specified, there must be exactly one private and one public subnet specified for each availability zone.
 	Subnets []string `json:"subnets,omitempty"`
 
 	// InstanceType defines the ec2 instance type.

--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -58,6 +58,7 @@ type Client interface {
 	DescribeImages(*ec2.DescribeImagesInput) (*ec2.DescribeImagesOutput, error)
 	DescribeVpcs(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
 	DescribeSubnets(*ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
+	DescribeRouteTables(*ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error)
 	DescribeSecurityGroups(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error)
 	RunInstances(*ec2.RunInstancesInput) (*ec2.Reservation, error)
 	DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error)
@@ -138,6 +139,11 @@ func (c *awsClient) DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpc
 func (c *awsClient) DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
 	metricAWSAPICalls.WithLabelValues("DescribeSubnets").Inc()
 	return c.ec2Client.DescribeSubnets(input)
+}
+
+func (c *awsClient) DescribeRouteTables(input *ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error) {
+	metricAWSAPICalls.WithLabelValues("DescribeRouteTables").Inc()
+	return c.ec2Client.DescribeRouteTables(input)
 }
 
 func (c *awsClient) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {

--- a/pkg/awsclient/mock/client_generated.go
+++ b/pkg/awsclient/mock/client_generated.go
@@ -101,6 +101,21 @@ func (mr *MockClientMockRecorder) DescribeSubnets(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubnets", reflect.TypeOf((*MockClient)(nil).DescribeSubnets), arg0)
 }
 
+// DescribeRouteTables mocks base method
+func (m *MockClient) DescribeRouteTables(arg0 *ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeRouteTables", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeRouteTablesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeRouteTables indicates an expected call of DescribeRouteTables
+func (mr *MockClientMockRecorder) DescribeRouteTables(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRouteTables", reflect.TypeOf((*MockClient)(nil).DescribeRouteTables), arg0)
+}
+
 // DescribeSecurityGroups mocks base method
 func (m *MockClient) DescribeSecurityGroups(arg0 *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
To be consistent with install config, allow public subnets to be
specified in MachinePool even if the MachineSets created would use only
private subnets.

Account for success in all of the following cases:
- No subnets specified
- Only private subnets specified
- Both public and private subnets specified

Private subnets are required to be exactly one per availability zone if
subnets are specified. If public subnets are also specified, then there
should be exactly 1 public and 1 private subnet for each availability
zone.
