### PR TITLE
Make metadata admin password secret optional.

### DIFF
--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -264,7 +264,8 @@ type ClusterMetadata struct {
 	AdminKubeconfigSecretRef corev1.LocalObjectReference `json:"adminKubeconfigSecretRef"`
 
 	// AdminPasswordSecretRef references the secret containing the admin username/password which can be used to login to this cluster.
-	AdminPasswordSecretRef corev1.LocalObjectReference `json:"adminPasswordSecretRef"`
+	// +optional
+	AdminPasswordSecretRef *corev1.LocalObjectReference `json:"adminPasswordSecretRef,omitempty"`
 }
 
 // ClusterDeploymentStatus defines the observed state of ClusterDeployment

--- a/apis/hive/v1/zz_generated.deepcopy.go
+++ b/apis/hive/v1/zz_generated.deepcopy.go
@@ -723,7 +723,7 @@ func (in *ClusterDeploymentSpec) DeepCopyInto(out *ClusterDeploymentSpec) {
 	if in.ClusterMetadata != nil {
 		in, out := &in.ClusterMetadata, &out.ClusterMetadata
 		*out = new(ClusterMetadata)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Provisioning != nil {
 		in, out := &in.Provisioning, &out.Provisioning
@@ -1172,7 +1172,11 @@ func (in *ClusterInstallLocalReference) DeepCopy() *ClusterInstallLocalReference
 func (in *ClusterMetadata) DeepCopyInto(out *ClusterMetadata) {
 	*out = *in
 	out.AdminKubeconfigSecretRef = in.AdminKubeconfigSecretRef
-	out.AdminPasswordSecretRef = in.AdminPasswordSecretRef
+	if in.AdminPasswordSecretRef != nil {
+		in, out := &in.AdminPasswordSecretRef, &out.AdminPasswordSecretRef
+		*out = new(corev1.LocalObjectReference)
+		**out = **in
+	}
 	return
 }
 

--- a/apis/hivecontracts/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/hivecontracts/v1alpha1/zz_generated.deepcopy.go
@@ -83,7 +83,7 @@ func (in *ClusterInstallSpec) DeepCopyInto(out *ClusterInstallSpec) {
 	if in.ClusterMetadata != nil {
 		in, out := &in.ClusterMetadata, &out.ClusterMetadata
 		*out = new(hivev1.ClusterMetadata)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/apis/hiveinternal/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/hiveinternal/v1alpha1/zz_generated.deepcopy.go
@@ -291,7 +291,7 @@ func (in *FakeClusterInstallSpec) DeepCopyInto(out *FakeClusterInstallSpec) {
 	if in.ClusterMetadata != nil {
 		in, out := &in.ClusterMetadata, &out.ClusterMetadata
 		*out = new(v1.ClusterMetadata)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -165,7 +165,6 @@ spec:
                     type: string
                 required:
                 - adminKubeconfigSecretRef
-                - adminPasswordSecretRef
                 - clusterID
                 - infraID
                 type: object

--- a/config/crds/hiveinternal.openshift.io_fakeclusterinstalls.yaml
+++ b/config/crds/hiveinternal.openshift.io_fakeclusterinstalls.yaml
@@ -84,7 +84,6 @@ spec:
                     type: string
                 required:
                 - adminKubeconfigSecretRef
-                - adminPasswordSecretRef
                 - clusterID
                 - infraID
                 type: object

--- a/pkg/clusterresource/builder.go
+++ b/pkg/clusterresource/builder.go
@@ -328,7 +328,7 @@ func (o *Builder) generateClusterDeployment() *hivev1.ClusterDeployment {
 		}
 		cd.Spec.Installed = true
 		if o.AdoptAdminUsername != "" {
-			cd.Spec.ClusterMetadata.AdminPasswordSecretRef = corev1.LocalObjectReference{
+			cd.Spec.ClusterMetadata.AdminPasswordSecretRef = &corev1.LocalObjectReference{
 				Name: o.getAdoptAdminPasswordSecretName(),
 			}
 		}

--- a/pkg/controller/argocdregister/argocdregister_controller_test.go
+++ b/pkg/controller/argocdregister/argocdregister_controller_test.go
@@ -294,7 +294,7 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 			ClusterID:                testClusterID,
 			InfraID:                  testInfraID,
 			AdminKubeconfigSecretRef: corev1.LocalObjectReference{Name: adminKubeconfigSecret},
-			AdminPasswordSecretRef:   corev1.LocalObjectReference{Name: adminPasswordSecret},
+			AdminPasswordSecretRef:   &corev1.LocalObjectReference{Name: adminPasswordSecret},
 		},
 	}
 

--- a/pkg/controller/clusterclaim/clusterclaim_controller_test.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller_test.go
@@ -90,7 +90,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 		func(cd *hivev1.ClusterDeployment) {
 			cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
 				AdminKubeconfigSecretRef: corev1.LocalObjectReference{Name: kubeconfigSecretName},
-				AdminPasswordSecretRef:   corev1.LocalObjectReference{Name: passwordSecretName},
+				AdminPasswordSecretRef:   &corev1.LocalObjectReference{Name: passwordSecretName},
 			}
 		},
 	)

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -592,7 +592,7 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 			if err := r.addOwnershipToSecret(cd, cdLog, cd.Spec.ClusterMetadata.AdminKubeconfigSecretRef.Name); err != nil {
 				return reconcile.Result{}, err
 			}
-			if cd.Spec.ClusterMetadata.AdminPasswordSecretRef.Name != "" {
+			if cd.Spec.ClusterMetadata.AdminPasswordSecretRef != nil && cd.Spec.ClusterMetadata.AdminPasswordSecretRef.Name != "" {
 				if err := r.addOwnershipToSecret(cd, cdLog, cd.Spec.ClusterMetadata.AdminPasswordSecretRef.Name); err != nil {
 					return reconcile.Result{}, err
 				}

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -1353,7 +1353,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 						InfraID:                  "old-infra-id",
 						ClusterID:                "old-cluster-id",
 						AdminKubeconfigSecretRef: corev1.LocalObjectReference{Name: "old-kubeconfig-secret"},
-						AdminPasswordSecretRef:   corev1.LocalObjectReference{Name: "old-password-secret"},
+						AdminPasswordSecretRef:   &corev1.LocalObjectReference{Name: "old-password-secret"},
 					}
 					return cd
 				}(),
@@ -1484,7 +1484,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 					cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
 						InfraID:                  "fakeinfra",
 						AdminKubeconfigSecretRef: corev1.LocalObjectReference{Name: adminKubeconfigSecret},
-						AdminPasswordSecretRef:   corev1.LocalObjectReference{Name: adminPasswordSecret},
+						AdminPasswordSecretRef:   &corev1.LocalObjectReference{Name: adminPasswordSecret},
 					}
 					cd.Status.WebConsoleURL = "https://example.com"
 					cd.Status.APIURL = "https://example.com"
@@ -2012,7 +2012,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 					AdminKubeconfigSecretRef: corev1.LocalObjectReference{
 						Name: adminKubeconfigSecret,
 					},
-					AdminPasswordSecretRef: corev1.LocalObjectReference{
+					AdminPasswordSecretRef: &corev1.LocalObjectReference{
 						Name: adminPasswordSecret,
 					},
 				}),
@@ -2623,7 +2623,7 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 			ClusterID:                testClusterID,
 			InfraID:                  testInfraID,
 			AdminKubeconfigSecretRef: corev1.LocalObjectReference{Name: adminKubeconfigSecret},
-			AdminPasswordSecretRef:   corev1.LocalObjectReference{Name: adminPasswordSecret},
+			AdminPasswordSecretRef:   &corev1.LocalObjectReference{Name: adminPasswordSecret},
 		},
 	}
 
@@ -2795,9 +2795,12 @@ func testFakeClusterInstallWithClusterMetadata(name string, metadata hivev1.Clus
 		"adminKubeconfigSecretRef": map[string]interface{}{
 			"name": metadata.AdminKubeconfigSecretRef.Name,
 		},
-		"adminPasswordSecretRef": map[string]interface{}{
+	}
+
+	if metadata.AdminPasswordSecretRef != nil {
+		value["adminPasswordSecretRef"] = map[string]interface{}{
 			"name": metadata.AdminPasswordSecretRef.Name,
-		},
+		}
 	}
 
 	unstructured.SetNestedField(fake.UnstructuredContent(), value, "spec", "clusterMetadata")

--- a/pkg/controller/clusterdeployment/clusterprovisions.go
+++ b/pkg/controller/clusterdeployment/clusterprovisions.go
@@ -235,7 +235,7 @@ func (r *ReconcileClusterDeployment) reconcileExistingProvision(cd *hivev1.Clust
 			clusterMetadata.AdminKubeconfigSecretRef = *provision.Spec.AdminKubeconfigSecretRef
 		}
 		if provision.Spec.AdminPasswordSecretRef != nil {
-			clusterMetadata.AdminPasswordSecretRef = *provision.Spec.AdminPasswordSecretRef
+			clusterMetadata.AdminPasswordSecretRef = provision.Spec.AdminPasswordSecretRef
 		}
 		if !reflect.DeepEqual(clusterMetadata, cd.Spec.ClusterMetadata) {
 			cd.Spec.ClusterMetadata = clusterMetadata

--- a/pkg/controller/fakeclusterinstall/fakeclusterinstall_controller.go
+++ b/pkg/controller/fakeclusterinstall/fakeclusterinstall_controller.go
@@ -283,7 +283,7 @@ func (r *ReconcileClusterInstall) Reconcile(ctx context.Context, request reconci
 				InfraID:   "not-a-real-cluster",
 				// TODO: do we need to create dummy secrets?
 				AdminKubeconfigSecretRef: corev1.LocalObjectReference{Name: "admin-kubeconfig"},
-				AdminPasswordSecretRef:   corev1.LocalObjectReference{Name: "admin-password"},
+				AdminPasswordSecretRef:   &corev1.LocalObjectReference{Name: "admin-password"},
 			}
 			logger.Info("setting fake ClusterMetadata")
 			return reconcile.Result{}, r.Client.Update(context.Background(), fci)

--- a/pkg/controller/machinemanagement/machinemanagement_controller_test.go
+++ b/pkg/controller/machinemanagement/machinemanagement_controller_test.go
@@ -273,7 +273,7 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 			ClusterID:                testClusterID,
 			InfraID:                  testInfraID,
 			AdminKubeconfigSecretRef: corev1.LocalObjectReference{Name: adminKubeconfigSecret},
-			AdminPasswordSecretRef:   corev1.LocalObjectReference{Name: adminPasswordSecret},
+			AdminPasswordSecretRef:   &corev1.LocalObjectReference{Name: adminPasswordSecret},
 		},
 	}
 

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -264,7 +264,8 @@ type ClusterMetadata struct {
 	AdminKubeconfigSecretRef corev1.LocalObjectReference `json:"adminKubeconfigSecretRef"`
 
 	// AdminPasswordSecretRef references the secret containing the admin username/password which can be used to login to this cluster.
-	AdminPasswordSecretRef corev1.LocalObjectReference `json:"adminPasswordSecretRef"`
+	// +optional
+	AdminPasswordSecretRef *corev1.LocalObjectReference `json:"adminPasswordSecretRef,omitempty"`
 }
 
 // ClusterDeploymentStatus defines the observed state of ClusterDeployment

--- a/vendor/github.com/openshift/hive/apis/hive/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/zz_generated.deepcopy.go
@@ -723,7 +723,7 @@ func (in *ClusterDeploymentSpec) DeepCopyInto(out *ClusterDeploymentSpec) {
 	if in.ClusterMetadata != nil {
 		in, out := &in.ClusterMetadata, &out.ClusterMetadata
 		*out = new(ClusterMetadata)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Provisioning != nil {
 		in, out := &in.Provisioning, &out.Provisioning
@@ -1172,7 +1172,11 @@ func (in *ClusterInstallLocalReference) DeepCopy() *ClusterInstallLocalReference
 func (in *ClusterMetadata) DeepCopyInto(out *ClusterMetadata) {
 	*out = *in
 	out.AdminKubeconfigSecretRef = in.AdminKubeconfigSecretRef
-	out.AdminPasswordSecretRef = in.AdminPasswordSecretRef
+	if in.AdminPasswordSecretRef != nil {
+		in, out := &in.AdminPasswordSecretRef, &out.AdminPasswordSecretRef
+		*out = new(corev1.LocalObjectReference)
+		**out = **in
+	}
 	return
 }
 

--- a/vendor/github.com/openshift/hive/apis/hivecontracts/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/hive/apis/hivecontracts/v1alpha1/zz_generated.deepcopy.go
@@ -83,7 +83,7 @@ func (in *ClusterInstallSpec) DeepCopyInto(out *ClusterInstallSpec) {
 	if in.ClusterMetadata != nil {
 		in, out := &in.ClusterMetadata, &out.ClusterMetadata
 		*out = new(hivev1.ClusterMetadata)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/vendor/github.com/openshift/hive/apis/hiveinternal/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/hive/apis/hiveinternal/v1alpha1/zz_generated.deepcopy.go
@@ -291,7 +291,7 @@ func (in *FakeClusterInstallSpec) DeepCopyInto(out *FakeClusterInstallSpec) {
 	if in.ClusterMetadata != nil {
 		in, out := &in.ClusterMetadata, &out.ClusterMetadata
 		*out = new(v1.ClusterMetadata)
-		**out = **in
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }


### PR DESCRIPTION
Hive doesn't need this value, and we should not require users adopting
clusters to provide it.

/assign @2uasimojo 
/cc @lwan-wanglin 