### PR TITLE
claim: Consolidate ClusterDeleted into ClusterRunning

### DIFF
--- a/pkg/controller/clusterclaim/clusterclaim_controller.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller.go
@@ -38,7 +38,6 @@ const (
 // clusterClaimConditions are the cluster claim conditions controlled or initialized by cluster claim controller
 var clusterClaimConditions = []hivev1.ClusterClaimConditionType{
 	hivev1.ClusterClaimPendingCondition,
-	hivev1.ClusterClaimClusterDeletedCondition,
 	hivev1.ClusterRunningCondition,
 }
 
@@ -394,8 +393,8 @@ func (r *ReconcileClusterClaim) reconcileForDeletedCluster(claim *hivev1.Cluster
 	logger.Debug("assigned cluster has been deleted")
 	conds, changed := controllerutils.SetClusterClaimConditionWithChangeCheck(
 		claim.Status.Conditions,
-		hivev1.ClusterClaimClusterDeletedCondition,
-		corev1.ConditionTrue,
+		hivev1.ClusterRunningCondition,
+		corev1.ConditionFalse,
 		"ClusterDeleted",
 		"Assigned cluster has been deleted",
 		controllerutils.UpdateConditionIfReasonOrMessageChange,

--- a/pkg/controller/clusterclaim/clusterclaim_controller_test.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller_test.go
@@ -79,10 +79,6 @@ func TestReconcileClusterClaim(t *testing.T) {
 		}),
 		testclaim.WithCondition(hivev1.ClusterClaimCondition{
 			Status: corev1.ConditionUnknown,
-			Type:   hivev1.ClusterClaimClusterDeletedCondition,
-		}),
-		testclaim.WithCondition(hivev1.ClusterClaimCondition{
-			Status: corev1.ConditionUnknown,
 			Type:   hivev1.ClusterRunningCondition,
 		}),
 	)
@@ -119,10 +115,6 @@ func TestReconcileClusterClaim(t *testing.T) {
 			expectedConditions: []hivev1.ClusterClaimCondition{
 				{
 					Type:   hivev1.ClusterClaimPendingCondition,
-					Status: corev1.ConditionUnknown,
-				},
-				{
-					Type:   hivev1.ClusterClaimClusterDeletedCondition,
 					Status: corev1.ConditionUnknown,
 				},
 				{
@@ -201,8 +193,8 @@ func TestReconcileClusterClaim(t *testing.T) {
 			name:  "deleted cluster",
 			claim: initializedClaimBuilder.Build(testclaim.WithCluster(clusterName)),
 			expectedConditions: []hivev1.ClusterClaimCondition{{
-				Type:    hivev1.ClusterClaimClusterDeletedCondition,
-				Status:  corev1.ConditionTrue,
+				Type:    hivev1.ClusterRunningCondition,
+				Status:  corev1.ConditionFalse,
 				Reason:  "ClusterDeleted",
 				Message: "Assigned cluster has been deleted",
 			}},


### PR DESCRIPTION
Previously, the ClusterRunning condition of ClusterClaim was being used to store the state of the assigned ClusterDeployment, *except* when the CD was deleted. We had a whole separate condition, ClusterDeleted, for that. This was particularly confusing in the summary output for ClusterClaim, which could show something like:

```
[efried@efried ~]$ oc get clusterclaim claim-gllgp
NAME          POOL                     PENDING          CLUSTERNAMESPACE               CLUSTERRUNNING   AGE
claim-gllgp   fake-ocp-4-7-amd64-aws   ClusterClaimed   fake-ocp-4-7-amd64-aws-m2kkp   Running          4m23s
```

...even when the ClusterDeployment was deleted.

The reasonable fix is to twiddling the ClusterRunning condition to:

```
  {
    "lastProbeTime": "2021-07-16T20:02:01Z",
    "lastTransitionTime": "2021-07-16T20:02:01Z",
    "message": "Assigned cluster has been deleted",
    "reason": "ClusterDeleted",
    "status": "False",
    "type": "ClusterRunning"
  }
```

...at the same time as we set the ClusterDeleted condition to True. But that would make the ClusterDeleted condition redundant, so this commit just gets rid of it instead.

[HIVE-1592](https://issues.redhat.com/browse/HIVE-1592)