### PR TITLE
Add code coverage script & make target

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,26 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+coverage:
+  precision: 2
+  round: down
+  range: "20...100"
+
+  status:
+    project: no
+    patch: no
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no

--- a/Makefile
+++ b/Makefile
@@ -289,3 +289,7 @@ install-tools:
 	go install $(GO_MOD_FLAGS) github.com/golang/mock/mockgen
 	go install $(GO_MOD_FLAGS) golang.org/x/lint/golint
 	go install $(GO_MOD_FLAGS) github.com/golangci/golangci-lint/cmd/golangci-lint
+
+.PHONY: coverage
+coverage:
+	hack/codecov.sh

--- a/hack/codecov.sh
+++ b/hack/codecov.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+CI_SERVER_URL=https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test
+COVER_PROFILE=${COVER_PROFILE:-coverage.out}
+JOB_TYPE=${JOB_TYPE:-"local"}
+
+# Default concurrency to four threads. By default it's the number of procs,
+# which seems to be 16 in the CI env. Some consumers' coverage jobs were
+# regularly getting OOM-killed; so do this rather than boost the pod resources
+# unreasonably.
+COV_THREAD_COUNT=${COV_THREAD_COUNT:-4}
+make -C "${REPO_ROOT}" test-unit GO_TEST_FLAGS="-coverprofile=${COVER_PROFILE}.tmp -covermode=atomic -coverpkg=./... -p ${COV_THREAD_COUNT}"
+
+# NOTE: The above runs `go test` in the repo root *and* ./apis, creating
+# ${COVER_PROFILE}.tmp in both. The following will:
+# - combine the reports; and
+# - remove generated files from them.
+# FIXME: This is brittle, and will fall over (possibly silently!) if the
+# directory structure or test split changes.
+TMP_PROFILES="${COVER_PROFILE}.tmp ./apis/${COVER_PROFILE}.tmp"
+cat $TMP_PROFILES | grep -v "zz_generated" > "${COVER_PROFILE}"
+rm -f ${TMP_PROFILES}
+
+# Configure the git refs and job link based on how the job was triggered via prow
+if [[ "${JOB_TYPE}" == "presubmit" ]]; then
+       echo "detected PR code coverage job for #${PULL_NUMBER}"
+       REF_FLAGS="-P ${PULL_NUMBER} -C ${PULL_PULL_SHA}"
+       JOB_LINK="${CI_SERVER_URL}/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+elif [[ "${JOB_TYPE}" == "postsubmit" ]]; then
+       echo "detected branch code coverage job for ${PULL_BASE_REF}"
+       REF_FLAGS="-B ${PULL_BASE_REF} -C ${PULL_BASE_SHA}"
+       JOB_LINK="${CI_SERVER_URL}/logs/${JOB_NAME}/${BUILD_ID}"
+elif [[ "${JOB_TYPE}" == "local" ]]; then
+       echo "coverage report available at ${COVER_PROFILE}"
+       exit 0
+else
+       echo "${JOB_TYPE} jobs not supported" >&2
+       exit 1
+fi
+
+# Configure certain internal codecov variables with values from prow.
+export CI_BUILD_URL="${JOB_LINK}"
+export CI_BUILD_ID="${JOB_NAME}"
+export CI_JOB_ID="${BUILD_ID}"
+
+if [[ "${JOB_TYPE}" != "local" ]]; then
+       if [[ -z "${ARTIFACT_DIR:-}" ]] || [[ ! -d "${ARTIFACT_DIR}" ]] || [[ ! -w "${ARTIFACT_DIR}" ]]; then
+              echo '${ARTIFACT_DIR} must be set for non-local jobs, and must point to a writable directory' >&2
+              exit 1
+       fi
+       curl -sS https://codecov.io/bash -o "${ARTIFACT_DIR}/codecov.sh"
+       bash <(cat "${ARTIFACT_DIR}/codecov.sh") -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
+else
+       bash <(curl -s https://codecov.io/bash) -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
+fi


### PR DESCRIPTION
This commit adds
- a `coverage` make rule that runs
- a new codecov.sh script adapted from [the one OSD operators use](https://github.com/openshift/boilerplate/blob/f3c8c8d393f69f83ce9dbdbc0aa72d2e5b9e5d96/boilerplate/openshift/golang-osd-operator/codecov.sh); and
- a codecov configuration file, stolen directly from [the one OSD operators use](https://github.com/openshift/boilerplate/blob/f3c8c8d393f69f83ce9dbdbc0aa72d2e5b9e5d96/boilerplate/openshift/golang-osd-operator/.codecov.yml).

This is designed to be run in three modes: local, presubmit, and postsubmit.

- In all modes, it runs the go cover tool, scrubs out the stats for generated files, and writes the raw report to `coverage.out`.
- In local mode, that's it.
- Presubmit and postsubmit modes are intended for use in CI jobs, where they save codecov.io's reporting tool as a build artifact, and run it.
  - Presubmit mode writes a hypothetical ("if this were to merge now") coverage report to the PR.
  - Postsubmit mode saves the coverage report to codecov.io where it becomes permanently available in the historical record for this repository.