### PR TITLE
Remove unused Dockerfile.hivebase

### DIFF
--- a/Dockerfile.hivebase
+++ b/Dockerfile.hivebase
@@ -1,3 +1,0 @@
-FROM registry.ci.openshift.org/openshift/origin-v4.0:base as hivebase
-
-RUN yum -y install openssh-clients && yum clean all


### PR DESCRIPTION
We stopped using this via https://github.com/openshift/release/pull/19191