### PR TITLE
clusterdeployment: include InstallImagesNotResolved condition when job fails

### DIFF
--- a/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -295,6 +295,10 @@ const (
 	// (ie manageDNS==true) has not yet indicated that the DNS zone is successfully responding to queries.
 	DNSNotReadyCondition ClusterDeploymentConditionType = "DNSNotReady"
 
+	// InstallImagesResolvedCondition indicates that the the install images for the clusterDeployment
+	// have been not been resolved. This usually includes the installer and OpenShift cli images.
+	InstallImagesNotResolvedCondition ClusterDeploymentConditionType = "InstallImagesNotResolved"
+
 	// ProvisionFailedCondition indicates that a provision failed
 	ProvisionFailedCondition ClusterDeploymentConditionType = "ProvisionFailed"
 

--- a/pkg/imageset/generate.go
+++ b/pkg/imageset/generate.go
@@ -82,7 +82,13 @@ func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAcco
 	}
 
 	completions := int32(1)
-	deadline := int64((24 * time.Hour).Seconds())
+	// make sure the deadline is small enough so that the controller can
+	// react to job failing and provide appropiate status update to the
+	// user.
+	// The cluster version operator that pulls the release image similar to this
+	// job has active deadline of 2 minutes (https://github.com/openshift/cluster-version-operator/blob/84b3884e422739dbbfa33078e62349752b5afa18/pkg/cvo/updatepayload.go#L146)
+	// and that should be good to follow here too.
+	deadline := int64((2 * time.Minute).Seconds())
 	backoffLimit := int32(123456)
 	labels := map[string]string{
 		ImagesetJobLabel:                     "true",


### PR DESCRIPTION
The cluster deployment controller creates a job that resolves the installer and cli
images for installing the cluster. this job uses the release image to extract these details.
When the release image being used can't be pulled due to some failure like authentication
the controller provides no update / condition that would provide use details on this failure and
the user sees no update on the clusterdeployment object.
With this change we add InstallImagesNotResolved condition to the clusterdeployment when the job fails.

Previously the job had activeDeadline set to 24 hrs, therefore the job controller would wait for that interval
before marking it complete+failed. To make sure the controller can actually give users report of job failure
the deadline is reduces to 2 minutes. This now matches the deadline used by CVO that uses a very similar job to
interact with the release-image contents [1].

NOTE: currently this depends on job controller's status reporting to provide user the reason for failure, but
we could later extend it to summarize the pods's failure reason as the pods from job stay until the job is deleted.

[1]: https://github.com/openshift/cluster-version-operator/blob/84b3884e422739dbbfa33078e62349752b5afa18/pkg/cvo/updatepayload.go#L146

xref: https://issues.redhat.com/browse/CO-1306