### PR TITLE
Don't allow excess claims to create extra CDs

### DIFF
--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -325,6 +325,10 @@ func (r *ReconcileClusterPool) Reconcile(ctx context.Context, request reconcile.
 
 	// reserveSize is the number of clusters that the pool currently has in reserve
 	reserveSize := len(installingCDs) + len(readyCDs) - len(pendingClaims)
+	// Don't allow excess claims to add CDs
+	if reserveSize < 0 {
+		reserveSize = 0
+	}
 
 	readyCDs, err = r.assignClustersToClaims(pendingClaims, readyCDs, logger)
 	if err != nil {

--- a/pkg/controller/clusterpool/clusterpool_controller_test.go
+++ b/pkg/controller/clusterpool/clusterpool_controller_test.go
@@ -885,6 +885,25 @@ func TestReconcileClusterPool(t *testing.T) {
 			expectedObservedReady:   2,
 			expectedDeletedClusters: []string{"c4"},
 		},
+		{
+			name: "claims exceed capacity",
+			existing: []runtime.Object{
+				initializedPoolBuilder.Build(testcp.WithSize(2)),
+				testclaim.FullBuilder(testNamespace, "test-claim1", scheme).Build(testclaim.WithPool(testLeasePoolName)),
+				testclaim.FullBuilder(testNamespace, "test-claim2", scheme).Build(testclaim.WithPool(testLeasePoolName)),
+				testclaim.FullBuilder(testNamespace, "test-claim3", scheme).Build(testclaim.WithPool(testLeasePoolName)),
+			},
+			expectedTotalClusters:    2,
+			expectedUnassignedClaims: 3,
+		},
+		{
+			name: "zero size pool",
+			existing: []runtime.Object{
+				initializedPoolBuilder.Build(testcp.WithSize(0)),
+				testclaim.FullBuilder(testNamespace, "test-claim", scheme).Build(testclaim.WithPool(testLeasePoolName)),
+			},
+			expectedUnassignedClaims: 1,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Previously, due to a math error, if the number of pending claims exceeded the pool size, we would create the surplus number of CDs, assign them, and then delete them. This commit fixes the math error: any excess claim will remain Pending until capacity becomes available to create a CD for it.

**NOTE:**
The above also applies to the edge case where the pool size is zero. A claim against such a pool will remain Pending *until the pool is edited to have a nonzero size*.

This differs from other scenarios when we're at capacity:
- If we've reached `MaxSize`, capacity becomes available when a *CD* is deleted (which may be prompted by its *claim* being deleted).
- If we've reached `MaxConcurrent`, capacity becomes available when a *CD* finishes provisioning or deprovisioning.

Due to this discrepancy, the argument could be made to treat a zero-size pool specially and simply fail any claim against it. We can debate that separately; this commit doesn't address it.

[HIVE-1593](https://issues.redhat.com/browse/HIVE-1593)