### PR TITLE
use ClusterDeployment's CA data when validating vsphere credentials

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
+	github.com/vmware/govmomi v0.22.2
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 	golang.org/x/mod v0.3.0
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -676,6 +676,7 @@ github.com/ultraware/whitespace
 # github.com/uudashr/gocognit v1.0.1
 github.com/uudashr/gocognit
 # github.com/vmware/govmomi v0.22.2
+## explicit
 github.com/vmware/govmomi
 github.com/vmware/govmomi/nfc
 github.com/vmware/govmomi/object


### PR DESCRIPTION
When a vSphere ClusterDeployment defines the CA certificates Secret, use the CA certificate data when validating vSphere credentials.

The high-level client library doesn't allow providing a CA certificate early enough, so we need to implement a lot of the lower-level connection setup so that we can slip in the custom CA data when needed.