### PR TITLE
Fix hotloop in awsprivatelink controller in some situations

### DIFF
--- a/pkg/controller/awsprivatelink/awsprivatelink_controller.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller.go
@@ -260,7 +260,7 @@ func (r *ReconcileAWSPrivateLink) Reconcile(ctx context.Context, request reconci
 				return reconcile.Result{}, err
 			}
 
-			if err := r.setProgressCondition(cd, corev1.ConditionFalse,
+			if err := r.setReadyCondition(cd, corev1.ConditionFalse,
 				"PreviousAttemptCleanupComplete",
 				"successfully cleaned up resources from previous provision attempt so that next attempt can start",
 				logger); err != nil {
@@ -357,7 +357,7 @@ func (r *ReconcileAWSPrivateLink) setErrCondition(cd *hivev1.ClusterDeployment,
 	return r.Status().Update(context.TODO(), curr)
 }
 
-func (r *ReconcileAWSPrivateLink) setProgressCondition(cd *hivev1.ClusterDeployment,
+func (r *ReconcileAWSPrivateLink) setReadyCondition(cd *hivev1.ClusterDeployment,
 	completed corev1.ConditionStatus,
 	reason string, message string,
 	logger log.FieldLogger) error {
@@ -427,7 +427,7 @@ func (r *ReconcileAWSPrivateLink) reconcilePrivateLink(cd *hivev1.ClusterDeploym
 		if awsErrCodeEquals(err, "LoadBalancerNotFound") {
 			logger.WithField("infraID", clusterMetadata.InfraID).Debug("NLB is not yet created for the cluster, will retry later")
 
-			if err := r.setProgressCondition(cd, corev1.ConditionFalse,
+			if err := r.setReadyCondition(cd, corev1.ConditionFalse,
 				"DiscoveringNLBNotYetFound",
 				"discovering NLB for the cluster, but it does not exist yet",
 				logger); err != nil {
@@ -458,7 +458,7 @@ func (r *ReconcileAWSPrivateLink) reconcilePrivateLink(cd *hivev1.ClusterDeploym
 		return reconcile.Result{}, errors.Wrap(err, "failed to reconcile the VPC Endpoint Service")
 	}
 	if serviceModified {
-		if err := r.setProgressCondition(cd, corev1.ConditionFalse,
+		if err := r.setReadyCondition(cd, corev1.ConditionFalse,
 			"ReconciledVPCEndpointService",
 			"reconciled the VPC Endpoint Service for the cluster",
 			logger); err != nil {
@@ -487,7 +487,7 @@ func (r *ReconcileAWSPrivateLink) reconcilePrivateLink(cd *hivev1.ClusterDeploym
 	}
 
 	if endpointModified {
-		if err := r.setProgressCondition(cd, corev1.ConditionFalse,
+		if err := r.setReadyCondition(cd, corev1.ConditionFalse,
 			"ReconciledVPCEndpoint",
 			"reconciled the VPC Endpoint for the cluster",
 			logger); err != nil {
@@ -522,7 +522,7 @@ func (r *ReconcileAWSPrivateLink) reconcilePrivateLink(cd *hivev1.ClusterDeploym
 	}
 
 	if hzModified {
-		if err := r.setProgressCondition(cd, corev1.ConditionFalse,
+		if err := r.setReadyCondition(cd, corev1.ConditionFalse,
 			"ReconciledPrivateHostedZone",
 			"reconciled the Private Hosted Zone for the VPC Endpoint of the cluster",
 			logger); err != nil {
@@ -544,7 +544,7 @@ func (r *ReconcileAWSPrivateLink) reconcilePrivateLink(cd *hivev1.ClusterDeploym
 	}
 
 	if associationsModified {
-		if err := r.setProgressCondition(cd, corev1.ConditionFalse,
+		if err := r.setReadyCondition(cd, corev1.ConditionFalse,
 			"ReconciledAssociationsToVPCs",
 			"reconciled the associations of all the required VPCs to the Private Hosted Zone for the VPC Endpoint",
 			logger); err != nil {
@@ -553,7 +553,7 @@ func (r *ReconcileAWSPrivateLink) reconcilePrivateLink(cd *hivev1.ClusterDeploym
 		}
 	}
 
-	if err := r.setProgressCondition(cd, corev1.ConditionTrue,
+	if err := r.setReadyCondition(cd, corev1.ConditionTrue,
 		"PrivateLinkAccessReady",
 		"private link access is ready for use",
 		logger); err != nil {

--- a/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
@@ -747,7 +747,7 @@ users:
 			Status:  corev1.ConditionFalse,
 			Type:    hivev1.AWSPrivateLinkReadyClusterDeploymentCondition,
 			Reason:  "DiscoveringNLBNotYetFound",
-			Message: "discovering NLB for the cluster, but it does not exists yet",
+			Message: "discovering NLB for the cluster, but it does not exist yet",
 		}},
 
 		hasFinalizer: true,

--- a/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
@@ -298,7 +298,7 @@ func Test_setProgressCondition(t *testing.T) {
 			}
 			logger := log.New()
 			logger.SetLevel(log.DebugLevel)
-			err := reconciler.setProgressCondition(cd, test.completed, test.reason, test.message, logger)
+			err := reconciler.setReadyCondition(cd, test.completed, test.reason, test.message, logger)
 			require.NoError(t, err)
 
 			cd = &hivev1.ClusterDeployment{}

--- a/pkg/controller/awsprivatelink/cleanup.go
+++ b/pkg/controller/awsprivatelink/cleanup.go
@@ -35,7 +35,7 @@ func (r *ReconcileAWSPrivateLink) cleanupClusterDeployment(cd *hivev1.ClusterDep
 			return reconcile.Result{}, err
 		}
 
-		if err := r.setProgressCondition(cd, corev1.ConditionFalse,
+		if err := r.setReadyCondition(cd, corev1.ConditionFalse,
 			"DeprovisionCleanupComplete",
 			"successfully cleaned up private link resources created to deprovision cluster",
 			logger); err != nil {

--- a/pkg/controller/awsprivatelink/cleanup.go
+++ b/pkg/controller/awsprivatelink/cleanup.go
@@ -24,14 +24,6 @@ func (r *ReconcileAWSPrivateLink) cleanupClusterDeployment(cd *hivev1.ClusterDep
 		return reconcile.Result{}, nil
 	}
 
-	if err := r.setProgressCondition(cd, corev1.ConditionFalse,
-		"CleanupForDeprovisionInprogress",
-		"cleaning up all the resources created for private link access for deprovisioning the cluster",
-		logger); err != nil {
-		logger.WithError(err).Error("failed to update condition on cluster deployment")
-		return reconcile.Result{}, err
-	}
-
 	if metadata != nil && cleanupRequired(cd) {
 		if err := r.cleanupPrivateLink(cd, metadata, logger); err != nil {
 			logger.WithError(err).Error("error cleaning up PrivateLink resources for ClusterDeployment")
@@ -40,6 +32,14 @@ func (r *ReconcileAWSPrivateLink) cleanupClusterDeployment(cd *hivev1.ClusterDep
 				logger.WithError(err).Error("failed to update condition on cluster deployment")
 				return reconcile.Result{}, err
 			}
+			return reconcile.Result{}, err
+		}
+
+		if err := r.setProgressCondition(cd, corev1.ConditionFalse,
+			"DeprovisionCleanupComplete",
+			"successfully cleaned up private link resources created to deprovision cluster",
+			logger); err != nil {
+			logger.WithError(err).Error("failed to update condition on cluster deployment")
 			return reconcile.Result{}, err
 		}
 	}


### PR DESCRIPTION
x-ref: https://issues.redhat.com/browse/HIVE-1536

In this scenario the controllers are trying to teardown a cluster that
was never fully installed, and failing because aws private link cleanup
requires an admin kubeconfig Secret, which does not seem to exist. (this
fix will be pursued separately)

The hotloop was caused by the fact that we were setting the Ready
condition to indicate we're trying to tear down, and then also setting
it after an error occurs. Each write causes another reconcile, so we're
flapping the condition back and forth between these two states. The
reconciles then fan out to all other controllers watching
ClusterDeployment.

Per latest kube api guidelines:

"Condition type names should describe the current observed state of the
resource, rather than describing the current state transitions. This
typically means that the name should be an adjective ("Ready",
"OutOfDisk") or a past-tense verb ("Succeeded", "Failed") rather than a
present-tense verb ("Deploying"). Intermediate states may be indicated
by setting the status of the condition to Unknown."

As such I have changed these conditions to only be set once we've
successfully cleaned up the resources. Users will not see "I am
deprovisioning" status, rather "I have deprovisioned" or "I have failed
to deprovision". This will hopefully correct the hotloop.

Per above the fix for the missing secret will be pursued in another PR.
