### PR TITLE
install: add active deadline seconds on provision/deprovision jobs

### DIFF
--- a/apis/hive/v1/clusterdeprovision_types.go
+++ b/apis/hive/v1/clusterdeprovision_types.go
@@ -155,6 +155,9 @@ type ClusterDeprovisionConditionType string
 const (
 	// AuthenticationFailureClusterDeprovisionCondition is true when credentials cannot be used because of authentication failure
 	AuthenticationFailureClusterDeprovisionCondition ClusterDeprovisionConditionType = "AuthenticationFailure"
+
+	// DeprovisionFailedClusterDeprovisionCondition is true when deprovision attempt failed
+	DeprovisionFailedClusterDeprovisionCondition ClusterDeprovisionConditionType = "DeprovisionFailed"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/go.sum
+++ b/go.sum
@@ -1925,7 +1925,6 @@ go.uber.org/zap v0.0.0-20180814183419-67bc79d13d15/go.mod h1:vwi/ZaCAaUcBkycHslx
 go.uber.org/zap v1.8.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
-go.uber.org/zap v1.14.1 h1:nYDKopTbvAPq/NrUVZwT15y2lpROBiLLyoRTbXOYWOo=
 go.uber.org/zap v1.14.1/go.mod h1:Mb2vm2krFEG5DV0W9qcHBYFtp/Wku1cvYaqPsS/WYfc=
 go.uber.org/zap v1.15.0 h1:ZZCA22JRF2gQE5FoNmhmrf7jeJJ2uhqDUNRYKm8dvmM=
 go.uber.org/zap v1.15.0/go.mod h1:Mb2vm2krFEG5DV0W9qcHBYFtp/Wku1cvYaqPsS/WYfc=

--- a/pkg/controller/clusterprovision/clusterprovision_controller.go
+++ b/pkg/controller/clusterprovision/clusterprovision_controller.go
@@ -383,6 +383,9 @@ func (r *ReconcileClusterProvision) reconcileSuccessfulJob(instance *hivev1.Clus
 func (r *ReconcileClusterProvision) reconcileFailedJob(instance *hivev1.ClusterProvision, job *batchv1.Job, pLog log.FieldLogger) (reconcile.Result, error) {
 	pLog.Info("install job failed")
 	reason, message := r.parseInstallLog(instance.Spec.InstallLog, pLog)
+	if controllerutils.IsDeadlineExceeded(job) && reason == unknownReason {
+		reason, message = "AttemptDeadlineExceeded", "Install job failed due to deadline being exceeded for the attempt"
+	}
 	result, err := r.transitionStage(instance, hivev1.ClusterProvisionStageFailed, reason, message, pLog)
 	if err == nil {
 		// Increment a counter metric for this cluster type and error reason:

--- a/pkg/controller/clusterprovision/installlogmonitor.go
+++ b/pkg/controller/clusterprovision/installlogmonitor.go
@@ -96,5 +96,5 @@ func (r *ReconcileClusterProvision) parseInstallLog(log *string, pLog log.FieldL
 		}
 	}
 
-	return unknownReason, unknownMessage
+	return unknownReason, *log
 }

--- a/pkg/controller/utils/jobs.go
+++ b/pkg/controller/utils/jobs.go
@@ -29,6 +29,19 @@ func IsFailed(job *batchv1.Job) bool {
 	return getJobConditionStatus(job, batchv1.JobFailed) == corev1.ConditionTrue
 }
 
+// IsDeadlineExceeded returns true if the job failed due to deadline being exceeded
+func IsDeadlineExceeded(job *batchv1.Job) bool {
+	if !IsFailed(job) {
+		return false
+	}
+	for _, condition := range job.Status.Conditions {
+		if condition.Type == batchv1.JobFailed {
+			return condition.Reason == "DeadlineExceeded"
+		}
+	}
+	return false
+}
+
 // IsFinished returns true if the job completed (succeeded or failed)
 func IsFinished(job *batchv1.Job) bool {
 	return IsSuccessful(job) || IsFailed(job)

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeprovision_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeprovision_types.go
@@ -155,6 +155,9 @@ type ClusterDeprovisionConditionType string
 const (
 	// AuthenticationFailureClusterDeprovisionCondition is true when credentials cannot be used because of authentication failure
 	AuthenticationFailureClusterDeprovisionCondition ClusterDeprovisionConditionType = "AuthenticationFailure"
+
+	// DeprovisionFailedClusterDeprovisionCondition is true when deprovision attempt failed
+	DeprovisionFailedClusterDeprovisionCondition ClusterDeprovisionConditionType = "DeprovisionFailed"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Setting an active deadline seconds for the job limits the time an attempt
can continue to run. This is useful when install/cleanup is stuck for
really long and cannot make progress.

In cases when no progress can be be made it is useful to give up the
attempt as failure and report the failure so that we can reattempt. This
also also reattempt limits to be useful.

/assign @dgoodwin 
/cc @joelddiaz 
