### PR TITLE
include the installLog from failed provision in clusterdeployment condition

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -1038,11 +1038,13 @@ func (r *ReconcileClusterDeployment) reconcileProvisioningProvision(cd *hivev1.C
 func (r *ReconcileClusterDeployment) reconcileFailedProvision(cd *hivev1.ClusterDeployment, provision *hivev1.ClusterProvision, cdLog log.FieldLogger) (reconcile.Result, error) {
 	nextProvisionTime := time.Now()
 	reason := "MissingCondition"
+	message := fmt.Sprintf("Provision %s failed. Next provision will begin soon.", provision.Name)
 
 	failedCond := controllerutils.FindClusterProvisionCondition(provision.Status.Conditions, hivev1.ClusterProvisionFailedCondition)
 	if failedCond != nil && failedCond.Status == corev1.ConditionTrue {
 		nextProvisionTime = calculateNextProvisionTime(failedCond.LastTransitionTime.Time, cd.Status.InstallRestarts, cdLog)
 		reason = failedCond.Reason
+		message = fmt.Sprintf("Provision %s failed. Next provision at %s.\n\n%s", provision.Name, nextProvisionTime.UTC().Format(time.RFC3339), failedCond.Message)
 	} else {
 		cdLog.Warnf("failed provision does not have a %s condition", hivev1.ClusterProvisionFailedCondition)
 	}
@@ -1052,7 +1054,7 @@ func (r *ReconcileClusterDeployment) reconcileFailedProvision(cd *hivev1.Cluster
 		hivev1.ProvisionFailedCondition,
 		corev1.ConditionTrue,
 		reason,
-		fmt.Sprintf("Provision %s failed. Next provision at %s.", provision.Name, nextProvisionTime.UTC().Format(time.RFC3339)),
+		message,
 		controllerutils.UpdateConditionIfReasonOrMessageChange,
 	)
 	cd.Status.Conditions = newConditions

--- a/pkg/controller/clusterprovision/installlogmonitor.go
+++ b/pkg/controller/clusterprovision/installlogmonitor.go
@@ -96,5 +96,5 @@ func (r *ReconcileClusterProvision) parseInstallLog(log *string, pLog log.FieldL
 		}
 	}
 
-	return unknownReason, unknownMessage
+	return unknownReason, *log
 }

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -38,10 +38,11 @@ const (
 func TestParseInstallLog(t *testing.T) {
 	apis.AddToScheme(scheme.Scheme)
 	tests := []struct {
-		name           string
-		log            *string
-		existing       []runtime.Object
-		expectedReason string
+		name            string
+		log             *string
+		existing        []runtime.Object
+		expectedReason  string
+		expectedMessage *string
 	}{
 		{
 			name:           "DNS already exists",
@@ -257,7 +258,11 @@ func TestParseInstallLog(t *testing.T) {
 			}
 			reason, message := r.parseInstallLog(test.log, log.WithFields(log.Fields{}))
 			assert.Equal(t, test.expectedReason, reason, "unexpected reason")
-			assert.NotEmpty(t, message, "expected message to be not empty")
+			if test.expectedMessage != nil {
+				assert.Equal(t, *test.expectedMessage, message)
+			} else {
+				assert.NotEmpty(t, message, "expected message to be not empty")
+			}
 		})
 	}
 }


### PR DESCRIPTION
When the provision fails, we store a piece of the failure in
.spec.installLog for the clusterprovision. When we can't find any match
we known failures, we report the install log as-is as part of the failed
provision condition's message.

This message can now be added to the clusterdeployment, when it
reconciles a failed clusterprovision.

including the logs from failed attempt in the condition when the error
is unknown allows users and sre's to at glance look the failure. this
prevents users not understanding the failure.

/assign @dgoodwin 