### PR TITLE
create clusterpool: make sure clusterpool has namespace set when using -n

### DIFF
--- a/contrib/pkg/clusterpool/clusterpool.go
+++ b/contrib/pkg/clusterpool/clusterpool.go
@@ -380,7 +380,8 @@ func (o *ClusterPoolOptions) generateClusterPool(builder *clusterresource.Builde
 			APIVersion: hivev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: o.Name,
+			Name:      o.Name,
+			Namespace: o.Namespace,
 		},
 		Spec: hivev1.ClusterPoolSpec{
 			BaseDomain: o.BaseDomain,


### PR DESCRIPTION
```
$ bin/hiveutil clusterpool create-pool lwan-pool-aws \
 --region us-east-2 \
 --base-domain qe.devcluster.openshift.com \
 --size 2 \
 --release-image registry.svc.ci.openshift.org/ocp/release:4.7.0-0.nightly-2020-12-13-202314 \
 -n test-test -o yaml
apiVersion: v1
items:
- apiVersion: hive.openshift.io/v1
  kind: ClusterPool
  metadata:
    creationTimestamp: null
    name: lwan-pool-aws
    namespace: test-test
  spec:
    baseDomain: qe.devcluster.openshift.com
    imageSetRef:
      name: lwan-pool-aws-imageset
    platform:
      aws:
        credentialsSecretRef:
          name: lwan-pool-aws-aws-creds
        region: us-east-2
    size: 2
  status:
    ready: 0
    size: 0

... more
```

now namespace is added to the cluster pool object when -n flag is used.
xref: https://issues.redhat.com/browse/HIVE-1321

/assign @abutcher 
/cc @dgoodwin 