### PR TITLE
Add a temporary Fedora 33 dev docker build/push setup.

### DIFF
--- a/hack/fedora33dev/Dockerfile.dev
+++ b/hack/fedora33dev/Dockerfile.dev
@@ -1,0 +1,9 @@
+FROM hive-dev-base:latest
+
+ADD bin/hiveadmission /opt/services/
+ADD bin/operator /opt/services/hive-operator
+ADD bin/manager /opt/services/
+ADD bin/hiveutil /usr/bin/
+
+# TODO: should this be the operator?
+ENTRYPOINT ["/opt/services/manager"]

--- a/hack/fedora33dev/Dockerfile.devbase
+++ b/hack/fedora33dev/Dockerfile.devbase
@@ -1,0 +1,31 @@
+FROM fedora:33
+
+# ssh-agent required for gathering logs in some situations:
+RUN if ! rpm -q openssh-clients; then yum install -y openssh-clients && yum clean all && rm -rf /var/cache/yum/*; fi
+#
+# libvirt libraries required for running bare metal installer.
+RUN yum install -y libvirt-devel && yum clean all && rm -rf /var/cache/yum/*
+
+# Hacks to allow writing known_hosts, homedir is / by default in OpenShift.
+# Bare metal installs need to write to $HOME/.cache, and $HOME/.ssh for as long as
+# we're hitting libvirt over ssh. OpenShift will not let you write these directories
+# by default so we must setup some permissions here.
+ENV HOME /home/hive
+RUN mkdir -p /home/hive && \
+    chgrp -R 0 /home/hive && \
+    chmod -R g=u /home/hive
+
+# This is so that we can write source certificate anchors during container start up.
+RUN mkdir -p /etc/pki/ca-trust/source/anchors && \
+    chgrp -R 0 /etc/pki/ca-trust/source/anchors && \
+    chmod -R g=u /etc/pki/ca-trust/source/anchors
+
+# This is so that we can run update-ca-trust during container start up.
+RUN mkdir -p /etc/pki/ca-trust/extracted/openssl && \
+    mkdir -p /etc/pki/ca-trust/extracted/pem && \
+    mkdir -p /etc/pki/ca-trust/extracted/java && \
+    chgrp -R 0 /etc/pki/ca-trust/extracted && \
+    chmod -R g=u /etc/pki/ca-trust/extracted
+
+# TODO: should this be the operator?
+ENTRYPOINT ["/opt/services/manager"]

--- a/hack/fedora33dev/README.md
+++ b/hack/fedora33dev/README.md
@@ -1,0 +1,24 @@
+# Unrefined Fedora 33 Docker Build Steps
+
+Workaround for an error you will see trying to do make docker-dev-push on Fedora 33 where glibc errors surface due to conflicts between the binaries you compiled on your system, and the OS in the Docker container where they run:
+
+```
+oc logs hive-operator-7dfdb6d59-vkttv -n hive
+/opt/services/hive-operator: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by /opt/services/hive-operator)
+```
+
+*Run all commands from the root of your hive.git.*
+
+Build the base development image (really just one time needed):
+
+```bash
+$ docker build -t hive-dev-base -f hack/fedora33dev/Dockerfile.devbase .
+```
+
+Run script to build hive binaries locally (much faster than from scratch in a container), push to a registry, and restart all Hive pods in your current Kube context.
+
+```bash
+$ IMG="quay.io/username/hive:latest" hack/fedora33dev/docker-dev-push.sh
+```
+
+

--- a/hack/fedora33dev/docker-dev-push.sh
+++ b/hack/fedora33dev/docker-dev-push.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
-IMG=quay.io/dgoodwin/hive:latest
+
+# exit if IMG is not set, should be a ref to a registry you can push to (i.e. quay.io/user/hive:latest)
+set -u
+: "$IMG"
 
 # TODO: update not strictly required here unless dealing with manifest changes
 make update build

--- a/hack/fedora33dev/docker-dev-push.sh
+++ b/hack/fedora33dev/docker-dev-push.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+IMG=quay.io/dgoodwin/hive:latest
+
+# TODO: update not strictly required here unless dealing with manifest changes
+make update build
+docker build -t ${IMG} -f hack/fedora33dev/Dockerfile.dev .
+docker push ${IMG}
+kubectl delete pod -n hive -l control-plane=clustersync --wait=false
+kubectl delete pod -n hive -l control-plane=controller-manager --wait=false
+kubectl delete pod -n hive -l control-plane=hive-operator --wait=false
+kubectl delete pod -n hive -l app=hiveadmission --wait=false


### PR DESCRIPTION
I've been using this for a long time, but ideally it would be nice to see cleaned up and a recommended dev path in the docs.

For now, just publishing to help out Andrew.

/assign @abutcher 