### PR TITLE
Fix stuck privatelink clusters deleted prior to install.

### DIFF
--- a/pkg/controller/awsprivatelink/awsprivatelink_controller.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller.go
@@ -1186,7 +1186,7 @@ func initialURL(c client.Client, key client.ObjectKey) (string, error) {
 		key,
 		kubeconfigSecret,
 	); err != nil {
-		return "", errors.Wrap(err, "could not get admin kubeconfig secret")
+		return "", err
 	}
 	cfg, err := restConfigFromSecret(kubeconfigSecret)
 	if err != nil {

--- a/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
@@ -984,8 +984,8 @@ users:
 			VPCEndpointID:      "vpce-12345",
 		},
 		expectedConditions: getExpectedConditions(true, "CouldNotCalculateAPIDomain",
-			"could not get admin kubeconfig secret: secrets \"test-cd-provision-0-kubeconfig\" not found"),
-		err: "could not get admin kubeconfig secret: secrets \"test-cd-provision-0-kubeconfig\" not found",
+			"secrets \"test-cd-provision-0-kubeconfig\" not found"),
+		err: "secrets \"test-cd-provision-0-kubeconfig\" not found",
 	}, {
 		name: "cd with privatelink enabled, provision started, nlb found, no previous service, no previous endpoint, no previous PHZ",
 


### PR DESCRIPTION
In some scenarios when an AWS privatelink cluster is deleted prior to
being fully installed, it was possible for the code to jam up in a
situation where no hosted zone ID was recorded in status, and we cannot
discover it because the admin kubeconfig secret is already gone.

To fix we just gracefully exit in this scenario as we have nothing to
cleanup.

x-ref: https://issues.redhat.com/browse/HIVE-1537

/assign @abhinavdahiya 
/cc @suhanime 