### PR TITLE
apiextensions s/v1beta1/v1/

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -126,7 +126,7 @@ func newRootCommand() *cobra.Command {
 					log.Fatal(err)
 				}
 
-				if err := apiextv1beta1.AddToScheme(mgr.GetScheme()); err != nil {
+				if err := apiextv1.AddToScheme(mgr.GetScheme()); err != nil {
 					log.Fatal(err)
 				}
 

--- a/pkg/operator/hive/hive_controller.go
+++ b/pkg/operator/hive/hive_controller.go
@@ -18,7 +18,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -206,7 +206,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Monitor CRDs so that we can keep latest list of supported contracts
-	err = c.Watch(&source.Kind{Type: &apiextv1beta1.CustomResourceDefinition{}},
+	err = c.Watch(&source.Kind{Type: &apiextv1.CustomResourceDefinition{}},
 		handler.EnqueueRequestsFromMapFunc(func(_ client.Object) []reconcile.Request {
 			retval := []reconcile.Request{}
 

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -27,7 +27,7 @@ import (
 
 	admregv1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -287,7 +287,7 @@ func (r *ReconcileHiveConfig) injectCerts(apiService *apiregistrationv1.APIServi
 // is311 returns true if this is a 3.11 OpenShift cluster. We check by looking for a ClusterVersion CRD,
 // which should only exist on OpenShift 4.x. We do not expect Hive to ever be deployed on pre-3.11.
 func (r *ReconcileHiveConfig) is311(hLog log.FieldLogger) (bool, error) {
-	cvCRD := &apiextv1beta1.CustomResourceDefinition{}
+	cvCRD := &apiextv1.CustomResourceDefinition{}
 	err := r.Client.Get(context.Background(), types.NamespacedName{Name: clusterVersionCRDName}, cvCRD)
 	if err != nil && errors.IsNotFound(err) {
 		// If this CRD does not exist, we must not be on a 4.x cluster.
@@ -354,7 +354,7 @@ func (r *ReconcileHiveConfig) deploySupportedContractsConfigMap(hLog log.FieldLo
 		supported[k.Name] = k.Supported
 	}
 
-	crdList := &apiextv1beta1.CustomResourceDefinitionList{}
+	crdList := &apiextv1.CustomResourceDefinitionList{}
 	if err := r.Client.List(context.TODO(), crdList); err != nil {
 		hLog.WithError(err).Error("error getting crds for collect contract implementations")
 		return "", err


### PR DESCRIPTION
We were still using v1beta1 of apiextensions. If we try to run on OCP 4.9 where CRD v1beta1 has been removed, this crashes the operator on startup while trying to add it to the scheme. This commit cuts over to apiextensions v1.

[HIVE-1598](https://issues.redhat.com/browse/HIVE-1598)