### PR TITLE
Tag hashicorp/go-slug to v0.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -102,3 +102,6 @@ replace (
 
 // needed because otherwise v12.0.0 is picked up as a more recent version
 replace k8s.io/client-go => k8s.io/client-go v0.19.5
+
+// needed for fixing CVE-2020-29529
+replace github.com/hashicorp/go-slug => github.com/hashicorp/go-slug v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -961,7 +961,7 @@ github.com/hashicorp/go-retryablehttp v0.6.4/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-rootcerts v1.0.1/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
-github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
+github.com/hashicorp/go-slug v0.5.0/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1845,3 +1845,4 @@ sigs.k8s.io/yaml
 # google.golang.org/genproto => google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 # google.golang.org/grpc => google.golang.org/grpc v1.29.1
 # k8s.io/client-go => k8s.io/client-go v0.19.5
+# github.com/hashicorp/go-slug => github.com/hashicorp/go-slug v0.5.0


### PR DESCRIPTION
Tag go-slug to v0.5.0 for BZ [1914887](https://bugzilla.redhat.com/show_bug.cgi?id=1914887)

https://issues.redhat.com/browse/HIVE-1356

/assign @abutcher 
/cc @akhil-rane 