### PR TITLE
Validate region in InstallConfig matches ClusterDeployment.

### DIFF
--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -391,6 +391,10 @@ const (
 	// ProvisionStoppedCondition is set when cluster provisioning is stopped
 	ProvisionStoppedCondition ClusterDeploymentConditionType = "ProvisionStopped"
 
+	// RequirementsMetCondition is set True when all pre-provision requirements have been met,
+	// and the controllers can begin the cluster install.
+	RequirementsMetCondition ClusterDeploymentConditionType = "RequirementsMet"
+
 	// AuthenticationFailureCondition is true when platform credentials cannot be used because of authentication failure
 	AuthenticationFailureClusterDeploymentCondition ClusterDeploymentConditionType = "AuthenticationFailure"
 
@@ -418,6 +422,7 @@ var PositivePolarityClusterDeploymentConditions = []ClusterDeploymentConditionTy
 	AWSPrivateLinkReadyClusterDeploymentCondition,
 	ClusterInstallCompletedClusterDeploymentCondition,
 	ClusterInstallRequirementsMetClusterDeploymentCondition,
+	RequirementsMetCondition,
 }
 
 // Cluster hibernating reasons

--- a/pkg/controller/clusterdeployment/installconfigvalidation.go
+++ b/pkg/controller/clusterdeployment/installconfigvalidation.go
@@ -1,0 +1,50 @@
+package clusterdeployment
+
+import (
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+
+	installertypes "github.com/openshift/installer/pkg/types"
+
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+)
+
+const (
+	noAWSPlatformErr   = "install config did not contain an AWS platform"
+	noGCPPlatformErr   = "install config did not contain a GCP platform"
+	noAzurePlatformErr = "install config did not contain an Azure platform"
+	regionMismatchErr  = "install config region does not match cluster deployment region"
+)
+
+func ValidateInstallConfig(cd *hivev1.ClusterDeployment, installConfig []byte) error {
+
+	ic := &installertypes.InstallConfig{}
+	if err := yaml.Unmarshal(installConfig, &ic); err != nil {
+		return errors.Wrap(err, "could not unmarshal InstallConfig")
+	}
+
+	switch platform := cd.Spec.Platform; {
+	case platform.AWS != nil:
+		if ic.Platform.AWS == nil {
+			return errors.New(noAWSPlatformErr)
+		}
+		if ic.Platform.AWS.Region != cd.Spec.Platform.AWS.Region {
+			return errors.New(regionMismatchErr)
+		}
+	case platform.GCP != nil:
+		if ic.Platform.GCP == nil {
+			return errors.New(noGCPPlatformErr)
+		}
+		if ic.Platform.GCP.Region != cd.Spec.Platform.GCP.Region {
+			return errors.New(regionMismatchErr)
+		}
+	case platform.Azure != nil:
+		if ic.Platform.Azure == nil {
+			return errors.New(noAzurePlatformErr)
+		}
+		if ic.Platform.Azure.Region != cd.Spec.Platform.Azure.Region {
+			return errors.New(regionMismatchErr)
+		}
+	}
+	return nil
+}

--- a/pkg/controller/clusterdeployment/installconfigvalidation_test.go
+++ b/pkg/controller/clusterdeployment/installconfigvalidation_test.go
@@ -1,0 +1,233 @@
+package clusterdeployment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/openshift/hive/apis"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	hivev1aws "github.com/openshift/hive/apis/hive/v1/aws"
+	hivev1azure "github.com/openshift/hive/apis/hive/v1/azure"
+	hivev1gcp "github.com/openshift/hive/apis/hive/v1/gcp"
+	testcd "github.com/openshift/hive/pkg/test/clusterdeployment"
+)
+
+const testAWSIC = `apiVersion: v1
+metadata:
+  creationTimestamp: null
+  name: testcluster
+baseDomain: example.com
+compute:
+- name: worker
+  platform:
+    aws:
+      rootVolume:
+        iops: 100
+        size: 22
+        type: gp2
+      type: m4.xlarge
+  replicas: 3
+controlPlane:
+  name: master
+  platform:
+    aws:
+      rootVolume:
+        iops: 100
+        size: 22
+        type: gp2
+      type: m4.xlarge
+  replicas: 3
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+  networkType: OpenShiftSDN
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  aws:
+    region: us-east-1
+pullSecret: ""
+`
+
+const testGCPIC = `
+apiVersion: v1
+baseDomain: example.com
+compute:
+- name: worker
+  platform:
+    gcp:
+      osDisk:
+        DiskSizeGB: 0
+        DiskType: ""
+      type: n1-standard-4
+  replicas: 3
+controlPlane:
+  name: master
+  platform:
+    gcp:
+      osDisk:
+        DiskSizeGB: 0
+        DiskType: ""
+      type: n1-standard-4
+  replicas: 3
+metadata:
+  creationTimestamp: null
+  name: testcluster-gcp
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+  networkType: OpenShiftSDN
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  gcp:
+    projectID: myproject
+    region: us-east1
+pullSecret: ""
+`
+
+const testAzureIC = `
+apiVersion: v1
+baseDomain: example.com
+compute:
+- name: worker
+  platform:
+    azure:
+      osDisk:
+        diskSizeGB: 0
+        diskType: ""
+      type: ""
+  replicas: 3
+controlPlane:
+  name: master
+  platform:
+    azure:
+      osDisk:
+        diskSizeGB: 0
+        diskType: ""
+      type: ""
+  replicas: 3
+metadata:
+  creationTimestamp: null
+  name: testcluster-azure
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+  networkType: OpenShiftSDN
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  azure:
+    baseDomainResourceGroupName: rg
+    outboundType: ""
+    region: centralus
+pullSecret: ""
+`
+
+func TestInstallConfigValidation(t *testing.T) {
+	apis.AddToScheme(scheme.Scheme)
+
+	cdBuilder := testcd.FullBuilder("testns", "testcluster", scheme.Scheme)
+
+	tests := []struct {
+		name          string
+		ic            string
+		cd            *hivev1.ClusterDeployment
+		expectedError string
+	}{
+		{
+			name: "test aws install config valid",
+			cd: cdBuilder.Build(
+				testcd.WithAWSPlatform(&hivev1aws.Platform{Region: "us-east-1"}),
+			),
+			ic: testAWSIC,
+		},
+		{
+			name: "test install config no aws platform",
+			cd: cdBuilder.Build(
+				testcd.WithAWSPlatform(&hivev1aws.Platform{Region: "us-east-1"}),
+			),
+			ic:            testGCPIC,
+			expectedError: noAWSPlatformErr,
+		},
+		{
+			name: "test aws install config mismatched regions",
+			cd: cdBuilder.Build(
+				testcd.WithAWSPlatform(&hivev1aws.Platform{Region: "us-west-2"}),
+			),
+			ic:            testAWSIC,
+			expectedError: regionMismatchErr,
+		},
+		{
+			name: "test gcp install config valid",
+			cd: cdBuilder.Build(
+				testcd.WithGCPPlatform(&hivev1gcp.Platform{Region: "us-east1"}),
+			),
+			ic: testGCPIC,
+		},
+		{
+			name: "test install config no gcp platform",
+			cd: cdBuilder.Build(
+				testcd.WithGCPPlatform(&hivev1gcp.Platform{Region: "us-east1"}),
+			),
+			ic:            testAWSIC,
+			expectedError: noGCPPlatformErr,
+		},
+		{
+			name: "test gcp install config mismatched regions",
+			cd: cdBuilder.Build(
+				testcd.WithGCPPlatform(&hivev1gcp.Platform{Region: "us-west2"}),
+			),
+			ic:            testGCPIC,
+			expectedError: regionMismatchErr,
+		},
+		{
+			name: "test azure install config valid",
+			cd: cdBuilder.Build(
+				testcd.WithAzurePlatform(&hivev1azure.Platform{Region: "centralus"}),
+			),
+			ic: testAzureIC,
+		},
+		{
+			name: "test install config no azure platform",
+			cd: cdBuilder.Build(
+				testcd.WithAzurePlatform(&hivev1azure.Platform{Region: "centralus"}),
+			),
+			ic:            testAWSIC,
+			expectedError: noAzurePlatformErr,
+		},
+		{
+			name: "test azure install config mismatched regions",
+			cd: cdBuilder.Build(
+				testcd.WithAzurePlatform(&hivev1azure.Platform{Region: "us-west2"}),
+			),
+			ic:            testAzureIC,
+			expectedError: regionMismatchErr,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, "foo", "foo")
+			err := ValidateInstallConfig(test.cd, []byte(test.ic))
+			if test.expectedError == "" {
+				assert.NoError(t, err)
+			} else {
+				if assert.Error(t, err, test.expectedError) {
+					assert.Contains(t, err.Error(), test.expectedError)
+				}
+			}
+		})
+	}
+}

--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -8,6 +8,8 @@ import (
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	hivev1aws "github.com/openshift/hive/apis/hive/v1/aws"
+	hivev1azure "github.com/openshift/hive/apis/hive/v1/azure"
+	hivev1gcp "github.com/openshift/hive/apis/hive/v1/gcp"
 	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/test/generic"
 )
@@ -167,5 +169,19 @@ func WithHibernateAfter(dur time.Duration) Option {
 func WithAWSPlatform(platform *hivev1aws.Platform) Option {
 	return func(clusterDeployment *hivev1.ClusterDeployment) {
 		clusterDeployment.Spec.Platform.AWS = platform
+	}
+}
+
+// WithGCPPlatform sets the specified gcp platform on the supplied object.
+func WithGCPPlatform(platform *hivev1gcp.Platform) Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Spec.Platform.GCP = platform
+	}
+}
+
+// WithAzurePlatform sets the specified azure platform on the supplied object.
+func WithAzurePlatform(platform *hivev1azure.Platform) Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Spec.Platform.Azure = platform
 	}
 }

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -391,6 +391,10 @@ const (
 	// ProvisionStoppedCondition is set when cluster provisioning is stopped
 	ProvisionStoppedCondition ClusterDeploymentConditionType = "ProvisionStopped"
 
+	// RequirementsMetCondition is set True when all pre-provision requirements have been met,
+	// and the controllers can begin the cluster install.
+	RequirementsMetCondition ClusterDeploymentConditionType = "RequirementsMet"
+
 	// AuthenticationFailureCondition is true when platform credentials cannot be used because of authentication failure
 	AuthenticationFailureClusterDeploymentCondition ClusterDeploymentConditionType = "AuthenticationFailure"
 
@@ -418,6 +422,7 @@ var PositivePolarityClusterDeploymentConditions = []ClusterDeploymentConditionTy
 	AWSPrivateLinkReadyClusterDeploymentCondition,
 	ClusterInstallCompletedClusterDeploymentCondition,
 	ClusterInstallRequirementsMetClusterDeploymentCondition,
+	RequirementsMetCondition,
 }
 
 // Cluster hibernating reasons


### PR DESCRIPTION
In general we try not to fully validate install configs match what you
set in ClusterDeployment. In this particular case however, a region
mismatch will cause the cluster to keep provisioning machines in the
wrong region until your cloud quota is fully exhausted.

Add a minimal check to ensure the InstallConfig region matches the
cluster deployment for AWS, Azure, and GCP.

In the event of a problem, a ReadyToProvision condition on the
ClusterDeployment will go False. Hoping to use this condition to
consolidate a few others in this controller that are failing pre-flight
checks.

x-ref: https://issues.redhat.com/browse/HIVE-1337
