### PR TITLE
Initialize all cluster deployment conditions

### DIFF
--- a/pkg/controller/clusterrelocate/clusterrelocate_controller_test.go
+++ b/pkg/controller/clusterrelocate/clusterrelocate_controller_test.go
@@ -99,7 +99,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "only clusterdeployment",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 			},
@@ -180,7 +183,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "existing namespace",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 			},
@@ -196,7 +202,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "single dependent",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 				secretBuilder.Build(testsecret.WithDataKeyValue("test-key", []byte("test-data"))),
@@ -211,7 +220,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "multiple dependents",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 				secretBuilder.Build(
@@ -240,7 +252,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "dependent in other namespace",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 				secretBuilder.Build(
@@ -266,7 +281,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "existing dependent",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 				secretBuilder.Build(testsecret.WithDataKeyValue("test-key", []byte("test-data"))),
@@ -284,7 +302,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "out-of-date dependent",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 				secretBuilder.Build(testsecret.WithDataKeyValue("test-key", []byte("test-data"))),
@@ -302,7 +323,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "existing dependent with different status",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 				mpBuilder.Build(
@@ -324,7 +348,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "existing dependent with different instance-specific metadata",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 				secretBuilder.Build(
@@ -350,7 +377,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "ignore service account token",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 				secretBuilder.Build(
@@ -367,7 +397,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "ignore secret owned by service account token",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 				secretBuilder.Build(
@@ -395,7 +428,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "configmap",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 				cmBuilder.Build(testcm.WithDataKeyValue("test-key", "test-data")),
@@ -410,7 +446,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "machinepool",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 				mpBuilder.Build(),
@@ -425,7 +464,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "syncset",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 				ssBuilder.Build(),
@@ -440,7 +482,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "syncidentityprovider",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 				sipBuilder.Build(),
@@ -455,7 +500,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "dnszone",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 				dnsZoneBuilder.Build(),
@@ -472,7 +520,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "non-child dnszone",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 				dnsZoneBuilder.Build(testdnszone.Generic(testgeneric.WithName("other-dnszone"))),
@@ -486,7 +537,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "non-dependent",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 				jobBuilder.Build(),
@@ -500,7 +554,10 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 		},
 		{
 			name: "full",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
 				cdBuilder.Build(testcd.WithName("other-cluster-deployment")),
@@ -779,8 +836,11 @@ func TestReconcileClusterRelocate_Reconcile_RelocateStatus(t *testing.T) {
 		validate                          func(t *testing.T, cd *hivev1.ClusterDeployment)
 	}{
 		{
-			name:    "fresh clusterdeployment",
-			cd:      cdBuilder.Build(),
+			name: "fresh clusterdeployment",
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			dnsZone: dnsZoneBuilder.Build(),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
@@ -790,7 +850,10 @@ func TestReconcileClusterRelocate_Reconcile_RelocateStatus(t *testing.T) {
 		},
 		{
 			name: "clusterdeployment with dnszone already relocating",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			dnsZone: dnsZoneBuilder.Build(
 				testdnszone.Generic(withRelocateAnnotation("other-relocate", hivev1.RelocateOutgoing)),
 			),
@@ -804,6 +867,10 @@ func TestReconcileClusterRelocate_Reconcile_RelocateStatus(t *testing.T) {
 			name: "switch relocates",
 			cd: cdBuilder.Build(
 				testcd.Generic(withRelocateAnnotation("other-relocate", hivev1.RelocateOutgoing)),
+				testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.RelocationFailedCondition,
+					Status: corev1.ConditionUnknown,
+				}),
 			),
 			dnsZone: dnsZoneBuilder.Build(
 				testdnszone.Generic(withRelocateAnnotation("other-relocate", hivev1.RelocateOutgoing)),
@@ -815,8 +882,11 @@ func TestReconcileClusterRelocate_Reconcile_RelocateStatus(t *testing.T) {
 			expectedDeletionTimestamp: true,
 		},
 		{
-			name:    "multiple relocates",
-			cd:      cdBuilder.Build(),
+			name: "multiple relocates",
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			dnsZone: dnsZoneBuilder.Build(),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
@@ -833,6 +903,10 @@ func TestReconcileClusterRelocate_Reconcile_RelocateStatus(t *testing.T) {
 			name: "multiple relocates when already relocating",
 			cd: cdBuilder.Build(
 				testcd.Generic(withRelocateAnnotation("other-relocate", hivev1.RelocateOutgoing)),
+				testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.RelocationFailedCondition,
+					Status: corev1.ConditionUnknown,
+				}),
 			),
 			dnsZone: dnsZoneBuilder.Build(
 				testdnszone.Generic(withRelocateAnnotation("other-relocate", hivev1.RelocateOutgoing)),
@@ -852,6 +926,10 @@ func TestReconcileClusterRelocate_Reconcile_RelocateStatus(t *testing.T) {
 			name: "already relocated clusterdeployment",
 			cd: cdBuilder.Build(
 				testcd.Generic(withRelocateAnnotation(crName, hivev1.RelocateComplete)),
+				testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.RelocationFailedCondition,
+					Status: corev1.ConditionUnknown,
+				}),
 			),
 			dnsZone: dnsZoneBuilder.Build(
 				testdnszone.Generic(withRelocateAnnotation(crName, hivev1.RelocateComplete)),
@@ -863,8 +941,11 @@ func TestReconcileClusterRelocate_Reconcile_RelocateStatus(t *testing.T) {
 			expectedDeletionTimestamp: true,
 		},
 		{
-			name:    "already moved clusterdeployment",
-			cd:      cdBuilder.Build(),
+			name: "already moved clusterdeployment",
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			dnsZone: dnsZoneBuilder.Build(),
 			srcResources: []runtime.Object{
 				crBuilder.Build(),
@@ -877,7 +958,10 @@ func TestReconcileClusterRelocate_Reconcile_RelocateStatus(t *testing.T) {
 		},
 		{
 			name: "already moved clusterdeployment with dnszone already completed",
-			cd:   cdBuilder.Build(),
+			cd: cdBuilder.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RelocationFailedCondition,
+				Status: corev1.ConditionUnknown,
+			})),
 			dnsZone: dnsZoneBuilder.Build(
 				testdnszone.Generic(withRelocateAnnotation(crName, hivev1.RelocateComplete)),
 			),
@@ -895,6 +979,10 @@ func TestReconcileClusterRelocate_Reconcile_RelocateStatus(t *testing.T) {
 			cd: cdBuilder.Build(
 				func(cd *hivev1.ClusterDeployment) {
 					cd.Spec.BaseDomain = "test-domain"
+					cd.Status.Conditions = append(cd.Status.Conditions, hivev1.ClusterDeploymentCondition{
+						Status: corev1.ConditionUnknown,
+						Type:   hivev1.RelocationFailedCondition,
+					})
 				},
 			),
 			dnsZone: dnsZoneBuilder.Build(),
@@ -917,6 +1005,10 @@ func TestReconcileClusterRelocate_Reconcile_RelocateStatus(t *testing.T) {
 			name: "incoming",
 			cd: cdBuilder.Build(
 				testcd.Generic(withRelocateAnnotation("other-relocate", hivev1.RelocateIncoming)),
+				testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.RelocationFailedCondition,
+					Status: corev1.ConditionUnknown,
+				}),
 			),
 			dnsZone: dnsZoneBuilder.Build(
 				testdnszone.Generic(withRelocateAnnotation("other-relocate", hivev1.RelocateIncoming)),
@@ -930,6 +1022,10 @@ func TestReconcileClusterRelocate_Reconcile_RelocateStatus(t *testing.T) {
 			name: "incoming with dnszone already released",
 			cd: cdBuilder.Build(
 				testcd.Generic(withRelocateAnnotation("other-relocate", hivev1.RelocateIncoming)),
+				testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.RelocationFailedCondition,
+					Status: corev1.ConditionUnknown,
+				}),
 			),
 			dnsZone: dnsZoneBuilder.Build(),
 			expectedRelocationFailedCondition: &hivev1.ClusterDeploymentCondition{

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
@@ -69,9 +69,17 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 		expectedNotFoundStatus corev1.ConditionStatus
 	}{
 		{
-			name: "no control plane certs",
+			name: "initialize conditions",
 			existing: []runtime.Object{
 				fakeClusterDeployment().obj(),
+			},
+			expectNoSyncSet:        true,
+			expectedNotFoundStatus: corev1.ConditionUnknown,
+		},
+		{
+			name: "no control plane certs",
+			existing: []runtime.Object{
+				fakeClusterDeployment().withNotFoundCondition(corev1.ConditionUnknown).obj(),
 			},
 			expectNoSyncSet: true,
 		},
@@ -119,6 +127,7 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 			name: "missing secret",
 			existing: []runtime.Object{
 				fakeClusterDeployment().
+					withNotFoundCondition(corev1.ConditionUnknown).
 					defaultCert("default", "secret0").
 					namedCert("cert1", "foo.com", "secret1").
 					namedCert("cert2", "bar.com", "secret2").obj(),

--- a/pkg/controller/remoteingress/remoteingress_controller_test.go
+++ b/pkg/controller/remoteingress/remoteingress_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/resource"
+	testassert "github.com/openshift/hive/pkg/test/assert"
 )
 
 const (
@@ -66,9 +67,16 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 		},
 		{
 			name: "Test single ingress (only default)",
-			localObjects: []runtime.Object{
-				testClusterDeployment(),
-			},
+			localObjects: func() []runtime.Object {
+				objects := []runtime.Object{}
+				cd := testClusterDeployment()
+				cd.Status.Conditions = append(cd.Status.Conditions, hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.IngressCertificateNotFoundCondition,
+					Status: corev1.ConditionUnknown,
+				})
+				objects = append(objects, cd)
+				return objects
+			}(),
 			expectedSyncSetIngressEntries: []SyncSetIngressEntry{
 				{
 					name:   testDefaultIngressName,
@@ -79,9 +87,16 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 
 		{
 			name: "Test multiple ingress",
-			localObjects: []runtime.Object{
-				addIngressToClusterDeployment(testClusterDeployment(), "secondingress", "moreingress.example.com", nil, nil, ""),
-			},
+			localObjects: func() []runtime.Object {
+				objects := []runtime.Object{}
+				cd := addIngressToClusterDeployment(testClusterDeployment(), "secondingress", "moreingress.example.com", nil, nil, "")
+				cd.Status.Conditions = append(cd.Status.Conditions, hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.IngressCertificateNotFoundCondition,
+					Status: corev1.ConditionUnknown,
+				})
+				objects = append(objects, cd)
+				return objects
+			}(),
 			expectedSyncSetIngressEntries: []SyncSetIngressEntry{
 				{
 					name:   testDefaultIngressName,
@@ -95,10 +110,18 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 		},
 		{
 			name: "Test updating existing syncset",
-			localObjects: []runtime.Object{
-				addIngressToClusterDeployment(testClusterDeployment(), "secondingress", "moreingress.example.com", nil, nil, ""),
-				syncSetFromClusterDeployment(testClusterDeployment()),
-			},
+			localObjects: func() []runtime.Object {
+				objects := []runtime.Object{}
+				cd := addIngressToClusterDeployment(testClusterDeployment(), "secondingress", "moreingress.example.com", nil, nil, "")
+				cd.Status.Conditions = append(cd.Status.Conditions, hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.IngressCertificateNotFoundCondition,
+					Status: corev1.ConditionUnknown,
+				})
+				objects = append(objects, cd)
+				ss := syncSetFromClusterDeployment(testClusterDeployment())
+				objects = append(objects, ss)
+				return objects
+			}(),
 			expectedSyncSetIngressEntries: []SyncSetIngressEntry{
 				{
 					name:   testDefaultIngressName,
@@ -127,6 +150,10 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 
 				// create the current cluster deployment with only a single ingress
 				cd = testClusterDeployment()
+				cd.Status.Conditions = append(cd.Status.Conditions, hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.IngressCertificateNotFoundCondition,
+					Status: corev1.ConditionUnknown,
+				})
 				objects = append(objects, cd)
 
 				return objects
@@ -140,9 +167,16 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 		},
 		{
 			name: "Test setting routeSelector",
-			localObjects: []runtime.Object{
-				addIngressToClusterDeployment(testClusterDeployment(), "secondingress", "moreingress.example.com", testRouteSelector(), nil, ""),
-			},
+			localObjects: func() []runtime.Object {
+				objects := []runtime.Object{}
+				cd := addIngressToClusterDeployment(testClusterDeployment(), "secondingress", "moreingress.example.com", testRouteSelector(), nil, "")
+				cd.Status.Conditions = append(cd.Status.Conditions, hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.IngressCertificateNotFoundCondition,
+					Status: corev1.ConditionUnknown,
+				})
+				objects = append(objects, cd)
+				return objects
+			}(),
 			expectedSyncSetIngressEntries: []SyncSetIngressEntry{
 				{
 					name:   testDefaultIngressName,
@@ -157,9 +191,16 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 		},
 		{
 			name: "Test setting namespaceSelector",
-			localObjects: []runtime.Object{
-				addIngressToClusterDeployment(testClusterDeployment(), "secondingress", "moreingress.example.com", nil, testNamespaceSelector(), ""),
-			},
+			localObjects: func() []runtime.Object {
+				objects := []runtime.Object{}
+				cd := addIngressToClusterDeployment(testClusterDeployment(), "secondingress", "moreingress.example.com", nil, testNamespaceSelector(), "")
+				cd.Status.Conditions = append(cd.Status.Conditions, hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.IngressCertificateNotFoundCondition,
+					Status: corev1.ConditionUnknown,
+				})
+				objects = append(objects, cd)
+				return objects
+			}(),
 			expectedSyncSetIngressEntries: []SyncSetIngressEntry{
 				{
 					name:   testDefaultIngressName,
@@ -177,6 +218,10 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 			localObjects: func() []runtime.Object {
 				objects := []runtime.Object{}
 				cd := testClusterDeploymentWithManualCertificate()
+				cd.Status.Conditions = append(cd.Status.Conditions, hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.IngressCertificateNotFoundCondition,
+					Status: corev1.ConditionUnknown,
+				})
 				objects = append(objects, cd)
 
 				// put the expected secrets to satisfy the list of certificateBundles
@@ -210,6 +255,10 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 				// now add the extra ingress entry (use same certBundle)
 				addIngressToClusterDeployment(cd, "secondingress", "moreingress.example.com", nil, nil, testDefaultIngressServingCertificate)
 				cd.Spec.CertificateBundles = addCertificateBundlesForIngressList(cd)
+				cd.Status.Conditions = append(cd.Status.Conditions, hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.IngressCertificateNotFoundCondition,
+					Status: corev1.ConditionUnknown,
+				})
 				objects = append(objects, cd)
 
 				// secrets for the clusterDeployment
@@ -249,6 +298,10 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 
 				// clusterDeployment with only one ingress
 				cd := testClusterDeploymentWithManualCertificate()
+				cd.Status.Conditions = append(cd.Status.Conditions, hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.IngressCertificateNotFoundCondition,
+					Status: corev1.ConditionUnknown,
+				})
 				objects = append(objects, cd)
 
 				// secrets for the clusterDeployment
@@ -278,6 +331,10 @@ func TestRemoteClusterIngressReconcile(t *testing.T) {
 				cd := testClusterDeploymentWithManualCertificate()
 				addIngressToClusterDeployment(cd, "secondingress", "moreingress.example.com", nil, nil, "secondCertBundle")
 				cd.Spec.CertificateBundles = addCertificateBundlesForIngressList(cd)
+				cd.Status.Conditions = append(cd.Status.Conditions, hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.IngressCertificateNotFoundCondition,
+					Status: corev1.ConditionUnknown,
+				})
 				objects = append(objects, cd)
 
 				// add the secrets for the certbundles
@@ -342,13 +399,23 @@ func TestRemoteClusterIngressReconcileConditions(t *testing.T) {
 	ingresscontroller.AddToScheme(scheme.Scheme)
 
 	tests := []struct {
-		name                    string
-		localObjects            []runtime.Object
-		expectClusterCondition  bool
-		expectedConditionReason string
-		expectedConditionStatus corev1.ConditionStatus
+		name                      string
+		localObjects              []runtime.Object
+		expectedClusterConditions []hivev1.ClusterDeploymentCondition
 	}{
 		{
+			name: "Test initialize conditions",
+			localObjects: []runtime.Object{
+				testClusterDeployment(),
+			},
+			expectedClusterConditions: []hivev1.ClusterDeploymentCondition{
+				{
+					Type:   hivev1.IngressCertificateNotFoundCondition,
+					Status: corev1.ConditionUnknown,
+					Reason: hivev1.InitializedConditionReason,
+				},
+			},
+		}, {
 			name: "Test no issue no condition",
 			localObjects: func() []runtime.Object {
 				objects := []runtime.Object{}
@@ -361,27 +428,44 @@ func TestRemoteClusterIngressReconcileConditions(t *testing.T) {
 
 				return objects
 			}(),
-			expectClusterCondition: false,
 		},
 		{
 			name: "Test certbundle missing",
 			localObjects: func() []runtime.Object {
 				cd := testClusterDeploymentWithManualCertificate()
+				cd.Status.Conditions = append(cd.Status.Conditions, hivev1.ClusterDeploymentCondition{
+					Status: corev1.ConditionUnknown,
+					Type:   hivev1.IngressCertificateNotFoundCondition,
+				})
 				cd.Spec.CertificateBundles = []hivev1.CertificateBundleSpec{}
 
 				return []runtime.Object{cd}
 			}(),
-			expectClusterCondition:  true,
-			expectedConditionReason: ingressCertificateNotFoundReason,
-			expectedConditionStatus: corev1.ConditionTrue,
+			expectedClusterConditions: []hivev1.ClusterDeploymentCondition{
+				{
+					Type:   hivev1.IngressCertificateNotFoundCondition,
+					Status: corev1.ConditionTrue,
+					Reason: ingressCertificateNotFoundReason,
+				},
+			},
 		},
 		{
 			name: "Test secret missing",
-			localObjects: []runtime.Object{
-				testClusterDeploymentWithManualCertificate(),
+			localObjects: func() []runtime.Object {
+				cd := testClusterDeploymentWithManualCertificate()
+				cd.Status.Conditions = append(cd.Status.Conditions, hivev1.ClusterDeploymentCondition{
+					Status: corev1.ConditionUnknown,
+					Type:   hivev1.IngressCertificateNotFoundCondition,
+				})
+				return []runtime.Object{cd}
+			}(),
+			expectedClusterConditions: []hivev1.ClusterDeploymentCondition{
+				{
+					Type:   hivev1.IngressCertificateNotFoundCondition,
+					Status: corev1.ConditionTrue,
+					Reason: ingressCertificateNotFoundReason,
+				},
 			},
-			expectedConditionReason: ingressCertificateNotFoundReason,
-			expectedConditionStatus: corev1.ConditionTrue,
 		},
 		{
 			name: "Test clear previous condition",
@@ -399,9 +483,13 @@ func TestRemoteClusterIngressReconcileConditions(t *testing.T) {
 
 				return objects
 			}(),
-			expectClusterCondition:  true,
-			expectedConditionReason: ingressCertificateFoundReason,
-			expectedConditionStatus: corev1.ConditionFalse,
+			expectedClusterConditions: []hivev1.ClusterDeploymentCondition{
+				{
+					Type:   hivev1.IngressCertificateNotFoundCondition,
+					Status: corev1.ConditionFalse,
+					Reason: ingressCertificateFoundReason,
+				},
+			},
 		},
 	}
 
@@ -428,16 +516,11 @@ func TestRemoteClusterIngressReconcileConditions(t *testing.T) {
 
 			assert.NoError(t, err, "unexpected error returned from Reconcile()")
 
-			if test.expectClusterCondition {
+			if len(test.expectedClusterConditions) > 0 {
 				cd := hivev1.ClusterDeployment{}
 				searchKey := types.NamespacedName{Name: testClusterName, Namespace: testNamespace}
 				assert.NoError(t, fakeClient.Get(context.TODO(), searchKey, &cd), "error fetching resulting clusterDeployment")
-
-				condition := utils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.IngressCertificateNotFoundCondition)
-				assert.NotNil(t, condition, "didn't find expected condition")
-
-				assert.Equal(t, test.expectedConditionReason, condition.Reason)
-				assert.Equal(t, test.expectedConditionStatus, condition.Status)
+				testassert.AssertConditions(t, &cd, test.expectedClusterConditions)
 			}
 		})
 	}

--- a/pkg/imageset/updateinstaller.go
+++ b/pkg/imageset/updateinstaller.go
@@ -207,17 +207,14 @@ func (o *UpdateInstallerImageOptions) Run() (returnErr error) {
 	cd.Status.InstallerImage = &installerImage
 	cd.Status.CLIImage = &cliImage
 	cd.Status.InstallVersion = &releaseVersion
-	// Set InstallerImageResolutionFailedCondition to false if it exists
-	if cond := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions,
-		hivev1.InstallerImageResolutionFailedCondition); cond != nil {
-		cd.Status.Conditions = controllerutils.SetClusterDeploymentCondition(
-			cd.Status.Conditions,
-			hivev1.InstallerImageResolutionFailedCondition,
-			corev1.ConditionFalse,
-			installerImageResolvedReason,
-			installerImageResolvedMessage,
-			controllerutils.UpdateConditionNever)
-	}
+	// Set InstallerImageResolutionFailedCondition to false
+	cd.Status.Conditions = controllerutils.SetClusterDeploymentCondition(
+		cd.Status.Conditions,
+		hivev1.InstallerImageResolutionFailedCondition,
+		corev1.ConditionFalse,
+		installerImageResolvedReason,
+		installerImageResolvedMessage,
+		controllerutils.UpdateConditionNever)
 	logger.Debug("updating clusterdeployment status")
 	return errors.Wrap(
 		o.client.Status().Update(context.TODO(), cd),

--- a/pkg/imageset/updateinstaller_test.go
+++ b/pkg/imageset/updateinstaller_test.go
@@ -153,8 +153,9 @@ func validateSuccessfulExecution(t *testing.T, clusterDeployment *hivev1.Cluster
 		*clusterDeployment.Status.InstallerImage != testInstallerImage {
 		t.Errorf("did not get expected installer image in status")
 	}
-	if len(clusterDeployment.Status.Conditions) != 0 {
-		t.Errorf("conditions is not empty")
+	condition := controllerutils.FindClusterDeploymentCondition(clusterDeployment.Status.Conditions, hivev1.InstallerImageResolutionFailedCondition)
+	if condition != nil && condition.Status != corev1.ConditionFalse {
+		t.Errorf("unexpected condition status")
 	}
 }
 

--- a/pkg/remoteclient/remoteclient.go
+++ b/pkg/remoteclient/remoteclient.go
@@ -140,7 +140,7 @@ func InitialURL(c client.Client, cd *hivev1.ClusterDeployment) (string, error) {
 // the ClusterDeployment to determine if the remote cluster is reachable.
 func Unreachable(cd *hivev1.ClusterDeployment) (unreachable bool, lastCheck time.Time) {
 	cond := utils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.UnreachableCondition)
-	if cond == nil {
+	if cond.Status == corev1.ConditionUnknown {
 		unreachable = true
 		return
 	}

--- a/pkg/remoteclient/remoteclient_test.go
+++ b/pkg/remoteclient/remoteclient_test.go
@@ -144,8 +144,11 @@ func Test_Unreachable(t *testing.T) {
 		expectedLastCheck   time.Time
 	}{
 		{
-			name:                "unreachable unset",
-			cd:                  testcd.Build(),
+			name: "unreachable still unknown",
+			cd: testcd.Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Status: corev1.ConditionUnknown,
+				Type:   hivev1.UnreachableCondition,
+			})),
 			expectedUnreachable: true,
 		},
 		{

--- a/pkg/test/assert/assertions.go
+++ b/pkg/test/assert/assertions.go
@@ -8,6 +8,8 @@ import (
 	testifyassert "github.com/stretchr/testify/assert"
 
 	corev1 "k8s.io/api/core/v1"
+
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
 )
 
 // BetweenTimes asserts that the time is within the time window, inclusive of the start and end times.
@@ -35,5 +37,37 @@ func AssertAllContainersHaveEnvVar(t *testing.T, podSpec *corev1.PodSpec, key, v
 		}
 		testifyassert.True(t, found, "env var %s=%s not found on container %s", key, value, c.Name)
 		testifyassert.Equal(t, 1, foundCtr, "found %d occurrences of env var %s on container %s", foundCtr, key, c.Name)
+	}
+}
+
+// findClusterDeploymentCondition finds the specified condition type in the given list of cluster deployment conditions.
+// If none exists, then returns nil.
+func findClusterDeploymentCondition(conditions []hivev1.ClusterDeploymentCondition, conditionType hivev1.ClusterDeploymentConditionType) *hivev1.ClusterDeploymentCondition {
+	for i, condition := range conditions {
+		if condition.Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+// AssertConditionStatus asserts if a condition is present on the cluster deployment and has the expected status
+func AssertConditionStatus(t *testing.T, cd *hivev1.ClusterDeployment, condType hivev1.ClusterDeploymentConditionType, status corev1.ConditionStatus) {
+	condition := findClusterDeploymentCondition(cd.Status.Conditions, condType)
+	if testifyassert.NotNilf(t, condition, "did not find expected condition type: %v", condType) {
+		testifyassert.Equal(t, string(status), string(condition.Status), "condition found with unexpected status")
+	}
+}
+
+// AssertConditions asserts if the expected conditions are present on the cluster deployment.
+// It also asserts if those conditions have the expected status and reason
+func AssertConditions(t *testing.T, cd *hivev1.ClusterDeployment, expectedConditions []hivev1.ClusterDeploymentCondition) {
+	testifyassert.LessOrEqual(t, len(expectedConditions), len(cd.Status.Conditions), "some conditions are not present")
+	for _, expectedCond := range expectedConditions {
+		condition := findClusterDeploymentCondition(cd.Status.Conditions, expectedCond.Type)
+		if testifyassert.NotNilf(t, condition, "did not find expected condition type: %v", expectedCond.Type) {
+			testifyassert.Equal(t, expectedCond.Status, condition.Status, "condition found with unexpected status")
+			testifyassert.Equal(t, expectedCond.Reason, condition.Reason, "condition found with unexpected reason")
+		}
 	}
 }


### PR DESCRIPTION
As per kube api guidelines, conditions should be placed by the controller as soon as possible, to indicate that it has began processing the resource. If a decision cannot be made regarding the status of the condition at that time, it can be set to Unknown.

xref: https://issues.redhat.com/browse/HIVE-1529