### PR TITLE
Add hive_cluster_deployment_provision_underway_install_restarts metric

### DIFF
--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -151,7 +151,8 @@ func Add(mgr manager.Manager) error {
 		Client:   mgr.GetClient(),
 		Interval: 2 * time.Minute,
 	}
-	metrics.Registry.MustRegister(newProvisioningUnderwayCollector(mgr.GetClient()))
+	metrics.Registry.MustRegister(newProvisioningUnderwaySecondsCollector(mgr.GetClient(), 1*time.Hour))
+	metrics.Registry.MustRegister(newProvisioningUnderwayInstallRestartsCollector(mgr.GetClient(), 1))
 	err := mgr.Add(mc)
 	if err != nil {
 		return err

--- a/pkg/controller/metrics/provision_underway_collector.go
+++ b/pkg/controller/metrics/provision_underway_collector.go
@@ -30,6 +30,11 @@ var (
 type provisioningUnderwayCollector struct {
 	client client.Client
 
+	// minDuration, when non-zero, is the minimum duration afer which clusters provisioning
+	// will start becomming part of this metric. When set to zero, all clusters provisioning
+	// will be included in the metric.
+	minDuration time.Duration
+
 	// metricClusterDeploymentProvisionUnderwaySeconds is a prometheus metric for the number of seconds
 	// between when a still provisioning cluster was created and now.
 	metricClusterDeploymentProvisionUnderwaySeconds *prometheus.Desc
@@ -56,17 +61,7 @@ func (cc provisioningUnderwayCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 
 		// Add install failure details for stuck provision
-		condition, reason := "Unknown", "Unknown"
-		for _, delayCondition := range provisioningDelayCondition {
-			if cdCondition := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions,
-				delayCondition); cdCondition != nil {
-				if cdCondition.Status == corev1.ConditionTrue && cdCondition.Reason != "" {
-					condition = string(delayCondition)
-					reason = cdCondition.Reason
-				}
-				break
-			}
-		}
+		condition, reason := getKnownConditions(cd.Status.Conditions)
 
 		platform := cd.Labels[hivev1.HiveClusterPlatformLabel]
 		imageSet := "none"
@@ -74,11 +69,16 @@ func (cc provisioningUnderwayCollector) Collect(ch chan<- prometheus.Metric) {
 			imageSet = cd.Spec.Provisioning.ImageSetRef.Name
 		}
 
+		elapsedDuration := time.Since(cd.CreationTimestamp.Time)
+		if cc.minDuration.Seconds() > 0 && elapsedDuration < cc.minDuration {
+			continue // skip reporting the metric for clusterdeployment until the elapsed time is at least minDuration
+		}
+
 		// For installing clusters we report the seconds since the cluster was created.
 		ch <- prometheus.MustNewConstMetric(
 			cc.metricClusterDeploymentProvisionUnderwaySeconds,
 			prometheus.GaugeValue,
-			time.Since(cd.CreationTimestamp.Time).Seconds(),
+			elapsedDuration.Seconds(),
 			cd.Name,
 			cd.Namespace,
 			GetClusterDeploymentType(&cd),
@@ -96,14 +96,124 @@ func (cc provisioningUnderwayCollector) Describe(ch chan<- *prometheus.Desc) {
 	prometheus.DescribeByCollect(cc, ch)
 }
 
-func newProvisioningUnderwayCollector(client client.Client) prometheus.Collector {
+var (
+	metricClusterDeploymentProvisionUnderwaySecondsDesc = prometheus.NewDesc(
+		"hive_cluster_deployment_provision_underway_seconds",
+		"Length of time a cluster has been provisioning.",
+		[]string{"cluster_deployment", "namespace", "cluster_type", "condition", "reason", "platform", "image_set"},
+		nil,
+	)
+)
+
+func newProvisioningUnderwaySecondsCollector(client client.Client, minimum time.Duration) prometheus.Collector {
 	return provisioningUnderwayCollector{
 		client: client,
-		metricClusterDeploymentProvisionUnderwaySeconds: prometheus.NewDesc(
-			"hive_cluster_deployment_provision_underway_seconds",
-			"Length of time a cluster has been provisioning.",
-			[]string{"cluster_deployment", "namespace", "cluster_type", "condition", "reason", "platform", "image_set"},
-			nil,
-		),
+		metricClusterDeploymentProvisionUnderwaySeconds: metricClusterDeploymentProvisionUnderwaySecondsDesc,
+		minDuration: minimum,
 	}
+}
+
+// provisioning underway install restarts metrics collected through a custom prometheus collector
+type provisioningUnderwayInstallRestartsCollector struct {
+	client client.Client
+
+	// minRestarts, when non-zero, is the minimum restarts after which clusters provisioning
+	// will start becoming part of the metric. When set to zero, all clusters provisioning
+	// will be included in the metric.
+	minRestarts int
+
+	// metricClusterDeploymentProvisionUnderwayInstallRestarts is a prometheus metric for the number of install
+	// restarts for a still provisioning cluster.
+	metricClusterDeploymentProvisionUnderwayInstallRestarts *prometheus.Desc
+}
+
+// collects the metrics for provisioningUnderwayInstallRestartsCollector
+func (cc provisioningUnderwayInstallRestartsCollector) Collect(ch chan<- prometheus.Metric) {
+	ccLog := log.WithField("controller", "metrics")
+	ccLog.Info("calculating provisioning underway install restarts metrics across all ClusterDeployments")
+
+	// Load all ClusterDeployments so we can accumulate facts about them.
+	clusterDeployments := &hivev1.ClusterDeploymentList{}
+	err := cc.client.List(context.Background(), clusterDeployments)
+	if err != nil {
+		log.WithError(err).Error("error listing cluster deployments")
+		return
+	}
+	for _, cd := range clusterDeployments.Items {
+		if cd.DeletionTimestamp != nil {
+			continue
+		}
+		if cd.Spec.Installed {
+			continue
+		}
+
+		// Add install failure details for stuck provision
+		condition, reason := getKnownConditions(cd.Status.Conditions)
+
+		platform := cd.Labels[hivev1.HiveClusterPlatformLabel]
+		imageSet := "none"
+		if cd.Spec.Provisioning != nil && cd.Spec.Provisioning.ImageSetRef != nil {
+			imageSet = cd.Spec.Provisioning.ImageSetRef.Name
+		}
+
+		restarts := cd.Status.InstallRestarts
+		if restarts == 0 {
+			continue // skip reporting the metric for clusterdeployment that hasn't restarted at all
+		}
+		if cc.minRestarts > 0 && restarts < cc.minRestarts {
+			continue // skip reporting the metric for clusterdeployment until the InstallRestarts is at least minRestarts
+		}
+
+		// For installing clusters we report the seconds since the cluster was created.
+		ch <- prometheus.MustNewConstMetric(
+			cc.metricClusterDeploymentProvisionUnderwayInstallRestarts,
+			prometheus.GaugeValue,
+			float64(restarts),
+			cd.Name,
+			cd.Namespace,
+			GetClusterDeploymentType(&cd),
+			condition,
+			reason,
+			platform,
+			imageSet,
+		)
+
+	}
+
+}
+
+func (cc provisioningUnderwayInstallRestartsCollector) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(cc, ch)
+}
+
+var (
+	provisioningUnderwayInstallRestartsCollectorDesc = prometheus.NewDesc(
+		"hive_cluster_deployment_provision_underway_install_restarts",
+		"Number install restarts for a cluster that has been provisioning.",
+		[]string{"cluster_deployment", "namespace", "cluster_type", "condition", "reason", "platform", "image_set"},
+		nil,
+	)
+)
+
+func newProvisioningUnderwayInstallRestartsCollector(client client.Client, minimum int) prometheus.Collector {
+	return provisioningUnderwayInstallRestartsCollector{
+		client: client,
+		metricClusterDeploymentProvisionUnderwayInstallRestarts: provisioningUnderwayInstallRestartsCollectorDesc,
+		minRestarts: minimum,
+	}
+}
+
+func getKnownConditions(conditions []hivev1.ClusterDeploymentCondition) (condition, reason string) {
+	condition, reason = "Unknown", "Unknown"
+	for _, delayCondition := range provisioningDelayCondition {
+		if cdCondition := controllerutils.FindClusterDeploymentCondition(conditions,
+			delayCondition); cdCondition != nil {
+			if cdCondition.Status == corev1.ConditionTrue && cdCondition.Reason != "" {
+				condition = string(delayCondition)
+				reason = cdCondition.Reason
+			}
+			break
+		}
+	}
+	return condition, reason
 }

--- a/pkg/controller/metrics/provision_underway_collector_test.go
+++ b/pkg/controller/metrics/provision_underway_collector_test.go
@@ -1,0 +1,519 @@
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	testcd "github.com/openshift/hive/pkg/test/clusterdeployment"
+	testgeneric "github.com/openshift/hive/pkg/test/generic"
+)
+
+func TestProvisioningUnderwayCollector(t *testing.T) {
+	scheme := runtime.NewScheme()
+	hivev1.AddToScheme(scheme)
+
+	cdBuilder := func(name string) testcd.Builder {
+		return testcd.FullBuilder(name, name, scheme).
+			GenericOptions(testgeneric.WithCreationTimestamp(time.Now().Add(-2 * time.Hour)))
+	}
+
+	cases := []struct {
+		name string
+
+		existing []runtime.Object
+		min      time.Duration
+
+		expected []string
+	}{{
+		name: "all installed",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.Installed()),
+			cdBuilder("cd-3").Build(testcd.Installed()),
+		},
+	}, {
+		name: "mix of installed and deleting",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").GenericOptions(testgeneric.Deleted()).Build(testcd.Installed()),
+			cdBuilder("cd-3").Build(testcd.Installed()),
+		},
+	}, {
+		name: "provisioning with no conditions",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(),
+		},
+		expected: []string{
+			"cluster_deployment = cd-2 cluster_type = unspecified condition = Unknown image_set = none namespace = cd-2 platform =  reason = Unknown",
+		},
+	}, {
+		name: "provisioning with other conditions",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ClusterHibernatingCondition,
+				Status: corev1.ConditionTrue,
+			})),
+		},
+		expected: []string{
+			"cluster_deployment = cd-2 cluster_type = unspecified condition = Unknown image_set = none namespace = cd-2 platform =  reason = Unknown",
+		},
+	}, {
+		name: "provisioning with ProvisionFailed condition",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ProvisionFailedCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "FailedDueToQuotas",
+			})),
+		},
+		expected: []string{
+			"cluster_deployment = cd-2 cluster_type = unspecified condition = ProvisionFailed image_set = none namespace = cd-2 platform =  reason = FailedDueToQuotas",
+		},
+	}, {
+		name: "provisioning with ProvisionFailed, DNSNotReadyCondition condition",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ProvisionFailedCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "FailedDueToQuotas",
+			})),
+			cdBuilder("cd-3").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.DNSNotReadyCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "FailedDueToQuotas",
+			})),
+		},
+		expected: []string{
+			"cluster_deployment = cd-2 cluster_type = unspecified condition = ProvisionFailed image_set = none namespace = cd-2 platform =  reason = FailedDueToQuotas",
+			"cluster_deployment = cd-3 cluster_type = unspecified condition = DNSNotReady image_set = none namespace = cd-3 platform =  reason = FailedDueToQuotas",
+		},
+	}, {
+		name: "provisioning with no conditions and duration more than min duration",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(),
+		},
+		min: 1 * time.Hour,
+		expected: []string{
+			"cluster_deployment = cd-2 cluster_type = unspecified condition = Unknown image_set = none namespace = cd-2 platform =  reason = Unknown",
+		},
+	}, {
+		name: "provisioning with other conditions and duration more than min duration",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ClusterHibernatingCondition,
+				Status: corev1.ConditionTrue,
+			})),
+		},
+		min: 1 * time.Hour,
+		expected: []string{
+			"cluster_deployment = cd-2 cluster_type = unspecified condition = Unknown image_set = none namespace = cd-2 platform =  reason = Unknown",
+		},
+	}, {
+		name: "provisioning with ProvisionFailed condition and duration more than min duration",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ProvisionFailedCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "FailedDueToQuotas",
+			})),
+		},
+		min: 1 * time.Hour,
+		expected: []string{
+			"cluster_deployment = cd-2 cluster_type = unspecified condition = ProvisionFailed image_set = none namespace = cd-2 platform =  reason = FailedDueToQuotas",
+		},
+	}, {
+		name: "provisioning with ProvisionFailed, DNSNotReadyCondition condition and duration more than min duration",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ProvisionFailedCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "FailedDueToQuotas",
+			})),
+			cdBuilder("cd-3").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.DNSNotReadyCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "FailedDueToQuotas",
+			})),
+		},
+		min: 1 * time.Hour,
+		expected: []string{
+			"cluster_deployment = cd-2 cluster_type = unspecified condition = ProvisionFailed image_set = none namespace = cd-2 platform =  reason = FailedDueToQuotas",
+			"cluster_deployment = cd-3 cluster_type = unspecified condition = DNSNotReady image_set = none namespace = cd-3 platform =  reason = FailedDueToQuotas",
+		},
+	}, {
+		name: "provisioning with no conditions and duration less than min duration",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").GenericOptions(testgeneric.WithCreationTimestamp(time.Now().Add(-30 * time.Minute))).Build(),
+		},
+		min: 1 * time.Hour,
+	}, {
+		name: "provisioning with other conditions and duration less than min duration",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").
+				GenericOptions(testgeneric.WithCreationTimestamp(time.Now().Add(-30 * time.Minute))).
+				Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.ClusterHibernatingCondition,
+					Status: corev1.ConditionTrue,
+				})),
+		},
+		min: 1 * time.Hour,
+	}, {
+		name: "provisioning with ProvisionFailed condition and duration less than min duration",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").
+				GenericOptions(testgeneric.WithCreationTimestamp(time.Now().Add(-30 * time.Minute))).
+				Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.ProvisionFailedCondition,
+					Status: corev1.ConditionTrue,
+					Reason: "FailedDueToQuotas",
+				})),
+		},
+		min: 1 * time.Hour,
+	}, {
+		name: "provisioning with ProvisionFailed, DNSNotReadyCondition condition and duration less than min duration",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").
+				GenericOptions(testgeneric.WithCreationTimestamp(time.Now().Add(-30 * time.Minute))).
+				Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.ProvisionFailedCondition,
+					Status: corev1.ConditionTrue,
+					Reason: "FailedDueToQuotas",
+				})),
+			cdBuilder("cd-3").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.DNSNotReadyCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "FailedDueToQuotas",
+			})),
+		},
+		min: 1 * time.Hour,
+		expected: []string{
+			"cluster_deployment = cd-3 cluster_type = unspecified condition = DNSNotReady image_set = none namespace = cd-3 platform =  reason = FailedDueToQuotas",
+		},
+	}}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			c := fake.NewFakeClientWithScheme(scheme, test.existing...)
+			collect := newProvisioningUnderwaySecondsCollector(c, test.min)
+
+			descCh := make(chan *prometheus.Desc)
+			go func() {
+				for range descCh {
+				}
+			}()
+			collect.Describe(descCh)
+			close(descCh)
+			ch := make(chan prometheus.Metric)
+			go func() {
+				collect.Collect(ch)
+				close(ch)
+			}()
+
+			var got []string
+			for sample := range ch {
+				var d dto.Metric
+				require.NoError(t, sample.Write(&d))
+				got = append(got, metricPretty(d))
+			}
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}
+
+func TestProvisioningUnderwayInstallRestartsCollector(t *testing.T) {
+	scheme := runtime.NewScheme()
+	hivev1.AddToScheme(scheme)
+
+	cdBuilder := func(name string) testcd.Builder {
+		return testcd.FullBuilder(name, name, scheme)
+	}
+
+	cases := []struct {
+		name string
+
+		existing []runtime.Object
+		min      int
+
+		expected []string
+	}{{
+		name: "all installed",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.Installed()),
+			cdBuilder("cd-3").Build(testcd.Installed()),
+		},
+	}, {
+		name: "mix of installed and deleting",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").GenericOptions(testgeneric.Deleted()).Build(testcd.Installed()),
+			cdBuilder("cd-3").Build(testcd.Installed()),
+		},
+	}, {
+		name: "provisioning with no conditions, zero restarts",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(),
+		},
+	}, {
+		name: "provisioning with other conditions, zero restarts",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ClusterHibernatingCondition,
+				Status: corev1.ConditionTrue,
+			})),
+		},
+	}, {
+		name: "provisioning with ProvisionFailed condition, zero restarts",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ProvisionFailedCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "FailedDueToQuotas",
+			})),
+		},
+	}, {
+		name: "provisioning with ProvisionFailed, DNSNotReadyCondition condition, zero restarts",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ProvisionFailedCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "FailedDueToQuotas",
+			})),
+			cdBuilder("cd-3").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.DNSNotReadyCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "FailedDueToQuotas",
+			})),
+		},
+	}, {
+		name: "provisioning with no conditions, non-zero restarts",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.InstallRestarts(2)),
+		},
+		expected: []string{
+			"cluster_deployment = cd-2 cluster_type = unspecified condition = Unknown image_set = none namespace = cd-2 platform =  reason = Unknown 2",
+		},
+	}, {
+		name: "provisioning with other conditions",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.InstallRestarts(2), testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ClusterHibernatingCondition,
+				Status: corev1.ConditionTrue,
+			})),
+		},
+		expected: []string{
+			"cluster_deployment = cd-2 cluster_type = unspecified condition = Unknown image_set = none namespace = cd-2 platform =  reason = Unknown 2",
+		},
+	}, {
+		name: "provisioning with ProvisionFailed condition, non-zero restarts",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.InstallRestarts(2), testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ProvisionFailedCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "FailedDueToQuotas",
+			})),
+		},
+		expected: []string{
+			"cluster_deployment = cd-2 cluster_type = unspecified condition = ProvisionFailed image_set = none namespace = cd-2 platform =  reason = FailedDueToQuotas 2",
+		},
+	}, {
+		name: "provisioning with ProvisionFailed, DNSNotReadyCondition condition, non-zero restarts",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.InstallRestarts(2), testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ProvisionFailedCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "FailedDueToQuotas",
+			})),
+			cdBuilder("cd-3").Build(testcd.InstallRestarts(2), testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.DNSNotReadyCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "FailedDueToQuotas",
+			})),
+		},
+		expected: []string{
+			"cluster_deployment = cd-2 cluster_type = unspecified condition = ProvisionFailed image_set = none namespace = cd-2 platform =  reason = FailedDueToQuotas 2",
+			"cluster_deployment = cd-3 cluster_type = unspecified condition = DNSNotReady image_set = none namespace = cd-3 platform =  reason = FailedDueToQuotas 2",
+		},
+	}, {
+		name: "provisioning with no conditions and restarts more than min restarts",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.InstallRestarts(2)),
+		},
+		min: 1,
+		expected: []string{
+			"cluster_deployment = cd-2 cluster_type = unspecified condition = Unknown image_set = none namespace = cd-2 platform =  reason = Unknown 2",
+		},
+	}, {
+		name: "provisioning with other conditions and restarts more than min restarts",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.InstallRestarts(2), testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ClusterHibernatingCondition,
+				Status: corev1.ConditionTrue,
+			})),
+		},
+		min: 1,
+		expected: []string{
+			"cluster_deployment = cd-2 cluster_type = unspecified condition = Unknown image_set = none namespace = cd-2 platform =  reason = Unknown 2",
+		},
+	}, {
+		name: "provisioning with ProvisionFailed condition and restarts more than min restarts",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.InstallRestarts(2), testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ProvisionFailedCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "FailedDueToQuotas",
+			})),
+		},
+		min: 1,
+		expected: []string{
+			"cluster_deployment = cd-2 cluster_type = unspecified condition = ProvisionFailed image_set = none namespace = cd-2 platform =  reason = FailedDueToQuotas 2",
+		},
+	}, {
+		name: "provisioning with ProvisionFailed, DNSNotReadyCondition condition and restarts more than min restarts",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.InstallRestarts(2), testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ProvisionFailedCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "FailedDueToQuotas",
+			})),
+			cdBuilder("cd-3").Build(testcd.InstallRestarts(2), testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.DNSNotReadyCondition,
+				Status: corev1.ConditionTrue,
+				Reason: "FailedDueToQuotas",
+			})),
+		},
+		min: 1,
+		expected: []string{
+			"cluster_deployment = cd-2 cluster_type = unspecified condition = ProvisionFailed image_set = none namespace = cd-2 platform =  reason = FailedDueToQuotas 2",
+			"cluster_deployment = cd-3 cluster_type = unspecified condition = DNSNotReady image_set = none namespace = cd-3 platform =  reason = FailedDueToQuotas 2",
+		},
+	}, {
+		name: "provisioning with no conditions and restarts less than min restarts",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.InstallRestarts(1)),
+		},
+		min: 2,
+	}, {
+		name: "provisioning with other conditions and restarts less than min restarts",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").
+				Build(testcd.InstallRestarts(1), testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.ClusterHibernatingCondition,
+					Status: corev1.ConditionTrue,
+				})),
+		},
+		min: 2,
+	}, {
+		name: "provisioning with ProvisionFailed condition and restarts less than min restarts",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").
+				Build(testcd.InstallRestarts(1), testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.ProvisionFailedCondition,
+					Status: corev1.ConditionTrue,
+					Reason: "FailedDueToQuotas",
+				})),
+		},
+		min: 2,
+	}, {
+		name: "provisioning with ProvisionFailed, DNSNotReadyCondition condition and restarts less than min restarts",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").
+				Build(testcd.InstallRestarts(1), testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.ProvisionFailedCondition,
+					Status: corev1.ConditionTrue,
+					Reason: "FailedDueToQuotas",
+				})),
+			cdBuilder("cd-3").
+				Build(testcd.InstallRestarts(2), testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.DNSNotReadyCondition,
+					Status: corev1.ConditionTrue,
+					Reason: "FailedDueToQuotas",
+				})),
+		},
+		min: 2,
+		expected: []string{
+			"cluster_deployment = cd-3 cluster_type = unspecified condition = DNSNotReady image_set = none namespace = cd-3 platform =  reason = FailedDueToQuotas 2",
+		},
+	}}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			c := fake.NewFakeClientWithScheme(scheme, test.existing...)
+			collect := newProvisioningUnderwayInstallRestartsCollector(c, test.min)
+
+			descCh := make(chan *prometheus.Desc)
+			go func() {
+				for range descCh {
+				}
+			}()
+			collect.Describe(descCh)
+			close(descCh)
+			ch := make(chan prometheus.Metric)
+			go func() {
+				collect.Collect(ch)
+				close(ch)
+			}()
+
+			var got []string
+			for sample := range ch {
+				var d dto.Metric
+				require.NoError(t, sample.Write(&d))
+				got = append(got, metricPrettyWithValue(d))
+			}
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}
+func metricPretty(d dto.Metric) string {
+	labels := make([]string, len(d.Label))
+	for _, label := range d.Label {
+		labels = append(labels, fmt.Sprintf("%s = %s", *label.Name, *label.Value))
+	}
+	return strings.TrimSpace(strings.Join(labels, " "))
+}
+
+func metricPrettyWithValue(d dto.Metric) string {
+	labels := metricPretty(d)
+	value := 0
+	if d.Gauge != nil {
+		value = int(*d.Gauge.Value)
+	}
+	return fmt.Sprintf("%s %d", labels, value)
+}

--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -130,6 +130,12 @@ func InstalledTimestamp(instTime time.Time) Option {
 	}
 }
 
+func InstallRestarts(restarts int) Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Status.InstallRestarts = restarts
+	}
+}
+
 func WithClusterVersion(version string) Option {
 	return Generic(generic.WithLabel(constants.VersionMajorMinorPatchLabel, version))
 }


### PR DESCRIPTION
###  provision_underway_collector.go: allow setting min duration for provision time, add metric for install restarts

hive_cluster_deployment_provision_underway_seconds metric currently reports the elapsed time for all clusterdeployments
that provisioning. To allow for reduce the metrics reported and still ensure the metric can be used to alert installs taking
too long, the collector now allows setting minDuration. The minDuration ensures the collector only cares about provisioning times
greater than minDuration.

Another metric that's important for tracking failing installs is the number of restarts for installs. This allows catching failures
that fail really quickly, like permissions, compared to underway_seconds where the installs might have to restart for a very large value
to be alerted.

so a new metric hive_cluster_deployment_provision_underway_install_restarts is added that tracks the number of restarts for a cluster that
is still provisioning.


### controller/metrics/metrics.go: report metrics for only at least 1 hour elapsed time and 1 install restarts

track clusters in hive_cluster_deployment_provision_underway_seconds which have been provisioning for atleast
1 hour.
track clusters in hive_cluster_deployment_provision_underway_install_restarts which have atleast 1 restarts.

This makes sure the amount of metrics collected are smaller but still provide most value in alerting failed installs.

xref: https://issues.redhat.com/browse/HIVE-1341

/assign @dgoodwin
/cc @suhanime 