### PR TITLE
Fix build-machinery-go dependencies

### DIFF
--- a/config/operator/operator_role_binding.yaml
+++ b/config/operator/operator_role_binding.yaml
@@ -10,4 +10,3 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: hive-operator
-  namespace: hive

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -28,17 +28,6 @@ fi
 echo "Running e2e with HIVE_IMAGE ${HIVE_IMAGE}"
 echo "Running e2e with RELEASE_IMAGE ${RELEASE_IMAGE}"
 
-if ! which kustomize > /dev/null; then
-  kustomize_dir="$(mktemp -d)"
-  export PATH="$PATH:${kustomize_dir}"
-  # download kustomize so we can use it for deploying
-  pushd "${kustomize_dir}"
-  curl -O -L https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.0/kustomize_2.0.0_linux_amd64
-  mv kustomize_2.0.0_linux_amd64 kustomize
-  chmod u+x kustomize
-  popd
-fi
-
 i=1
 while [ $i -le ${max_tries} ]; do
   if [ $i -gt 1 ]; then


### PR DESCRIPTION
This commit fixes two things about our build-machinery-go includes:
- The `images.mk` include uses `ensure-imagebuilder`, which comes from `imagebuilder.mk`. We shouldn't have to include the latter explicitly. https://github.com/openshift/build-machinery-go/pull/50 is fixing that, but until that merges and we can vendor it in, include it explicitly.
- `ensure-kustomize` was working as far as it went, but it was installing kustomize into a subdirectory which is (usually) not in
`$PATH`, so things like `make deploy` were either breaking (bad) or picking up kustomize from somewhere else (potentially worse). Fix our usage of kustomize to ref the variable that `ensure-kustomize` sets up to point to the binary it installs. This is also a different version of kustomize (4.1.3) from what our e2e test was installing (2.0.0) and it behaves slightly differently when constructing the ServiceAccount for the deployment: the namespace hardcoded into the rolebinding manifest is not overridden as expected. Removing the namespace from that manifest fixes the problem.