### PR TITLE
allow to set zero replicas also when zones are set

### DIFF
--- a/pkg/validating-webhooks/hive/v1/machinepool_validating_admission_hook.go
+++ b/pkg/validating-webhooks/hive/v1/machinepool_validating_admission_hook.go
@@ -318,7 +318,7 @@ func validateMachinePoolSpecInvariants(spec *hivev1.MachinePoolSpec, fldPath *fi
 				allErrs = append(allErrs, field.Invalid(autoscalingPath.Child("minReplicas"), spec.Autoscaling.MinReplicas, "minimum replicas must be at least 1"))
 			}
 		} else {
-			if spec.Autoscaling.MinReplicas < int32(numberOfMachineSets) {
+			if spec.Autoscaling.MinReplicas < int32(numberOfMachineSets) && !validZeroSizeAutoscalingMinReplicas {
 				allErrs = append(allErrs, field.Invalid(autoscalingPath.Child("minReplicas"), spec.Autoscaling.MinReplicas, "minimum replicas must be at least the number of zones"))
 			}
 		}

--- a/pkg/validating-webhooks/hive/v1/machinepool_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/machinepool_validating_admission_hook_test.go
@@ -237,6 +237,7 @@ func Test_MachinePoolAdmission_Validate_Create(t *testing.T) {
 				}
 				return pool
 			}(),
+			expectAllowed: true,
 		},
 		{
 			name: "min replicas equal to number of AWS zones",
@@ -262,6 +263,7 @@ func Test_MachinePoolAdmission_Validate_Create(t *testing.T) {
 				}
 				return pool
 			}(),
+			expectAllowed: true,
 		},
 		{
 			name: "min replicas equal to number of GCP zones",
@@ -287,6 +289,7 @@ func Test_MachinePoolAdmission_Validate_Create(t *testing.T) {
 				}
 				return pool
 			}(),
+			expectAllowed: true,
 		},
 		{
 			name: "min replicas equal to number of Azure zones",
@@ -465,6 +468,19 @@ func Test_MachinePoolAdmission_Validate_Create(t *testing.T) {
 			name: "zero autoscaling",
 			provision: func() *hivev1.MachinePool {
 				pool := testMachinePool()
+				pool.Spec.Autoscaling = &hivev1.MachinePoolAutoscaling{
+					MinReplicas: 0,
+					MaxReplicas: 0,
+				}
+				return pool
+			}(),
+			expectAllowed: true,
+		},
+		{
+			name: "zero autoscaling with defined zones",
+			provision: func() *hivev1.MachinePool {
+				pool := testMachinePool()
+				pool.Spec.Platform.AWS.Zones = []string{"zoneA", "zoneB"}
 				pool.Spec.Autoscaling = &hivev1.MachinePoolAutoscaling{
 					MinReplicas: 0,
 					MaxReplicas: 0,


### PR DESCRIPTION
in addition to allowing zero replicas w/o zones, also allow it when the
machinepool has a list of zones defined.

xref: https://issues.redhat.com/browse/HIVE-1486