### PR TITLE
Make agent install strat MachineNetwork optional.

### DIFF
--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -752,8 +752,6 @@ spec:
                                 type: string
                               maxItems: 1
                               type: array
-                          required:
-                          - machineNetwork
                           type: object
                         provisionRequirements:
                           description: ProvisionRequirements defines configuration

--- a/pkg/apis/hive/v1/agent/installstrategy.go
+++ b/pkg/apis/hive/v1/agent/installstrategy.go
@@ -39,7 +39,8 @@ type ProvisionRequirements struct {
 // Networking defines the pod network provider in the cluster.
 type Networking struct {
 	// MachineNetwork is the list of IP address pools for machines.
-	MachineNetwork []MachineNetworkEntry `json:"machineNetwork"`
+	// +optional
+	MachineNetwork []MachineNetworkEntry `json:"machineNetwork,omitempty"`
 
 	// ClusterNetwork is the list of IP address pools for pods.
 	// Default is 10.128.0.0/14 and a host prefix of /23.


### PR DESCRIPTION
This field cannot be used with VIPDHCPAllocationMode false. We will have to handle it in validation.

cc @filanov 