### PR TITLE
Skip uninstalled clusters in clustersync controller.

### DIFF
--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -375,11 +375,15 @@ func (r *ReconcileClusterSync) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, nil
 	}
 
+	if !cd.Spec.Installed {
+		logger.Debug("cluster is not yet installed")
+		return reconcile.Result{}, nil
+	}
+
 	if unreachable, _ := remoteclient.Unreachable(cd); unreachable {
 		logger.Debug("cluster is unreachable")
 		return reconcile.Result{}, nil
 	}
-
 	restConfig, err := r.remoteClusterAPIClientBuilder(cd).RESTConfig()
 	if err != nil {
 		logger.WithError(err).Error("unable to get REST config")

--- a/pkg/controller/clustersync/clustersync_controller_test.go
+++ b/pkg/controller/clustersync/clustersync_controller_test.go
@@ -289,6 +289,18 @@ func TestReconcileClusterSync_NoWorkToDo(t *testing.T) {
 			),
 		},
 		{
+			name: "uninstalled and unreachable unknown",
+			cd: testcd.FullBuilder(testNamespace, testCDName, scheme).
+				GenericOptions(
+					testgeneric.WithUID(testCDUID),
+				).
+				Options(
+					testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+						Type:   hivev1.UnreachableCondition,
+						Status: corev1.ConditionUnknown,
+					})).Build(),
+		},
+		{
 			name: "syncset pause",
 			cd:   cdBuilder(scheme).GenericOptions(testgeneric.WithAnnotation(constants.SyncsetPauseAnnotation, "true")).Build(),
 		},


### PR DESCRIPTION
This was happening previously for most clusters due to an assumption
that if no Unreachable condition exists, then the cluster must not be
installed yet. However an integrating application stumbled into a crash
where they were misusing the Unreachable condition, with status Unknown,
and our code interpreted this as must be installed (it wasn't), and
reachable, leading to the crash as no cluster metadata is defined.

The misused of Unknown condition will be fixed on their end, but we
should have an explicit installed check regardless.

/assign @abutcher 