### PR TITLE
operator: use the correct cache to get secrets

### DIFF
--- a/pkg/operator/hive/hive_controller.go
+++ b/pkg/operator/hive/hive_controller.go
@@ -224,19 +224,20 @@ var _ reconcile.Reconciler = &ReconcileHiveConfig{}
 // ReconcileHiveConfig reconciles a Hive object
 type ReconcileHiveConfig struct {
 	client.Client
-	scheme                            *runtime.Scheme
-	kubeClient                        kubernetes.Interface
-	discoveryClient                   discovery.DiscoveryInterface
-	dynamicClient                     dynamic.Interface
-	restConfig                        *rest.Config
-	hiveImage                         string
-	hiveOperatorNamespace             string
-	hiveImagePullPolicy               corev1.PullPolicy
-	syncAggregatorCA                  bool
-	managedConfigCMLister             corev1listers.ConfigMapLister
-	ctrlr                             controller.Controller
-	servingCertSecretWatchEstablished bool
-	mgr                               manager.Manager
+	scheme                 *runtime.Scheme
+	kubeClient             kubernetes.Interface
+	discoveryClient        discovery.DiscoveryInterface
+	dynamicClient          dynamic.Interface
+	restConfig             *rest.Config
+	hiveImage              string
+	hiveOperatorNamespace  string
+	hiveImagePullPolicy    corev1.PullPolicy
+	syncAggregatorCA       bool
+	managedConfigCMLister  corev1listers.ConfigMapLister
+	ctrlr                  controller.Controller
+	hiveSecretLister       corev1listers.SecretLister
+	secretWatchEstablished bool
+	mgr                    manager.Manager
 }
 
 // Reconcile reads that state of the cluster for a Hive object and makes changes based on the state read
@@ -264,7 +265,7 @@ func (r *ReconcileHiveConfig) Reconcile(ctx context.Context, request reconcile.R
 			// Object not found, return.  Created objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers.
 			hLog.Debug("HiveConfig not found, deleted?")
-			r.servingCertSecretWatchEstablished = false
+			r.secretWatchEstablished = false
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
@@ -408,13 +409,14 @@ func (r *ReconcileHiveConfig) Reconcile(ctx context.Context, request reconcile.R
 func (r *ReconcileHiveConfig) establishSecretWatch(hLog *log.Entry, hiveNSName string) error {
 	// We need to establish a watch on Secret in the Hive namespace, one time only. We do not know this namespace until
 	// we have a HiveConfig.
-	if !r.servingCertSecretWatchEstablished {
+	if !r.secretWatchEstablished {
 		hLog.WithField("namespace", hiveNSName).Info("establishing watch on secrets in hive namespace")
 
 		// Create an informer that only listens to events in the OpenShift managed namespace
 		kubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(r.kubeClient, watchResyncInterval,
 			kubeinformers.WithNamespace(hiveNSName))
 		secretsInformer := kubeInformerFactory.Core().V1().Secrets().Informer()
+		r.hiveSecretLister = kubeInformerFactory.Core().V1().Secrets().Lister()
 		if err := r.mgr.Add(&informerRunnable{informer: secretsInformer}); err != nil {
 			hLog.WithError(err).Error("error adding secret informer to manager")
 			return err
@@ -474,7 +476,7 @@ func (r *ReconcileHiveConfig) establishSecretWatch(hLog *log.Entry, hiveNSName s
 			return err
 		}
 
-		r.servingCertSecretWatchEstablished = true
+		r.secretWatchEstablished = true
 	} else {
 		hLog.Debug("secret watch already established")
 	}

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -160,7 +160,7 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h resour
 	}
 
 	// Set the serving cert CA secret hash as an annotation on the pod template to force a rollout in the event it changes:
-	servingCertSecret := &corev1.Secret{}
+	servingCertSecret, err := r.hiveSecretLister.Secrets(hiveNSName).Get(hiveAdmissionServingCertSecretName)
 	if err := r.Client.Get(context.Background(), types.NamespacedName{Namespace: hiveNSName, Name: hiveAdmissionServingCertSecretName}, servingCertSecret); err != nil {
 		hLog.WithError(err).WithField("secretName", hiveAdmissionServingCertSecretName).Log(
 			controllerutils.LogLevel(err), "error getting serving cert secret")


### PR DESCRIPTION
When we receive a watch, and we reconcile for that watch and then use
that cache to get the latest version of the changed object, we can
assume this gurantee.

Currently, due to historical reasons, we have a separate cache for
watching secrets in hive namespace, but then use the reconciler's client
to get the secrets. This means that our assumption of having the latest
update secret is no longer valid.

So in the current setup, we should use the lister from the correct
cache to get secrets. This is now achieved by storing the lister for the
secrets and then using that when required.

> https://github.com/openshift/hive/pull/1350

that change allows reconcile on secret changes that are used in hiveconfig esp the client certificates secret.
but when the secret was updated, the reconcile would use the state secret data in reconciler client's cache. To make
sure we have the updated secret content we must use the cache that triggered the watch. So using hiveSecretLister
allows us to get the updated secret content.

/assign @joelddiaz 