### PR TITLE
add new prometheus metric to indicate that the cluster provision failed after all the retries

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -1749,7 +1749,8 @@ func TestDeleteStaleProvisions(t *testing.T) {
 				Client: fakeClient,
 				scheme: scheme.Scheme,
 			}
-			rcd.deleteStaleProvisions(getProvisions(fakeClient), log.WithField("test", "TestDeleteStaleProvisions"))
+			cd := testClusterDeployment()
+			rcd.deleteStaleProvisions(getProvisions(fakeClient), cd, log.WithField("test", "TestDeleteStaleProvisions"))
 			actualAttempts := []int{}
 			for _, p := range getProvisions(fakeClient) {
 				actualAttempts = append(actualAttempts, p.Spec.Attempt)

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -87,6 +87,15 @@ var (
 		},
 		[]string{"cluster_deployment", "namespace", "cluster_type"},
 	)
+	// MetricClusterDeploymentProvisionOutOfRetries is a prometheus metric to indicate that
+	// all the cluster provision retries are failed.
+	MetricClusterDeploymentProvisionOutOfRetries = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "hive_cluster_deployment_provision_out_of_retries",
+			Help: "Indicates that the cluster provision failed after the given retry times",
+		},
+		[]string{"cluster_deployment", "namespace", "cluster_type"},
+	)
 	// metricControllerReconcileTime tracks the length of time our reconcile loops take. controller-runtime
 	// technically tracks this for us, but due to bugs currently also includes time in the queue, which leads to
 	// extremely strange results. For now, track our own metric.
@@ -130,6 +139,7 @@ func init() {
 	metrics.Registry.MustRegister(metricControllerReconcileTime)
 
 	metrics.Registry.MustRegister(MetricClusterDeploymentDeprovisioningUnderwaySeconds)
+	metrics.Registry.MustRegister(MetricClusterDeploymentProvisionOutOfRetries)
 }
 
 // Add creates a new metrics Calculator and adds it to the Manager.


### PR DESCRIPTION
Currently, the alert will be fired after 2 hours, but the cluster provision will retry for 3 times, which will exceed the 2 hours.

Maybe the better solution here is fire the ClusterProvisionDelay as warning, which will not page.
And the use the new metric to alert like ClusterProvisionFailed, which is the real problem people should work on.