### PR TITLE
Add an 'Age' printer column to ClusterClaims

### DIFF
--- a/apis/hive/v1/clusterclaim_types.go
+++ b/apis/hive/v1/clusterclaim_types.go
@@ -82,6 +82,7 @@ const (
 // +kubebuilder:printcolumn:name="Pending",type="string",JSONPath=".status.conditions[?(@.type=='Pending')].reason"
 // +kubebuilder:printcolumn:name="ClusterNamespace",type="string",JSONPath=".spec.namespace"
 // +kubebuilder:printcolumn:name="ClusterRunning",type="string",JSONPath=".status.conditions[?(@.type=='ClusterRunning')].reason"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ClusterClaim struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crds/hive.openshift.io_clusterclaims.yaml
+++ b/config/crds/hive.openshift.io_clusterclaims.yaml
@@ -17,6 +17,9 @@ spec:
   - JSONPath: .status.conditions[?(@.type=='ClusterRunning')].reason
     name: ClusterRunning
     type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: hive.openshift.io
   names:
     kind: ClusterClaim

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterclaim_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterclaim_types.go
@@ -82,6 +82,7 @@ const (
 // +kubebuilder:printcolumn:name="Pending",type="string",JSONPath=".status.conditions[?(@.type=='Pending')].reason"
 // +kubebuilder:printcolumn:name="ClusterNamespace",type="string",JSONPath=".spec.namespace"
 // +kubebuilder:printcolumn:name="ClusterRunning",type="string",JSONPath=".status.conditions[?(@.type=='ClusterRunning')].reason"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type ClusterClaim struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
## Summary of Changes

This PR adds an "Age" column back to the ClusterClaim output by adding a printcolumn annotation.  In Hive v1.0.19, a number of (very useful) new columns were added but this had the effect of removing the "Age" column, a useful metric when computing how much of a ClusterClaim's `Lifetime` remains or determining which clusters may have been unintentionally leaked or left around without a Lifetime by users/automation.  

## New Output
```
gbuchana-mac:hive-1 gurnben$ oc get clusterclaim -n default
NAME                       POOL             PENDING   CLUSTERNAMESPACE   CLUSTERRUNNING   AGE
gurnben-hive-deploy-test   canary-aws-470                                                 11m
```