### PR TITLE
Add PreserveOnDelete to DNSZones.

### DIFF
--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -94,6 +94,7 @@ type ClusterDeploymentSpec struct {
 
 	// PreserveOnDelete allows the user to disconnect a cluster from Hive without deprovisioning it. This can also be
 	// used to abandon ongoing cluster deprovision.
+	// +optional
 	PreserveOnDelete bool `json:"preserveOnDelete,omitempty"`
 
 	// ControlPlaneConfig contains additional configuration for the target cluster's control plane

--- a/apis/hive/v1/dnszone_types.go
+++ b/apis/hive/v1/dnszone_types.go
@@ -27,6 +27,12 @@ type DNSZoneSpec struct {
 	// +optional
 	LinkToParentDomain bool `json:"linkToParentDomain,omitempty"`
 
+	// PreserveOnDelete allows the user to disconnect a DNSZone from Hive without deprovisioning it.
+	// This can also be used to abandon ongoing DNSZone deprovision.
+	// Typically set automatically due to PreserveOnDelete being set on a ClusterDeployment.
+	// +optional
+	PreserveOnDelete bool `json:"preserveOnDelete,omitempty"`
+
 	// AWS specifies AWS-specific cloud configuration
 	// +optional
 	AWS *AWSDNSZoneSpec `json:"aws,omitempty"`

--- a/config/crds/hive.openshift.io_dnszones.yaml
+++ b/config/crds/hive.openshift.io_dnszones.yaml
@@ -131,6 +131,12 @@ spec:
                 description: LinkToParentDomain specifies whether DNS records should
                   be automatically created to link this DNSZone with a parent domain.
                 type: boolean
+              preserveOnDelete:
+                description: PreserveOnDelete allows the user to disconnect a DNSZone
+                  from Hive without deprovisioning it. This can also be used to abandon
+                  ongoing DNSZone deprovision. Typically set automatically due to
+                  PreserveOnDelete being set on a ClusterDeployment.
+                type: boolean
               zone:
                 description: Zone is the DNS zone to host
                 type: string

--- a/pkg/controller/dnszone/dnszone_controller_test.go
+++ b/pkg/controller/dnszone/dnszone_controller_test.go
@@ -135,6 +135,14 @@ func TestReconcileDNSProviderForAWS(t *testing.T) {
 			expectZoneDeleted: true,
 		},
 		{
+			name:    "Delete zone with PreserveOnDelete",
+			dnsZone: validDNSZoneBeingDeletedWithPreserve(),
+			// No AWS calls expected in this case, our creds may be bad:
+			setupAWSMock: func(expect *mock.MockClientMockRecorder) {
+			},
+			expectZoneDeleted: true,
+		},
+		{
 			name: "Delete DNSZone without status",
 			dnsZone: func() *hivev1.DNSZone {
 				dz := validDNSZoneBeingDeleted()

--- a/pkg/controller/dnszone/test_helpers.go
+++ b/pkg/controller/dnszone/test_helpers.go
@@ -159,6 +159,12 @@ var (
 		return zone
 	}
 
+	validDNSZoneBeingDeletedWithPreserve = func() *hivev1.DNSZone {
+		zone := validDNSZoneBeingDeleted()
+		zone.Spec.PreserveOnDelete = true
+		return zone
+	}
+
 	validAzureDNSZoneBeingDeleted = func() *hivev1.DNSZone {
 		// Take a copy of the default validAzureDNSZone object
 		zone := validAzureDNSZone()

--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -125,6 +125,12 @@ func WithClusterPoolReference(namespace, poolName, claimName string) Option {
 	}
 }
 
+func PreserveOnDelete() Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Spec.PreserveOnDelete = true
+	}
+}
+
 func Installed() Option {
 	return func(clusterDeployment *hivev1.ClusterDeployment) {
 		clusterDeployment.Spec.Installed = true

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -94,6 +94,7 @@ type ClusterDeploymentSpec struct {
 
 	// PreserveOnDelete allows the user to disconnect a cluster from Hive without deprovisioning it. This can also be
 	// used to abandon ongoing cluster deprovision.
+	// +optional
 	PreserveOnDelete bool `json:"preserveOnDelete,omitempty"`
 
 	// ControlPlaneConfig contains additional configuration for the target cluster's control plane

--- a/vendor/github.com/openshift/hive/apis/hive/v1/dnszone_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/dnszone_types.go
@@ -27,6 +27,12 @@ type DNSZoneSpec struct {
 	// +optional
 	LinkToParentDomain bool `json:"linkToParentDomain,omitempty"`
 
+	// PreserveOnDelete allows the user to disconnect a DNSZone from Hive without deprovisioning it.
+	// This can also be used to abandon ongoing DNSZone deprovision.
+	// Typically set automatically due to PreserveOnDelete being set on a ClusterDeployment.
+	// +optional
+	PreserveOnDelete bool `json:"preserveOnDelete,omitempty"`
+
 	// AWS specifies AWS-specific cloud configuration
 	// +optional
 	AWS *AWSDNSZoneSpec `json:"aws,omitempty"`


### PR DESCRIPTION
ClusterDeployment PreserveOnDelete is now being used to abandon stuck
deprovisions where a customer typically has revoked the cloud
credentials we have. It was discovered that if managed DNS was in play,
the DNS zone cleanup was still trying to use the AWS creds and getting
stuck.

CD controller will automatically transfer the clusters setting to the
DNS zone to allow it to remain independent and not require a CD to
exist.
