### PR TITLE
HIVE-1394: Add generic install failing reason ResourceLimitExceeded.

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -6,17 +6,27 @@ metadata:
 data:
   regexes: |
     # AWS Specific
+    - name: AWSNATGatewayLimitExceeded
+      searchRegexStrings:
+      - "NatGatewayLimitExceeded"
+      installFailingReason: AWSNATGatewayLimitExceeded
+      installFailingMessage: AWS NAT gateway limit exceeded
+    - name: AWSVPCLimitExceeded
+      searchRegexStrings:
+      - "VpcLimitExceeded"
+      installFailingReason: AWSVPCLimitExceeded
+      installFailingMessage: AWS VPC limit exceeded
+    - name: LimitExceeded
+      searchRegexStrings:
+      - "LimitExceeded"
+      installFailingReason: ResourceLimitExceeded
+      installFailingMessage: Resource limit exceeded
     # https://bugzilla.redhat.com/show_bug.cgi?id=1844320
     - name: AWSUnableToFindMatchingRouteTable
       searchRegexStrings:
       - "Error: Unable to find matching route for Route Table"
       installFailingReason: AWSUnableToFindMatchingRouteTable
       installFailingMessage: Unable to find matching route for route table
-    - name: AWSNATGatewayLimitExceeded
-      searchRegexStrings:
-      - "NatGatewayLimitExceeded"
-      installFailingReason: AWSNATGatewayLimitExceeded
-      installFailingMessage: AWS NAT gateway limit exceeded
     - name: DNSAlreadyExists
       searchRegexStrings:
       - "aws_route53_record.*Error building changeset:.*Tried to create resource record set.*but it already exists"
@@ -42,11 +52,6 @@ data:
       - "Throttling: Rate exceeded"
       installFailingReason: AWSAPIRateLimitExceeded
       installFailingMessage: AWS API rate limit exceeded
-    - name: AWSVPCLimitExceeded
-      searchRegexStrings:
-      - "VpcLimitExceeded"
-      installFailingReason: AWSVPCLimitExceeded
-      installFailingMessage: AWS VPC limit exceeded
     # GCP Specific
     - name: GCPInvalidProjectID
       searchRegexStrings:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1533,17 +1533,27 @@ metadata:
 data:
   regexes: |
     # AWS Specific
+    - name: AWSNATGatewayLimitExceeded
+      searchRegexStrings:
+      - "NatGatewayLimitExceeded"
+      installFailingReason: AWSNATGatewayLimitExceeded
+      installFailingMessage: AWS NAT gateway limit exceeded
+    - name: AWSVPCLimitExceeded
+      searchRegexStrings:
+      - "VpcLimitExceeded"
+      installFailingReason: AWSVPCLimitExceeded
+      installFailingMessage: AWS VPC limit exceeded
+    - name: LimitExceeded
+      searchRegexStrings:
+      - "LimitExceeded"
+      installFailingReason: ResourceLimitExceeded
+      installFailingMessage: Resource limit exceeded
     # https://bugzilla.redhat.com/show_bug.cgi?id=1844320
     - name: AWSUnableToFindMatchingRouteTable
       searchRegexStrings:
       - "Error: Unable to find matching route for Route Table"
       installFailingReason: AWSUnableToFindMatchingRouteTable
       installFailingMessage: Unable to find matching route for route table
-    - name: AWSNATGatewayLimitExceeded
-      searchRegexStrings:
-      - "NatGatewayLimitExceeded"
-      installFailingReason: AWSNATGatewayLimitExceeded
-      installFailingMessage: AWS NAT gateway limit exceeded
     - name: DNSAlreadyExists
       searchRegexStrings:
       - "aws_route53_record.*Error building changeset:.*Tried to create resource record set.*but it already exists"
@@ -1569,11 +1579,6 @@ data:
       - "Throttling: Rate exceeded"
       installFailingReason: AWSAPIRateLimitExceeded
       installFailingMessage: AWS API rate limit exceeded
-    - name: AWSVPCLimitExceeded
-      searchRegexStrings:
-      - "VpcLimitExceeded"
-      installFailingReason: AWSVPCLimitExceeded
-      installFailingMessage: AWS VPC limit exceeded
     # GCP Specific
     - name: GCPInvalidProjectID
       searchRegexStrings:


### PR DESCRIPTION
We're encountering more and more "*LimitExceeded" errors and this would capture all of them generically. Do we prefer this to having a regex for each type of resource limit exceeded to prevent needing to check logs.

Add tests for `"NATGatewayLimitExceeded"` and `"VPCLimitExceeded"`.

/assign @dgoodwin 
/cc @gregsheremeta 