### PR TITLE
Transfer proxy env vars from hive-operator pod to all hive/provision …

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -781,6 +781,9 @@ func (r *ReconcileClusterDeployment) startNewProvision(
 		provisionName,
 		releaseImage,
 		controllerutils.InstallServiceAccountName,
+		os.Getenv("HTTP_PROXY"),
+		os.Getenv("HTTPS_PROXY"),
+		os.Getenv("NO_PROXY"),
 		extraEnvVars,
 	)
 	if err != nil {
@@ -1212,7 +1215,10 @@ func (r *ReconcileClusterDeployment) resolveInstallerImage(cd *hivev1.ClusterDep
 			return nil, r.setInstallImagesNotResolvedCondition(cd, corev1.ConditionFalse, imagesResolvedReason, imagesResolvedMsg, cdLog)
 		}
 
-		job := imageset.GenerateImageSetJob(cd, releaseImage, controllerutils.InstallServiceAccountName)
+		job := imageset.GenerateImageSetJob(cd, releaseImage, controllerutils.InstallServiceAccountName,
+			os.Getenv("HTTP_PROXY"),
+			os.Getenv("HTTPS_PROXY"),
+			os.Getenv("NO_PROXY"))
 
 		cdLog.WithField("derivedObject", job.Name).Debug("Setting labels on derived object")
 		job.Labels = k8slabels.AddLabel(job.Labels, constants.ClusterDeploymentNameLabel, cd.Name)

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
@@ -289,7 +289,12 @@ func (r *ReconcileClusterDeprovision) Reconcile(ctx context.Context, request rec
 
 	// Generate an uninstall job
 	rLog.Debug("generating uninstall job")
-	uninstallJob, err := install.GenerateUninstallerJobForDeprovision(instance, controllerutils.UninstallServiceAccountName, extraEnvVars)
+	uninstallJob, err := install.GenerateUninstallerJobForDeprovision(instance,
+		controllerutils.UninstallServiceAccountName,
+		os.Getenv("HTTP_PROXY"),
+		os.Getenv("HTTPS_PROXY"),
+		os.Getenv("NO_PROXY"),
+		extraEnvVars)
 	if err != nil {
 		rLog.Errorf("error generating uninstaller job: %v", err)
 		return reconcile.Result{}, err

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller_test.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller_test.go
@@ -322,7 +322,8 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 }
 
 func testUninstallJob() *batchv1.Job {
-	uninstallJob, _ := install.GenerateUninstallerJobForDeprovision(testClusterDeprovision(), "someserviceaccount", nil)
+	uninstallJob, _ := install.GenerateUninstallerJobForDeprovision(testClusterDeprovision(),
+		"someserviceaccount", "", "", "", nil)
 	hash, err := controllerutils.CalculateJobSpecHash(uninstallJob)
 	if err != nil {
 		panic("should never get error calculating job spec hash")

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -351,16 +351,39 @@ func BuildControllerLogger(controller hivev1.ControllerName, resource string, ns
 	})
 }
 
-// CopyProxyEnvVars will add the standard proxy environment variables to all containers in the given pod spec,
-// if they are currently set for this controller process. Used to pass vars set by OLM for
-// hive-operator on to hive-controllers, clustersync, hiveadmission, and provision/deprovision pods.
-func CopyProxyEnvVars(podSpec *corev1.PodSpec) {
-	for _, envVar := range [3]string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"} {
-		if os.Getenv(envVar) != "" {
-			log.WithField("key", envVar).WithField("value", os.Getenv(envVar)).Warn("transferring env var to podspec")
-			for i := range podSpec.Containers {
-				podSpec.Containers[i].Env = append(podSpec.Containers[i].Env, corev1.EnvVar{Name: envVar, Value: os.Getenv(envVar)})
+// SetProxyEnvVars will add the standard proxy environment variables to all containers in the given pod spec. If
+// any of the provided values are empty, the environment variable will not be set.
+func SetProxyEnvVars(podSpec *corev1.PodSpec, httpProxy, httpsProxy, noProxy string) {
+	setEnvVarOnContainers := func(podSpec *corev1.PodSpec, envVar, value string) {
+		if value == "" {
+			return
+		}
+		for i := range podSpec.Containers {
+			// Check if the env var is already set, if so we preserve the original but warn if they differ:
+			found := false
+			for j := range podSpec.Containers[i].Env {
+				if podSpec.Containers[i].Env[j].Name == envVar {
+					found = true
+					if podSpec.Containers[i].Env[j].Value != value {
+						log.Warnf("container %s already has env var %s=%s, overwriting with %s", podSpec.Containers[i].Name, envVar, podSpec.Containers[i].Env[j].Value, value)
+						podSpec.Containers[i].Env[j].Value = value
+					}
+				}
+			}
+			if !found {
+				log.WithField(envVar, value).Info("transferring env var to PodSpec")
+				podSpec.Containers[i].Env = append(podSpec.Containers[i].Env, corev1.EnvVar{Name: envVar, Value: value})
 			}
 		}
+	}
+
+	if httpProxy != "" {
+		setEnvVarOnContainers(podSpec, "HTTP_PROXY", httpProxy)
+	}
+	if httpsProxy != "" {
+		setEnvVarOnContainers(podSpec, "HTTPS_PROXY", httpsProxy)
+	}
+	if noProxy != "" {
+		setEnvVarOnContainers(podSpec, "NO_PROXY", noProxy)
 	}
 }

--- a/pkg/imageset/generate.go
+++ b/pkg/imageset/generate.go
@@ -24,7 +24,7 @@ const (
 
 // GenerateImageSetJob creates a job to determine the installer image for a ClusterImageSet
 // given a release image
-func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAccountName string) *batchv1.Job {
+func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAccountName, httpProxy, httpsProxy, noProxy string) *batchv1.Job {
 	logger := log.WithFields(log.Fields{
 		"clusterdeployment": types.NamespacedName{Namespace: cd.Namespace, Name: cd.Name}.String(),
 	})
@@ -101,7 +101,7 @@ func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAcco
 			labels[hivev1.HiveClusterTypeLabel] = typeStr
 		}
 	}
-	controllerutils.CopyProxyEnvVars(&podSpec)
+	controllerutils.SetProxyEnvVars(&podSpec, httpProxy, httpsProxy, noProxy)
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/imageset/generate.go
+++ b/pkg/imageset/generate.go
@@ -3,6 +3,7 @@ package imageset
 import (
 	"time"
 
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	log "github.com/sirupsen/logrus"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -100,6 +101,7 @@ func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAcco
 			labels[hivev1.HiveClusterTypeLabel] = typeStr
 		}
 	}
+	controllerutils.CopyProxyEnvVars(&podSpec)
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/imageset/generate_test.go
+++ b/pkg/imageset/generate_test.go
@@ -3,14 +3,24 @@ package imageset
 import (
 	"testing"
 
+	hiveassert "github.com/openshift/hive/pkg/test/assert"
 	batchv1 "k8s.io/api/batch/v1"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 )
 
+const (
+	testHttpProxy  = "localhost:3112"
+	testHttpsProxy = "localhost:4432"
+	testNoProxy    = "example.com,foo.com,bar.org"
+)
+
 func TestGenerateImageSetJob(t *testing.T) {
-	job := GenerateImageSetJob(testClusterDeployment(), testImageSet().Spec.ReleaseImage, "test-service-account")
+	job := GenerateImageSetJob(testClusterDeployment(), testImageSet().Spec.ReleaseImage, "test-service-account", testHttpProxy, testHttpsProxy, testNoProxy)
 	validateJob(t, job)
+	hiveassert.AssertAllContainersHaveEnvVar(t, &job.Spec.Template.Spec, "HTTP_PROXY", testHttpProxy)
+	hiveassert.AssertAllContainersHaveEnvVar(t, &job.Spec.Template.Spec, "HTTPS_PROXY", testHttpsProxy)
+	hiveassert.AssertAllContainersHaveEnvVar(t, &job.Spec.Template.Spec, "NO_PROXY", testNoProxy)
 }
 
 func testClusterDeployment() *hivev1.ClusterDeployment {

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -132,9 +132,10 @@ credential_process = %s
 // InstallerPodSpec generates a spec for an installer pod.
 func InstallerPodSpec(
 	cd *hivev1.ClusterDeployment,
-	provisionName string,
-	releaseImage string,
-	serviceAccountName string,
+	provisionName,
+	releaseImage,
+	serviceAccountName,
+	httpProxy, httpsProxy, noProxy string,
 	extraEnvVars []corev1.EnvVar,
 ) (*corev1.PodSpec, error) {
 
@@ -549,7 +550,7 @@ func InstallerPodSpec(
 		ServiceAccountName: serviceAccountName,
 		ImagePullSecrets:   []corev1.LocalObjectReference{{Name: constants.GetMergedPullSecretName(cd)}},
 	}
-	controllerutils.CopyProxyEnvVars(podSpec)
+	controllerutils.SetProxyEnvVars(podSpec, httpProxy, httpsProxy, noProxy)
 	return podSpec, nil
 }
 
@@ -604,7 +605,7 @@ func GetUninstallJobName(name string) string {
 // GenerateUninstallerJobForDeprovision generates an uninstaller job for a given deprovision request
 func GenerateUninstallerJobForDeprovision(
 	req *hivev1.ClusterDeprovision,
-	serviceAccountName string,
+	serviceAccountName, httpProxy, httpsProxy, noProxy string,
 	extraEnvVars []corev1.EnvVar) (*batchv1.Job, error) {
 
 	restartPolicy := corev1.RestartPolicyOnFailure
@@ -658,7 +659,7 @@ func GenerateUninstallerJobForDeprovision(
 	for idx := range job.Spec.Template.Spec.Containers {
 		job.Spec.Template.Spec.Containers[idx].Env = append(job.Spec.Template.Spec.Containers[idx].Env, extraEnvVars...)
 	}
-	controllerutils.CopyProxyEnvVars(&job.Spec.Template.Spec)
+	controllerutils.SetProxyEnvVars(&job.Spec.Template.Spec, httpProxy, httpsProxy, noProxy)
 
 	return job, nil
 }

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -541,14 +541,16 @@ func InstallerPodSpec(
 		},
 	}
 
-	return &corev1.PodSpec{
+	podSpec := &corev1.PodSpec{
 		DNSPolicy:          corev1.DNSClusterFirst,
 		RestartPolicy:      corev1.RestartPolicyNever,
 		Containers:         containers,
 		Volumes:            volumes,
 		ServiceAccountName: serviceAccountName,
 		ImagePullSecrets:   []corev1.LocalObjectReference{{Name: constants.GetMergedPullSecretName(cd)}},
-	}, nil
+	}
+	controllerutils.CopyProxyEnvVars(podSpec)
+	return podSpec, nil
 }
 
 // GenerateInstallerJob creates a job to install an OpenShift cluster
@@ -656,6 +658,7 @@ func GenerateUninstallerJobForDeprovision(
 	for idx := range job.Spec.Template.Spec.Containers {
 		job.Spec.Template.Spec.Containers[idx].Env = append(job.Spec.Template.Spec.Containers[idx].Env, extraEnvVars...)
 	}
+	controllerutils.CopyProxyEnvVars(&job.Spec.Template.Spec)
 
 	return job, nil
 }

--- a/pkg/operator/hive/clustersync.go
+++ b/pkg/operator/hive/clustersync.go
@@ -2,6 +2,7 @@ package hive
 
 import (
 	"context"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 
@@ -111,7 +112,8 @@ func (r *ReconcileHiveConfig) deployClusterSync(hLog log.FieldLogger, h resource
 	}
 	newClusterSyncStatefulSet.Annotations[hiveClusterSyncStatefulSetSpecHashAnnotation] = newClusterSyncStatefulSetSpecHash
 
-	controllerutils.CopyProxyEnvVars(&newClusterSyncStatefulSet.Spec.Template.Spec)
+	controllerutils.SetProxyEnvVars(&newClusterSyncStatefulSet.Spec.Template.Spec,
+		os.Getenv("HTTP_PROXY"), os.Getenv("HTTPS_PROXY"), os.Getenv("NO_PROXY"))
 
 	existingClusterSyncStatefulSet := &appsv1.StatefulSet{}
 	existingClusterSyncStatefulSetNamespacedName := apitypes.NamespacedName{Name: newClusterSyncStatefulSet.Name, Namespace: newClusterSyncStatefulSet.Namespace}

--- a/pkg/operator/hive/clustersync.go
+++ b/pkg/operator/hive/clustersync.go
@@ -111,6 +111,8 @@ func (r *ReconcileHiveConfig) deployClusterSync(hLog log.FieldLogger, h resource
 	}
 	newClusterSyncStatefulSet.Annotations[hiveClusterSyncStatefulSetSpecHashAnnotation] = newClusterSyncStatefulSetSpecHash
 
+	controllerutils.CopyProxyEnvVars(&newClusterSyncStatefulSet.Spec.Template.Spec)
+
 	existingClusterSyncStatefulSet := &appsv1.StatefulSet{}
 	existingClusterSyncStatefulSetNamespacedName := apitypes.NamespacedName{Name: newClusterSyncStatefulSet.Name, Namespace: newClusterSyncStatefulSet.Namespace}
 	err = r.Get(context.TODO(), existingClusterSyncStatefulSetNamespacedName, existingClusterSyncStatefulSet)

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift/hive/pkg/constants"
 	hiveconstants "github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/controller/images"
+	"github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/operator/assets"
 	"github.com/openshift/hive/pkg/operator/util"
 	"github.com/openshift/hive/pkg/resource"
@@ -209,6 +210,8 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 	}
 	hiveDeployment.Spec.Template.Annotations[hiveConfigHashAnnotation] = hiveControllersConfigHash
 	hiveDeployment.Spec.Template.Annotations[hiveConfigHashAnnotation] = hiveControllersConfigHash
+
+	utils.CopyProxyEnvVars(&hiveDeployment.Spec.Template.Spec)
 
 	// Load namespaced assets, decode them, set to our target namespace, and apply:
 	namespacedAssets := []string{

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -211,7 +211,8 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 	hiveDeployment.Spec.Template.Annotations[hiveConfigHashAnnotation] = hiveControllersConfigHash
 	hiveDeployment.Spec.Template.Annotations[hiveConfigHashAnnotation] = hiveControllersConfigHash
 
-	utils.CopyProxyEnvVars(&hiveDeployment.Spec.Template.Spec)
+	utils.SetProxyEnvVars(&hiveDeployment.Spec.Template.Spec,
+		os.Getenv("HTTP_PROXY"), os.Getenv("HTTPS_PROXY"), os.Getenv("NO_PROXY"))
 
 	// Load namespaced assets, decode them, set to our target namespace, and apply:
 	namespacedAssets := []string{

--- a/pkg/operator/hive/hive_controller.go
+++ b/pkg/operator/hive/hive_controller.go
@@ -69,7 +69,12 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileHiveConfig{Client: mgr.GetClient(), scheme: mgr.GetScheme(), restConfig: mgr.GetConfig(), mgr: mgr}
+	return &ReconcileHiveConfig{
+		Client:     mgr.GetClient(),
+		scheme:     mgr.GetScheme(),
+		restConfig: mgr.GetConfig(),
+		mgr:        mgr,
+	}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -116,7 +117,8 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h resour
 		hasher.Write([]byte(v))
 	}
 	hiveAdmDeployment.Spec.Template.ObjectMeta.Annotations[inputHashAnnotation] = hex.EncodeToString(hasher.Sum(nil))
-	controllerutils.CopyProxyEnvVars(&hiveAdmDeployment.Spec.Template.Spec)
+	controllerutils.SetProxyEnvVars(&hiveAdmDeployment.Spec.Template.Spec,
+		os.Getenv("HTTP_PROXY"), os.Getenv("HTTPS_PROXY"), os.Getenv("NO_PROXY"))
 
 	addManagedDomainsVolume(&hiveAdmDeployment.Spec.Template.Spec, mdConfigMap.Name)
 	addAWSPrivateLinkConfigVolume(&hiveAdmDeployment.Spec.Template.Spec)

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -116,6 +116,7 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h resour
 		hasher.Write([]byte(v))
 	}
 	hiveAdmDeployment.Spec.Template.ObjectMeta.Annotations[inputHashAnnotation] = hex.EncodeToString(hasher.Sum(nil))
+	controllerutils.CopyProxyEnvVars(&hiveAdmDeployment.Spec.Template.Spec)
 
 	addManagedDomainsVolume(&hiveAdmDeployment.Spec.Template.Spec, mdConfigMap.Name)
 	addAWSPrivateLinkConfigVolume(&hiveAdmDeployment.Spec.Template.Spec)

--- a/pkg/test/assert/assertions.go
+++ b/pkg/test/assert/assertions.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	testifyassert "github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // BetweenTimes asserts that the time is within the time window, inclusive of the start and end times.
@@ -19,4 +21,19 @@ func BetweenTimes(t *testing.T, actual, startTime, endTime time.Time, msgAndArgs
 		return testifyassert.Fail(t, fmt.Sprintf("Actual time %v is after end time %v", actual, endTime), msgAndArgs...)
 	}
 	return true
+}
+
+func AssertAllContainersHaveEnvVar(t *testing.T, podSpec *corev1.PodSpec, key, value string) {
+	for _, c := range podSpec.Containers {
+		found := false
+		foundCtr := 0
+		for _, ev := range c.Env {
+			if ev.Name == key {
+				foundCtr++
+				found = ev.Value == value
+			}
+		}
+		testifyassert.True(t, found, "env var %s=%s not found on container %s", key, value, c.Name)
+		testifyassert.Equal(t, 1, foundCtr, "found %d occurrences of env var %s on container %s", foundCtr, key, c.Name)
+	}
 }


### PR DESCRIPTION
…pods.

These env vars should be set by OLM if a cluster is configured with a
global proxy. This change ensures they are passed through to all pods
the operator creates, and all pods hive-controllers creates.

x-ref: https://issues.redhat.com/browse/HIVE-1355

/assign @abhinavdahiya 
/cc @abutcher 