### PR TITLE
catch failures for iam.googleapis.com/quota/service-account-count quota

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -98,6 +98,11 @@ data:
       - "compute\\.googleapis\\.com/cpus is not available in [a-z0-9-]* because the required number of resources \\([0-9]*\\) is more than remaining quota"
       installFailingReason: GCPComputeQuotaExceeded
       installFailingMessage: GCP CPUs quota exceeded
+    - name: GCPServiceAccountQuota
+      searchRegexStrings:
+      - "iam\\.googleapis\\.com/quota/service-account-count is not available in global because the required number of resources \\([0-9]*\\) is more than remaining quota"
+      installFailingReason: GCPServiceAccountQuotaExceeded
+      installFailingMessage: GCP Service Account quota exceeded
     # Bare Metal
     - name: LibvirtSSHKeyPermissionDenied
       searchRegexStrings:

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -24,18 +24,19 @@ func init() {
 }
 
 const (
-	dnsAlreadyExistsLog     = "blahblah\naws_route53_record.api_external: [ERR]: Error building changeset: InvalidChangeBatch: [Tried to create resource record set [name='api.jh-stg-2405-2.n6b3.s1.devshift.org.'type='A'] but it already exists]\n\nblahblah"
-	pendingVerificationLog  = "blahblah\naws_instance.master.2: Error launching source instance: PendingVerification: Your request for accessing resources in this region is being validated, and you will not be able to launch additional resources in this region until the validation is complete. We will notify you by email once your request has been validated. While normally resolved within minutes, please allow up to 4 hours for this process to complete. If the issue still persists, please let us know by writing to awsa\n\nblahblah"
-	gcpInvalidProjectIDLog  = "blahblah\ntime=\"2020-11-13T16:05:07Z\" level=fatal msg=\"failed to fetch Master Machines: failed to load asset \"Install Config\": platform.gcp.project: Invalid value: \"o-6b20f250\": invalid project ID\nblahblah"
-	gcpSSDQUotaLog          = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=error msg=\"Error: Error waiting for instance to create: Quota 'SSD_TOTAL_GB' exceeded. Limit: 500.0 in region asia-northeast2.\nblahblah"
-	gcpCPUQuotaLog          = "level=fatal msg=failed to fetch Cluster: failed to fetch dependency of \"Cluster\": failed to generate asset \"Platform Quota Check\": error(MissingQuota): compute.googleapis.com/cpus is not available in us-east1 because the required number of resources (20) is more than remaining quota of 16"
-	kubeAPIWaitTimeoutLog   = "blahblah\ntime=\"2021-01-03T07:04:44Z\" level=fatal msg=\"waiting for Kubernetes API: context deadline exceeded\""
-	natGatewayLimitExceeded = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=error msg=\"Error creating NAT Gateway: NatGatewayLimitExceeded: The maximum number of NAT Gateways has been reached.\""
-	vpcLimitExceeded        = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=error msg=\"Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.\""
-	genericLimitExceeded    = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=error msg=\"Error: Error creating Generic: GenericLimitExceeded: The maximum number of Generics has been reached.\""
-	invalidCredentials      = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=error msg=\"Error: error waiting for Route53 Hosted Zone (Z1009177L956IM4ANFHL) creation: InvalidClientTokenId: The security token included in the request is invalid.\""
-	kubeAPIWaitFailedLog    = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=error msg=\"Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane.\""
-	noMatchLog              = "an example of something that doesn't match the log regexes"
+	dnsAlreadyExistsLog       = "blahblah\naws_route53_record.api_external: [ERR]: Error building changeset: InvalidChangeBatch: [Tried to create resource record set [name='api.jh-stg-2405-2.n6b3.s1.devshift.org.'type='A'] but it already exists]\n\nblahblah"
+	pendingVerificationLog    = "blahblah\naws_instance.master.2: Error launching source instance: PendingVerification: Your request for accessing resources in this region is being validated, and you will not be able to launch additional resources in this region until the validation is complete. We will notify you by email once your request has been validated. While normally resolved within minutes, please allow up to 4 hours for this process to complete. If the issue still persists, please let us know by writing to awsa\n\nblahblah"
+	gcpInvalidProjectIDLog    = "blahblah\ntime=\"2020-11-13T16:05:07Z\" level=fatal msg=\"failed to fetch Master Machines: failed to load asset \"Install Config\": platform.gcp.project: Invalid value: \"o-6b20f250\": invalid project ID\nblahblah"
+	gcpSSDQUotaLog            = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=error msg=\"Error: Error waiting for instance to create: Quota 'SSD_TOTAL_GB' exceeded. Limit: 500.0 in region asia-northeast2.\nblahblah"
+	gcpCPUQuotaLog            = "level=fatal msg=failed to fetch Cluster: failed to fetch dependency of \"Cluster\": failed to generate asset \"Platform Quota Check\": error(MissingQuota): compute.googleapis.com/cpus is not available in us-east1 because the required number of resources (20) is more than remaining quota of 16"
+	gcpServiceAccountQuotaLog = "level=fatal msg=failed to fetch Cluster: failed to fetch dependency of \"Cluster\": failed to generate asset \"Platform Quota Check\": error(MissingQuota): iam.googleapis.com/quota/service-account-count is not available in global because the required number of resources (5) is more than remaining quota of 0"
+	kubeAPIWaitTimeoutLog     = "blahblah\ntime=\"2021-01-03T07:04:44Z\" level=fatal msg=\"waiting for Kubernetes API: context deadline exceeded\""
+	natGatewayLimitExceeded   = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=error msg=\"Error creating NAT Gateway: NatGatewayLimitExceeded: The maximum number of NAT Gateways has been reached.\""
+	vpcLimitExceeded          = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=error msg=\"Error: Error creating VPC: VpcLimitExceeded: The maximum number of VPCs has been reached.\""
+	genericLimitExceeded      = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=error msg=\"Error: Error creating Generic: GenericLimitExceeded: The maximum number of Generics has been reached.\""
+	invalidCredentials        = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=error msg=\"Error: error waiting for Route53 Hosted Zone (Z1009177L956IM4ANFHL) creation: InvalidClientTokenId: The security token included in the request is invalid.\""
+	kubeAPIWaitFailedLog      = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=error msg=\"Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane.\""
+	noMatchLog                = "an example of something that doesn't match the log regexes"
 )
 
 func TestParseInstallLog(t *testing.T) {
@@ -282,6 +283,26 @@ func TestParseInstallLog(t *testing.T) {
 				},
 			}},
 			expectedReason: "GCPComputeQuotaExceeded",
+		},
+		{
+			name: "GCP service account quota",
+			log:  pointer.StringPtr(gcpServiceAccountQuotaLog),
+			existing: []runtime.Object{&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      regexConfigMapName,
+					Namespace: constants.DefaultHiveNamespace,
+				},
+				Data: map[string]string{
+					"regexes": `
+- name: GCPServiceAccountQuota
+  searchRegexStrings:
+  - "iam\\.googleapis\\.com/quota/service-account-count is not available in global because the required number of resources \\([0-9]*\\) is more than remaining quota"
+  installFailingReason: GCPServiceAccountQuotaExceeded
+  installFailingMessage: GCP Service Account quota exceeded
+`,
+				},
+			}},
+			expectedReason: "GCPServiceAccountQuotaExceeded",
 		},
 	}
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1638,6 +1638,11 @@ data:
       - "compute\\.googleapis\\.com/cpus is not available in [a-z0-9-]* because the required number of resources \\([0-9]*\\) is more than remaining quota"
       installFailingReason: GCPComputeQuotaExceeded
       installFailingMessage: GCP CPUs quota exceeded
+    - name: GCPServiceAccountQuota
+      searchRegexStrings:
+      - "iam\\.googleapis\\.com/quota/service-account-count is not available in global because the required number of resources \\([0-9]*\\) is more than remaining quota"
+      installFailingReason: GCPServiceAccountQuotaExceeded
+      installFailingMessage: GCP Service Account quota exceeded
     # Bare Metal
     - name: LibvirtSSHKeyPermissionDenied
       searchRegexStrings:


### PR DESCRIPTION
as seen in https://redhat.pagerduty.com/incidents/P6W7F8B , clusters can fail to install when the GCP service account quota is exceeded:

> iam.googleapis.com/quota/service-account-count is not available in global because
the required number of resources (5) is more than remaining quota of 0

this will catch that error in the installlog monitor