### PR TITLE
Initialize Hibernating condition

### DIFF
--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -452,6 +452,10 @@ const (
 	SyncSetsNotAppliedReason = "SyncSetsNotApplied"
 )
 
+// InitializedConditionReason is used when a condition is initialized for the first time, and the status of the
+// condition is still Unknown
+const InitializedConditionReason = "Initialized"
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -41,6 +41,26 @@ func shouldUpdateCondition(
 	return updateConditionCheck(oldReason, oldMessage, newReason, newMessage)
 }
 
+// InitializeClusterDeploymentConditions initializes the given set of conditions for the first time, set with Status Unknown
+func InitializeClusterDeploymentConditions(existingConditions []hivev1.ClusterDeploymentCondition, conditionsToBeAdded []hivev1.ClusterDeploymentConditionType) []hivev1.ClusterDeploymentCondition {
+	now := metav1.Now()
+	for _, conditionType := range conditionsToBeAdded {
+		if FindClusterDeploymentCondition(existingConditions, conditionType) == nil {
+			existingConditions = append(
+				existingConditions,
+				hivev1.ClusterDeploymentCondition{
+					Type:               conditionType,
+					Status:             corev1.ConditionUnknown,
+					Reason:             hivev1.InitializedConditionReason,
+					Message:            "Condition Initialized",
+					LastTransitionTime: now,
+					LastProbeTime:      now,
+				})
+		}
+	}
+	return existingConditions
+}
+
 // SetClusterDeploymentCondition sets a condition on a ClusterDeployment resource's status
 func SetClusterDeploymentCondition(
 	conditions []hivev1.ClusterDeploymentCondition,

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -452,6 +452,10 @@ const (
 	SyncSetsNotAppliedReason = "SyncSetsNotApplied"
 )
 
+// InitializedConditionReason is used when a condition is initialized for the first time, and the status of the
+// condition is still Unknown
+const InitializedConditionReason = "Initialized"
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 


### PR DESCRIPTION
As per kube api guidelines, conditions should be placed by the controller as soon as possible, to indicate that it has began processing the resource. If a decision cannot be made regarding the status of the condition at that time, it can be set to Unknown.

This commit Initializes cluster hibernating condition as soon as possible.
It is to False for Unsupported clouds, and to Unknown for others

xref https://issues.redhat.com/browse/HIVE-1509

/cc @dgoodwin 