### PR TITLE
Update build-machinery-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ all: vendor update test build
 # Include the library makefile
 include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	golang.mk \
-	lib/tmp.mk \
 	targets/openshift/controller-gen.mk \
 	targets/openshift/yq.mk \
 	targets/openshift/bindata.mk \
 	targets/openshift/deps.mk \
 	targets/openshift/images.mk \
+	targets/openshift/kustomize.mk \
 )
 
 DOCKER_CMD ?= docker
@@ -180,7 +180,7 @@ install: crd
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 .PHONY: deploy
-deploy: install
+deploy: ensure-kustomize install
 	# Deploy the operator manifests:
 	oc create namespace ${HIVE_OPERATOR_NS} || true
 	mkdir -p overlays/deploy

--- a/config/crds/hive.openshift.io_checkpoints.yaml
+++ b/config/crds/hive.openshift.io_checkpoints.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: checkpoints.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterclaims.yaml
+++ b/config/crds/hive.openshift.io_clusterclaims.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: clusterclaims.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: clusterdeployments.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterdeprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterdeprovisions.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: clusterdeprovisions.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterimagesets.yaml
+++ b/config/crds/hive.openshift.io_clusterimagesets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: clusterimagesets.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: clusterpools.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterprovisions.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   labels:
     contracts.hive.openshift.io/clusterinstall: "false"

--- a/config/crds/hive.openshift.io_clusterrelocates.yaml
+++ b/config/crds/hive.openshift.io_clusterrelocates.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: clusterrelocates.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_clusterstates.yaml
+++ b/config/crds/hive.openshift.io_clusterstates.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: clusterstates.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_dnszones.yaml
+++ b/config/crds/hive.openshift.io_dnszones.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: dnszones.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: hiveconfigs.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_machinepoolnameleases.yaml
+++ b/config/crds/hive.openshift.io_machinepoolnameleases.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: machinepoolnameleases.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: machinepools.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_selectorsyncidentityproviders.yaml
+++ b/config/crds/hive.openshift.io_selectorsyncidentityproviders.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: selectorsyncidentityproviders.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_selectorsyncsets.yaml
+++ b/config/crds/hive.openshift.io_selectorsyncsets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: selectorsyncsets.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_syncidentityproviders.yaml
+++ b/config/crds/hive.openshift.io_syncidentityproviders.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: syncidentityproviders.hive.openshift.io
 spec:

--- a/config/crds/hive.openshift.io_syncsets.yaml
+++ b/config/crds/hive.openshift.io_syncsets.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: syncsets.hive.openshift.io
 spec:

--- a/config/crds/hiveinternal.openshift.io_clustersyncleases.yaml
+++ b/config/crds/hiveinternal.openshift.io_clustersyncleases.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: clustersyncleases.hiveinternal.openshift.io
 spec:

--- a/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
+++ b/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   name: clustersyncs.hiveinternal.openshift.io
 spec:

--- a/config/crds/hiveinternal.openshift.io_fakeclusterinstalls.yaml
+++ b/config/crds/hiveinternal.openshift.io_fakeclusterinstalls.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
+    controller-gen.kubebuilder.io/version: v0.6.0
   creationTimestamp: null
   labels:
     contracts.hive.openshift.io/clusterinstall: "true"

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
-	github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab
+	github.com/openshift/build-machinery-go v0.0.0-20210701182933-efa47ed39f2e
 	github.com/openshift/cluster-api v0.0.0-20191129101638-b09907ac6668 // indirect
 	github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20201203141909-4dc702fd57a5
 	github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20200504092944-27473ea1ae43

--- a/go.sum
+++ b/go.sum
@@ -1418,6 +1418,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc/go.mo
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab h1:lBrojddP6C9C2p67EMs2vcdpC8eF+H0DDom+fgI2IF0=
 github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
+github.com/openshift/build-machinery-go v0.0.0-20210701182933-efa47ed39f2e h1:/1to3fmWP80/eZqBuF99jpNjTDOKHzt7J5Xzeq3dFGM=
+github.com/openshift/build-machinery-go v0.0.0-20210701182933-efa47ed39f2e/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20190923180330-3b6373338c9b/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/client-go v0.0.0-20191125132246-f6563a70e19a/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=

--- a/vendor/github.com/openshift/build-machinery-go/Makefile
+++ b/vendor/github.com/openshift/build-machinery-go/Makefile
@@ -19,7 +19,7 @@ define update-makefile-log
 mkdir -p "$(3)"
 set -o pipefail; $(MAKE) -j 1 -C "$(dir $(1))" -f "$(notdir $(1))" --no-print-directory --warn-undefined-variables $(2) 2>&1 | \
    sed 's/\.\(buildDate\|versionFromGit\|commitFromGit\|gitTreeState\)="[^"]*" /.\1="<redacted_for_diff>" /g' | \
-   sed -E 's~/.*/(github.com/openshift/build-machinery-go/.*)~/\1~g' | \
+   sed -E 's~/[^ ]*/(github.com/openshift/build-machinery-go/[^ ]*)~/\1~g' | \
    sed '/\/tmp\/tmp./d' | \
    sed '/git checkout -b/d' | \
    sed -E 's~^[<> ]*((\+\+\+|\-\-\-) \./(testing/)?manifests/.*.yaml).*~\1~' | \

--- a/vendor/github.com/openshift/build-machinery-go/OWNERS
+++ b/vendor/github.com/openshift/build-machinery-go/OWNERS
@@ -1,10 +1,9 @@
 reviewers:
-  - tnozicka
   - sttts
   - mfojtik
   - soltysh
+  - 2uasimojo
 approvers:
-  - tnozicka
   - sttts
   - mfojtik
   - soltysh

--- a/vendor/github.com/openshift/build-machinery-go/README.md
+++ b/vendor/github.com/openshift/build-machinery-go/README.md
@@ -35,3 +35,10 @@ Extends [#Default]().
 
 ## Scripts
 `scripts` contain more complicated logic that is used in some make targets.
+
+## Contributing
+### Updating generated files
+We track the log output from the makefile tests to make sure any change is visible and can be audited. Unfortunately due to subtle linux tooling differences in distributions and versions, `make update` may not get you the exact output as the CI. To avoid it, just run the command in the same container as CI:   
+```
+podman run -it --rm --pull=always -v $( pwd ):/go/src/$( go list -m ) --workdir=/go/src/$( go list -m ) registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.15-openshift-4.7 make update
+```

--- a/vendor/github.com/openshift/build-machinery-go/make/default.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/default.example.mk.help.log
@@ -3,6 +3,7 @@ all
 build
 clean
 clean-binaries
+ensure-imagebuilder
 help
 image-ocp-cli
 images
@@ -20,5 +21,6 @@ verify-codegen
 verify-deps
 verify-generated
 verify-gofmt
+verify-golang-versions
 verify-golint
 verify-govet

--- a/vendor/github.com/openshift/build-machinery-go/make/default.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/default.mk
@@ -1,4 +1,10 @@
-self_dir := $(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	targets/openshift/deps.mk \
+	targets/openshift/images.mk \
+	targets/openshift/bindata.mk \
+	targets/openshift/codegen.mk \
+	golang.mk \
+)
 
 # We extend the default verify/update for Golang
 
@@ -9,15 +15,3 @@ verify: verify-bindata
 update: update-codegen
 update: update-bindata
 .PHONY: update
-
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	targets/openshift/deps.mk \
-	targets/openshift/images.mk \
-	targets/openshift/bindata.mk \
-	targets/openshift/codegen.mk \
-	golang.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/golang.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/golang.example.mk.help.log
@@ -10,5 +10,6 @@ update
 update-gofmt
 verify
 verify-gofmt
+verify-golang-versions
 verify-golint
 verify-govet

--- a/vendor/github.com/openshift/build-machinery-go/make/golang.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/golang.mk
@@ -1,11 +1,14 @@
 all: build
 .PHONY: all
 
-self_dir := $(dir $(lastword $(MAKEFILE_LIST)))
-
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	targets/help.mk \
+	targets/golang/*.mk \
+)
 
 verify: verify-gofmt
 verify: verify-govet
+verify: verify-golang-versions
 .PHONY: verify
 
 update: update-gofmt
@@ -17,12 +20,3 @@ test: test-unit
 
 clean: clean-binaries
 .PHONY: clean
-
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	targets/help.mk \
-	targets/golang/*.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
@@ -3,6 +3,11 @@ all
 build
 clean
 clean-binaries
+clean-yaml-patch
+clean-yq
+ensure-imagebuilder
+ensure-yaml-patch
+ensure-yq
 help
 image-ocp-openshift-apiserver-operator
 images
@@ -15,11 +20,14 @@ update-codegen
 update-deps-overrides
 update-generated
 update-gofmt
+update-profile-manifests
 verify
 verify-bindata
 verify-codegen
 verify-deps
 verify-generated
 verify-gofmt
+verify-golang-versions
 verify-golint
 verify-govet
+verify-profile-manifests

--- a/vendor/github.com/openshift/build-machinery-go/make/operator.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/operator.mk
@@ -1,11 +1,4 @@
-self_dir := $(dir $(lastword $(MAKEFILE_LIST)))
-
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 	default.mk \
 	targets/openshift/operator/*.mk \
 )
-

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/build.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/build.mk
@@ -1,4 +1,6 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+)
 
 define build-package
 	$(if $(GO_BUILD_BINDIR),mkdir -p '$(GO_BUILD_BINDIR)',)
@@ -20,10 +22,3 @@ clean-binaries:
 
 clean: clean-binaries
 .PHONY: clean
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/test-unit.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/test-unit.mk
@@ -1,4 +1,6 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+)
 
 test-unit:
 ifndef JUNITFILE
@@ -10,10 +12,3 @@ endif
 	set -o pipefail; $(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) -json $(GO_TEST_PACKAGES) | gotest2junit > $(JUNITFILE)
 endif
 .PHONY: test-unit
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/verify-update.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/verify-update.mk
@@ -1,4 +1,6 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+)
 
 go_files_count :=$(words $(GO_FILES))
 
@@ -26,11 +28,4 @@ verify-govet:
 
 verify-golint:
 	$(GOLINT) $(GO_PACKAGES)
-.PHONY: verify-govet
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-)
+.PHONY: verify-golint

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/version.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/version.mk
@@ -1,0 +1,58 @@
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+	../../lib/tmp.mk \
+)
+
+.empty-golang-versions-files:
+	@rm -f "$(PERMANENT_TMP)/golang-versions" "$(PERMANENT_TMP)/named-golang-versions"
+.PHONE: .empty-golang-versions-files
+
+verify-golang-versions:
+	@if [ -f "$(PERMANENT_TMP)/golang-versions" ]; then \
+		LINES=$$(cat "$(PERMANENT_TMP)/golang-versions" | sort | uniq | wc -l); \
+			if [ $${LINES} -gt 1 ]; then \
+			echo "Golang version mismatch:"; \
+			cat "$(PERMANENT_TMP)/named-golang-versions" | sort | sed 's/^/- /'; \
+			false; \
+		fi; \
+	fi
+.PHONY: verify-golang-versions
+
+# $1 - filename (symbolic, used as postfix in Makefile target)
+# $2 - golang version
+define verify-golang-version-reference-internal
+verify-golang-versions-$(1): .empty-golang-versions-files
+verify-golang-versions-$(1):
+	@mkdir -p "$(PERMANENT_TMP)"
+	@echo "$(1): $(2)" >> "$(PERMANENT_TMP)/named-golang-versions"
+	@echo "$(2)" >> "$(PERMANENT_TMP)/golang-versions"
+.PHONY: verify-golang-versions-$(1)
+
+verify-golang-versions: verify-golang-versions-$(1)
+endef
+
+# $1 - filename (symbolic, used as postfix in Makefile target)
+# $2 - golang version
+define verify-golang-version-reference
+$(eval $(call verify-golang-version-reference-internal,$(1),$(2)))
+endef
+
+# $1 - Dockerfile filename (symbolic, used as postfix in Makefile target)
+define verify-Dockerfile-builder-golang-version
+$(call verify-golang-version-reference,$(1),$(shell grep "AS builder" "$(1)" | sed 's/.*golang-\([[:digit:]][[:digit:]]*.[[:digit:]][[:digit:]]*\).*/\1/'))
+endef
+
+define verify-go-mod-golang-version
+$(call verify-golang-version-reference,go.mod,$(shell grep -e 'go [[:digit:]]*\.[[:digit:]]*' go.mod 2>/dev/null | sed 's/go //'))
+endef
+
+define verify-buildroot-golang-version
+$(call verify-golang-version-reference,.ci-operator.yaml,$(shell grep -e 'tag: .*golang-[[:digit:]]*\.[[:digit:]]' .ci-operator.yaml 2>/dev/null | sed 's/.*golang-\([[:digit:]][[:digit:]]*.[[:digit:]][[:digit:]]*\).*/\1/'))
+endef
+
+# $1 - optional Dockerfile filename (symbolic, used as postfix in Makefile target)
+define verify-golang-versions
+$(if $(1),$(call verify-Dockerfile-builder-golang-version,$(1))) \
+$(if $(wildcard ./.ci-operator.yaml),$(if $(shell grep 'build_root_image:' .ci-operator.yaml 2>/dev/null),$(call verify-buildroot-golang-version))) \
+$(if $(wildcard ./go.mod),$(call verify-go-mod-golang-version))
+endef

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/controller-gen.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/controller-gen.mk
@@ -1,7 +1,26 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+	../../lib/tmp.mk \
+)
 
-CONTROLLER_GEN_VERSION ?=v0.2.5
+# NOTE: The release binary specified here needs to be built properly so that
+# `--version` works correctly. Just using `go build` will result in it
+# reporting `(devel)`. To build for a given platform:
+# 	GOOS=xxx GOARCH=yyy go install sigs.k8s.io/controller-tools/cmd/controller-gen@$version
+# e.g.
+# 	GOOS=darwin GOARCH=amd64 go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.0
+#
+# If GOOS and GOARCH match your current go env, this will install the binary at
+# 	$(go env GOPATH)/bin/controller-gen
+# Otherwise (when cross-compiling) it will install the binary at
+# 	$(go env GOPATH)/bin/${GOOS}_${GOARCH}/conroller-gen
+# e.g.
+# 	/home/efried/.gvm/pkgsets/go1.16/global/bin/darwin_amd64/controller-gen
+CONTROLLER_GEN_VERSION ?=v0.6.0
 CONTROLLER_GEN ?=$(PERMANENT_TMP_GOPATH)/bin/controller-gen
+ifneq "" "$(wildcard $(CONTROLLER_GEN))"
+_controller_gen_installed_version = $(shell $(CONTROLLER_GEN) --version | awk '{print $$2}')
+endif
 controller_gen_dir :=$(dir $(CONTROLLER_GEN))
 
 ensure-controller-gen:
@@ -12,6 +31,8 @@ ifeq "" "$(wildcard $(CONTROLLER_GEN))"
 	chmod +x '$(CONTROLLER_GEN)';
 else
 	$(info Using existing controller-gen from "$(CONTROLLER_GEN)")
+	@[[ "$(_controller_gen_installed_version)" == $(CONTROLLER_GEN_VERSION) ]] || \
+	echo "Warning: Installed controller-gen version $(_controller_gen_installed_version) does not match expected version $(CONTROLLER_GEN_VERSION)."
 endif
 .PHONY: ensure-controller-gen
 
@@ -21,11 +42,3 @@ clean-controller-gen:
 .PHONY: clean-controller-gen
 
 clean: clean-controller-gen
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-	../../lib/tmp.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/crd-schema-gen.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/crd-schema-gen.mk
@@ -1,4 +1,10 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+	../../lib/tmp.mk \
+	../../targets/openshift/controller-gen.mk \
+	../../targets/openshift/yq.mk \
+	../../targets/openshift/yaml-patch.mk \
+)
 
 # $1 - crd file
 # $2 - patch file
@@ -76,15 +82,3 @@ verify: verify-generated
 define add-crd-gen
 $(eval $(call add-crd-gen-internal,$(1),$(2),$(3),$(4)))
 endef
-
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-	../../lib/tmp.mk \
-	../../targets/openshift/controller-gen.mk \
-	../../targets/openshift/yq.mk \
-    ../../targets/openshift/yaml-patch.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/deps-glide.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/deps-glide.mk
@@ -1,5 +1,4 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
-scripts_dir :=$(self_dir)/../../../scripts
+scripts_dir :=$(dir $(lastword $(MAKEFILE_LIST)))/../../../scripts
 
 # We need to force localle so different envs sort files the same way for recursive traversals
 deps_diff :=LC_COLLATE=C diff --no-dereference -N

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/deps-gomod.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/deps-gomod.mk
@@ -1,4 +1,6 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+)
 
 # We need to force localle so different envs sort files the same way for recursive traversals
 deps_diff :=LC_COLLATE=C diff --no-dereference -N
@@ -24,6 +26,7 @@ verify-deps:
 		echo "If this is an intentional change (a carry patch) please update the 'deps.diff' using 'make update-deps-overrides'." && \
 		false \
 	)
+	rm -rf $(tmp_dir)
 .PHONY: verify-deps
 
 update-deps-overrides: tmp_dir:=$(shell mktemp -d)
@@ -31,11 +34,3 @@ update-deps-overrides:
 	$(call restore-deps,$(tmp_dir))
 	cp "$(tmp_dir)"/{updated,current}/deps.diff
 .PHONY: update-deps-overrides
-
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/deps.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/deps.mk
@@ -1,8 +1,10 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+# Use a unique variable name to avoid conflicting with generic
+# `self_dir` elsewhere.
+_self_dir_openshift_deps :=$(dir $(lastword $(MAKEFILE_LIST)))
 
-deps_gomod_mkfile := $(self_dir)/deps-gomod.mk
-deps_glide_mkfile := $(self_dir)/deps-glide.mk
-include $(addprefix $(self_dir), \
+deps_gomod_mkfile := $(_self_dir_openshift_deps)/deps-gomod.mk
+deps_glide_mkfile := $(_self_dir_openshift_deps)/deps-glide.mk
+include $(addprefix $(_self_dir_openshift_deps), \
 	../../lib/golang.mk \
 )
 

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/imagebuilder.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/imagebuilder.mk
@@ -1,0 +1,25 @@
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+	../../lib/tmp.mk \
+)
+
+IMAGEBUILDER_VERSION ?=1.2.1
+
+IMAGEBUILDER ?= $(shell which imagebuilder 2>/dev/null)
+ifneq "" "$(IMAGEBUILDER)"
+_imagebuilder_installed_version = $(shell $(IMAGEBUILDER) --version)
+endif
+
+# NOTE: We would like to
+#     go get github.com/openshift/imagebuilder/cmd/imagebuilder@v$(IMAGEBUILDER_VERSION)
+# ...but `go get` is too unreliable. So instead we use this to make the
+# "you don't have imagebuilder" error useful.
+ensure-imagebuilder:
+ifeq "" "$(IMAGEBUILDER)"
+	$(error imagebuilder not found! Get it with: `go get github.com/openshift/imagebuilder/cmd/imagebuilder@v$(IMAGEBUILDER_VERSION)`)
+else
+	$(info Using existing imagebuilder from $(IMAGEBUILDER))
+	@[[ "$(_imagebuilder_installed_version)" == $(IMAGEBUILDER_VERSION) ]] || \
+	echo "Warning: Installed imagebuilder version $(_imagebuilder_installed_version) does not match expected version $(IMAGEBUILDER_VERSION)."
+endif
+.PHONY: ensure-imagebuilder

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/images.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/images.mk
@@ -9,7 +9,7 @@ IMAGE_BUILD_EXTRA_FLAGS ?=
 # $3 - Dockerfile path
 # $4 - context
 define build-image-internal
-image-$(1):
+image-$(1): ensure-imagebuilder
 	$(strip \
 		imagebuilder \
 		$(IMAGE_BUILD_DEFAULT_FLAGS) \

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/kustomize.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/kustomize.mk
@@ -1,0 +1,27 @@
+# We need to include this before we use PERMANENT_TMP_GOPATH
+# (indirectly) from ifeq.
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/tmp.mk \
+)
+
+KUSTOMIZE_VERSION ?= 4.1.3
+KUSTOMIZE ?= $(PERMANENT_TMP_GOPATH)/bin/kustomize
+kustomize_dir := $(dir $(KUSTOMIZE))
+
+ensure-kustomize:
+ifeq "" "$(wildcard $(KUSTOMIZE))"
+	$(info Installing kustomize into '$(KUSTOMIZE)')
+	mkdir -p '$(kustomize_dir)'
+	@# NOTE: Pinning script to a tag rather than `master` for security reasons
+	curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v$(KUSTOMIZE_VERSION)/hack/install_kustomize.sh"  | bash -s $(KUSTOMIZE_VERSION) $(kustomize_dir)
+else
+	$(info Using existing kustomize from "$(KUSTOMIZE)")
+endif
+.PHONY: ensure-kustomize
+
+clean-kustomize:
+	$(RM) '$(KUSTOMIZE)'
+	if [ -d '$(kustomize_dir)' ]; then rmdir --ignore-fail-on-non-empty -p '$(kustomize_dir)'; fi
+.PHONY: clean-kustomize
+
+clean: clean-kustomize

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/profile-manifests.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/profile-manifests.mk
@@ -1,0 +1,80 @@
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../../lib/tmp.mk \
+	../yq.mk \
+	../yaml-patch.mk \
+)
+
+# Merge yaml patch using mikefarah/yq
+# $1 - patch file
+# $2 - manifest file
+# $3 - output file
+define patch-manifest-yq
+	( echo '# *** AUTOMATICALLY GENERATED FILE - DO NOT EDIT ***'; \
+		$(YQ) m -x '$(2)' '$(1)' ) > '$(3)'
+
+endef
+
+# Apply yaml-patch using krishicks/yaml-patch
+# $1 - patch file
+# $2 - manifest file
+# $3 - output file
+define patch-manifest-yaml-patch
+	( echo '# *** AUTOMATICALLY GENERATED FILE - DO NOT EDIT ***'; \
+		$(YAML_PATCH) -o '$(1)' < '$(2)' ) > '$(3)'
+
+endef
+
+profile-yaml-patches = $(sort $(shell find $(1) -type f -name '*.yaml-patch'))
+profile-yaml-merge-patches = $(sort $(shell find $(1) -type f -name '*.yaml-merge-patch'))
+
+# Apply profile patches to manifests
+# $1 - patch dir
+# $2 - manifests dir
+define apply-profile-manifest-patches
+	$$(foreach p,$$(call profile-yaml-patches,$(1)),$$(call patch-manifest-yaml-patch,$$(p),$$(realpath $(2))/$$(basename $$(notdir $$(p))).yaml,$$(realpath $(2))/$$(basename $$(notdir $$(p)))-$$(notdir $$(realpath $$(dir $$(p)))).yaml))
+	$$(foreach p,$$(call profile-yaml-merge-patches,$(1)),$$(call patch-manifest-yq,$$(p),$$(realpath $(2))/$$(basename $$(notdir $$(p))).yaml,$$(realpath $(2))/$$(basename $$(notdir $$(p)))-$$(notdir $$(realpath $$(dir $$(p)))).yaml))
+endef
+
+# $1 - target name
+# $2 - patch dir
+# $3 - manifest dir
+define add-profile-manifests-internal
+
+update-profile-manifests-$(1): ensure-yq ensure-yaml-patch
+	$(call apply-profile-manifest-patches,$(2),$(3))
+.PHONY: update-profile-manifests-$(1)
+
+update-profile-manifests: update-profile-manifests-$(1)
+.PHONY: update-profile-manifests
+
+verify-profile-manifests-$(1): VERIFY_PROFILE_MANIFESTS_TMP_DIR:=$$(shell mktemp -d)
+verify-profile-manifests-$(1): ensure-yq ensure-yaml-patch
+	cp -R $(3)/* $$(VERIFY_PROFILE_MANIFESTS_TMP_DIR)/
+	$(call apply-profile-manifest-patches,$(2),$$(VERIFY_PROFILE_MANIFESTS_TMP_DIR))
+	diff -Naup $(3) $$(VERIFY_PROFILE_MANIFESTS_TMP_DIR)
+.PHONY: verify-profile-manifests-$(1)
+
+verify-profile-manifests: verify-profile-manifests-$(1)
+.PHONY: verify-profile-manifests
+
+update-generated: update-profile-manifests
+.PHONY: update-generated
+
+update: update-generated
+.PHONY: update
+
+verify-generated: verify-profile-manifests
+.PHONY: verify-generated
+
+verify: verify-generated
+.PHONY: verify
+
+endef
+
+
+# $1 - target name
+# $2 - profile patches dir
+# $3 - manifests dir
+define add-profile-manifests
+$(eval $(call add-profile-manifests-internal,$(1),$(2),$(3)))
+endef

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/telepresence.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/telepresence.mk
@@ -1,5 +1,4 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
-scripts_dir :=$(shell realpath $(self_dir)../../../../scripts)
+scripts_dir :=$(shell realpath $(dir $(lastword $(MAKEFILE_LIST)))../../../../scripts)
 
 telepresence:
 	$(info Running operator locally against a remote cluster using telepresence (https://telepresence.io))

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/rpm.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/rpm.mk
@@ -1,3 +1,7 @@
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+)
+
 RPM_OUTPUT_DIR ?=_output
 RPM_TOPDIR ?=$(abspath ./)
 RPM_BUILDDIR ?=$(RPM_TOPDIR)
@@ -32,10 +36,3 @@ clean-rpms:
 .PHONY: clean-rpms
 
 clean: clean-rpms
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-)

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yaml-patch.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yaml-patch.mk
@@ -1,4 +1,10 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+ifndef _YAML_PATCH_MK_
+_YAML_PATCH_MK_ := defined
+
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+	../../lib/tmp.mk \
+)
 
 YAML_PATCH ?=$(PERMANENT_TMP_GOPATH)/bin/yaml-patch
 yaml_patch_dir :=$(dir $(YAML_PATCH))
@@ -22,11 +28,4 @@ clean-yaml-patch:
 
 clean: clean-yaml-patch
 
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-	../../lib/tmp.mk \
-)
+endif

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yq.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yq.mk
@@ -1,4 +1,10 @@
-self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+ifndef _YQ_MK_
+_YQ_MK_ := defined
+
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	../../lib/golang.mk \
+	../../lib/tmp.mk \
+)
 
 YQ ?=$(PERMANENT_TMP_GOPATH)/bin/yq
 yq_dir :=$(dir $(YQ))
@@ -22,11 +28,4 @@ clean-yq:
 
 clean: clean-yq
 
-
-# We need to be careful to expand all the paths before any include is done
-# or self_dir could be modified for the next include by the included file.
-# Also doing this at the end of the file allows us to use self_dir before it could be modified.
-include $(addprefix $(self_dir), \
-	../../lib/golang.mk \
-	../../lib/tmp.mk \
-)
+endif

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -537,7 +537,7 @@ github.com/openshift/api/image/v1
 github.com/openshift/api/operator/v1
 github.com/openshift/api/pkg/serialization
 github.com/openshift/api/route/v1
-# github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab
+# github.com/openshift/build-machinery-go v0.0.0-20210701182933-efa47ed39f2e
 ## explicit
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make


### PR DESCRIPTION
Bump to the latest commit of build-machinery-go. This brings in several improvements:
- Fixes imports so we don't have to explicitly import tmp.mk anymore.
- Adds `ensure-kustomize`, which we can now use where we need it.
- Adds `ensure-imagebuilder`, which is implicitly used where we need it (from within bmg itself).
- Adds idempotency and a version check to `ensure-controller-gen`, cause that's been tripping us up lately:

```
[efried@efried hive]$ make ensure-controller-gen
Using existing controller-gen from "_output/tools/bin/controller-gen"
Warning: Installed controller-gen version (devel) does not match expected version v0.6.0.
[efried@efried hive]$ make clean-controller-gen
rm -f '_output/tools/bin/controller-gen'
if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
[efried@efried hive]$ make ensure-controller-gen
Installing controller-gen into '_output/tools/bin/controller-gen'
mkdir -p '_output/tools/bin/'
curl -s -f -L https://github.com/openshift/kubernetes-sigs-controller-tools/releases/download/v0.6.0/controller-gen-linux-amd64 -o '_output/tools/bin/controller-gen'
chmod +x '_output/tools/bin/controller-gen';
[efried@efried hive]$ make ensure-controller-gen
Using existing controller-gen from "_output/tools/bin/controller-gen"
```