### PR TITLE
Allow updates to ClusterImageSet.Spec

### DIFF
--- a/pkg/validating-webhooks/hive/v1/clusterimageset_validating_admission_hook.go
+++ b/pkg/validating-webhooks/hive/v1/clusterimageset_validating_admission_hook.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"net/http"
-	"reflect"
 
 	log "github.com/sirupsen/logrus"
 
@@ -211,19 +210,6 @@ func (a *ClusterImageSetValidatingAdmissionHook) validateUpdate(admissionSpec *a
 
 	// Add the new data to the contextLogger
 	contextLogger.Data["oldObject.Name"] = oldObject.Name
-
-	if !reflect.DeepEqual(oldObject.Spec, newObject.Spec) {
-		message := "ClusterImageSet.Spec is immutable"
-		contextLogger.Infof("Failed validation: %v", message)
-
-		return &admissionv1beta1.AdmissionResponse{
-			Allowed: false,
-			Result: &metav1.Status{
-				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
-				Message: message,
-			},
-		}
-	}
 
 	// If we get here, then all checks passed, so the object is valid.
 	contextLogger.Info("Successful validation")

--- a/pkg/validating-webhooks/hive/v1/clusterimageset_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/clusterimageset_validating_admission_hook_test.go
@@ -85,7 +85,7 @@ func TestClusterImageSetValidate(t *testing.T) {
 			expectedAllowed: false,
 		},
 		{
-			name: "Test ClusterImageSet.Spec is immutable (updates not allowed)",
+			name: "Test ClusterImageSet.Spec is mutable (updates allowed)",
 			newSpec: hivev1.ClusterImageSetSpec{
 				ReleaseImage: "a:tag",
 			},
@@ -93,7 +93,7 @@ func TestClusterImageSetValidate(t *testing.T) {
 				ReleaseImage: "b:tag",
 			},
 			operation:       admissionv1beta1.Update,
-			expectedAllowed: false,
+			expectedAllowed: true,
 		},
 		{
 			name:            "Test that we don't validate deletes",


### PR DESCRIPTION
Per a conversation with @dgoodwin, this PR removes the immutability check from the `ClusterImageSet` webhook. This permits the `Spec` of CIS objects to be updated, such as the case where the image you wish to use has changed location (different registry, or changing from tag to digest references).

There was some consideration around the fact that this may cause some confusion around which release image was used to generate a particular `ClusterDeployment`, however the CD status contains at least the installer and cli image digests that are retrieved from inside the release bundle image so this may not be strictly necessary.