### PR TITLE
Lower leader election lease durations.

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -66,9 +66,9 @@ import (
 const (
 	defaultLogLevel             = "info"
 	leaderElectionConfigMap     = "hive-controllers-leader"
-	leaderElectionLeaseDuration = "360s"
-	leaderElectionRenewDeadline = "270s"
-	leaderElectionRetryPeriod   = "90s"
+	leaderElectionLeaseDuration = "120s"
+	leaderElectionRenewDeadline = "90s"
+	leaderElectionRetryPeriod   = "30s"
 )
 
 type controllerSetupFunc func(manager.Manager) error

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -40,9 +40,9 @@ import (
 const (
 	defaultLogLevel             = "info"
 	leaderElectionConfigMap     = "hive-operator-leader"
-	leaderElectionLeaseDuration = "360s"
-	leaderElectionRenewDeadline = "270s"
-	leaderElectionRetryPeriod   = "90s"
+	leaderElectionLeaseDuration = "120s"
+	leaderElectionRenewDeadline = "90s"
+	leaderElectionRetryPeriod   = "30s"
 )
 
 type controllerManagerOptions struct {


### PR DESCRIPTION
We currently alert if hive is down for 5 minutes, however our leader
election timeouts can easily blow past this if a pod loses
leader status without a clean exit.

These limits were originally from CCO and requests to avoid the default
writes to etcd every 2s.

Cut the limits in half such that we're writing to etcd every 30s, and we
timeout after 2 minutes, which should work well with our 5 min alert.
