### PR TITLE
Fix clusters stuck resuming due to stopped instance.

### DIFF
--- a/pkg/controller/hibernation/aws_actuator.go
+++ b/pkg/controller/hibernation/aws_actuator.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+
 	awsclient "github.com/openshift/hive/pkg/awsclient"
 )
 
@@ -76,7 +77,7 @@ func (a *awsActuator) StartMachines(cd *hivev1.ClusterDeployment, c client.Clien
 		return err
 	}
 	if len(instanceIDs) == 0 {
-		logger.Warning("No instances were found to start")
+		logger.Info("No instances were found to start")
 		return nil
 	}
 	logger.WithField("instanceIDs", instanceIDs).Info("Starting cluster instances")

--- a/pkg/controller/hibernation/azure_actuator.go
+++ b/pkg/controller/hibernation/azure_actuator.go
@@ -90,7 +90,7 @@ func (a *azureActuator) StartMachines(cd *hivev1.ClusterDeployment, c client.Cli
 		return err
 	}
 	if len(machines) == 0 {
-		logger.Warning("No machines were found to start")
+		logger.Info("No machines were found to start")
 		return nil
 	}
 	var errs []error

--- a/pkg/controller/hibernation/gcp_actuator.go
+++ b/pkg/controller/hibernation/gcp_actuator.go
@@ -79,6 +79,10 @@ func (a *gcpActuator) StartMachines(cd *hivev1.ClusterDeployment, hiveClient cli
 	if err != nil {
 		return err
 	}
+	if len(instances) == 0 {
+		logger.Info("No instances were found to start")
+		return nil
+	}
 	var errs []error
 	for _, instance := range instances {
 		logger.WithField("instance", instance.Name).Info("Starting instance")

--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -331,6 +331,11 @@ func (r *hibernationReconciler) checkClusterResumed(cd *hivev1.ClusterDeployment
 		return reconcile.Result{}, err
 	}
 	if !running {
+		// Ensure all machines have been started. Should have been handled already but we've seen VMs left in stopped state.
+		if err := actuator.StartMachines(cd, r.Client, logger); err != nil {
+			logger.WithError(err).Error("error starting machines")
+			return reconcile.Result{}, err
+		}
 		return reconcile.Result{RequeueAfter: stateCheckInterval}, nil
 	}
 	remoteClient, err := r.remoteClientBuilder(cd).Build()

--- a/pkg/controller/hibernation/hibernation_controller_test.go
+++ b/pkg/controller/hibernation/hibernation_controller_test.go
@@ -256,6 +256,7 @@ func TestReconcile(t *testing.T) {
 			cd:   cdBuilder.Options(o.resuming).Build(),
 			cs:   csBuilder.Build(),
 			setupActuator: func(actuator *mock.MockHibernationActuator) {
+				actuator.EXPECT().StartMachines(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
 				actuator.EXPECT().MachinesRunning(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(false, nil)
 			},
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
@@ -481,6 +482,7 @@ func TestHibernateAfter(t *testing.T) {
 		{
 			name: "cluster waking from hibernate",
 			setupActuator: func(actuator *mock.MockHibernationActuator) {
+				actuator.EXPECT().StartMachines(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
 				actuator.EXPECT().MachinesRunning(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(false, nil)
 			},
 			cd: cdBuilder.Build(


### PR DESCRIPTION
x-ref: https://issues.redhat.com/browse/HIVE-1455

Encountered a cluster deployment stuck resuming for several days, and
thus was not powered off after the hibernateAfter interval.

Issue appeared to be because one worker VM was still in stopped state.
The code made the assumption that we must have issued the start command
when transitioning to resuming state, and then never tried to again.

To fix we now will issue StartMachines every time we check if we're
resumed. All three providers are implemented to only issue to VMs that
are stopped / stopping so the change should have no impact normally.