### PR TITLE
Fix issue with the upload when logs are collected using oc adm must-gather

### DIFF
--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -930,6 +930,12 @@ func (m *InstallManager) gatherClusterLogs(cd *hivev1.ClusterDeployment) error {
 	cmd.Env = append(cmd.Env, fmt.Sprintf("KUBECONFIG=%s", filepath.Join(m.WorkDir, "auth", "kubeconfig")))
 	stdout, err := cmd.Output()
 	m.log.Infof("must-gather output: %s", stdout)
+	if err != nil {
+		return err
+	}
+	// Creating a compressed file of the must-gather directory in m.LogsDir
+	tarCmd := exec.Command("tar", "cvaf", filepath.Join(m.LogsDir, "must-gather.tar.gz"), destDir)
+	err = tarCmd.Run()
 	return err
 }
 


### PR DESCRIPTION
Currently, `oc adm must-gather` stores logs inside `logs/must-gather` dir of the
install pod. While uploading we iterate through `logs` dir and only upload files,
ignoring directories.

This fix creates a tar archive file of the `logs/must-gather` dir in the `logs` dir
so that it does not get ignored while uploading to S3.

x-ref: https://issues.redhat.com/browse/HIVE-1462