### PR TITLE
Fix cluster claim for fake clusterpool

### DIFF
--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -176,9 +176,9 @@ func (r *hibernationReconciler) Reconcile(ctx context.Context, request reconcile
 	if !cd.Spec.Installed {
 		return reconcile.Result{}, nil
 	}
-	// If cluster is fake, skip any processing
+	// If cluster is fake, set hibernating false and skip further processing
 	if controllerutils.IsFakeCluster(cd) {
-		return reconcile.Result{}, nil
+		return r.setHibernatingCondition(cd, hivev1.HibernatingHibernationReason, "Skipping hibernation for fake cluster", corev1.ConditionFalse, cdLog)
 	}
 
 	// set hibernating condition to false for unsupported clouds

--- a/pkg/controller/hibernation/hibernation_controller_test.go
+++ b/pkg/controller/hibernation/hibernation_controller_test.go
@@ -357,6 +357,21 @@ func TestReconcile(t *testing.T) {
 				assert.Equal(t, "Hibernation capable", cond.Message)
 			},
 		},
+		{
+			name: "skip hibernation for fake cluster",
+			cd: cdBuilder.Build(
+				testcd.WithHibernateAfter(1*time.Hour),
+				testcd.InstalledTimestamp(time.Now().Add(-1*time.Hour)),
+				testcd.WithAnnotation(constants.HiveFakeClusterAnnotation, "true")),
+			cs: csBuilder.Build(),
+			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
+				cond := getHibernatingCondition(cd)
+				require.NotNil(t, cond)
+				assert.Equal(t, hivev1.HibernatingHibernationReason, cond.Reason)
+				assert.Equal(t, corev1.ConditionFalse, cond.Status)
+				assert.Equal(t, "Skipping hibernation for fake cluster", cond.Message)
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
New changes to how we set conditions beforehand led to hibernating
condition status set to unknown for fake cluster. This fix
explicitly sets hibernating condition to false for fake cluster.