### PR TITLE
Add support for custom KMS key AWS disk encryption.

### DIFF
--- a/apis/hive/v1/aws/machinepool.go
+++ b/apis/hive/v1/aws/machinepool.go
@@ -41,4 +41,9 @@ type EC2RootVolume struct {
 	Size int `json:"size"`
 	// Type defines the type of the storage.
 	Type string `json:"type"`
+	// The KMS key that will be used to encrypt the EBS volume.
+	// If no key is provided the default KMS key for the account will be used.
+	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetEbsDefaultKmsKeyId.html
+	// +optional
+	KMSKeyARN string `json:"kmsKeyARN,omitempty"`
 }

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -95,6 +95,11 @@ spec:
                           iops:
                             description: IOPS defines the iops for the storage.
                             type: integer
+                          kmsKeyARN:
+                            description: The KMS key that will be used to encrypt
+                              the EBS volume. If no key is provided the default KMS
+                              key for the account will be used. https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetEbsDefaultKmsKeyId.html
+                            type: string
                           size:
                             description: Size defines the size of the storage.
                             type: integer

--- a/pkg/controller/remotemachineset/awsactuator.go
+++ b/pkg/controller/remotemachineset/awsactuator.go
@@ -137,9 +137,10 @@ func (a *AWSActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *hi
 		AMIID:        a.amiID,
 		InstanceType: pool.Spec.Platform.AWS.InstanceType,
 		EC2RootVolume: installertypesaws.EC2RootVolume{
-			IOPS: pool.Spec.Platform.AWS.EC2RootVolume.IOPS,
-			Size: pool.Spec.Platform.AWS.EC2RootVolume.Size,
-			Type: pool.Spec.Platform.AWS.EC2RootVolume.Type,
+			IOPS:      pool.Spec.Platform.AWS.EC2RootVolume.IOPS,
+			Size:      pool.Spec.Platform.AWS.EC2RootVolume.Size,
+			Type:      pool.Spec.Platform.AWS.EC2RootVolume.Type,
+			KMSKeyARN: pool.Spec.Platform.AWS.EC2RootVolume.KMSKeyARN,
 		},
 		Zones: pool.Spec.Platform.AWS.Zones,
 	}

--- a/vendor/github.com/openshift/hive/apis/hive/v1/aws/machinepool.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/aws/machinepool.go
@@ -41,4 +41,9 @@ type EC2RootVolume struct {
 	Size int `json:"size"`
 	// Type defines the type of the storage.
 	Type string `json:"type"`
+	// The KMS key that will be used to encrypt the EBS volume.
+	// If no key is provided the default KMS key for the account will be used.
+	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetEbsDefaultKmsKeyId.html
+	// +optional
+	KMSKeyARN string `json:"kmsKeyARN,omitempty"`
 }


### PR DESCRIPTION
Per GCP support, the field is immutable for now.

x-ref: https://issues.redhat.com/browse/HIVE-1374