### PR TITLE
controller/dnszone: rate limit UPDATE events that are in error state

### DIFF
--- a/pkg/controller/dnszone/awsactuator.go
+++ b/pkg/controller/dnszone/awsactuator.go
@@ -561,9 +561,7 @@ func (a *AWSActuator) setInsufficientCredentialsConditionToTrue(message string) 
 		hivev1.InsufficientCredentialsCondition,
 		corev1.ConditionTrue,
 		accessDeniedReason,
-		// FIXME: including the error message as is leads to status update hotloop when
-		// error message includes a dynamically generated AWS user https://issues.redhat.com/browse/HIVE-1542
-		"AccessDenied error encountered (see controller logs for details)",
+		message,
 		controllerutils.UpdateConditionIfReasonOrMessageChange,
 	)
 

--- a/pkg/controller/dnszone/dnszone_controller_test.go
+++ b/pkg/controller/dnszone/dnszone_controller_test.go
@@ -801,7 +801,7 @@ func TestSetConditionsForErrorForAWS(t *testing.T) {
 				Type:    hivev1.InsufficientCredentialsCondition,
 				Status:  corev1.ConditionTrue,
 				Reason:  accessDeniedReason,
-				Message: "AccessDenied error encountered (see controller logs for details)",
+				Message: "User: arn:aws:iam::0123456789:user/testAdmin is not authorized to perform: tag:GetResources with an explicit deny",
 			},
 		},
 		{

--- a/pkg/controller/utils/ratelimitedeventhandler.go
+++ b/pkg/controller/utils/ratelimitedeventhandler.go
@@ -1,0 +1,50 @@
+package utils
+
+import (
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+)
+
+// NewRateLimitedUpdateEventHandler wraps the specified event handler inside a new
+// event handler that will rate limit the incoming UPDATE events when the provided
+// shouldRateLimit function returns true.
+func NewRateLimitedUpdateEventHandler(eventHandler handler.EventHandler, shouldRateLimitFunc func(event.UpdateEvent) bool) handler.EventHandler {
+	return &rateLimitedUpdateEventHandler{
+		EventHandler:    eventHandler,
+		shouldRateLimit: shouldRateLimitFunc,
+	}
+}
+
+// rateLimitedUpdateEventHandler wraps the specified event handler such
+// that it will rate limit the incoming UPDATE events when the provided
+// shouldRateLimit function returns true.
+type rateLimitedUpdateEventHandler struct {
+	handler.EventHandler
+
+	shouldRateLimit func(event.UpdateEvent) bool
+}
+
+var _ handler.EventHandler = &rateLimitedUpdateEventHandler{}
+
+// Update implements handler.EventHandler
+func (h *rateLimitedUpdateEventHandler) Update(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	nq := q
+	if h.shouldRateLimit(e) {
+		nq = &rateLimitedAddQueue{q}
+	}
+	h.EventHandler.Update(e, nq)
+}
+
+// rateLimitedAddQueue add queue wraps RateLimitingInterface queue
+// such that the Add call also becomes rate limited.
+type rateLimitedAddQueue struct {
+	workqueue.RateLimitingInterface
+}
+
+var _ workqueue.RateLimitingInterface = &rateLimitedAddQueue{}
+
+// Add implements workqueue.Interface
+func (q *rateLimitedAddQueue) Add(item interface{}) {
+	q.RateLimitingInterface.AddRateLimited(item)
+}

--- a/pkg/controller/utils/ratelimitedeventhandler_test.go
+++ b/pkg/controller/utils/ratelimitedeventhandler_test.go
@@ -1,0 +1,92 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRateLimitedEventHandler(t *testing.T) {
+	o := &hivev1.DNSZone{ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-name"}}
+
+	// always not rate limited
+	q := &trackedQueue{RateLimitingInterface: workqueue.NewRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter())}
+	h := NewRateLimitedUpdateEventHandler(&handler.EnqueueRequestForObject{}, func(_ event.UpdateEvent) bool { return false })
+	h.Update(event.UpdateEvent{ObjectOld: o, ObjectNew: o}, q)
+
+	require.Equal(t, 2, len(q.added))
+	require.Equal(t, 0, len(q.ratelimitAdded))
+
+	// always rate limited
+	q = &trackedQueue{RateLimitingInterface: workqueue.NewRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter())}
+	h = NewRateLimitedUpdateEventHandler(&handler.EnqueueRequestForObject{}, func(_ event.UpdateEvent) bool { return true })
+	h.Update(event.UpdateEvent{ObjectOld: o, ObjectNew: o}, q)
+
+	require.Equal(t, 0, len(q.added))
+	require.Equal(t, 2, len(q.ratelimitAdded))
+
+	// always rate limited not UPDATE
+	q = &trackedQueue{RateLimitingInterface: workqueue.NewRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter())}
+	h = NewRateLimitedUpdateEventHandler(&handler.EnqueueRequestForObject{}, func(_ event.UpdateEvent) bool { return true })
+	h.Generic(event.GenericEvent{Object: o}, q)
+
+	require.Equal(t, 1, len(q.added))
+	require.Equal(t, 0, len(q.ratelimitAdded))
+
+	// always rate limited with complex handler
+	q = &trackedQueue{RateLimitingInterface: workqueue.NewRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter())}
+	h = NewRateLimitedUpdateEventHandler(handler.EnqueueRequestsFromMapFunc(func(_ client.Object) []reconcile.Request {
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{
+				Namespace: "test-ns",
+				Name:      "test-name-1",
+			},
+		}, {
+			NamespacedName: types.NamespacedName{
+				Namespace: "test-ns",
+				Name:      "test-name-2",
+			},
+		}, {
+			NamespacedName: types.NamespacedName{
+				Namespace: "test-ns",
+				Name:      "test-name-3",
+			},
+		}}
+	}), func(_ event.UpdateEvent) bool { return true })
+	h.Update(event.UpdateEvent{ObjectOld: o, ObjectNew: o}, q)
+
+	require.Equal(t, 0, len(q.added))
+	require.Equal(t, 6, len(q.ratelimitAdded))
+
+}
+
+type trackedQueue struct {
+	workqueue.RateLimitingInterface
+
+	added          []string
+	ratelimitAdded []string
+}
+
+var _ workqueue.RateLimitingInterface = &trackedQueue{}
+
+// Add implements workqueue.Interface
+func (q *trackedQueue) Add(item interface{}) {
+	q.added = append(q.added, fmt.Sprintf("%s", item))
+	q.RateLimitingInterface.Add(item)
+}
+
+// AddRateLimited implements workqueue.RateLimitingInterface
+func (q *trackedQueue) AddRateLimited(item interface{}) {
+	q.ratelimitAdded = append(q.ratelimitAdded, fmt.Sprintf("%s", item))
+	q.RateLimitingInterface.AddRateLimited(item)
+}


### PR DESCRIPTION
#### controller/utils: add event handler wrapper that force rate limits update event

Event handlers in controller-runtime add Update events to non-rate limited queues.
In many cases it is desireable that the Update event be rate limited for
preventing excessive reconciles.

One of the main examples of the use case is when controller adds Failure
condition to the objects. This causes Update event to be trigerred and
immediately handled for the object and almost always ending up in the
same Failure state. The effect is increased if the error message in the
condition changes every time error is enconterred like request ids in
error messages returned from cloud providers.
To make sure the controller can backoff these error states, a new event
handler wrapper is added that can force the UPDATE event to be rate
limited when the controller configured function returns true. Allowing
controllers to write code that can recognize error transitions/states
and rate limit such events.

#### controller/dnszone: rate limit UPDATE events that are in error state

When the controller receives an UPDATE event when the object in in error
state i.e. conditions like InsufficientCredentialsCondition,
AuthenticationFailureCondition are True, add that reconcile request to
the rate limited queue of the reconciler.

xref: https://issues.redhat.com/browse/HIVE-1542

/cc @dgoodwin @joelddiaz 
/assign @suhanime 