### PR TITLE
Add regex to detect install failed waiting for kube api

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -120,6 +120,11 @@ data:
       - "failed to initialize the cluster: Some cluster operators are still updating:"
       installFailingReason: GeneralClusterOperatorsStillUpdating
       installFailingMessage: Timeout waiting for all cluster operators to become ready
+    - name: KubeAPIWaitFailed
+      searchRegexStrings:
+      - "Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane"
+      installFailingReason: KubeAPIWaitFailed
+      installFailingMessage: Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane
     # Processing stops at the first match, so this more generic
     # message about the connection failure must always come after the
     # more specific message for LibvirtSSHKeyPermissionDenied.

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -33,6 +33,7 @@ const (
 	vpcLimitExceeded        = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=error msg=\"Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.\""
 	genericLimitExceeded    = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=error msg=\"Error: Error creating Generic: GenericLimitExceeded: The maximum number of Generics has been reached.\""
 	invalidCredentials      = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=error msg=\"Error: error waiting for Route53 Hosted Zone (Z1009177L956IM4ANFHL) creation: InvalidClientTokenId: The security token included in the request is invalid.\""
+	kubeAPIWaitFailedLog    = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=error msg=\"Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane.\""
 	noMatchLog              = "an example of something that doesn't match the log regexes"
 )
 
@@ -92,6 +93,12 @@ func TestParseInstallLog(t *testing.T) {
 			log:            pointer.StringPtr(invalidCredentials),
 			existing:       []runtime.Object{buildRegexConfigMap()},
 			expectedReason: "InvalidCredentials",
+		},
+		{
+			name:           "Failed waiting for Kubernetes API",
+			log:            pointer.StringPtr(kubeAPIWaitFailedLog),
+			existing:       []runtime.Object{buildRegexConfigMap()},
+			expectedReason: "KubeAPIWaitFailed",
 		},
 		{
 			name: "KubeAPIWaitTimeout from additional regex entries",
@@ -324,6 +331,11 @@ func buildRegexConfigMap() *corev1.ConfigMap {
   - "InvalidClientTokenId: The security token included in the request is invalid."
   installFailingReason: InvalidCredentials
   installFailingMessage: Credentials are invalid
+- name: KubeAPIWaitFailed
+  searchRegexStrings:
+  - "Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane"
+  installFailingReason: KubeAPIWaitFailed
+  installFailingMessage: Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane
 `,
 		},
 	}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1654,6 +1654,11 @@ data:
       - "failed to initialize the cluster: Some cluster operators are still updating:"
       installFailingReason: GeneralClusterOperatorsStillUpdating
       installFailingMessage: Timeout waiting for all cluster operators to become ready
+    - name: KubeAPIWaitFailed
+      searchRegexStrings:
+      - "Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane"
+      installFailingReason: KubeAPIWaitFailed
+      installFailingMessage: Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane
     # Processing stops at the first match, so this more generic
     # message about the connection failure must always come after the
     # more specific message for LibvirtSSHKeyPermissionDenied.


### PR DESCRIPTION
install log snippet

```
      level=info msg=Creating infrastructure resources...
      level=info msg=Waiting up to 20m0s for the Kubernetes API at https://api.osde2e-nci3m.xmbp.p2.openshiftapps.com:6443...
      level=error msg=Attempted to gather ClusterOperator status after installation failure: listing ClusterOperator objects: Get "https://api.osde2e-nci3m.xmbp.p2.openshiftapps.com:6443/apis/config.openshift.io/v1/clusteroperators": dial tcp: lookup api.osde2e-nci3m.xmbp.p2.openshiftapps.com on 172.30.0.10:53: no such host
      level=info msg=Pulling debug logs from the bootstrap machine
      level=info msg=Bootstrap gather logs captured here "/output/log-bundle-20210421123336.tar.gz"
      level=error msg=Bootstrap failed to complete: Get "https://api.osde2e-nci3m.xmbp.p2.openshiftapps.com:6443/version?timeout=32s": dial tcp: lookup api.osde2e-nci3m.xmbp.p2.openshiftapps.com on 172.30.0.10:53: no such host
      level=error msg=Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane.
      level=fatal msg=Bootstrap failed to complete
      level=info msg=Pulling debug logs from the bootstrap machine
      level=info msg=Bootstrap gather logs captured here "/output/log-bundle-20210421123524.tar.gz"
```

