### PR TITLE
Check for no applyMode set (defaults to Upsert) when clearing resourcesToDelete

### DIFF
--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -568,10 +568,12 @@ func (r *ReconcileClusterSync) applySyncSets(
 			ObservedGeneration: syncSet.AsMetaObject().GetGeneration(),
 			Result:             hiveintv1alpha1.SuccessSyncSetResult,
 		}
-		if syncSet.GetSpec().ResourceApplyMode == hivev1.SyncResourceApplyMode {
+		applyMode := syncSet.GetSpec().ResourceApplyMode
+		if applyMode == hivev1.SyncResourceApplyMode {
 			newSyncStatus.ResourcesToDelete = resourcesApplied
 		}
-		if syncSet.GetSpec().ResourceApplyMode == hivev1.UpsertResourceApplyMode && len(oldSyncStatus.ResourcesToDelete) > 0 {
+		// applyMode defaults to UpsertResourceApplyMode
+		if (applyMode == hivev1.UpsertResourceApplyMode || applyMode == "") && len(oldSyncStatus.ResourcesToDelete) > 0 {
 			logger.Infof("resource apply mode is %v but there are resources to delete in clustersync status", hivev1.UpsertResourceApplyMode)
 			oldSyncStatus.ResourcesToDelete = nil
 		}

--- a/pkg/controller/clustersync/clustersync_controller_test.go
+++ b/pkg/controller/clustersync/clustersync_controller_test.go
@@ -885,16 +885,19 @@ func TestReconcileClusterSync_ResourceRemovedFromSyncSet(t *testing.T) {
 		name                     string
 		includeResourcesToDelete bool
 		expectDelete             bool
+		resourceApplyMode        hivev1.SyncSetResourceApplyMode
 	}{
 		{
 			name:                     "upsert",
 			includeResourcesToDelete: false,
 			expectDelete:             false,
+			resourceApplyMode:        hivev1.UpsertResourceApplyMode,
 		},
 		{
 			name:                     "sync",
 			includeResourcesToDelete: true,
 			expectDelete:             true,
+			resourceApplyMode:        hivev1.SyncResourceApplyMode,
 		},
 	}
 	for _, tc := range cases {
@@ -907,6 +910,7 @@ func TestReconcileClusterSync_ResourceRemovedFromSyncSet(t *testing.T) {
 				testsyncset.ForClusterDeployments(testCDName),
 				testsyncset.WithGeneration(2),
 				testsyncset.WithResources(resourceToApply),
+				testsyncset.WithApplyMode(tc.resourceApplyMode),
 			)
 			existingSyncStatusBuilder := newSyncStatusBuilder("test-syncset").Options(
 				withTransitionInThePast(),
@@ -1728,6 +1732,7 @@ func TestReconcileClusterSync_DeleteErrorDoesNotBlockOtherDeletes(t *testing.T) 
 					testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
 						testsyncset.ForClusterDeployments(testCDName),
 						testsyncset.WithGeneration(2),
+						testsyncset.WithApplyMode(hivev1.SyncResourceApplyMode),
 					),
 				)
 			}


### PR DESCRIPTION
When `SyncSet` `resourceApplyMode` is changed from `Sync` to `Upsert`, we remove the `resourcesToDelete` from `ClusterSync` status. Since `resourceApplyMode` defaults to `Upsert` we should check for no `resourceApplyMode` when clearing the `resourcesToDelete`.

/assign @dgoodwin 