### PR TITLE
add a match for GCP CPU quota

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -93,6 +93,11 @@ data:
       - "Quota \'SSD_TOTAL_GB\' exceeded"
       installFailingReason: GCPQuotaSSDTotalGBExceeded
       installFailingMessage: GCP quota SSD_TOTAL_GB exceeded
+    - name: GCPComputeQuota
+      searchRegexStrings:
+      - "compute\\.googleapis\\.com/cpus is not available in [a-z0-9-]* because the required number of resources \\([0-9]*\\) is more than remaining quota"
+      installFailingReason: GCPComputeQuotaExceeded
+      installFailingMessage: GCP CPUs quota exceeded
     # Bare Metal
     - name: LibvirtSSHKeyPermissionDenied
       searchRegexStrings:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1633,6 +1633,11 @@ data:
       - "Quota \'SSD_TOTAL_GB\' exceeded"
       installFailingReason: GCPQuotaSSDTotalGBExceeded
       installFailingMessage: GCP quota SSD_TOTAL_GB exceeded
+    - name: GCPComputeQuota
+      searchRegexStrings:
+      - "compute\\.googleapis\\.com/cpus is not available in [a-z0-9-]* because the required number of resources \\([0-9]*\\) is more than remaining quota"
+      installFailingReason: GCPComputeQuotaExceeded
+      installFailingMessage: GCP CPUs quota exceeded
     # Bare Metal
     - name: LibvirtSSHKeyPermissionDenied
       searchRegexStrings:


### PR DESCRIPTION
i was investigating a [cluster provisioning delay](https://redhat.pagerduty.com/incidents/PP1XFXV) and this error was the cause

per [the SOP](https://github.com/openshift/hive-sops/blob/master/sop/ClusterProvisioningFailure.md#check-clusterdeployment-conditions), i opened this to add the error to the configmap