### PR TITLE
Drop agent platform apivipdnsname.

### DIFF
--- a/apis/hive/v1/agent/platform.go
+++ b/apis/hive/v1/agent/platform.go
@@ -10,10 +10,6 @@ type BareMetalPlatform struct {
 	// +optional
 	APIVIP string `json:"apiVIP,omitempty"`
 
-	// APIVIPDNSName is the domain name used to reach the OpenShift cluster API.
-	// +optional
-	APIVIPDNSName string `json:"apiVIPDNSName,omitempty"`
-
 	// IngressVIP is the virtual IP used for cluster ingress traffic.
 	// +optional
 	IngressVIP string `json:"ingressVIP,omitempty"`

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -428,10 +428,6 @@ spec:
                       description: APIVIP is the virtual IP used to reach the OpenShift
                         cluster's API.
                       type: string
-                    apiVIPDNSName:
-                      description: APIVIPDNSName is the domain name used to reach
-                        the OpenShift cluster API.
-                      type: string
                     ingressVIP:
                       description: IngressVIP is the virtual IP used for cluster ingress
                         traffic.

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -181,10 +181,6 @@ spec:
                       description: APIVIP is the virtual IP used to reach the OpenShift
                         cluster's API.
                       type: string
-                    apiVIPDNSName:
-                      description: APIVIPDNSName is the domain name used to reach
-                        the OpenShift cluster API.
-                      type: string
                     ingressVIP:
                       description: IngressVIP is the virtual IP used for cluster ingress
                         traffic.

--- a/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook_test.go
@@ -144,9 +144,8 @@ func validOvirtClusterDeployment() *hivev1.ClusterDeployment {
 func validAgentBareMetalClusterDeployment() *hivev1.ClusterDeployment {
 	cd := clusterDeploymentTemplate()
 	cd.Spec.Platform.AgentBareMetal = &hivev1agent.BareMetalPlatform{
-		APIVIP:        "127.0.0.1",
-		APIVIPDNSName: "foo.example.com",
-		IngressVIP:    "127.0.0.1",
+		APIVIP:     "127.0.0.1",
+		IngressVIP: "127.0.0.1",
 		AgentSelector: metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				"foo": "bar",

--- a/vendor/github.com/openshift/hive/apis/hive/v1/agent/platform.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/agent/platform.go
@@ -10,10 +10,6 @@ type BareMetalPlatform struct {
 	// +optional
 	APIVIP string `json:"apiVIP,omitempty"`
 
-	// APIVIPDNSName is the domain name used to reach the OpenShift cluster API.
-	// +optional
-	APIVIPDNSName string `json:"apiVIPDNSName,omitempty"`
-
 	// IngressVIP is the virtual IP used for cluster ingress traffic.
 	// +optional
 	IngressVIP string `json:"ingressVIP,omitempty"`


### PR DESCRIPTION
This field is not needed according to assisted team, it can be inferred
by cluster name and base domain.

x-ref: https://issues.redhat.com/browse/HIVE-1460