### PR TITLE
Fix velerobackup tests for DeepEquals

### DIFF
--- a/pkg/controller/velerobackup/helpers_test.go
+++ b/pkg/controller/velerobackup/helpers_test.go
@@ -1,12 +1,14 @@
 package velerobackup
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+	testassert "github.com/openshift/hive/pkg/test/assert"
 	testcheckpoint "github.com/openshift/hive/pkg/test/checkpoint"
 	testclusterdeployment "github.com/openshift/hive/pkg/test/clusterdeployment"
 	testdnszone "github.com/openshift/hive/pkg/test/dnszone"
@@ -151,5 +153,13 @@ func assertAggregateErrorsAreEqualType(t *testing.T, expected, actual utilerrors
 
 	for i := range expectedErrors {
 		assert.Equal(t, reflect.TypeOf(expectedErrors[i]), reflect.TypeOf(actualErrors[i]))
+	}
+}
+
+// assertObjectArraysMostlyEqual wraps AssertEqualWhereItCounts for lists of objects
+func assertObjectArraysMostlyEqual(t *testing.T, expected, actual []runtime.Object) {
+	assert.Equal(t, len(expected), len(actual), fmt.Sprintf("Expected (%d) and Actual (%d) are different sizes.", len(expected), len(actual)))
+	for i := 0; i < len(expected); i++ {
+		testassert.AssertEqualWhereItCounts(t, expected[i], actual[i], fmt.Sprintf("Mismatch in object #%d", i+1))
 	}
 }

--- a/pkg/controller/velerobackup/velerobackup_controller_test.go
+++ b/pkg/controller/velerobackup/velerobackup_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	testassert "github.com/openshift/hive/pkg/test/assert"
 	"github.com/openshift/hive/pkg/test/generic"
 	"github.com/openshift/hive/pkg/test/manager/mock"
 	testsyncset "github.com/openshift/hive/pkg/test/syncset"
@@ -282,7 +283,7 @@ func TestReconcile(t *testing.T) {
 			assert.Equal(t, test.expectedResult.Requeue, actualResult.Requeue)
 			assert.InDelta(t, test.expectedResult.RequeueAfter, actualResult.RequeueAfter, tolerance)
 			assert.Equal(t, test.expectedError, actualError)
-			assert.Equal(t, test.expectedObjects, actualObjects)
+			assertObjectArraysMostlyEqual(t, test.expectedObjects, actualObjects)
 		})
 	}
 }
@@ -356,7 +357,7 @@ func TestGetRuntimeObjects(t *testing.T) {
 
 			// Assert
 			assert.NoError(t, actualError)
-			assert.Equal(t, test.expectedObjects, actualObjects)
+			assertObjectArraysMostlyEqual(t, test.expectedObjects, actualObjects)
 		})
 	}
 }
@@ -397,7 +398,7 @@ func TestGetNamespaceCheckpoint(t *testing.T) {
 			actualCheckpoint, actualFound, actualError := r.getNamespaceCheckpoint(namespace, r.logger)
 
 			// Assert
-			assert.Equal(t, test.expectedCheckpoint, actualCheckpoint)
+			testassert.AssertEqualWhereItCounts(t, test.expectedCheckpoint, actualCheckpoint, "")
 			assert.Equal(t, test.expectedFound, actualFound)
 			assertErrorsAreEqualType(t, test.expectedError, actualError)
 		})
@@ -466,7 +467,7 @@ func TestCreateOrUpdateNamespaceCheckpoint(t *testing.T) {
 			r.Get(context.TODO(), namespacedName, actualCheckpoint)
 
 			// Assert
-			assert.Equal(t, test.expectedCheckpoint, actualCheckpoint)
+			testassert.AssertEqualWhereItCounts(t, test.expectedCheckpoint, actualCheckpoint, "")
 			assertErrorsAreEqualType(t, test.expectedError, actualError)
 		})
 	}

--- a/pkg/controller/velerobackup/velerobackup_controller_test.go
+++ b/pkg/controller/velerobackup/velerobackup_controller_test.go
@@ -116,9 +116,9 @@ func TestReconcile(t *testing.T) {
 			},
 			expectedResult: reconcile.Result{},
 			expectedObjects: []runtime.Object{
-				testclusterdeployment.Build(clusterDeploymentBase(), testclusterdeployment.WithResourceVersion("999")),
-				testsyncset.Build(syncSetBase(), testsyncset.WithResourceVersion("999")),
-				testdnszone.Build(dnsZoneBase(), testdnszone.WithResourceVersion("999")),
+				testclusterdeployment.Build(clusterDeploymentBase()),
+				testsyncset.Build(syncSetBase()),
+				testdnszone.Build(dnsZoneBase()),
 				testcheckpoint.Build(checkpointBase(), testcheckpoint.WithLastBackupChecksum(calculateRuntimeObjectsChecksum(
 					[]runtime.Object{
 						testclusterdeployment.Build(clusterDeploymentBase()),
@@ -150,7 +150,7 @@ func TestReconcile(t *testing.T) {
 			},
 			expectedResult: reconcile.Result{},
 			expectedObjects: []runtime.Object{
-				testclusterdeployment.Build(clusterDeploymentBase(), testclusterdeployment.WithResourceVersion("999")),
+				testclusterdeployment.Build(clusterDeploymentBase()),
 				testcheckpoint.Build(checkpointBase(),
 					testcheckpoint.WithLastBackupRef(hivev1.BackupReference{Name: "notarealbackup", Namespace: namespace}),
 					testcheckpoint.WithLastBackupTime(fiveHoursAgo),
@@ -186,8 +186,8 @@ func TestReconcile(t *testing.T) {
 				RequeueAfter: ((3 * time.Minute) - twoMinuteDuration),
 			},
 			expectedObjects: []runtime.Object{
-				testclusterdeployment.Build(clusterDeploymentBase(), testclusterdeployment.WithResourceVersion("999")),
-				testsyncset.Build(syncSetBase(), testsyncset.WithResourceVersion("999")),
+				testclusterdeployment.Build(clusterDeploymentBase()),
+				testsyncset.Build(syncSetBase()),
 				testcheckpoint.Build(checkpointBase(),
 					testcheckpoint.WithLastBackupRef(hivev1.BackupReference{Name: "notarealbackup", Namespace: namespace}),
 					testcheckpoint.WithLastBackupTime(twoMinutesAgo),
@@ -218,8 +218,8 @@ func TestReconcile(t *testing.T) {
 			},
 			expectedResult: reconcile.Result{},
 			expectedObjects: []runtime.Object{
-				testclusterdeployment.Build(clusterDeploymentBase(), testclusterdeployment.WithResourceVersion("999")),
-				testsyncset.Build(syncSetBase(), testsyncset.WithResourceVersion("999")),
+				testclusterdeployment.Build(clusterDeploymentBase()),
+				testsyncset.Build(syncSetBase()),
 				testcheckpoint.Build(checkpointBase(), testcheckpoint.WithLastBackupChecksum(calculateRuntimeObjectsChecksum(
 					[]runtime.Object{
 						testclusterdeployment.Build(clusterDeploymentBase()),
@@ -249,8 +249,8 @@ func TestReconcile(t *testing.T) {
 			},
 			expectedResult: reconcile.Result{},
 			expectedObjects: []runtime.Object{
-				testclusterdeployment.Build(clusterDeploymentBase(), testclusterdeployment.WithResourceVersion("999")),
-				testsyncset.Build(syncSetBase(), testsyncset.WithResourceVersion("999")),
+				testclusterdeployment.Build(clusterDeploymentBase()),
+				testsyncset.Build(syncSetBase()),
 				testcheckpoint.Build(checkpointBase(), testcheckpoint.WithLastBackupChecksum(calculateRuntimeObjectsChecksum(
 					[]runtime.Object{
 						testclusterdeployment.Build(clusterDeploymentBase()),
@@ -331,17 +331,17 @@ func TestGetRuntimeObjects(t *testing.T) {
 				testclusterdeployment.Build(clusterDeploymentBase()),
 			},
 			expectedObjects: []runtime.Object{
-				testclusterdeployment.Build(clusterDeploymentBase(), testclusterdeployment.WithResourceVersion("999")),
+				testclusterdeployment.Build(clusterDeploymentBase()),
 			},
 		},
 		{
 			name: "2 ClusterDeployments in different namespaces",
 			existingObjects: []runtime.Object{
 				testclusterdeployment.Build(clusterDeploymentBase()),
-				testclusterdeployment.Build(clusterDeploymentBase(), testclusterdeployment.Generic(generic.WithNamespace("not the correct namespace")), testclusterdeployment.WithResourceVersion("999")),
+				testclusterdeployment.Build(clusterDeploymentBase(), testclusterdeployment.Generic(generic.WithNamespace("not the correct namespace"))),
 			},
 			expectedObjects: []runtime.Object{
-				testclusterdeployment.Build(clusterDeploymentBase(), testclusterdeployment.WithResourceVersion("999")),
+				testclusterdeployment.Build(clusterDeploymentBase()),
 			},
 		},
 	}
@@ -383,7 +383,7 @@ func TestGetNamespaceCheckpoint(t *testing.T) {
 			name:               "Existing Checkpoint",
 			expectedFound:      true,
 			existingObjects:    []runtime.Object{testcheckpoint.Build(checkpointBase(), testcheckpoint.WithLastBackupChecksum("NOTREAL"))},
-			expectedCheckpoint: testcheckpoint.Build(checkpointBase(), testcheckpoint.WithLastBackupChecksum("NOTREAL"), testcheckpoint.WithTypeMeta(), testcheckpoint.WithResourceVersion("999")),
+			expectedCheckpoint: testcheckpoint.Build(checkpointBase(), testcheckpoint.WithLastBackupChecksum("NOTREAL"), testcheckpoint.WithTypeMeta()),
 			expectedError:      nil,
 		},
 	}
@@ -441,7 +441,7 @@ func TestCreateOrUpdateNamespaceCheckpoint(t *testing.T) {
 			existingObjects: []runtime.Object{
 				testcheckpoint.Build(checkpointBase(), testcheckpoint.WithLastBackupChecksum("NOTREAL-BEFORE")),
 			},
-			expectedCheckpoint: testcheckpoint.Build(checkpointBase(), testcheckpoint.WithLastBackupChecksum("NOTREAL-BEFORE"), testcheckpoint.WithTypeMeta(), testcheckpoint.WithResourceVersion("999")),
+			expectedCheckpoint: testcheckpoint.Build(checkpointBase(), testcheckpoint.WithLastBackupChecksum("NOTREAL-BEFORE"), testcheckpoint.WithTypeMeta()),
 			expectedError:      statusErr,
 		},
 		{
@@ -480,7 +480,7 @@ func TestCalculateObjectsChecksumWithoutStatus(t *testing.T) {
 	}{
 		{
 			name:             "Valid ClusterDeployment Checksum",
-			object:           testclusterdeployment.Build(clusterDeploymentBase(), testclusterdeployment.WithResourceVersion("999")),
+			object:           testclusterdeployment.Build(clusterDeploymentBase()),
 			expectedChecksum: calculateClusterDeploymentChecksum(testclusterdeployment.Build(clusterDeploymentBase())),
 		},
 		{

--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -81,11 +81,6 @@ func WithName(name string) Option {
 	return Generic(generic.WithName(name))
 }
 
-// WithResourceVersion sets the specified resource version on the supplied object.
-func WithResourceVersion(resourceVersion string) Option {
-	return Generic(generic.WithResourceVersion(resourceVersion))
-}
-
 // WithNamespace sets the object.Namespace field when building an object with Build.
 func WithNamespace(namespace string) Option {
 	return Generic(generic.WithNamespace(namespace))

--- a/pkg/test/syncset/syncset.go
+++ b/pkg/test/syncset/syncset.go
@@ -127,8 +127,3 @@ func WithPatches(patches ...hivev1.SyncObjectPatch) Option {
 		syncSet.Spec.Patches = patches
 	}
 }
-
-// WithResourceVersion sets the specified resource version on the supplied object.
-func WithResourceVersion(resourceVersion string) Option {
-	return Generic(generic.WithResourceVersion(resourceVersion))
-}


### PR DESCRIPTION
Several tests were using DeepEquals (under testify's `assert.Equal`) to compare a runtime.Object from the (fake) kube server to a locally-constructed expected value. This is brittle, as fields such as ResourceVersion cannot be relied on to have predictable values.

Commit c7d60527612c141f58d748b8bf2e25d72f9499d5 in #1407 worked around the problem by explicitly setting the ResourceVersion to the value set by the fake kube server in controller-runtime 0.8.x. This PR has two commits:
- Revert that workaround;
- Switch to a comparison that disregards ResourceVersion and TypeMeta.
