### PR TITLE
Document Duration types better

### DIFF
--- a/apis/hive/v1/clusterclaim_types.go
+++ b/apis/hive/v1/clusterclaim_types.go
@@ -23,6 +23,7 @@ type ClusterClaimSpec struct {
 
 	// Lifetime is the maximum lifetime of the claim after it is assigned a cluster. If the claim still exists
 	// when the lifetime has elapsed, the claim will be deleted by Hive.
+	// This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
 	// +optional
 	Lifetime *metav1.Duration `json:"lifetime,omitempty"`
 }

--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -143,6 +143,7 @@ type ClusterDeploymentSpec struct {
 	// HibernateAfter will transition a cluster to hibernating power state after it has been running for the
 	// given duration. The time that a cluster has been running is the time since the cluster was installed or the
 	// time since the cluster last came out of hibernation.
+	// This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
 	// +optional
 	HibernateAfter *metav1.Duration `json:"hibernateAfter,omitempty"`
 

--- a/apis/hive/v1/clusterpool_types.go
+++ b/apis/hive/v1/clusterpool_types.go
@@ -61,6 +61,7 @@ type ClusterPoolSpec struct {
 	// clusters in the clusterpool to hibernating power state after it has been running for the given duration. The time
 	// that a cluster has been running is the time since the cluster was installed or the time since the cluster last came
 	// out of hibernation.
+	// This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
 	// +optional
 	HibernateAfter *metav1.Duration `json:"hibernateAfter,omitempty"`
 
@@ -76,12 +77,14 @@ type ClusterPoolSpec struct {
 // ClusterPoolClaimLifetime defines the lifetimes for claims for the cluster pool.
 type ClusterPoolClaimLifetime struct {
 	// Default is the default lifetime of the claim when no lifetime is set on the claim itself.
+	// This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
 	// +optional
 	Default *metav1.Duration `json:"default,omitempty"`
 
 	// Maximum is the maximum lifetime of the claim after it is assigned a cluster. If the claim still exists
 	// when the lifetime has elapsed, the claim will be deleted by Hive.
 	// The lifetime of a claim is the mimimum of the lifetimes set by the cluster pool and the claim itself.
+	// This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
 	// +optional
 	Maximum *metav1.Duration `json:"maximum,omitempty"`
 }

--- a/config/crds/hive.openshift.io_clusterclaims.yaml
+++ b/config/crds/hive.openshift.io_clusterclaims.yaml
@@ -57,7 +57,8 @@ spec:
               lifetime:
                 description: Lifetime is the maximum lifetime of the claim after it
                   is assigned a cluster. If the claim still exists when the lifetime
-                  has elapsed, the claim will be deleted by Hive.
+                  has elapsed, the claim will be deleted by Hive. This is a Duration
+                  value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
                 type: string
               namespace:
                 description: Namespace is the namespace containing the ClusterDeployment

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -247,6 +247,8 @@ spec:
                   power state after it has been running for the given duration. The
                   time that a cluster has been running is the time since the cluster
                   was installed or the time since the cluster last came out of hibernation.
+                  This is a Duration value; see https://pkg.go.dev/time#ParseDuration
+                  for accepted formats.
                 type: string
               ingress:
                 description: Ingress allows defining desired clusteringress/shards

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -68,14 +68,16 @@ spec:
                 properties:
                   default:
                     description: Default is the default lifetime of the claim when
-                      no lifetime is set on the claim itself.
+                      no lifetime is set on the claim itself. This is a Duration value;
+                      see https://pkg.go.dev/time#ParseDuration for accepted formats.
                     type: string
                   maximum:
                     description: Maximum is the maximum lifetime of the claim after
                       it is assigned a cluster. If the claim still exists when the
                       lifetime has elapsed, the claim will be deleted by Hive. The
                       lifetime of a claim is the mimimum of the lifetimes set by the
-                      cluster pool and the claim itself.
+                      cluster pool and the claim itself. This is a Duration value;
+                      see https://pkg.go.dev/time#ParseDuration for accepted formats.
                     type: string
                 type: object
               hibernateAfter:
@@ -84,7 +86,8 @@ spec:
                   the clusterpool to hibernating power state after it has been running
                   for the given duration. The time that a cluster has been running
                   is the time since the cluster was installed or the time since the
-                  cluster last came out of hibernation.
+                  cluster last came out of hibernation. This is a Duration value;
+                  see https://pkg.go.dev/time#ParseDuration for accepted formats.
                 type: string
               imageSetRef:
                 description: ImageSetRef is a reference to a ClusterImageSet. The

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterclaim_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterclaim_types.go
@@ -23,6 +23,7 @@ type ClusterClaimSpec struct {
 
 	// Lifetime is the maximum lifetime of the claim after it is assigned a cluster. If the claim still exists
 	// when the lifetime has elapsed, the claim will be deleted by Hive.
+	// This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
 	// +optional
 	Lifetime *metav1.Duration `json:"lifetime,omitempty"`
 }

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -143,6 +143,7 @@ type ClusterDeploymentSpec struct {
 	// HibernateAfter will transition a cluster to hibernating power state after it has been running for the
 	// given duration. The time that a cluster has been running is the time since the cluster was installed or the
 	// time since the cluster last came out of hibernation.
+	// This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
 	// +optional
 	HibernateAfter *metav1.Duration `json:"hibernateAfter,omitempty"`
 

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
@@ -61,6 +61,7 @@ type ClusterPoolSpec struct {
 	// clusters in the clusterpool to hibernating power state after it has been running for the given duration. The time
 	// that a cluster has been running is the time since the cluster was installed or the time since the cluster last came
 	// out of hibernation.
+	// This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
 	// +optional
 	HibernateAfter *metav1.Duration `json:"hibernateAfter,omitempty"`
 
@@ -76,12 +77,14 @@ type ClusterPoolSpec struct {
 // ClusterPoolClaimLifetime defines the lifetimes for claims for the cluster pool.
 type ClusterPoolClaimLifetime struct {
 	// Default is the default lifetime of the claim when no lifetime is set on the claim itself.
+	// This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
 	// +optional
 	Default *metav1.Duration `json:"default,omitempty"`
 
 	// Maximum is the maximum lifetime of the claim after it is assigned a cluster. If the claim still exists
 	// when the lifetime has elapsed, the claim will be deleted by Hive.
 	// The lifetime of a claim is the mimimum of the lifetimes set by the cluster pool and the claim itself.
+	// This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
 	// +optional
 	Maximum *metav1.Duration `json:"maximum,omitempty"`
 }


### PR DESCRIPTION
To help consumers understand how Duration fields should be formatted, add a reference to the upstream documentation.

(This came out of a [slack conversation](https://coreos.slack.com/archives/CE3ETN3J8/p1626184245263600?thread_ts=1626144477.250800&cid=CE3ETN3J8) around the referenced card.)

[HIVE-1587](https://issues.redhat.com/browse/HIVE-1587)