### PR TITLE
do not include error message in status condition

### DIFF
--- a/pkg/controller/dnszone/awsactuator.go
+++ b/pkg/controller/dnszone/awsactuator.go
@@ -561,7 +561,9 @@ func (a *AWSActuator) setInsufficientCredentialsConditionToTrue(message string) 
 		hivev1.InsufficientCredentialsCondition,
 		corev1.ConditionTrue,
 		accessDeniedReason,
-		message,
+		// FIXME: including the error message as is leads to status update hotloop when
+		// error message includes a dynamically generated AWS user https://issues.redhat.com/browse/HIVE-1542
+		"AccessDenied error encountered (see controller logs for details)",
 		controllerutils.UpdateConditionIfReasonOrMessageChange,
 	)
 

--- a/pkg/controller/dnszone/dnszone_controller_test.go
+++ b/pkg/controller/dnszone/dnszone_controller_test.go
@@ -523,7 +523,7 @@ func TestSetConditionsForErrorForAWS(t *testing.T) {
 				Type:    hivev1.InsufficientCredentialsCondition,
 				Status:  corev1.ConditionTrue,
 				Reason:  accessDeniedReason,
-				Message: "User: arn:aws:iam::0123456789:user/testAdmin is not authorized to perform: tag:GetResources with an explicit deny",
+				Message: "AccessDenied error encountered (see controller logs for details)",
 			},
 		},
 		{


### PR DESCRIPTION
error message can contain AWS generated username (when doing
AssumeRole/STS). This can cause a loop of Status() followed by
Reconcile().