### PR TITLE
report release image version in clusterdeployment status

### DIFF
--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -1044,6 +1044,10 @@ spec:
                       type: integer
                   type: object
               type: object
+            installVersion:
+              description: InstallVersion is the version of OpenShift as reported
+                by the release image resolved for the installation.
+              type: string
             installedTimestamp:
               description: InstalledTimestamp is the time we first detected that the
                 cluster has been successfully installed.

--- a/pkg/apis/hive/v1/clusterdeployment_types.go
+++ b/pkg/apis/hive/v1/clusterdeployment_types.go
@@ -229,6 +229,11 @@ type ClusterDeploymentStatus struct {
 	// +optional
 	InstallerImage *string `json:"installerImage,omitempty"`
 
+	// InstallVersion is the version of OpenShift as reported by the release image
+	// resolved for the installation.
+	// +optional
+	InstallVersion *string `json:"installVersion,omitempty"`
+
 	// CLIImage is the name of the oc cli image to use when installing the target cluster
 	// +optional
 	CLIImage *string `json:"cliImage,omitempty"`

--- a/pkg/apis/hive/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/hive/v1/zz_generated.deepcopy.go
@@ -600,6 +600,11 @@ func (in *ClusterDeploymentStatus) DeepCopyInto(out *ClusterDeploymentStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.InstallVersion != nil {
+		in, out := &in.InstallVersion, &out.InstallVersion
+		*out = new(string)
+		**out = **in
+	}
 	if in.CLIImage != nil {
 		in, out := &in.CLIImage, &out.CLIImage
 		*out = new(string)

--- a/pkg/imageset/generate.go
+++ b/pkg/imageset/generate.go
@@ -45,7 +45,7 @@ func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAcco
 				Image:           releaseImage,
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Command:         []string{"/bin/sh", "-c"},
-				Args:            []string{"cp -v /release-manifests/image-references /common/image-references"},
+				Args:            []string{"cp -v /release-manifests/image-references /release-manifests/release-metadata  /common/"},
 				VolumeMounts:    volumeMounts,
 			},
 		},


### PR DESCRIPTION
The release image today include the metadata (cincinatti metadata) for version
information in release-metadata file, see [1].

The update-installer-image job today reads the release image contents and then
extracts images for installer and cli for each cluster deployment. Since it already
interacts with release image once per cluster deployment, it seems like the right place
to also include code to extract and report the release image version.

- the install image set job init container now copies /release-image/release-metadata file
  in additions to the image-references file.

- the update-installer-image command reads this release-metadata file and reports the version
  to the status like the installer, cli images.

NOTE: oc uses the release metadata to get the version field and fallback to image stream name
from the image-references [2] and update-installer-image keeps the same behavior.

[1]: https://github.com/openshift/oc/blob/c66c03f3012a10f16eb86fdce6330433adf6c9ee/pkg/cli/admin/release/info.go#L787
[2]: https://github.com/openshift/oc/blob/c66c03f3012a10f16eb86fdce6330433adf6c9ee/pkg/cli/admin/release/info.go#L718-L723

xref: https://issues.redhat.com/browse/HIVE-1350

/assign @dgoodwin 