### PR TITLE
add issue template to tell people to use issues.redhat.com

### DIFF
--- a/.github/ISSUE_TEMPLATE/please-use-issues-redhat-com.md
+++ b/.github/ISSUE_TEMPLATE/please-use-issues-redhat-com.md
@@ -1,0 +1,10 @@
+---
+name: please use issues.redhat.com
+about: please use issues.redhat.com
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+The team doesn't follow issues filed here. Please open your issue at https://issues.redhat.com project HIVE. Thank you!


### PR DESCRIPTION
add issue template to tell people to use issues.redhat.com. We don't use this tracker, and if people open things here, we usually don't see them.