### PR TITLE
Scrub frequent Azure cloud dns errors

### DIFF
--- a/pkg/controller/utils/errorscrub.go
+++ b/pkg/controller/utils/errorscrub.go
@@ -5,8 +5,11 @@ import (
 )
 
 var (
+	newlineTabRE = regexp.MustCompile(`\n\t`)
+	// aws
 	awsRequestIDRE = regexp.MustCompile(`(, )*(?i)(request id: )(?:[-[:xdigit:]]+)`)
-	newlineTabRE   = regexp.MustCompile(`(\n\t)`)
+	// azure
+	azureErrorDescriptionRE = regexp.MustCompile(`\"error_description\":\"(.*?)\\r\\n`)
 )
 
 // ErrorScrub scrubs cloud error messages destined for CRD status to remove things that
@@ -17,5 +20,10 @@ func ErrorScrub(err error) string {
 	}
 	s := newlineTabRE.ReplaceAllString(err.Error(), ", ")
 	s = awsRequestIDRE.ReplaceAllString(s, "")
+	// if Azure error, return just the error description
+	match := azureErrorDescriptionRE.FindStringSubmatch(s)
+	if len(match) > 0 {
+		return match[1]
+	}
 	return s
 }

--- a/pkg/controller/utils/errorscrub_test.go
+++ b/pkg/controller/utils/errorscrub_test.go
@@ -34,6 +34,11 @@ func TestErrorScrubber(t *testing.T) {
 			input:    nil,
 			expected: "",
 		},
+		{
+			name:     "azure error",
+			input:    errors.New("azure.BearerAuthorizer#WithAuthorization: Failed to refresh the Token for request to https://management.azure.com/subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourceGroups/os4-common/providers/Microsoft.Network/dnsZones/hive-managed.qe.azure.devcluster.openshift.com?api-version=2018-05-01: StatusCode=401 -- Original Error: adal: Refresh request failed. Status Code = '401'. Response body: {\"error\":\"invalid_client\",\"error_description\":\"AADSTS7000215: Invalid client secret is provided.\\r\\nTrace ID: 9a06fe2e-c2af-44eb-b3ec-036929a15701\\r\\nCorrelation ID: ae4130a3-7160-40d5-b67e-b6f4a0dd18a5\\r\\nTimestamp: 2021-07-02 09:28:53Z\",\"error_codes\":[7000215],\"timestamp\":\"2021-07-02 09:28:53Z\",\"trace_id\":\"9a06fe2e-c2af-44eb-b3ec-036929a15701\",\"correlation_id\":\"ae4130a3-7160-40d5-b67e-b6f4a0dd18a5\",\"error_uri\":\"https://login.microsoftonline.com/error?code=7000215"),
+			expected: "AADSTS7000215: Invalid client secret is provided.",
+		},
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
When dns controller hits Invalid credentials on Azure cloud, Azure API
constantly tries to login and refresh the token. This results in
frequent update of dns condition for generic cloud errors.
While we do have rate limiter on cloud errors for dns, we can still
scrub the Azure error and bubble up only the error description. This
will make the error easier to interpret and restrict frequent status
updates.

xref: https://issues.redhat.com/browse/HIVE-1582