### PR TITLE
Add option to fake out all the clusterdeployments in the clusterpool

### DIFF
--- a/apis/hive/v1/clusterpool_types.go
+++ b/apis/hive/v1/clusterpool_types.go
@@ -46,6 +46,11 @@ type ClusterPoolSpec struct {
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 
+	// Annotations to be applied to new ClusterDeployments created for the pool. ClusterDeployments that have already been
+	// claimed will not be affected when this value is modified.
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// InstallConfigSecretTemplateRef is a secret with the key install-config.yaml consisting of the content of the install-config.yaml
 	// to be used as a template for all clusters in this pool.
 	// Cluster specific settings (name, basedomain) will be injected dynamically when the ClusterDeployment install-config Secret is generated.

--- a/apis/hive/v1/zz_generated.deepcopy.go
+++ b/apis/hive/v1/zz_generated.deepcopy.go
@@ -1307,6 +1307,13 @@ func (in *ClusterPoolSpec) DeepCopyInto(out *ClusterPoolSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.InstallConfigSecretTemplateRef != nil {
 		in, out := &in.InstallConfigSecretTemplateRef, &out.InstallConfigSecretTemplateRef
 		*out = new(corev1.LocalObjectReference)

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -52,6 +52,13 @@ spec:
         spec:
           description: ClusterPoolSpec defines the desired state of the ClusterPool.
           properties:
+            annotations:
+              additionalProperties:
+                type: string
+              description: Annotations to be applied to new ClusterDeployments created
+                for the pool. ClusterDeployments that have already been claimed will
+                not be affected when this value is modified.
+              type: object
             baseDomain:
               description: BaseDomain is the base domain to use for all clusters created
                 in this pool.

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -548,6 +548,7 @@ func (r *ReconcileClusterPool) createCluster(
 		PullSecret:            pullSecret,
 		CloudBuilder:          cloudBuilder,
 		Labels:                clp.Spec.Labels,
+		Annotations:           clp.Spec.Annotations,
 		InstallConfigTemplate: installConfigTemplate,
 		SkipMachinePools:      clp.Spec.SkipMachinePools,
 	}

--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -159,6 +159,10 @@ func (r *hibernationReconciler) Reconcile(ctx context.Context, request reconcile
 	if !cd.Spec.Installed {
 		return reconcile.Result{}, nil
 	}
+	// If cluster is fake, skip any processing
+	if controllerutils.IsFakeCluster(cd) {
+		return reconcile.Result{}, nil
+	}
 
 	shouldHibernate := cd.Spec.PowerState == hivev1.HibernatingClusterPowerState
 	hibernatingCondition := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ClusterHibernatingCondition)

--- a/pkg/controller/hibernation/hibernation_controller_test.go
+++ b/pkg/controller/hibernation/hibernation_controller_test.go
@@ -26,6 +26,7 @@ import (
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	hiveintv1alpha1 "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
+	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/controller/hibernation/mock"
 	"github.com/openshift/hive/pkg/remoteclient"
 	remoteclientmock "github.com/openshift/hive/pkg/remoteclient/mock"
@@ -528,6 +529,15 @@ func TestHibernateAfter(t *testing.T) {
 				testcs.WithFirstSuccessTime(time.Now()),
 			).Build(),
 			expectedPowerState: hivev1.HibernatingClusterPowerState,
+		},
+		{
+			name: "skip hibernation for fake cluster",
+			cd: cdBuilder.Build(
+				testcd.WithHibernateAfter(1*time.Hour),
+				testcd.InstalledTimestamp(time.Now().Add(-1*time.Hour)),
+				testcd.WithAnnotation(constants.HiveFakeClusterAnnotation, "true")),
+			cs:                 csBuilder.Build(),
+			expectedPowerState: "",
 		},
 	}
 

--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -91,6 +91,11 @@ func WithLabel(key, value string) Option {
 	return Generic(generic.WithLabel(key, value))
 }
 
+// WithAnnotation sets the specified annotation on the supplied object.
+func WithAnnotation(key, value string) Option {
+	return Generic(generic.WithAnnotation(key, value))
+}
+
 // WithCondition adds the specified condition to the ClusterDeployment
 func WithCondition(cond hivev1.ClusterDeploymentCondition) Option {
 	return func(clusterDeployment *hivev1.ClusterDeployment) {

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
@@ -46,6 +46,11 @@ type ClusterPoolSpec struct {
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 
+	// Annotations to be applied to new ClusterDeployments created for the pool. ClusterDeployments that have already been
+	// claimed will not be affected when this value is modified.
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// InstallConfigSecretTemplateRef is a secret with the key install-config.yaml consisting of the content of the install-config.yaml
 	// to be used as a template for all clusters in this pool.
 	// Cluster specific settings (name, basedomain) will be injected dynamically when the ClusterDeployment install-config Secret is generated.

--- a/vendor/github.com/openshift/hive/apis/hive/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/zz_generated.deepcopy.go
@@ -1307,6 +1307,13 @@ func (in *ClusterPoolSpec) DeepCopyInto(out *ClusterPoolSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.InstallConfigSecretTemplateRef != nil {
 		in, out := &in.InstallConfigSecretTemplateRef, &out.InstallConfigSecretTemplateRef
 		*out = new(corev1.LocalObjectReference)


### PR DESCRIPTION
- Created `clusterpool.spec.annotations` field that can be used to apply fake cluster annotation on the cluster deployments
- Hibernation controller will now skip processing for cluster deployments with fake annotation

x-ref: https://issues.redhat.com/browse/HIVE-1493