### PR TITLE
Separate out DNSNotReady condition reasons

### DIFF
--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	hivev1 "github.com/openshift/hive/pkg/apis/hive/v1"
+	hivev1aws "github.com/openshift/hive/pkg/apis/hive/v1/aws"
 	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/test/generic"
 )
@@ -149,5 +150,12 @@ func WithPowerState(powerState hivev1.ClusterPowerState) Option {
 func WithHibernateAfter(dur time.Duration) Option {
 	return func(clusterDeployment *hivev1.ClusterDeployment) {
 		clusterDeployment.Spec.HibernateAfter = &metav1.Duration{Duration: dur}
+	}
+}
+
+// WithAWSPlatform sets the specified aws platform on the supplied object.
+func WithAWSPlatform(platform *hivev1aws.Platform) Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Spec.Platform.AWS = platform
 	}
 }

--- a/pkg/test/dnszone/dnszone.go
+++ b/pkg/test/dnszone/dnszone.go
@@ -110,6 +110,19 @@ func WithLabelOwner(owner *hivev1.ClusterDeployment) Option {
 	}
 }
 
+// WithCondition adds the specified condition to the DNSZone
+func WithCondition(cond hivev1.DNSZoneCondition) Option {
+	return func(dnsZone *hivev1.DNSZone) {
+		for i, c := range dnsZone.Status.Conditions {
+			if c.Type == cond.Type {
+				dnsZone.Status.Conditions[i] = cond
+				return
+			}
+		}
+		dnsZone.Status.Conditions = append(dnsZone.Status.Conditions, cond)
+	}
+}
+
 func WithZone(zone string) Option {
 	return func(dnsZone *hivev1.DNSZone) {
 		dnsZone.Spec.Zone = zone


### PR DESCRIPTION
- [x] Set reason DNSUnsupportedPlatform when the platform doesn't
      support managed dns
- [x] Set reason DNSZoneResoucreConflict when the DNSZone already exists
- [x] Set reason DNSNotReadyTimedOut when in state DNSNotReady for
      longer than allowed
- [x] Add unit tests
- [x] Run manual tests

/assign @joelddiaz 
/cc @dgoodwin 

xref: https://issues.redhat.com/browse/HIVE-1129