### PR TITLE
fix app-sre build script current hash grab

### DIFF
--- a/hack/app_sre_create_image_catalog.sh
+++ b/hack/app_sre_create_image_catalog.sh
@@ -24,7 +24,7 @@ REMOVED_VERSIONS=""
 if [[ "$REMOVE_UNDEPLOYED" == true ]]; then
     DEPLOYED_HASH=$(
         curl -s https://gitlab.cee.redhat.com/service/app-interface/-/raw/master/data/services/hive/cicd/ci-int/saas-hive.yaml | \
-            docker run --rm -i quay.io/openshift-hive/yq:latest -r '.resourceTemplates[]|select(.name="hive").targets[]|select(.namespace."$ref"=="/services/hive/namespaces/hive-production.yml").ref'
+            docker run --rm -i quay.io/openshift-hive/yq:latest -r '.resourceTemplates[]|select(.name="hive").targets[]|select(.namespace."$ref"=="/services/hive/namespaces/hivep01ue1/hive-production.yml").ref'
     )
 
     delete=false


### PR DESCRIPTION
hack/app_sre_create_image_catalog.sh was grabbing the
hive-production v3 shard as the currently deployed hash,
and that's wrong because it's pinned to an old commit.
Use hivep01ue1's hash.

/assign @2uasimojo 
/cc @akhil-rane 