### PR TITLE
awsprivatelink: fix shouldSync for Ready leveled and installing clusters

### DIFF
--- a/pkg/controller/awsprivatelink/awsprivatelink_controller.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller.go
@@ -303,7 +303,14 @@ func shouldSync(desired *hivev1.ClusterDeployment) (shouldSync bool, delta time.
 		delta = time.Now().Sub(readyCondition.LastTransitionTime.Time)
 	}
 
-	if delta >= 2*time.Hour {
+	limit := 2 * time.Hour
+	if !desired.Spec.Installed {
+		// as cluster is installing, but the private link has been setup once, we wait
+		// for a shorter duration before reconciling again.
+		limit = 10 * time.Minute
+	}
+
+	if delta >= limit {
 		// We haven't sync'd in over resync duration time, sync now.
 		return true, delta
 	}

--- a/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
@@ -1743,9 +1743,23 @@ func Test_shouldSync(t *testing.T) {
 		shouldSync:           true,
 		deltaGreaterThanZero: true,
 	}, {
-		name: "ready for less than 2 hours",
+		name: "ready for less than 2 hours, installing",
 
 		desired: cdBuilder.Build(
+			testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:               hivev1.AWSPrivateLinkReadyClusterDeploymentCondition,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.Time{Time: time.Now().Add(-1 * time.Hour)},
+			}),
+		),
+
+		shouldSync:           true,
+		deltaGreaterThanZero: true,
+	}, {
+		name: "ready for less than 2 hours, installed",
+
+		desired: cdBuilder.Build(
+			testcd.Installed(),
 			testcd.WithCondition(hivev1.ClusterDeploymentCondition{
 				Type:               hivev1.AWSPrivateLinkReadyClusterDeploymentCondition,
 				Status:             corev1.ConditionTrue,

--- a/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
@@ -284,7 +284,7 @@ func Test_setProgressCondition(t *testing.T) {
 			Reason:  "AllLookingGood",
 			Message: "All looking good",
 		}},
-		completed: corev1.ConditionTrue,
+		completed: corev1.ConditionFalse,
 		message:   "progresing towards stage 1",
 		reason:    "InprogesStage1",
 
@@ -292,6 +292,25 @@ func Test_setProgressCondition(t *testing.T) {
 			Status:  corev1.ConditionTrue,
 			Type:    hivev1.AWSPrivateLinkReadyClusterDeploymentCondition,
 			Reason:  "AllLookingGood",
+			Message: "All looking good",
+		}},
+	}, {
+		name: "previous ready, now ready with different reason",
+
+		conditions: []hivev1.ClusterDeploymentCondition{{
+			Status:  corev1.ConditionTrue,
+			Type:    hivev1.AWSPrivateLinkReadyClusterDeploymentCondition,
+			Reason:  "AllLookingGood",
+			Message: "All looking good",
+		}},
+		completed: corev1.ConditionTrue,
+		message:   "All looking good",
+		reason:    "AllLookingGoodVersion2",
+
+		expectedConditions: []hivev1.ClusterDeploymentCondition{{
+			Status:  corev1.ConditionTrue,
+			Type:    hivev1.AWSPrivateLinkReadyClusterDeploymentCondition,
+			Reason:  "AllLookingGoodVersion2",
 			Message: "All looking good",
 		}},
 	}}
@@ -1680,24 +1699,21 @@ func Test_shouldSync(t *testing.T) {
 
 		desired    *hivev1.ClusterDeployment
 		shouldSync bool
-
-		deltaGreaterThanZero bool // required fake time to match exact value.
+		syncAfter  time.Duration
 	}{{
 		name: "deleted and no finalizer",
 
 		desired: cdBuilder.GenericOptions(generic.Deleted()).
 			Build(),
 
-		shouldSync:           false,
-		deltaGreaterThanZero: false,
+		shouldSync: false,
 	}, {
 		name: "deleted and finalizer",
 
 		desired: cdBuilder.GenericOptions(generic.Deleted(), generic.WithFinalizer(finalizer)).
 			Build(),
 
-		shouldSync:           true,
-		deltaGreaterThanZero: false,
+		shouldSync: true,
 	}, {
 		name: "failed condition",
 
@@ -1708,15 +1724,13 @@ func Test_shouldSync(t *testing.T) {
 			}),
 		),
 
-		shouldSync:           true,
-		deltaGreaterThanZero: false,
+		shouldSync: true,
 	}, {
 		name: "no ready condition",
 
 		desired: cdBuilder.Build(),
 
-		shouldSync:           true,
-		deltaGreaterThanZero: false,
+		shouldSync: true,
 	}, {
 		name: "ready condition false",
 
@@ -1727,54 +1741,51 @@ func Test_shouldSync(t *testing.T) {
 			}),
 		),
 
-		shouldSync:           true,
-		deltaGreaterThanZero: false,
+		shouldSync: true,
 	}, {
 		name: "ready for more than 2 hours",
 
 		desired: cdBuilder.Build(
 			testcd.WithCondition(hivev1.ClusterDeploymentCondition{
-				Type:               hivev1.AWSPrivateLinkReadyClusterDeploymentCondition,
-				Status:             corev1.ConditionTrue,
-				LastTransitionTime: metav1.Time{Time: time.Now().Add(-3 * time.Hour)},
+				Type:          hivev1.AWSPrivateLinkReadyClusterDeploymentCondition,
+				Status:        corev1.ConditionTrue,
+				LastProbeTime: metav1.Time{Time: time.Now().Add(-3 * time.Hour)},
 			}),
 		),
 
-		shouldSync:           true,
-		deltaGreaterThanZero: true,
+		shouldSync: true,
 	}, {
 		name: "ready for less than 2 hours, installing",
 
 		desired: cdBuilder.Build(
 			testcd.WithCondition(hivev1.ClusterDeploymentCondition{
-				Type:               hivev1.AWSPrivateLinkReadyClusterDeploymentCondition,
-				Status:             corev1.ConditionTrue,
-				LastTransitionTime: metav1.Time{Time: time.Now().Add(-1 * time.Hour)},
+				Type:          hivev1.AWSPrivateLinkReadyClusterDeploymentCondition,
+				Status:        corev1.ConditionTrue,
+				LastProbeTime: metav1.Time{Time: time.Now().Add(-1 * time.Hour)},
 			}),
 		),
 
-		shouldSync:           true,
-		deltaGreaterThanZero: true,
+		shouldSync: true,
 	}, {
 		name: "ready for less than 2 hours, installed",
 
 		desired: cdBuilder.Build(
 			testcd.Installed(),
 			testcd.WithCondition(hivev1.ClusterDeploymentCondition{
-				Type:               hivev1.AWSPrivateLinkReadyClusterDeploymentCondition,
-				Status:             corev1.ConditionTrue,
-				LastTransitionTime: metav1.Time{Time: time.Now().Add(-1 * time.Hour)},
+				Type:          hivev1.AWSPrivateLinkReadyClusterDeploymentCondition,
+				Status:        corev1.ConditionTrue,
+				LastProbeTime: metav1.Time{Time: time.Now().Add(-1 * time.Hour)},
 			}),
 		),
 
-		shouldSync:           false,
-		deltaGreaterThanZero: true,
+		shouldSync: false,
+		syncAfter:  1 * time.Hour,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, got1 := shouldSync(tt.desired)
 			assert.Equal(t, tt.shouldSync, got)
-			assert.Equal(t, tt.deltaGreaterThanZero, got1 > 0)
+			assert.Equal(t, tt.syncAfter, got1)
 		})
 	}
 }


### PR DESCRIPTION
There are cases where the cluster's private link will be ready, but the
installation attempt fails for reasons outside it. In this case we need
to reconcile the aws private link to cleanup the prev created resources
and allow for next attempt. since we have created the resources once, we
reconcile but quicker than when the cluster is installed.

setProgress(complete = true) updates already Ready condition with latest
probe time so that we can track the last Ready level time.

Now since we have the last Ready time, we update the shouldSync
function to use the Ready's last probe time to calculate the time passed
since last Ready sync.
should sync now returns when to syncAfter if it returns false. this
allows the caller to RequeueAfter with that duration.

/assign @dgoodwin 