### PR TITLE
Act on agent clusters

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -6,13 +6,14 @@ import (
 )
 
 const (
-	PlatformAWS       = "aws"
-	PlatformAzure     = "azure"
-	PlatformBaremetal = "baremetal"
-	PlatformGCP       = "gcp"
-	PlatformOpenStack = "openstack"
-	PlatformUnknown   = "unknown"
-	PlatformVSphere   = "vsphere"
+	PlatformAWS            = "aws"
+	PlatformAzure          = "azure"
+	PlatformBaremetal      = "baremetal"
+	PlatformAgentBaremetal = "agent-baremetal"
+	PlatformGCP            = "gcp"
+	PlatformOpenStack      = "openstack"
+	PlatformUnknown        = "unknown"
+	PlatformVSphere        = "vsphere"
 
 	mergedPullSecretSuffix = "merged-pull-secret"
 

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -456,14 +456,6 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 		return reconcile.Result{}, err
 	}
 
-	// Return early and stop processing if Agent install strategy is in play. The controllers that
-	// handle this portion of the API currently live in the assisted service repo, rather than hive.
-	// This will hopefully change in the future.
-	if cd.Spec.Provisioning != nil && cd.Spec.Provisioning.InstallStrategy != nil && cd.Spec.Provisioning.InstallStrategy.Agent != nil {
-		cdLog.Info("skipping processing of agent install strategy cluster")
-		return reconcile.Result{}, nil
-	}
-
 	if cd.DeletionTimestamp != nil {
 		if !controllerutils.HasFinalizer(cd, hivev1.FinalizerDeprovision) {
 			// Make sure we have no deprovision underway metric even though this was probably cleared when we
@@ -647,6 +639,14 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 
 	if !r.expectations.SatisfiedExpectations(request.String()) {
 		cdLog.Debug("waiting for expectations to be satisfied")
+		return reconcile.Result{}, nil
+	}
+
+	// Return early and stop processing if Agent install strategy is in play. The controllers that
+	// handle this portion of the API currently live in the assisted service repo, rather than hive.
+	// This will hopefully change in the future.
+	if cd.Spec.Provisioning != nil && cd.Spec.Provisioning.InstallStrategy != nil && cd.Spec.Provisioning.InstallStrategy.Agent != nil {
+		cdLog.Info("skipping processing of agent install strategy cluster")
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -2264,6 +2264,8 @@ func getClusterPlatform(cd *hivev1.ClusterDeployment) string {
 		return constants.PlatformVSphere
 	case cd.Spec.Platform.BareMetal != nil:
 		return constants.PlatformBaremetal
+	case cd.Spec.Platform.AgentBareMetal != nil:
+		return constants.PlatformAgentBaremetal
 	}
 	return constants.PlatformUnknown
 }


### PR DESCRIPTION
This change re-enables most of the clusterdeployment controller for Agent based clusters. Previously we just blanket disabled everything, but this skipped the imageset job which was required for extracting useful info for Agent installs, such as the specific semver openshift version.

Now the controller will mostly run as normal with the exception of creation of a ClusterProvision. Getting Agent clusters to link up with the ClusterProvision flow will be handled in the future.

/assign @abhinavdahiya 
/cc @abutcher @filanov @avishayt @mhrivnak 

