### PR TITLE
Claim: Add ClusterRunning=>ClusterDeleting condition

### DIFF
--- a/pkg/controller/clusterclaim/clusterclaim_controller_test.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller_test.go
@@ -190,6 +190,20 @@ func TestReconcileClusterClaim(t *testing.T) {
 			}},
 		},
 		{
+			name:  "deleting cluster",
+			claim: initializedClaimBuilder.Build(testclaim.WithCluster(clusterName)),
+			cd: cdBuilder.GenericOptions(testgeneric.Deleted()).Build(
+				testcd.WithClusterPoolReference(claimNamespace, "test-pool", claimName),
+			),
+			expectCompletedClaim: true,
+			expectedConditions: []hivev1.ClusterClaimCondition{{
+				Type:    hivev1.ClusterRunningCondition,
+				Status:  corev1.ConditionFalse,
+				Reason:  "ClusterDeleting",
+				Message: "Assigned cluster has been marked for deletion",
+			}},
+		},
+		{
 			name:  "deleted cluster",
 			claim: initializedClaimBuilder.Build(testclaim.WithCluster(clusterName)),
 			expectedConditions: []hivev1.ClusterClaimCondition{{


### PR DESCRIPTION
This is a UX improvement to reflect that a CD is deleting in the status of its assigned Claim: We set the ClusterRunning condition to False with Reason: ClusterDeleting.

Note that, although this triggers on both deletion timestamp and the `remove-claimed-cluster-from-pool` annotation, we are unlikely to notice in the latter case because the claim itself is deleted almost immediately in that code path. However, the code as written accounts for a future where that deletion may wait on some other finalizer.