### PR TITLE
Update install log regex definitions to detect GCP precondition failed error

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -53,6 +53,11 @@ data:
       - "platform.gcp.type: Invalid value:.* instance type.* not found]"
       installFailingReason: GCPInstanceTypeNotFound
       installFailingMessage: GCP instance type not found
+    - name: GCPPreconditionFailed
+      searchRegexStrings:
+      - "googleapi: Error 412"
+      installFailingReason: GCPPreconditionFailed
+      installFailingMessage: GCP Precondition Failed
     # Bare Metal
     - name: LibvirtSSHKeyPermissionDenied
       searchRegexStrings:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1577,6 +1577,11 @@ data:
       - "platform.gcp.type: Invalid value:.* instance type.* not found]"
       installFailingReason: GCPInstanceTypeNotFound
       installFailingMessage: GCP instance type not found
+    - name: GCPPreconditionFailed
+      searchRegexStrings:
+      - "googleapi: Error 412"
+      installFailingReason: GCPPreconditionFailed
+      installFailingMessage: GCP Precondition Failed
     # Bare Metal
     - name: LibvirtSSHKeyPermissionDenied
       searchRegexStrings:


### PR DESCRIPTION
The commit adds a regex to detect following error in the install log

```
level=info msg="Consuming Bootstrap Ignition Config from target directory"
level=info msg="Creating infrastructure resources..."
level=error
level=error msg="Error: googleapi: Error 412: Request violates constraint 'constraints/storage.uniformBucketLevelAccess', conditionNotMet"
level=error
level=error msg="  on ../tmp/openshift-install-281334585/bootstrap/main.tf line 1, in resource \"google_storage_bucket\" \"ignition\":"
level=error msg="   1: resource \"google_storage_bucket\" \"ignition\" {"
level=error
level=error
level=fatal msg="failed to fetch Cluster: failed to generate asset \"Cluster\": failed to create cluster: failed to apply Terraform: failed to complete the change"
level=fatal msg="failed to get bootstrap and control plane host addresses from \"terraform.tfstate\": no bootstrap instance found
```