### PR TITLE
hibernation: include machines in undesired state when hibernating/resuming

### DIFF
--- a/pkg/controller/hibernation/aws_actuator.go
+++ b/pkg/controller/hibernation/aws_actuator.go
@@ -95,35 +95,37 @@ func (a *awsActuator) StartMachines(cd *hivev1.ClusterDeployment, c client.Clien
 }
 
 // MachinesRunning will return true if the machines associated with the given
-// ClusterDeployment are in a running state.
-func (a *awsActuator) MachinesRunning(cd *hivev1.ClusterDeployment, c client.Client, logger log.FieldLogger) (bool, error) {
+// ClusterDeployment are in a running state. It also returns a list of machines that
+// are not running.
+func (a *awsActuator) MachinesRunning(cd *hivev1.ClusterDeployment, c client.Client, logger log.FieldLogger) (bool, []string, error) {
 	logger = logger.WithField("cloud", "aws")
 	logger.Infof("checking whether machines are running")
 	awsClient, err := a.awsClientFn(cd, c, logger)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 	instanceIDs, err := getClusterInstanceIDs(cd, awsClient, notRunningStates, logger)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
-	return len(instanceIDs) == 0, nil
+	return len(instanceIDs) == 0, aws.StringValueSlice(instanceIDs), nil
 }
 
 // MachinesStopped will return true if the machines associated with the given
-// ClusterDeployment are in a stopped state.
-func (a *awsActuator) MachinesStopped(cd *hivev1.ClusterDeployment, c client.Client, logger log.FieldLogger) (bool, error) {
+// ClusterDeployment are in a stopped state. It also returns a list of machines
+// that have not stopped.
+func (a *awsActuator) MachinesStopped(cd *hivev1.ClusterDeployment, c client.Client, logger log.FieldLogger) (bool, []string, error) {
 	logger = logger.WithField("cloud", "aws")
 	logger.Infof("checking whether machines are stopped")
 	awsClient, err := a.awsClientFn(cd, c, logger)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 	instanceIDs, err := getClusterInstanceIDs(cd, awsClient, notStoppedStates, logger)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
-	return len(instanceIDs) == 0, nil
+	return len(instanceIDs) == 0, aws.StringValueSlice(instanceIDs), nil
 }
 
 func getAWSClient(cd *hivev1.ClusterDeployment, c client.Client, logger log.FieldLogger) (awsclient.Client, error) {

--- a/pkg/controller/hibernation/aws_actuator_test.go
+++ b/pkg/controller/hibernation/aws_actuator_test.go
@@ -177,9 +177,9 @@ func TestMachinesStoppedAndRunning(t *testing.T) {
 			var result bool
 			switch test.testFunc {
 			case "MachinesStopped":
-				result, err = actuator.MachinesStopped(testClusterDeployment(), nil, log.New())
+				result, _, err = actuator.MachinesStopped(testClusterDeployment(), nil, log.New())
 			case "MachinesRunning":
-				result, err = actuator.MachinesRunning(testClusterDeployment(), nil, log.New())
+				result, _, err = actuator.MachinesRunning(testClusterDeployment(), nil, log.New())
 			default:
 				t.Fatal("Invalid function to test")
 			}

--- a/pkg/controller/hibernation/azure_actuator_test.go
+++ b/pkg/controller/hibernation/azure_actuator_test.go
@@ -171,9 +171,9 @@ func TestAzureMachinesStoppedAndRunning(t *testing.T) {
 			var result bool
 			switch test.testFunc {
 			case "MachinesStopped":
-				result, err = actuator.MachinesStopped(testAzureClusterDeployment(), nil, log.New())
+				result, _, err = actuator.MachinesStopped(testAzureClusterDeployment(), nil, log.New())
 			case "MachinesRunning":
-				result, err = actuator.MachinesRunning(testAzureClusterDeployment(), nil, log.New())
+				result, _, err = actuator.MachinesRunning(testAzureClusterDeployment(), nil, log.New())
 			default:
 				t.Fatal("Invalid function to test")
 			}

--- a/pkg/controller/hibernation/gcp_actuator_test.go
+++ b/pkg/controller/hibernation/gcp_actuator_test.go
@@ -181,9 +181,9 @@ func TestGCPMachinesStoppedAndRunning(t *testing.T) {
 			var result bool
 			switch test.testFunc {
 			case "MachinesStopped":
-				result, err = actuator.MachinesStopped(testClusterDeployment(), nil, log.New())
+				result, _, err = actuator.MachinesStopped(testClusterDeployment(), nil, log.New())
 			case "MachinesRunning":
-				result, err = actuator.MachinesRunning(testClusterDeployment(), nil, log.New())
+				result, _, err = actuator.MachinesRunning(testClusterDeployment(), nil, log.New())
 			default:
 				t.Fatal("Invalid function to test")
 			}

--- a/pkg/controller/hibernation/hibernation_actuator.go
+++ b/pkg/controller/hibernation/hibernation_actuator.go
@@ -20,9 +20,11 @@ type HibernationActuator interface {
 	// StartMachines will select machines belonging to the given ClusterDeployment
 	StartMachines(cd *hivev1.ClusterDeployment, hiveClient client.Client, logger log.FieldLogger) error
 	// MachinesRunning will return true if the machines associated with the given
-	// ClusterDeployment are in a running state.
-	MachinesRunning(cd *hivev1.ClusterDeployment, hiveClient client.Client, logger log.FieldLogger) (bool, error)
+	// ClusterDeployment are in a running state. It also returns a list of machines that
+	// are not running.
+	MachinesRunning(cd *hivev1.ClusterDeployment, hiveClient client.Client, logger log.FieldLogger) (bool, []string, error)
 	// MachinesStopped will return true if the machines associated with the given
-	// ClusterDeployment are in a stopped state.
-	MachinesStopped(cd *hivev1.ClusterDeployment, hiveClient client.Client, logger log.FieldLogger) (bool, error)
+	// ClusterDeployment are in a stopped state. it also returns a list of machines
+	// that have not stopped.
+	MachinesStopped(cd *hivev1.ClusterDeployment, hiveClient client.Client, logger log.FieldLogger) (bool, []string, error)
 }

--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -3,6 +3,8 @@ package hibernation
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -39,10 +41,10 @@ const (
 
 	// stateCheckInterval is the time interval for polling
 	// whether a cluster's machines are stopped or are running
-	stateCheckInterval = 60 * time.Second
+	stateCheckInterval = 1 * time.Minute
 
 	// csrCheckInterval is the time interval for polling
-	// pending CSRs
+	// pending CertificateSigningRequests
 	csrCheckInterval = 30 * time.Second
 
 	// nodeCheckWaitTime is the minimum time to wait for a node
@@ -330,14 +332,29 @@ func (r *hibernationReconciler) checkClusterStopped(cd *hivev1.ClusterDeployment
 		logger.Warning("No compatible actuator found to check machine status")
 		return reconcile.Result{}, nil
 	}
-	stopped, err := actuator.MachinesStopped(cd, r.Client, logger)
+
+	stopped, remaining, err := actuator.MachinesStopped(cd, r.Client, logger)
 	if err != nil {
 		logger.WithError(err).Log(controllerutils.LogLevel(err), "Failed to check whether machines are stopped.")
 		return reconcile.Result{}, err
 	}
 	if !stopped {
+		// Ensure all machines have been stopped. Should have been handled already but we've seen VMs left in running state.
+		if err := actuator.StopMachines(cd, r.Client, logger); err != nil {
+			logger.WithError(err).Error("error stopping machines")
+			return reconcile.Result{}, err
+		}
+
+		sort.Strings(remaining) // we want to make sure the message is stable.
+		msg := fmt.Sprintf("Some machines have not yet stopped: %s", strings.Join(remaining, ","))
+		_, condErr := r.setHibernatingCondition(cd, hivev1.StoppingHibernationReason, msg, corev1.ConditionTrue, logger)
+		if condErr != nil {
+			return reconcile.Result{}, condErr
+		}
+
 		return reconcile.Result{RequeueAfter: stateCheckInterval}, nil
 	}
+
 	logger.Info("Cluster has stopped and is in hibernating state")
 	return r.setHibernatingCondition(cd, hivev1.HibernatingHibernationReason, "Cluster is stopped", corev1.ConditionTrue, logger)
 }
@@ -348,7 +365,8 @@ func (r *hibernationReconciler) checkClusterResumed(cd *hivev1.ClusterDeployment
 		logger.Warning("No compatible actuator found to check machine status")
 		return reconcile.Result{}, nil
 	}
-	running, err := actuator.MachinesRunning(cd, r.Client, logger)
+
+	running, remaining, err := actuator.MachinesRunning(cd, r.Client, logger)
 	if err != nil {
 		logger.WithError(err).Log(controllerutils.LogLevel(err), "Failed to check whether machines are running.")
 		return reconcile.Result{}, err
@@ -359,8 +377,17 @@ func (r *hibernationReconciler) checkClusterResumed(cd *hivev1.ClusterDeployment
 			logger.WithError(err).Error("error starting machines")
 			return reconcile.Result{}, err
 		}
+
+		sort.Strings(remaining) // we want to make sure the message is stable.
+		msg := fmt.Sprintf("Some machines are not yet running: %s", strings.Join(remaining, ","))
+		_, condErr := r.setHibernatingCondition(cd, hivev1.ResumingHibernationReason, msg, corev1.ConditionTrue, logger)
+		if condErr != nil {
+			return reconcile.Result{}, condErr
+		}
+
 		return reconcile.Result{RequeueAfter: stateCheckInterval}, nil
 	}
+
 	remoteClient, err := r.remoteClientBuilder(cd).Build()
 	if err != nil {
 		logger.WithError(err).Log(controllerutils.LogLevel(err), "Failed to connect to target cluster")

--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -346,7 +346,7 @@ func (r *hibernationReconciler) checkClusterStopped(cd *hivev1.ClusterDeployment
 		}
 
 		sort.Strings(remaining) // we want to make sure the message is stable.
-		msg := fmt.Sprintf("Some machines have not yet stopped: %s", strings.Join(remaining, ","))
+		msg := fmt.Sprintf("Stopping cluster machines. Some machines have not yet stopped: %s", strings.Join(remaining, ","))
 		_, condErr := r.setHibernatingCondition(cd, hivev1.StoppingHibernationReason, msg, corev1.ConditionTrue, logger)
 		if condErr != nil {
 			return reconcile.Result{}, condErr
@@ -379,7 +379,7 @@ func (r *hibernationReconciler) checkClusterResumed(cd *hivev1.ClusterDeployment
 		}
 
 		sort.Strings(remaining) // we want to make sure the message is stable.
-		msg := fmt.Sprintf("Some machines are not yet running: %s", strings.Join(remaining, ","))
+		msg := fmt.Sprintf("Starting cluster machines. Some machines are not yet running: %s", strings.Join(remaining, ","))
 		_, condErr := r.setHibernatingCondition(cd, hivev1.ResumingHibernationReason, msg, corev1.ConditionTrue, logger)
 		if condErr != nil {
 			return reconcile.Result{}, condErr

--- a/pkg/controller/hibernation/hibernation_controller_test.go
+++ b/pkg/controller/hibernation/hibernation_controller_test.go
@@ -195,7 +195,7 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionTrue, cond.Status)
 				assert.Equal(t, hivev1.StoppingHibernationReason, cond.Reason)
-				assert.Equal(t, "Some machines have not yet stopped: pending-1,running-1,stopping-1", cond.Message)
+				assert.Equal(t, "Stopping cluster machines. Some machines have not yet stopped: pending-1,running-1,stopping-1", cond.Message)
 			},
 		},
 		{
@@ -283,7 +283,7 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionTrue, cond.Status)
 				assert.Equal(t, hivev1.ResumingHibernationReason, cond.Reason)
-				assert.Equal(t, "Some machines are not yet running: pending-1,stopped-1", cond.Message)
+				assert.Equal(t, "Starting cluster machines. Some machines are not yet running: pending-1,stopped-1", cond.Message)
 			},
 		},
 		{

--- a/pkg/controller/hibernation/mock/hibernation_actuator_generated.go
+++ b/pkg/controller/hibernation/mock/hibernation_actuator_generated.go
@@ -78,12 +78,13 @@ func (mr *MockHibernationActuatorMockRecorder) StartMachines(cd, hiveClient, log
 }
 
 // MachinesRunning mocks base method
-func (m *MockHibernationActuator) MachinesRunning(cd *v1.ClusterDeployment, hiveClient client.Client, logger logrus.FieldLogger) (bool, error) {
+func (m *MockHibernationActuator) MachinesRunning(cd *v1.ClusterDeployment, hiveClient client.Client, logger logrus.FieldLogger) (bool, []string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MachinesRunning", cd, hiveClient, logger)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].([]string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // MachinesRunning indicates an expected call of MachinesRunning
@@ -93,12 +94,13 @@ func (mr *MockHibernationActuatorMockRecorder) MachinesRunning(cd, hiveClient, l
 }
 
 // MachinesStopped mocks base method
-func (m *MockHibernationActuator) MachinesStopped(cd *v1.ClusterDeployment, hiveClient client.Client, logger logrus.FieldLogger) (bool, error) {
+func (m *MockHibernationActuator) MachinesStopped(cd *v1.ClusterDeployment, hiveClient client.Client, logger logrus.FieldLogger) (bool, []string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MachinesStopped", cd, hiveClient, logger)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].([]string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // MachinesStopped indicates an expected call of MachinesStopped


### PR DESCRIPTION
Currently when hibernation is in progress, the controller checks if all
machines for the cluster are in desired state (stopped when hibernating
and running when running). If all machines are not in that state, the
controller returns and retries after some timeout.
This means that there is no information from the controller about the
progress made and machines in mis-matched state.

With this change, when machines are in mis-matched state, we update the
Hibernating condition to include a message listing those machines.

xref: https://issues.redhat.com/browse/HIVE-1564

/assign @joelddiaz 
/cc @2uasimojo 