### PR TITLE
Initialize MachinePool conditions

### DIFF
--- a/pkg/controller/remotemachineset/awsactuator.go
+++ b/pkg/controller/remotemachineset/awsactuator.go
@@ -322,10 +322,10 @@ func (a *AWSActuator) getPrivateSubnetsByAvailabilityZone(pool *hivev1.MachinePo
 
 	results, err := a.awsClient.DescribeSubnets(&ec2.DescribeSubnetsInput{SubnetIds: idPointers})
 	if err != nil || len(results.Subnets) == 0 {
-		if strings.Contains(err.Error(), "InvalidSubnetID.NotFound") {
-			var conditionMessage string
+		if strings.Contains(err.Error(), "InvalidSubnet") {
+			conditionMessage := err.Error()
 			if submatches := reg.FindStringSubmatch(err.Error()); submatches != nil {
-				// formatting error message before adding it to condition
+				// formatting error message before adding it to condition when
 				// sample error message: InvalidSubnetID.NotFound: The subnet ID 'subnet-1,subnet-2' does not exist\tstatus code: 400, request id: ea8b3bb7-de56-405f-9345-e5690a3ea8b2
 				// message after formatting: The subnet ID 'subnet-1,subnet-2' does not exist
 				conditionMessage = submatches[1]

--- a/pkg/controller/remotemachineset/gcpactuator_test.go
+++ b/pkg/controller/remotemachineset/gcpactuator_test.go
@@ -585,13 +585,10 @@ func TestObtainLeaseChar(t *testing.T) {
 			require.Contains(t, test.expectedCharIn, string(leaseChar))
 
 			if test.expectCondition != nil {
-				for _, cond := range pool.Status.Conditions {
-					assert.Equal(t, cond.Type, test.expectCondition.Type)
-					assert.Equal(t, cond.Status, test.expectCondition.Status)
+				cond := controllerutils.FindMachinePoolCondition(pool.Status.Conditions, test.expectCondition.Type)
+				if assert.NotNilf(t, cond, "did not find expected condition type: %v", test.expectCondition.Type) {
+					assert.Equal(t, test.expectCondition.Status, cond.Status, "condition found with unexpected status")
 				}
-			} else {
-				// Assuming if you didn't expect a condition, there shouldn't be any.
-				assert.Equal(t, 0, len(pool.Status.Conditions))
 			}
 
 			if test.expectProceed {

--- a/pkg/controller/remotemachineset/remotemachineset_controller_test.go
+++ b/pkg/controller/remotemachineset/remotemachineset_controller_test.go
@@ -891,6 +891,26 @@ func testMachinePool() *hivev1.MachinePool {
 				},
 			},
 		},
+		Status: hivev1.MachinePoolStatus{
+			Conditions: []hivev1.MachinePoolCondition{
+				{
+					Status: corev1.ConditionUnknown,
+					Type:   hivev1.NotEnoughReplicasMachinePoolCondition,
+				},
+				{
+					Status: corev1.ConditionUnknown,
+					Type:   hivev1.NoMachinePoolNameLeasesAvailable,
+				},
+				{
+					Status: corev1.ConditionUnknown,
+					Type:   hivev1.InvalidSubnetsMachinePoolCondition,
+				},
+				{
+					Status: corev1.ConditionUnknown,
+					Type:   hivev1.UnsupportedConfigurationMachinePoolCondition,
+				},
+			},
+		},
 	}
 }
 
@@ -900,6 +920,14 @@ func testAutoscalingMachinePool(min, max int) *hivev1.MachinePool {
 	p.Spec.Autoscaling = &hivev1.MachinePoolAutoscaling{
 		MinReplicas: int32(min),
 		MaxReplicas: int32(max),
+	}
+	for i, cond := range p.Status.Conditions {
+		// Condition will always be present because it is initialized in testMachinePool
+		if cond.Type == hivev1.NotEnoughReplicasMachinePoolCondition {
+			cond.Status = corev1.ConditionFalse
+			cond.Reason = "EnoughReplicas"
+			p.Status.Conditions[i] = cond
+		}
 	}
 	return p
 }


### PR DESCRIPTION
As per kube api guidelines, conditions should be placed by the controller as soon as possible, to indicate that it has began processing the resource. If a decision cannot be made regarding the status of the condition at that time, it can be set to Unknown.
This PR initializes MachinePool conditions, and ensures conditions do not have to be "True" to be set for the first time.

xref: https://issues.redhat.com/browse/HIVE-1562

/assign @abutcher 
/cc @akhil-rane 