### PR TITLE
Tag hashicorp/go-slug to v0.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,3 +92,6 @@ replace github.com/openshift/library-go => github.com/openshift/library-go v0.0.
 
 // temporary hack fix for https://github.com/kubernetes/kubernetes/issues/95300
 replace k8s.io/apiserver => github.com/staebler/apiserver v0.19.1-0.20201005174924-a3ef0d1e45df
+
+// needed for fixing CVE-2020-29529
+replace github.com/hashicorp/go-slug => github.com/hashicorp/go-slug v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -856,7 +856,7 @@ github.com/hashicorp/go-retryablehttp v0.6.4/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-rootcerts v1.0.1/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
-github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
+github.com/hashicorp/go-slug v0.5.0/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1780,3 +1780,4 @@ sourcegraph.com/sqs/pbtypes
 # k8s.io/client-go => k8s.io/client-go v0.19.0
 # github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20200918101923-1e4c94603efe
 # k8s.io/apiserver => github.com/staebler/apiserver v0.19.1-0.20201005174924-a3ef0d1e45df
+# github.com/hashicorp/go-slug => github.com/hashicorp/go-slug v0.5.0


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/hive/pull/1281

Tag go-slug to v0.5.0 for BZ 1914887