### PR TITLE
awsclient: fix creating client from env when no config provided

### DIFF
--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -620,7 +620,6 @@ func NewSessionFromSecret(secret *corev1.Secret, region string) (*session.Sessio
 			EndpointResolver: endpoints.ResolverFunc(awsChinaEndpointResolver),
 		},
 		SharedConfigState: session.SharedConfigEnable,
-		Profile:           "default",
 	}
 
 	// Special case to not use a secret to gather credentials.
@@ -637,6 +636,7 @@ func NewSessionFromSecret(secret *corev1.Secret, region string) (*session.Sessio
 		defer os.Remove(f.Name())
 
 		options.SharedConfigFiles = []string{f.Name()}
+		options.Profile = "default"
 	}
 
 	// Otherwise default to relying on the environment where the actuator is running:


### PR DESCRIPTION
the session options always picked default profile for AWS Config. So
when the session was from secret object the AWS Config will be generated
for the default profile. But when the session needed to be created from
environment like in installerpod, the setting of default profile would
skip the environement variables weirdly (this is not how it should be
but tested and it acts like that).

/assign @joelddiaz 