### PR TITLE
fix support of OpenStack autoscalling.minRep=0

### DIFF
--- a/pkg/controller/remotemachineset/remotemachineset_controller.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller.go
@@ -985,13 +985,13 @@ func platformAllowsZeroAutoscalingMinReplicas(cd *hivev1.ClusterDeployment) bool
 
 	// Since 4.7, OpenStack allows zero-sized minReplicas for autoscaling
 	if cd.Spec.Platform.OpenStack != nil {
-		majorMinor, ok := cd.Labels[constants.VersionMajorMinorLabel]
+		majorMinorPatch, ok := cd.Labels[constants.VersionMajorMinorPatchLabel]
 		if !ok {
 			// can't determine whether to allow zero minReplicas
 			return false
 		}
 
-		currentVersion, err := semver.Make(majorMinor)
+		currentVersion, err := semver.Make(majorMinorPatch)
 		if err != nil {
 			// assume we can't set minReplicas to zero
 			return false


### PR DESCRIPTION
The semver library returns an error if you try to parse a version with
only major.minor. Provide the semver package the full major.minor.patch
to allow properly detecting whether a version of OpenStack can support
autocaling.minReplicas=0.

xref: https://issues.redhat.com/browse/HIVE-1539