### PR TITLE
Agent install strategy and platform validation

### DIFF
--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -767,6 +767,7 @@ spec:
                               description: WorkerAgents is the minimum number of matching
                                 approved and ready Agents with the worker role required
                                 to launch the install.
+                              minimum: 0
                               type: integer
                           required:
                           - controlPlaneAgents

--- a/pkg/apis/hive/v1/agent/installstrategy.go
+++ b/pkg/apis/hive/v1/agent/installstrategy.go
@@ -32,6 +32,7 @@ type ProvisionRequirements struct {
 
 	// WorkerAgents is the minimum number of matching approved and ready Agents with the worker role
 	// required to launch the install.
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	WorkerAgents int `json:"workerAgents,omitempty"`
 }

--- a/pkg/apis/hive/v1/agent/platform.go
+++ b/pkg/apis/hive/v1/agent/platform.go
@@ -23,6 +23,6 @@ type BareMetalPlatform struct {
 type VIPDHCPAllocationType string
 
 const (
-	Disabled VIPDHCPAllocationType = ""
-	Enabled  VIPDHCPAllocationType = "Enabled"
+	VIPDHCPAllocationDisabled VIPDHCPAllocationType = ""
+	VIPDHCPAllocationEnabled  VIPDHCPAllocationType = "Enabled"
 )


### PR DESCRIPTION
General approach: we have agreed that we are focused on declarative gitops driven workflows with the Kube CRDs rather than the imperative guided build up of a cluster definition from the assisted service today. As such, by default in Hive, most things are immutable and we must explicitly opt-fields into being mutable after creation. The programatic workflow would be to delete your clusterdeployment, correct what's wrong, and try again. With this in mind I skipped the plan to allow field edits until an install is launched.

At this layer we should not be doing any validations against external lookups, so this is primarily to make sure the data is logical when combined with other data, and well formed. I did not do any CIDR validation, we don't typically do this in Hive today and the underlying assisted service will, so I'm not sure it's worth duplicating here, though willing to hear other opinions.

Otherwise I'm not finding a ton of validation to do thus far, let me know what you think.

/cc @filanov @avishayt @mhrivnak
/assign @abhinavdahiya 
