### PR TITLE
Provision Underway Metric must report first condition with status=True

### DIFF
--- a/pkg/controller/metrics/provision_underway_collector.go
+++ b/pkg/controller/metrics/provision_underway_collector.go
@@ -208,11 +208,13 @@ func getKnownConditions(conditions []hivev1.ClusterDeploymentCondition) (conditi
 	for _, delayCondition := range provisioningDelayCondition {
 		if cdCondition := controllerutils.FindClusterDeploymentCondition(conditions,
 			delayCondition); cdCondition != nil {
-			if cdCondition.Status == corev1.ConditionTrue && cdCondition.Reason != "" {
+			if cdCondition.Status == corev1.ConditionTrue {
 				condition = string(delayCondition)
-				reason = cdCondition.Reason
+				if cdCondition.Reason != "" {
+					reason = cdCondition.Reason
+				}
+				break
 			}
-			break
 		}
 	}
 	return condition, reason

--- a/pkg/controller/metrics/provision_underway_collector_test.go
+++ b/pkg/controller/metrics/provision_underway_collector_test.go
@@ -422,6 +422,30 @@ func TestProvisioningUnderwayInstallRestartsCollector(t *testing.T) {
 			"cluster_deployment = cd-3 cluster_type = unspecified condition = DNSNotReady image_set = none namespace = cd-3 platform =  reason = FailedDueToQuotas 2",
 		},
 	}, {
+		name: "cluster deployment with multiple conditions",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.InstallRestarts(1),
+				testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.DNSNotReadyCondition,
+					Status: corev1.ConditionFalse,
+					Reason: "DNSReady",
+				}),
+				testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.ProvisionFailedCondition,
+					Status: corev1.ConditionTrue,
+					Reason: "FailedDueToQuotas",
+				}),
+				testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.ProvisionStoppedCondition,
+					Status: corev1.ConditionTrue,
+					Reason: "InstallRestartsReached",
+				})),
+		},
+		min: 1,
+		expected: []string{
+			"cluster_deployment = cd-1 cluster_type = unspecified condition = ProvisionFailed image_set = none namespace = cd-1 platform =  reason = FailedDueToQuotas 1",
+		},
+	}, {
 		name: "provisioning with no conditions and restarts less than min restarts",
 		existing: []runtime.Object{
 			cdBuilder("cd-1").Build(testcd.Installed()),


### PR DESCRIPTION
When Provision Underway metric collector fetches conditions and reasons
of clusterdeployment, it should continue fetching if first condition is
false, and report the first condition with status True

xref: https://issues.redhat.com/browse/HIVE-1475

/assign @dgoodwin 