### PR TITLE
Sort clusterdeployment conditions

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -1206,13 +1206,11 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 			existing: []runtime.Object{
 				func() runtime.Object {
 					cd := testClusterDeploymentWithInitializedConditions(testInstalledClusterDeployment(time.Now()))
-					cd.Status.Conditions = append(
-						cd.Status.Conditions,
-						hivev1.ClusterDeploymentCondition{
-							Type:   hivev1.SyncSetFailedCondition,
-							Status: corev1.ConditionTrue,
-						},
-					)
+					cd.Status.Conditions = addOrUpdateClusterDeploymentCondition(*cd,
+						hivev1.SyncSetFailedCondition,
+						corev1.ConditionTrue,
+						"test reason",
+						"test message")
 					return cd
 				}(),
 				testSecret(corev1.SecretTypeOpaque, adminKubeconfigSecret, "kubeconfig", adminKubeconfig),

--- a/pkg/controller/clusterdeployment/clusterinstalls.go
+++ b/pkg/controller/clusterdeployment/clusterinstalls.go
@@ -151,6 +151,7 @@ func (r *ReconcileClusterDeployment) reconcileExistingInstallingClusterInstall(c
 		statusModified = true
 	}
 
+	completed = controllerutils.FindClusterDeploymentCondition(conditions, hivev1.ClusterInstallCompletedClusterDeploymentCondition)
 	if completed.Status == corev1.ConditionTrue { // the cluster install is complete
 		cd.Spec.Installed = true
 		cd.Status.InstalledTimestamp = &completed.LastTransitionTime

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -8,7 +8,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -535,16 +534,8 @@ func (ca *clusterAccumulator) processCluster(cd *hivev1.ClusterDeployment) {
 
 	// Process conditions regardless if installed or not:
 	for _, cond := range cd.Status.Conditions {
-		// Conditions with positive polarity are in their undesired state when status = False
-		if controllerutils.IsConditionWithPositivePolarity(cond.Type) {
-			if cond.Status == corev1.ConditionFalse {
-				ca.addConditionToMap(cond.Type, clusterType)
-			}
-		} else {
-			// Assume all other conditions have negative polarity
-			if cond.Status == corev1.ConditionTrue {
-				ca.addConditionToMap(cond.Type, clusterType)
-			}
+		if !controllerutils.IsConditionInDesiredState(cond) {
+			ca.addConditionToMap(cond.Type, clusterType)
 		}
 	}
 }

--- a/pkg/controller/utils/conditions_test.go
+++ b/pkg/controller/utils/conditions_test.go
@@ -1,0 +1,45 @@
+package utils
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/stretchr/testify/assert"
+
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+)
+
+func TestSortedClusterDeploymentConditions(t *testing.T) {
+	addConditions := map[hivev1.ClusterDeploymentConditionType]corev1.ConditionStatus{
+		hivev1.ClusterImageSetNotFoundCondition:               corev1.ConditionFalse,
+		hivev1.DNSNotReadyCondition:                           corev1.ConditionTrue,
+		hivev1.SyncSetFailedCondition:                         corev1.ConditionUnknown,
+		hivev1.ProvisionStoppedCondition:                      corev1.ConditionUnknown,
+		hivev1.AWSPrivateLinkReadyClusterDeploymentCondition:  corev1.ConditionTrue,
+		hivev1.AWSPrivateLinkFailedClusterDeploymentCondition: corev1.ConditionTrue,
+	}
+	var conditions []hivev1.ClusterDeploymentCondition
+	for condType, condStatus := range addConditions {
+		conditions = SetClusterDeploymentCondition(conditions, condType, condStatus, "test-reason",
+			"test message", UpdateConditionAlways)
+	}
+	if assert.NotNil(t, conditions, "conditions were not set") {
+		if assert.Len(t, conditions, len(addConditions), "unexpected conditions found") {
+			compareConditions := []hivev1.ClusterDeploymentConditionType{
+				// undesired
+				hivev1.AWSPrivateLinkFailedClusterDeploymentCondition,
+				hivev1.DNSNotReadyCondition,
+				// desired
+				hivev1.AWSPrivateLinkReadyClusterDeploymentCondition,
+				hivev1.ClusterImageSetNotFoundCondition,
+				// unknown
+				hivev1.ProvisionStoppedCondition,
+				hivev1.SyncSetFailedCondition,
+			}
+			for i, cond := range conditions {
+				assert.Equal(t, compareConditions[i], cond.Type, "conditions not sorted as expected")
+			}
+		}
+	}
+}


### PR DESCRIPTION
Now that we have all possible cluster deployment conditions present on
the CR, it can become very difficult to debug.
This commit tries to sort the list of conditions, such that the
conditions in their undesired state are always at the top of the list

xref: https://issues.redhat.com/browse/HIVE-1552