### PR TITLE
Fix panic in dnszone controller

### DIFF
--- a/pkg/controller/utils/errorscrub.go
+++ b/pkg/controller/utils/errorscrub.go
@@ -12,6 +12,9 @@ var (
 // ErrorScrub scrubs cloud error messages destined for CRD status to remove things that
 // change every attempt, such as request IDs, which subsequently cause an infinite update/reconcile loop.
 func ErrorScrub(err error) string {
+	if err == nil {
+		return ""
+	}
 	s := newlineTabRE.ReplaceAllString(err.Error(), ", ")
 	s = awsRequestIDRE.ReplaceAllString(s, "")
 	return s

--- a/pkg/controller/utils/errorscrub_test.go
+++ b/pkg/controller/utils/errorscrub_test.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,28 +11,33 @@ func TestErrorScrubber(t *testing.T) {
 	cases := []struct {
 		name string
 
-		input    string
+		input    error
 		expected string
 	}{
 		{
 			name:     "aws request id",
-			input:    "failed to grant creds: error syncing creds in mint-mode: AWS Error: LimitExceeded - LimitExceeded: Cannot exceed quota for UsersPerAccount: 5000\n\tstatus code: 409, request id: 0604c1a4-0a68-4d1a-b8e6-cdcf68176d71",
+			input:    errors.New("failed to grant creds: error syncing creds in mint-mode: AWS Error: LimitExceeded - LimitExceeded: Cannot exceed quota for UsersPerAccount: 5000\n\tstatus code: 409, request id: 0604c1a4-0a68-4d1a-b8e6-cdcf68176d71"),
 			expected: "failed to grant creds: error syncing creds in mint-mode: AWS Error: LimitExceeded - LimitExceeded: Cannot exceed quota for UsersPerAccount: 5000, status code: 409",
 		},
 		{
 			name:     "request id mid",
-			input:    "AWS Error: LimitExceeded - LimitExceeded: Cannot exceed quota for UsersPerAccount: 5000\n\trequest id: 0604c1a4-0a68-4d1a-b8e6-cdcf68176d71, something else",
+			input:    errors.New("AWS Error: LimitExceeded - LimitExceeded: Cannot exceed quota for UsersPerAccount: 5000\n\trequest id: 0604c1a4-0a68-4d1a-b8e6-cdcf68176d71, something else"),
 			expected: "AWS Error: LimitExceeded - LimitExceeded: Cannot exceed quota for UsersPerAccount: 5000, something else",
 		},
 		{
 			name:     "request id start",
-			input:    "Request id: 0604c1a4-0a68-4d1a-b8e6-cdcf68176d71, something else", // shouldn't really happen
-			expected: ", something else",                                                 // not pretty but what I want to verify happens
+			input:    errors.New("Request id: 0604c1a4-0a68-4d1a-b8e6-cdcf68176d71, something else"), // shouldn't really happen
+			expected: ", something else",                                                             // not pretty but what I want to verify happens
+		},
+		{
+			name:     "handle nil",
+			input:    nil,
+			expected: "",
 		},
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, ErrorScrub(fmt.Errorf(test.input)))
+			assert.Equal(t, test.expected, ErrorScrub(test.input))
 		})
 	}
 }


### PR DESCRIPTION
While trying to get the actuator in dnszone controller, code was trying
to parse a re-assigned error variable, causing a panic

/assign @joelddiaz 