### PR TITLE
hibernation: support hibernating spot instance for AWS clusters

### DIFF
--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -65,6 +65,7 @@ type Client interface {
 	DescribeRouteTables(*ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error)
 	DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error)
 	StopInstances(*ec2.StopInstancesInput) (*ec2.StopInstancesOutput, error)
+	TerminateInstances(*ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error)
 	StartInstances(*ec2.StartInstancesInput) (*ec2.StartInstancesOutput, error)
 	CreateVpcEndpointServiceConfiguration(*ec2.CreateVpcEndpointServiceConfigurationInput) (*ec2.CreateVpcEndpointServiceConfigurationOutput, error)
 	DescribeVpcEndpointServiceConfigurations(*ec2.DescribeVpcEndpointServiceConfigurationsInput) (*ec2.DescribeVpcEndpointServiceConfigurationsOutput, error)
@@ -141,6 +142,11 @@ func (c *awsClient) DescribeInstances(input *ec2.DescribeInstancesInput) (*ec2.D
 func (c *awsClient) StopInstances(input *ec2.StopInstancesInput) (*ec2.StopInstancesOutput, error) {
 	metricAWSAPICalls.WithLabelValues("StopInstances").Inc()
 	return c.ec2Client.StopInstances(input)
+}
+
+func (c *awsClient) TerminateInstances(input *ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error) {
+	metricAWSAPICalls.WithLabelValues("TerminateInstances").Inc()
+	return c.ec2Client.TerminateInstances(input)
 }
 
 func (c *awsClient) StartInstances(input *ec2.StartInstancesInput) (*ec2.StartInstancesOutput, error) {

--- a/pkg/awsclient/mock/client_generated.go
+++ b/pkg/awsclient/mock/client_generated.go
@@ -114,6 +114,21 @@ func (mr *MockClientMockRecorder) StopInstances(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstances", reflect.TypeOf((*MockClient)(nil).StopInstances), arg0)
 }
 
+// TerminateInstances mocks base method
+func (m *MockClient) TerminateInstances(arg0 *ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TerminateInstances", arg0)
+	ret0, _ := ret[0].(*ec2.TerminateInstancesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TerminateInstances indicates an expected call of TerminateInstances
+func (mr *MockClientMockRecorder) TerminateInstances(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateInstances", reflect.TypeOf((*MockClient)(nil).TerminateInstances), arg0)
+}
+
 // StartInstances mocks base method
 func (m *MockClient) StartInstances(arg0 *ec2.StartInstancesInput) (*ec2.StartInstancesOutput, error) {
 	m.ctrl.T.Helper()

--- a/pkg/controller/hibernation/aws_actuator_test.go
+++ b/pkg/controller/hibernation/aws_actuator_test.go
@@ -1,8 +1,10 @@
 package hibernation
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -11,14 +13,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	hivev1aws "github.com/openshift/hive/apis/hive/v1/aws"
 	"github.com/openshift/hive/pkg/awsclient"
 	mockawsclient "github.com/openshift/hive/pkg/awsclient/mock"
 	testcd "github.com/openshift/hive/pkg/test/clusterdeployment"
+	machineapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 )
 
 func TestCanHandle(t *testing.T) {
@@ -118,6 +125,62 @@ func TestStopAndStartMachines(t *testing.T) {
 	}
 }
 
+func TestStopPreemptibleMachines(t *testing.T) {
+	tests := []struct {
+		name string
+		// number of on-demand and spot instances
+		onDemand int
+		spot     int
+
+		setupClient func(*testing.T, *mockawsclient.MockClient)
+	}{{
+		name:     "only on-demand instances",
+		onDemand: 1,
+		setupClient: func(t *testing.T, c *mockawsclient.MockClient) {
+			c.EXPECT().StopInstances(gomock.Any()).Do(
+				func(input *ec2.StopInstancesInput) {
+					input.InstanceIds = aws.StringSlice([]string{"onDemand-0"})
+				}).Return(nil, nil)
+		},
+	}, {
+		name: "only spot instances",
+		spot: 1,
+		setupClient: func(t *testing.T, c *mockawsclient.MockClient) {
+			c.EXPECT().TerminateInstances(gomock.Any()).Do(
+				func(input *ec2.TerminateInstancesInput) {
+					input.InstanceIds = aws.StringSlice([]string{"spot-0"})
+				}).Return(nil, nil)
+		},
+	}, {
+		name:     "mix of spot and on-demand instances",
+		onDemand: 1,
+		spot:     2,
+		setupClient: func(t *testing.T, c *mockawsclient.MockClient) {
+			c.EXPECT().StopInstances(gomock.Any()).Do(
+				func(input *ec2.StopInstancesInput) {
+					input.InstanceIds = aws.StringSlice([]string{"onDemand-0"})
+				}).Return(nil, nil)
+			c.EXPECT().TerminateInstances(gomock.Any()).Do(
+				func(input *ec2.TerminateInstancesInput) {
+					input.InstanceIds = aws.StringSlice([]string{"spot-0", "spot-1"})
+				}).Return(nil, nil)
+		},
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			awsClient := mockawsclient.NewMockClient(ctrl)
+			setupOnDemandAndSpotInstances(awsClient, test.onDemand, test.spot)
+			if test.setupClient != nil {
+				test.setupClient(t, awsClient)
+			}
+			actuator := testAWSActuator(awsClient)
+			err := actuator.StopMachines(testClusterDeployment(), nil, log.New())
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func TestMachinesStoppedAndRunning(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -167,6 +230,7 @@ func TestMachinesStoppedAndRunning(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 			awsClient := mockawsclient.NewMockClient(ctrl)
 			setupClientInstances(awsClient, test.instances)
 			if test.setupClient != nil {
@@ -187,6 +251,121 @@ func TestMachinesStoppedAndRunning(t *testing.T) {
 			assert.Equal(t, test.expected, result)
 		})
 	}
+}
+
+func TestReplacePreemptibleMachines(t *testing.T) {
+	logger := log.New()
+	logger.SetLevel(log.DebugLevel)
+
+	scheme := runtime.NewScheme()
+	hivev1.AddToScheme(scheme)
+	machineapi.AddToScheme(scheme)
+
+	testcd := testcd.FullBuilder(namespace, cdName, scheme).Options(
+		testcd.Installed(),
+		testcd.WithClusterVersion("4.4.9"),
+		testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+			Type:               hivev1.ClusterHibernatingCondition,
+			Reason:             hivev1.HibernatingHibernationReason,
+			Status:             corev1.ConditionFalse,
+			LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
+		}),
+	).Build()
+
+	tests := []struct {
+		name             string
+		existingMachines []runtime.Object
+
+		expectedReplaced bool
+		expectedErr      string
+		expectedMachines []string // machines that exist after replacement
+	}{{
+		name: "no machines",
+
+		expectedMachines: []string{},
+	}, {
+		name: "all on-demand machines",
+		existingMachines: []runtime.Object{
+			testMachine("ondemand-1", false, "Running", time.Now()),
+			testMachine("ondemand-2", false, "Provisioning", time.Now()),
+			testMachine("ondemand-3", false, "Provisioned", time.Now()),
+		},
+		expectedMachines: []string{"ondemand-1", "ondemand-2", "ondemand-3"},
+	}, {
+		name: "all running spot instances, updated after hibernation",
+		existingMachines: []runtime.Object{
+			testMachine("spot-1", true, "Running", time.Now()),
+			testMachine("spot-2", true, "Provisioning", time.Now()),
+			testMachine("spot-3", true, "Provisioned", time.Now()),
+		},
+		expectedMachines: []string{"spot-1", "spot-2", "spot-3"},
+	}, {
+		name: "all running spot instances, updated before hibernation",
+		existingMachines: []runtime.Object{
+			testMachine("spot-1", true, "Running", time.Now().Add(-1*time.Hour)),
+			testMachine("spot-2", true, "Provisioning", time.Now().Add(-1*time.Hour)),
+			testMachine("spot-3", true, "Provisioned", time.Now().Add(-1*time.Hour)),
+		},
+		expectedReplaced: true,
+		expectedMachines: []string{},
+	}, {
+		name: "some failed spot instances",
+		existingMachines: []runtime.Object{
+			testMachine("spot-1", true, "Running", time.Now().Add(-1*time.Hour)),
+			testMachine("spot-2", true, "Failed", time.Now()),
+			testMachine("spot-3", true, "Provisioned", time.Now()),
+		},
+		expectedReplaced: true,
+		expectedMachines: []string{"spot-3"},
+	}}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actuator := testAWSActuator(nil)
+			c := fake.NewFakeClientWithScheme(scheme, test.existingMachines...)
+
+			replaced, err := actuator.ReplaceMachines(testcd, c, logger)
+			if test.expectedErr != "" {
+				assert.EqualError(t, err, test.expectedErr)
+			} else {
+				assert.Equal(t, test.expectedReplaced, replaced)
+				machineList := &machineapi.MachineList{}
+				err = c.List(context.TODO(), machineList,
+					client.InNamespace(machineAPINamespace),
+				)
+				require.NoError(t, err)
+
+				machines := sets.NewString()
+				for _, m := range machineList.Items {
+					machines.Insert(m.GetName())
+				}
+				assert.Equal(t, test.expectedMachines, machines.List())
+			}
+		})
+	}
+}
+
+func testMachine(name string, interruptible bool, phase string, lastUpdated time.Time) *machineapi.Machine {
+	labels := map[string]string{}
+	if interruptible {
+		labels[machineAPIInterruptibleLabel] = ""
+	}
+
+	ms := machineapi.Machine{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: machineapi.SchemeGroupVersion.String(),
+			Kind:       "Machine",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: machineAPINamespace,
+			Labels:    labels,
+		},
+		Status: machineapi.MachineStatus{
+			Phase:       &phase,
+			LastUpdated: &metav1.Time{Time: lastUpdated},
+		},
+	}
+	return &ms
 }
 
 func matchInstanceIDs(t *testing.T, actual []*string, states map[string]int) {
@@ -231,6 +410,35 @@ func setupClientInstances(awsClient *mockawsclient.MockClient, states map[string
 			})
 		}
 	}
+	reservation := &ec2.Reservation{Instances: instances}
+	reservations := []*ec2.Reservation{reservation}
+	awsClient.EXPECT().DescribeInstances(gomock.Any()).Times(1).Return(
+		&ec2.DescribeInstancesOutput{
+			Reservations: reservations,
+		},
+		nil)
+}
+
+func setupOnDemandAndSpotInstances(awsClient *mockawsclient.MockClient, onDemand, spot int) {
+	instances := []*ec2.Instance{}
+	for i := 0; i < onDemand; i++ {
+		instances = append(instances, &ec2.Instance{
+			InstanceId: aws.String(fmt.Sprintf("%s-%d", "onDemand", i)),
+			State: &ec2.InstanceState{
+				Name: aws.String("running"),
+			},
+		})
+	}
+	for i := 0; i < spot; i++ {
+		instances = append(instances, &ec2.Instance{
+			InstanceId: aws.String(fmt.Sprintf("%s-%d", "spot", i)),
+			State: &ec2.InstanceState{
+				Name: aws.String("running"),
+			},
+			InstanceLifecycle: aws.String("spot"),
+		})
+	}
+
 	reservation := &ec2.Reservation{Instances: instances}
 	reservations := []*ec2.Reservation{reservation}
 	awsClient.EXPECT().DescribeInstances(gomock.Any()).Times(1).Return(

--- a/pkg/controller/hibernation/hibernation_actuator.go
+++ b/pkg/controller/hibernation/hibernation_actuator.go
@@ -28,3 +28,13 @@ type HibernationActuator interface {
 	// that have not stopped.
 	MachinesStopped(cd *hivev1.ClusterDeployment, hiveClient client.Client, logger log.FieldLogger) (bool, []string, error)
 }
+
+// HibernationPreemptibleMachines is the interface that the hibernation controller
+// for preemptible instances on cloud providers.
+type HibernationPreemptibleMachines interface {
+	// ReplaceMachines uses the remote client to replace the preemptible machines
+	// belonging to the given ClusterDeployment. Since it uses the remote client
+	// it should only be called when the API is reachable.
+	// replaced is true when at least one machine was replaced.
+	ReplaceMachines(cd *hivev1.ClusterDeployment, remoteClient client.Client, logger log.FieldLogger) (replaced bool, err error)
+}

--- a/pkg/controller/hibernation/mock/hibernation_actuator_generated.go
+++ b/pkg/controller/hibernation/mock/hibernation_actuator_generated.go
@@ -108,3 +108,41 @@ func (mr *MockHibernationActuatorMockRecorder) MachinesStopped(cd, hiveClient, l
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachinesStopped", reflect.TypeOf((*MockHibernationActuator)(nil).MachinesStopped), cd, hiveClient, logger)
 }
+
+// MockHibernationPreemptibleMachines is a mock of HibernationPreemptibleMachines interface
+type MockHibernationPreemptibleMachines struct {
+	ctrl     *gomock.Controller
+	recorder *MockHibernationPreemptibleMachinesMockRecorder
+}
+
+// MockHibernationPreemptibleMachinesMockRecorder is the mock recorder for MockHibernationPreemptibleMachines
+type MockHibernationPreemptibleMachinesMockRecorder struct {
+	mock *MockHibernationPreemptibleMachines
+}
+
+// NewMockHibernationPreemptibleMachines creates a new mock instance
+func NewMockHibernationPreemptibleMachines(ctrl *gomock.Controller) *MockHibernationPreemptibleMachines {
+	mock := &MockHibernationPreemptibleMachines{ctrl: ctrl}
+	mock.recorder = &MockHibernationPreemptibleMachinesMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockHibernationPreemptibleMachines) EXPECT() *MockHibernationPreemptibleMachinesMockRecorder {
+	return m.recorder
+}
+
+// ReplaceMachines mocks base method
+func (m *MockHibernationPreemptibleMachines) ReplaceMachines(cd *v1.ClusterDeployment, remoteClient client.Client, logger logrus.FieldLogger) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReplaceMachines", cd, remoteClient, logger)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReplaceMachines indicates an expected call of ReplaceMachines
+func (mr *MockHibernationPreemptibleMachinesMockRecorder) ReplaceMachines(cd, remoteClient, logger interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplaceMachines", reflect.TypeOf((*MockHibernationPreemptibleMachines)(nil).ReplaceMachines), cd, remoteClient, logger)
+}


### PR DESCRIPTION
OpenShift supports running spot instances for compute. Therefore when
cluster is hibernated these instances must also be stopped and started
like the on-demand instances.

But due to the nature of the spot instances, these instances are not
guaranteed. So if these instances are started, these might not start if
the spot instance constraints are not met. Therefore aws supports
stopping and starting spot instances only when the spot instance request
are persistent (compared to one-time). see [1] for more info.

machine-api add support for spot instances in AWS detailed in [2].
Some of the things to note are,
- machine-api has decided that one spot instance in aws is tied to one
  Machine object in api.
- which means, the spot instances are created as "one-time" type. Once
  the backing instance is gone (either terminated by aws or user) the
  Machine object goes into Failed state and stays there as-is.
- For new Machine to take the place of the previous Machine, the
  machine-api deploys MachineHealthCheck object that deletes Machines
  that were "deleted by AWS" only. If user deletes/terminated the
  instance, the user must also remove the object from API.

To shut down a "one-time" spot instance, the only option is to terminate
the instance. So for running -> hibernation, aws actuator terminated
these instances instead of stopping them like it does for on-demand
instances.

Since the spot instances were terminated, for hibernation -> running
state change the aws actuator must somehow replace the previous
instances with new ones.
The only way is to delete the Machine objects for the previously
terminated spot instance, and letting the MachineSet replace those to
match the expected replica count.
The aws actuator now looks for these Machines that need to be replaced
by
- finding machines with "machine.openshift.io/interruptible-instance"
  label
- filtering out machines that are "not failed" given that their status
  was updated after hibernation was started
The actuator then deletes those machines by
- updating the machine objects to skip draining. since the instances are
  already known to be gone, skipping draining prevents machine-api
  getting stuck for pods to scheduled.
- deleting those machine objects.

[1]: https://aws.amazon.com/about-aws/whats-new/2020/01/amazon-ec2-spot-instances-stopped-started-similar-to-on-demand-instances/
[2]: https://github.com/openshift/enhancements/blob/master/enhancements/machine-api/spot-instances.md

xref: https://issues.redhat.com/browse/HIVE-1195

/cc @dgoodwin @2uasimojo 
/assign @joelddiaz 