### PR TITLE
Metrics change to accomodate clusterdeployment conditions cleanup

### DIFF
--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -336,7 +336,6 @@ type ClusterDeploymentCondition struct {
 // ClusterDeploymentConditionType is a valid value for ClusterDeploymentCondition.Type
 type ClusterDeploymentConditionType string
 
-// WARNING: All ClusterDeploymentConditionTypes should be added to the AllClusterDeploymentConditions slice below.
 const (
 	// ClusterImageSetNotFoundCondition is set when the ClusterImageSet referenced by the
 	// ClusterDeployment is not found.
@@ -410,23 +409,15 @@ const (
 	ClusterInstallRequirementsMetClusterDeploymentCondition ClusterDeploymentConditionType = "ClusterInstallRequirementsMet"
 )
 
-// AllClusterDeploymentConditions is a slice containing all condition types. This can be used for dealing with
-// cluster deployment conditions dynamically.
-var AllClusterDeploymentConditions = []ClusterDeploymentConditionType{
-	ClusterImageSetNotFoundCondition,
-	InstallerImageResolutionFailedCondition,
-	ControlPlaneCertificateNotFoundCondition,
-	IngressCertificateNotFoundCondition,
-	UnreachableCondition,
+// PositivePolarityClusterDeploymentConditions is a slice containing all condition types with positive polarity
+// For controllers that handle these conditions, the desired state is True
+// All cluster deployment condition types that are not in this slice are assumed to have negative polarity
+var PositivePolarityClusterDeploymentConditions = []ClusterDeploymentConditionType{
 	ActiveAPIURLOverrideCondition,
-	DNSNotReadyCondition,
-	ProvisionFailedCondition,
-	SyncSetFailedCondition,
-	RelocationFailedCondition,
 	ClusterHibernatingCondition,
-	InstallLaunchErrorCondition,
 	AWSPrivateLinkReadyClusterDeploymentCondition,
-	AWSPrivateLinkFailedClusterDeploymentCondition,
+	ClusterInstallCompletedClusterDeploymentCondition,
+	ClusterInstallRequirementsMetClusterDeploymentCondition,
 }
 
 // Cluster hibernating reasons

--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -703,3 +703,13 @@ func FindClusterInstallCondition(conditions []hivev1.ClusterInstallCondition, co
 	}
 	return nil
 }
+
+// IsConditionWithPositivePolarity checks if cluster deployment condition has positive polarity
+func IsConditionWithPositivePolarity(conditionType hivev1.ClusterDeploymentConditionType) bool {
+	for _, condition := range hivev1.PositivePolarityClusterDeploymentConditions {
+		if condition == conditionType {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -336,7 +336,6 @@ type ClusterDeploymentCondition struct {
 // ClusterDeploymentConditionType is a valid value for ClusterDeploymentCondition.Type
 type ClusterDeploymentConditionType string
 
-// WARNING: All ClusterDeploymentConditionTypes should be added to the AllClusterDeploymentConditions slice below.
 const (
 	// ClusterImageSetNotFoundCondition is set when the ClusterImageSet referenced by the
 	// ClusterDeployment is not found.
@@ -410,23 +409,15 @@ const (
 	ClusterInstallRequirementsMetClusterDeploymentCondition ClusterDeploymentConditionType = "ClusterInstallRequirementsMet"
 )
 
-// AllClusterDeploymentConditions is a slice containing all condition types. This can be used for dealing with
-// cluster deployment conditions dynamically.
-var AllClusterDeploymentConditions = []ClusterDeploymentConditionType{
-	ClusterImageSetNotFoundCondition,
-	InstallerImageResolutionFailedCondition,
-	ControlPlaneCertificateNotFoundCondition,
-	IngressCertificateNotFoundCondition,
-	UnreachableCondition,
+// PositivePolarityClusterDeploymentConditions is a slice containing all condition types with positive polarity
+// For controllers that handle these conditions, the desired state is True
+// All cluster deployment condition types that are not in this slice are assumed to have negative polarity
+var PositivePolarityClusterDeploymentConditions = []ClusterDeploymentConditionType{
 	ActiveAPIURLOverrideCondition,
-	DNSNotReadyCondition,
-	ProvisionFailedCondition,
-	SyncSetFailedCondition,
-	RelocationFailedCondition,
 	ClusterHibernatingCondition,
-	InstallLaunchErrorCondition,
 	AWSPrivateLinkReadyClusterDeploymentCondition,
-	AWSPrivateLinkFailedClusterDeploymentCondition,
+	ClusterInstallCompletedClusterDeploymentCondition,
+	ClusterInstallRequirementsMetClusterDeploymentCondition,
 }
 
 // Cluster hibernating reasons


### PR DESCRIPTION
We have always assumed that all cluster deployment conditions have negative polarity, i.e., they are in their undesired state if their status=True.
This PR removes that assumption, and logs `hive_cluster_deployments_conditions` for all conditions in their undesired state.
For cluster deployment conditions in  `PositivePolarityClusterDeploymentConditions`, we assume that their desired state is True, and for all other conditions, the desired state is False..
Conditions with Unknown state are ignored.

xref: https://issues.redhat.com/browse/HIVE-1549

/assign @akhil-rane 
/cc @dgoodwin @abhinavdahiya 