### PR TITLE
New Floating IP option for Ingress with OpenStack

### DIFF
--- a/contrib/pkg/createcluster/create.go
+++ b/contrib/pkg/createcluster/create.go
@@ -163,11 +163,12 @@ type Options struct {
 	AzureBaseDomainResourceGroupName string
 
 	// OpenStack
-	OpenStackCloud           string
-	OpenStackExternalNetwork string
-	OpenStackMasterFlavor    string
-	OpenStackComputeFlavor   string
-	OpenStackAPIFloatingIP   string
+	OpenStackCloud             string
+	OpenStackExternalNetwork   string
+	OpenStackMasterFlavor      string
+	OpenStackComputeFlavor     string
+	OpenStackAPIFloatingIP     string
+	OpenStackIngressFloatingIP string
 
 	// VSphere
 	VSphereVCenter          string
@@ -290,6 +291,7 @@ create-cluster CLUSTER_DEPLOYMENT_NAME --cloud=ovirt --ovirt-api-vip 192.168.1.2
 	flags.StringVar(&opt.OpenStackMasterFlavor, "openstack-master-flavor", "ci.m4.xlarge", "Compute flavor to use for master nodes")
 	flags.StringVar(&opt.OpenStackComputeFlavor, "openstack-compute-flavor", "m1.large", "Compute flavor to use for worker nodes")
 	flags.StringVar(&opt.OpenStackAPIFloatingIP, "openstack-api-floating-ip", "", "Floating IP address to use for cluster's API")
+	flags.StringVar(&opt.OpenStackIngressFloatingIP, "openstack-ingress-floating-ip", "", "Floating IP address to use for cluster's Ingress service")
 
 	// vSphere flags
 	flags.StringVar(&opt.VSphereVCenter, "vsphere-vcenter", "", "Domain name or IP address of the vCenter")
@@ -605,6 +607,7 @@ func (o *Options) GenerateObjects() ([]runtime.Object, error) {
 			ComputeFlavor:     o.OpenStackComputeFlavor,
 			MasterFlavor:      o.OpenStackMasterFlavor,
 			APIFloatingIP:     o.OpenStackAPIFloatingIP,
+			IngressFloatingIP: o.OpenStackIngressFloatingIP,
 		}
 		builder.CloudBuilder = openStackProvider
 	case cloudVSphere:

--- a/pkg/clusterresource/openstack.go
+++ b/pkg/clusterresource/openstack.go
@@ -21,6 +21,9 @@ type OpenStackCloudBuilder struct {
 	// APIFloatingIP is the OpenStack Floating IP for the cluster to use for its API
 	APIFloatingIP string
 
+	// IngressFloatingIP is the OpenStack Floating IP for the cluster to use for its Ingress
+	IngressFloatingIP string
+
 	// Cloud is the named section from the clouds.yaml in the Secret containing the creds.
 	Cloud string
 
@@ -84,6 +87,7 @@ func (p *OpenStackCloudBuilder) addInstallConfigPlatform(o *Builder, ic *install
 			ExternalNetwork:      p.ExternalNetwork,
 			DeprecatedFlavorName: p.ComputeFlavor,
 			APIFloatingIP:        p.APIFloatingIP,
+			IngressFloatingIP:    p.IngressFloatingIP,
 		},
 	}
 


### PR DESCRIPTION
Here I've added the ability to specify the floating IP that users want to utilise for ingress services on an OpenStack based cluster.