### PR TITLE
Improve status reporting when syncsets are paused

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -2252,10 +2252,17 @@ func (r *ReconcileClusterDeployment) setSyncSetFailedCondition(cd *hivev1.Cluste
 	clusterSync := &hiveintv1alpha1.ClusterSync{}
 	switch err := r.Get(context.Background(), types.NamespacedName{Namespace: cd.Namespace, Name: cd.Name}, clusterSync); {
 	case apierrors.IsNotFound(err):
-		cdLog.Info("ClusterSync has not yet been created")
-		status = corev1.ConditionTrue
-		reason = "MissingClusterSync"
-		message = "ClusterSync has not yet been created"
+		if paused, err := strconv.ParseBool(cd.Annotations[constants.SyncsetPauseAnnotation]); err == nil && paused {
+			cdLog.Info("SyncSet is paused. ClusterSync will not be created")
+			status = corev1.ConditionTrue
+			reason = "SyncSetPaused"
+			message = "SyncSet is paused. ClusterSync will not be created"
+		} else {
+			cdLog.Info("ClusterSync has not yet been created")
+			status = corev1.ConditionTrue
+			reason = "MissingClusterSync"
+			message = "ClusterSync has not yet been created"
+		}
 	case err != nil:
 		cdLog.WithError(err).Log(controllerutils.LogLevel(err), "could not get ClusterSync")
 		return err


### PR DESCRIPTION
ClusterSync object is not created when syncset-paused annotation
is applied to the ClusterDeployment. This is not mentioned in the
status. This commit improves the status message.

x-ref: https://issues.redhat.com/browse/HIVE-1497