### PR TITLE
hiveconfig: allow choosing dns record type for private link

### DIFF
--- a/apis/hive/v1/hiveconfig_types.go
+++ b/apis/hive/v1/hiveconfig_types.go
@@ -172,7 +172,7 @@ type AWSPrivateLinkConfig struct {
 	AssociatedVPCs []AWSAssociatedVPC `json:"associatedVPCs,omitempty"`
 
 	// DNSRecordType defines what type of DNS record should be created in Private Hosted Zone
-	// for the customer clusters API endpoint (which is the VPC Endpoint's regional DNS name).
+	// for the customer cluster's API endpoint (which is the VPC Endpoint's regional DNS name).
 	//
 	// +kubebuilder:default=Alias
 	// +optional
@@ -180,18 +180,18 @@ type AWSPrivateLinkConfig struct {
 }
 
 // AWSPrivateLinkDNSRecordType defines what type of DNS record should be created in Private Hosted Zone
-// for the customer clusters API endpoint (which is the VPC Endpoint's regional DNS name).
+// for the customer cluster's API endpoint (which is the VPC Endpoint's regional DNS name).
 // +kubebuilder:validation:Enum=Alias;ARecord
 type AWSPrivateLinkDNSRecordType string
 
 const (
-	// AliasAWSPrivateLinkDNSRecordType uses Route53 Alias record type for pointing the customer clusters
+	// AliasAWSPrivateLinkDNSRecordType uses Route53 Alias record type for pointing the customer cluster's
 	// API DNS name to the DNS name of the VPC endpoint. This is the default and should be used for most
 	// cases as it is provided at no extra cost in terms of DNS queries and usually resolves faster in AWS
 	// environments.
 	AliasAWSPrivateLinkDNSRecordType AWSPrivateLinkDNSRecordType = "Alias"
 
-	// ARecordAWSPrivateLinkDNSRecordType uses Route53 A record type for pointing the customer clusters
+	// ARecordAWSPrivateLinkDNSRecordType uses Route53 A record type for pointing the customer cluster's
 	// API DNS name to the DNS name of the VPC endpoint. This should be used when Alias record type cannot
 	// be used or other restrictions prevent use of Alias records.
 	ARecordAWSPrivateLinkDNSRecordType AWSPrivateLinkDNSRecordType = "ARecord"

--- a/apis/hive/v1/hiveconfig_types.go
+++ b/apis/hive/v1/hiveconfig_types.go
@@ -170,7 +170,32 @@ type AWSPrivateLinkConfig struct {
 	//
 	// This list should at minimum include the VPC where the current Hive controller is running.
 	AssociatedVPCs []AWSAssociatedVPC `json:"associatedVPCs,omitempty"`
+
+	// DNSRecordType defines what type of DNS record should be created in Private Hosted Zone
+	// for the customer clusters API endpoint (which is the VPC Endpoint's regional DNS name).
+	//
+	// +kubebuilder:default=Alias
+	// +optional
+	DNSRecordType AWSPrivateLinkDNSRecordType `json:"dnsRecordType,omitempty"`
 }
+
+// AWSPrivateLinkDNSRecordType defines what type of DNS record should be created in Private Hosted Zone
+// for the customer clusters API endpoint (which is the VPC Endpoint's regional DNS name).
+// +kubebuilder:validation:Enum=Alias;ARecord
+type AWSPrivateLinkDNSRecordType string
+
+const (
+	// AliasAWSPrivateLinkDNSRecordType uses Route53 Alias record type for pointing the customer clusters
+	// API DNS name to the DNS name of the VPC endpoint. This is the default and should be used for most
+	// cases as it is provided at no extra cost in terms of DNS queries and usually resolves faster in AWS
+	// environments.
+	AliasAWSPrivateLinkDNSRecordType AWSPrivateLinkDNSRecordType = "Alias"
+
+	// ARecordAWSPrivateLinkDNSRecordType uses Route53 A record type for pointing the customer clusters
+	// API DNS name to the DNS name of the VPC endpoint. This should be used when Alias record type cannot
+	// be used or other restrictions prevent use of Alias records.
+	ARecordAWSPrivateLinkDNSRecordType AWSPrivateLinkDNSRecordType = "ARecord"
+)
 
 // AWSPrivateLinkInventory is a VPC and its corresponding subnets in an AWS region.
 // This VPC will be used to create an AWS VPC Endpoint whenever there is a VPC Endpoint Service

--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -123,7 +123,7 @@ spec:
                   dnsRecordType:
                     default: Alias
                     description: DNSRecordType defines what type of DNS record should
-                      be created in Private Hosted Zone for the customer clusters
+                      be created in Private Hosted Zone for the customer cluster's
                       API endpoint (which is the VPC Endpoint's regional DNS name).
                     enum:
                     - Alias

--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -120,6 +120,15 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                  dnsRecordType:
+                    default: Alias
+                    description: DNSRecordType defines what type of DNS record should
+                      be created in Private Hosted Zone for the customer clusters
+                      API endpoint (which is the VPC Endpoint's regional DNS name).
+                    enum:
+                    - Alias
+                    - ARecord
+                    type: string
                   endpointVPCInventory:
                     description: EndpointVPCInventory is a list of VPCs and the corresponding
                       subnets in various AWS regions. The controller uses this list

--- a/docs/awsprivatelink.md
+++ b/docs/awsprivatelink.md
@@ -226,25 +226,25 @@ expectations of required permissions for these credentials.
 ## Using A DNS records type in Private Hosted Zones
 
 Currently the private link controller creates an ALIAS record in the PHZ
-created for customer's cluster. This record points enables the dns
-resolution of customer clusters k8s API to the VPC endpoint, therefore
-allowing hive to transparently accessing the cluster over the private
+created for customer's cluster. This record points the dns
+resolution of customer cluster's k8s API to the VPC endpoint, therefore
+allowing hive to transparently access the cluster over the private
 link.
 
 In some cases the ALIAS record cannot be used. For example, in GovCloud
-environments the Route53 private hosted zones do not support ALIAS
+environments the Route53 private hosted zones do not support the ALIAS
 record type and therefore we have to use A records.
 
-CNAME records would have been more suitable replacement for ALIAS records, but
+CNAME records would have been a more suitable replacement for ALIAS records, but
 CNAME records cannot be created at the apex of a DNS zone like ALIAS records.
 The private link architecture uses a DNS zone like `api.<clustername>.<clusterdomain>`
-so that there is no conflicts with authority on DNS resolution. Since CNAME
+so that there are no conflicts with authority on DNS resolution. Since CNAME
 records are not supported on the apex, we use A records pointing the cluster's
 API DNS name to the IP addresses of the VPC endpoint directly. Since these IP
 addresses do not change as they are backed by Elastic Network Interfaces in the
 corresponding subnets of the VPC endpoint, this DNS record should remain stable.
 
-For simplicity and current desired use-case, the dns record type can be
+For simplicity and current desired use-case, the DNS record type can be
 configured globally for all clusters managed by private link controller.
 
 ```yaml
@@ -258,13 +258,13 @@ spec:
 
 ## Developing for Private Link
 
-Since Private link requires some networking setup before Hive controller can create
+Private link requires some networking setup before Hive controller can create
 clusters with Private link routing.
 
 ### Setup VPCs in AWS
 
 Create 2 sets of VPCs in the same region in an AWS account. One VPC will
-be used for creating an OCP cluster for Hive, and the another will be used
+be used for creating an OCP cluster for Hive, and the other will be used
 as inventory for VPC endpoints.
 
 1. Create a Hive VPC using cloudformation template.
@@ -393,7 +393,7 @@ You can use security groups from peered VPCs to allow flow of traffic using [AWS
 
 1. Find the security group for workers in Hive Cluster
 
-You the Hive VPC id to list the security groups.
+Use the Hive VPC id to list the security groups.
 
 ```
 aws --region us-east-1 ec2 describe-security-groups \
@@ -411,7 +411,7 @@ aws --region us-east-1 ec2 describe-security-groups \
 
 3. Allow all incoming traffic from Hive cluster's worker security group to VPC endpoints
 
-Create a incoming security group rule in Private link VPC's default security group that allows ALL traffic
+Create an incoming security group rule in Private link VPC's default security group that allows ALL traffic
 from the Hive cluster's worker security group.
 
 ```
@@ -422,7 +422,7 @@ aws --region us-east-1 ec2 authorize-security-group-ingress \
 
 4. Allow all incoming traffic from VPC endpoints to Hive cluster's worker security group
 
-Create a incoming security group rule in Hive cluster's worker security group that allows ALL traffic
+Create an incoming security group rule in Hive cluster's worker security group that allows ALL traffic
 from the Private link VPC's default security group.
 
 ```

--- a/docs/awsprivatelink.md
+++ b/docs/awsprivatelink.md
@@ -255,3 +255,188 @@ spec:
 
 [aws-private-link-overview]: https://docs.aws.amazon.com/vpc/latest/privatelink/endpoint-services-overview.html
 [control-access-vpc-endpoint]: https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints-access.html#vpc-endpoints-security-groups
+
+## Developing for Private Link
+
+Since Private link requires some networking setup before Hive controller can create
+clusters with Private link routing.
+
+### Setup VPCs in AWS
+
+Create 2 sets of VPCs in the same region in an AWS account. One VPC will
+be used for creating an OCP cluster for Hive, and the another will be used
+as inventory for VPC endpoints.
+
+1. Create a Hive VPC using cloudformation template.
+
+```
+aws --region us-east-1 cloudformation create-stack \
+  --stack-name hive-vpc \
+  --template-body "file://hack/awsprivatelink/vpc.cf.yaml" \
+  --parameters ParameterKey=AvailabilityZoneCount,ParameterValue=3 ParameterKey=VpcCidr,ParameterValue=10.0.0.0/16
+```
+
+2. Once the cloudformation completes, extract the VPC and subnets from the output.
+
+```
+aws --region us-east-1 cloudformation describe-stacks \
+  --stack-name hive-vpc --query 'Stacks[].Outputs'
+[
+  [
+    {
+      "OutputKey": "PrivateSubnetIds",
+      "OutputValue": "subnet-0bf2b8faf1c7d200b,subnet-09d53f09b54c38029,subnet-015d46e5f7fb7055d",
+      "Description": "Subnet IDs of the private subnets."
+    },
+    {
+      "OutputKey": "PublicSubnetIds",
+      "OutputValue": "subnet-00d5d89ce7b049296,subnet-0253d95c4bcfe7e17,subnet-03a4cfddbf7d9f73a",
+      "Description": "Subnet IDs of the public subnets."
+    },
+    {
+      "OutputKey": "VpcId",
+      "OutputValue": "vpc-0e0b3939a23a5e33e",
+      "Description": "ID of the new VPC."
+    }
+  ]
+]
+```
+
+3. Create a Private link VPC using cloudformation template.
+
+```
+aws --region us-east-1 cloudformation create-stack \
+  --stack-name private-link-vpc \
+  --template-body "file://hack/awsprivatelink/vpc.cf.yaml" \
+  --parameters ParameterKey=AvailabilityZoneCount,ParameterValue=3 ParameterKey=VpcCidr,ParameterValue=10.1.0.0/16
+```
+
+4. Once the cloudformation completes, extract the VPC and subnets from the output.
+
+```
+aws --region us-east-1 cloudformation describe-stacks \
+  --stack-name private-link-vpc --query 'Stacks[].Outputs'\
+[
+  [
+    {
+      "OutputKey": "PrivateSubnetIds",
+      "OutputValue": "subnet-0bf2b8faf1c7d200b,subnet-09d53f09b54c38029,subnet-015d46e5f7fb7055d",
+      "Description": "Subnet IDs of the private subnets."
+    },
+    {
+      "OutputKey": "PublicSubnetIds",
+      "OutputValue": "subnet-00d5d89ce7b049296,subnet-0253d95c4bcfe7e17,subnet-03a4cfddbf7d9f73a",
+      "Description": "Subnet IDs of the public subnets."
+    },
+    {
+      "OutputKey": "VpcId",
+      "OutputValue": "vpc-0e0b3939a23a5e33e",
+      "Description": "ID of the new VPC."
+    }
+  ]
+]
+```
+
+### Create OCP cluster in preexisting Hive VPC
+
+Follow the steps outlines in [OpenShift documentation][openshift-install-aws-existing-vpc].
+
+```yaml
+# install-config.yaml
+...
+platform:
+  aws:
+    region: us-east-1
+    subnets:
+    - # include all the subnets public and private created by cloudformation stack
+    defaultMachinePlatform:
+      zones:
+      - us-east-1a
+      - us-east-1b
+      - us-east-1c
+...
+```
+
+### Setup network peering connection between Hive and Private link VPCs
+
+Create and accept the VPC peering connection using [AWS documentation][aws-vpc-peering]
+
+```
+aws --region us-east-1 ec2 create-vpc-peering-connection \
+  --vpc-id $HIVE_VPC_ID \
+  --peer-vpc-id $PRIVATE_LINK_VPC_ID \
+  --tag-specification "ResourceType=vpc-peering-connection,Tags=[{Key=hive-private-link,Value=owned}]"
+```
+
+```
+aws --region us-east-1 ec2 accept-vpc-peering-connection --vpc-peering-connection-id $VPC_PEERING_CONNECTION_ID
+```
+
+Now update the Route tables using [AWS documentation][aws-vpc-peering-route-tables]
+
+The cloudformation stack creates one route table for all the public subnets, and one route table
+for each private subnet.
+
+First update the private route tables for Hive VPC. Update the routes so that `10.1.0.0/16`
+prefix routes to the VPC peering connection.
+
+Second update the private route tables for Private link VPC. Update the routes so that `10.0.0.0/16`
+prefix routes to the VPC peering connection.
+
+### Setup the security group rules to allow traffic
+
+So we want the workers in the Hive cluster to be able to communicate with the VPC
+endpoints that will be created in the Private link VPC. Secondly, we also want the
+workers to receive traffic from the VPC endpoints.
+
+You can use security groups from peered VPCs to allow flow of traffic using [AWS documentation][aws-vpc-peering-security-groups]
+
+1. Find the security group for workers in Hive Cluster
+
+You the Hive VPC id to list the security groups.
+
+```
+aws --region us-east-1 ec2 describe-security-groups \
+  --filter Name=vpc-id,Values=$HIVE_VPC_ID Name=tag:Name,Values=$HIVE_CLUSTER_INFRA_ID-worker-sg \
+  --query "SecurityGroups[*].{GroupName:GroupName,GroupId:GroupId}"
+```
+
+2. Find the default security group of the Private link VPC
+
+```
+aws --region us-east-1 ec2 describe-security-groups \
+    --filters Name=vpc-id,Values=$PRIVATE_LINK_VPC_ID,Name=group-name,Values=default \
+    --query "SecurityGroups[*].{GroupName:GroupName,GroupId:GroupId}"
+```
+
+3. Allow all incoming traffic from Hive cluster's worker security group to VPC endpoints
+
+Create a incoming security group rule in Private link VPC's default security group that allows ALL traffic
+from the Hive cluster's worker security group.
+
+```
+aws --region us-east-1 ec2 authorize-security-group-ingress \
+    --group-id $PRIVATE_LINK_VPC_DEFAULT_SG --protocol all --port -1 \
+    --source-group $HIVE_CLUSTER_WORKER_SG
+```
+
+4. Allow all incoming traffic from VPC endpoints to Hive cluster's worker security group
+
+Create a incoming security group rule in Hive cluster's worker security group that allows ALL traffic
+from the Private link VPC's default security group.
+
+```
+aws --region us-east-1 ec2 authorize-security-group-ingress \
+    --group-id $HIVE_CLUSTER_WORKER_SG --protocol all --port -1 \
+    --source-group $PRIVATE_LINK_VPC_DEFAULT_SG
+```
+
+### Configure the inventory for VPC endpoints in HiveConfig
+
+Use the private subnets from Private link VPC as inventory for VPC endpoints by following
+the steps mentioned [above](#configuring-hive-to-enable-aws-private-link)
+
+[openshift-install-aws-existing-vpc]: https://docs.openshift.com/container-platform/4.8/installing/installing_aws/installing-aws-vpc.html
+[aws-vpc-peering]: https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html
+[aws-vpc-peering-route-tables]: https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html
+[aws-vpc-peering-security-groups]: https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-security-groups.html

--- a/hack/awsprivatelink/vpc.cf.yaml
+++ b/hack/awsprivatelink/vpc.cf.yaml
@@ -1,0 +1,265 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Template for Best Practice VPC with 1-3 AZs
+
+Parameters:
+  VpcCidr:
+    AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-4]))$
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-24.
+    Default: 10.0.0.0/16
+    Description: CIDR block for VPC.
+    Type: String
+  AvailabilityZoneCount:
+    ConstraintDescription: "The number of availability zones. (Min: 1, Max: 3)"
+    MinValue: 1
+    MaxValue: 3
+    Default: 1
+    Description: "How many AZs to create VPC subnets for. (Min: 1, Max: 3)"
+    Type: Number
+  SubnetBits:
+    ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/19-27.
+    MinValue: 5
+    MaxValue: 13
+    Default: 12
+    Description: "Size of each subnet to create within the availability zones. (Min: 5 = /27, Max: 13 = /19)"
+    Type: Number
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: "Network Configuration"
+      Parameters:
+      - VpcCidr
+      - SubnetBits
+    - Label:
+        default: "Availability Zones"
+      Parameters:
+      - AvailabilityZoneCount
+    ParameterLabels:
+      AvailabilityZoneCount:
+        default: "Availability Zone Count"
+      VpcCidr:
+        default: "VPC CIDR"
+      SubnetBits:
+        default: "Bits Per Subnet"
+
+Conditions:
+  DoAz3: !Equals [3, !Ref AvailabilityZoneCount]
+  DoAz2: !Or [!Equals [2, !Ref AvailabilityZoneCount], Condition: DoAz3]
+
+Resources:
+  VPC:
+    Type: "AWS::EC2::VPC"
+    Properties:
+      EnableDnsSupport: "true"
+      EnableDnsHostnames: "true"
+      CidrBlock: !Ref VpcCidr
+  PublicSubnet:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [0, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      AvailabilityZone: !Select
+      - 0
+      - Fn::GetAZs: !Ref "AWS::Region"
+  PublicSubnet2:
+    Type: "AWS::EC2::Subnet"
+    Condition: DoAz2
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [1, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      AvailabilityZone: !Select
+      - 1
+      - Fn::GetAZs: !Ref "AWS::Region"
+  PublicSubnet3:
+    Type: "AWS::EC2::Subnet"
+    Condition: DoAz3
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [2, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      AvailabilityZone: !Select
+      - 2
+      - Fn::GetAZs: !Ref "AWS::Region"
+  InternetGateway:
+    Type: "AWS::EC2::InternetGateway"
+  GatewayToInternet:
+    Type: "AWS::EC2::VPCGatewayAttachment"
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+  PublicRouteTable:
+    Type: "AWS::EC2::RouteTable"
+    Properties:
+      VpcId: !Ref VPC
+  PublicRoute:
+    Type: "AWS::EC2::Route"
+    DependsOn: GatewayToInternet
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+  PublicSubnetRouteTableAssociation:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId: !Ref PublicSubnet
+      RouteTableId: !Ref PublicRouteTable
+  PublicSubnetRouteTableAssociation2:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Condition: DoAz2
+    Properties:
+      SubnetId: !Ref PublicSubnet2
+      RouteTableId: !Ref PublicRouteTable
+  PublicSubnetRouteTableAssociation3:
+    Condition: DoAz3
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId: !Ref PublicSubnet3
+      RouteTableId: !Ref PublicRouteTable
+  PrivateSubnet:
+    Type: "AWS::EC2::Subnet"
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [3, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      AvailabilityZone: !Select
+      - 0
+      - Fn::GetAZs: !Ref "AWS::Region"
+  PrivateRouteTable:
+    Type: "AWS::EC2::RouteTable"
+    Properties:
+      VpcId: !Ref VPC
+  PrivateSubnetRouteTableAssociation:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      SubnetId: !Ref PrivateSubnet
+      RouteTableId: !Ref PrivateRouteTable
+  NAT:
+    DependsOn:
+    - GatewayToInternet
+    Type: "AWS::EC2::NatGateway"
+    Properties:
+      AllocationId:
+        "Fn::GetAtt":
+        - EIP
+        - AllocationId
+      SubnetId: !Ref PublicSubnet
+  EIP:
+    Type: "AWS::EC2::EIP"
+    Properties:
+      Domain: vpc
+  Route:
+    Type: "AWS::EC2::Route"
+    Properties:
+      RouteTableId:
+        Ref: PrivateRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NAT
+  PrivateSubnet2:
+    Type: "AWS::EC2::Subnet"
+    Condition: DoAz2
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [4, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      AvailabilityZone: !Select
+      - 1
+      - Fn::GetAZs: !Ref "AWS::Region"
+  PrivateRouteTable2:
+    Type: "AWS::EC2::RouteTable"
+    Condition: DoAz2
+    Properties:
+      VpcId: !Ref VPC
+  PrivateSubnetRouteTableAssociation2:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Condition: DoAz2
+    Properties:
+      SubnetId: !Ref PrivateSubnet2
+      RouteTableId: !Ref PrivateRouteTable2
+  NAT2:
+    DependsOn:
+    - GatewayToInternet
+    Type: "AWS::EC2::NatGateway"
+    Condition: DoAz2
+    Properties:
+      AllocationId:
+        "Fn::GetAtt":
+        - EIP2
+        - AllocationId
+      SubnetId: !Ref PublicSubnet2
+  EIP2:
+    Type: "AWS::EC2::EIP"
+    Condition: DoAz2
+    Properties:
+      Domain: vpc
+  Route2:
+    Type: "AWS::EC2::Route"
+    Condition: DoAz2
+    Properties:
+      RouteTableId:
+        Ref: PrivateRouteTable2
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NAT2
+  PrivateSubnet3:
+    Type: "AWS::EC2::Subnet"
+    Condition: DoAz3
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: !Select [5, !Cidr [!Ref VpcCidr, 6, !Ref SubnetBits]]
+      AvailabilityZone: !Select
+      - 2
+      - Fn::GetAZs: !Ref "AWS::Region"
+  PrivateRouteTable3:
+    Type: "AWS::EC2::RouteTable"
+    Condition: DoAz3
+    Properties:
+      VpcId: !Ref VPC
+  PrivateSubnetRouteTableAssociation3:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Condition: DoAz3
+    Properties:
+      SubnetId: !Ref PrivateSubnet3
+      RouteTableId: !Ref PrivateRouteTable3
+  NAT3:
+    DependsOn:
+    - GatewayToInternet
+    Type: "AWS::EC2::NatGateway"
+    Condition: DoAz3
+    Properties:
+      AllocationId:
+        "Fn::GetAtt":
+        - EIP3
+        - AllocationId
+      SubnetId: !Ref PublicSubnet3
+  EIP3:
+    Type: "AWS::EC2::EIP"
+    Condition: DoAz3
+    Properties:
+      Domain: vpc
+  Route3:
+    Type: "AWS::EC2::Route"
+    Condition: DoAz3
+    Properties:
+      RouteTableId:
+        Ref: PrivateRouteTable3
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId:
+        Ref: NAT3
+
+Outputs:
+  VpcId:
+    Description: ID of the new VPC.
+    Value: !Ref VPC
+  PublicSubnetIds:
+    Description: Subnet IDs of the public subnets.
+    Value:
+      !Join [
+        ",",
+        [!Ref PublicSubnet, !If [DoAz2, !Ref PublicSubnet2, !Ref "AWS::NoValue"], !If [DoAz3, !Ref PublicSubnet3, !Ref "AWS::NoValue"]]
+      ]
+  PrivateSubnetIds:
+    Description: Subnet IDs of the private subnets.
+    Value:
+      !Join [
+        ",",
+        [!Ref PrivateSubnet, !If [DoAz2, !Ref PrivateSubnet2, !Ref "AWS::NoValue"], !If [DoAz3, !Ref PrivateSubnet3, !Ref "AWS::NoValue"]]
+      ]

--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -75,6 +75,7 @@ type Client interface {
 	ModifyVpcEndpointServicePermissions(*ec2.ModifyVpcEndpointServicePermissionsInput) (*ec2.ModifyVpcEndpointServicePermissionsOutput, error)
 	DescribeVpcEndpointServices(*ec2.DescribeVpcEndpointServicesInput) (*ec2.DescribeVpcEndpointServicesOutput, error)
 	DescribeVpcEndpoints(*ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error)
+	DescribeNetworkInterfaces(input *ec2.DescribeNetworkInterfacesInput) (*ec2.DescribeNetworkInterfacesOutput, error)
 	CreateVpcEndpoint(*ec2.CreateVpcEndpointInput) (*ec2.CreateVpcEndpointOutput, error)
 	DeleteVpcEndpoints(*ec2.DeleteVpcEndpointsInput) (*ec2.DeleteVpcEndpointsOutput, error)
 
@@ -192,6 +193,11 @@ func (c *awsClient) DescribeVpcEndpointServices(input *ec2.DescribeVpcEndpointSe
 func (c *awsClient) DescribeVpcEndpoints(input *ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error) {
 	metricAWSAPICalls.WithLabelValues("DescribeVpcEndpoints").Inc()
 	return c.ec2Client.DescribeVpcEndpoints(input)
+}
+
+func (c *awsClient) DescribeNetworkInterfaces(input *ec2.DescribeNetworkInterfacesInput) (*ec2.DescribeNetworkInterfacesOutput, error) {
+	metricAWSAPICalls.WithLabelValues("DescribeNetworkInterfaces").Inc()
+	return c.ec2Client.DescribeNetworkInterfaces(input)
 }
 
 func (c *awsClient) CreateVpcEndpoint(input *ec2.CreateVpcEndpointInput) (*ec2.CreateVpcEndpointOutput, error) {

--- a/pkg/awsclient/mock/client_generated.go
+++ b/pkg/awsclient/mock/client_generated.go
@@ -264,6 +264,21 @@ func (mr *MockClientMockRecorder) DescribeVpcEndpoints(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpoints", reflect.TypeOf((*MockClient)(nil).DescribeVpcEndpoints), arg0)
 }
 
+// DescribeNetworkInterfaces mocks base method
+func (m *MockClient) DescribeNetworkInterfaces(input *ec2.DescribeNetworkInterfacesInput) (*ec2.DescribeNetworkInterfacesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeNetworkInterfaces", input)
+	ret0, _ := ret[0].(*ec2.DescribeNetworkInterfacesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeNetworkInterfaces indicates an expected call of DescribeNetworkInterfaces
+func (mr *MockClientMockRecorder) DescribeNetworkInterfaces(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInterfaces", reflect.TypeOf((*MockClient)(nil).DescribeNetworkInterfaces), input)
+}
+
 // CreateVpcEndpoint mocks base method
 func (m *MockClient) CreateVpcEndpoint(arg0 *ec2.CreateVpcEndpointInput) (*ec2.CreateVpcEndpointOutput, error) {
 	m.ctrl.T.Helper()

--- a/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
@@ -172,7 +172,7 @@ type AWSPrivateLinkConfig struct {
 	AssociatedVPCs []AWSAssociatedVPC `json:"associatedVPCs,omitempty"`
 
 	// DNSRecordType defines what type of DNS record should be created in Private Hosted Zone
-	// for the customer clusters API endpoint (which is the VPC Endpoint's regional DNS name).
+	// for the customer cluster's API endpoint (which is the VPC Endpoint's regional DNS name).
 	//
 	// +kubebuilder:default=Alias
 	// +optional
@@ -180,18 +180,18 @@ type AWSPrivateLinkConfig struct {
 }
 
 // AWSPrivateLinkDNSRecordType defines what type of DNS record should be created in Private Hosted Zone
-// for the customer clusters API endpoint (which is the VPC Endpoint's regional DNS name).
+// for the customer cluster's API endpoint (which is the VPC Endpoint's regional DNS name).
 // +kubebuilder:validation:Enum=Alias;ARecord
 type AWSPrivateLinkDNSRecordType string
 
 const (
-	// AliasAWSPrivateLinkDNSRecordType uses Route53 Alias record type for pointing the customer clusters
+	// AliasAWSPrivateLinkDNSRecordType uses Route53 Alias record type for pointing the customer cluster's
 	// API DNS name to the DNS name of the VPC endpoint. This is the default and should be used for most
 	// cases as it is provided at no extra cost in terms of DNS queries and usually resolves faster in AWS
 	// environments.
 	AliasAWSPrivateLinkDNSRecordType AWSPrivateLinkDNSRecordType = "Alias"
 
-	// ARecordAWSPrivateLinkDNSRecordType uses Route53 A record type for pointing the customer clusters
+	// ARecordAWSPrivateLinkDNSRecordType uses Route53 A record type for pointing the customer cluster's
 	// API DNS name to the DNS name of the VPC endpoint. This should be used when Alias record type cannot
 	// be used or other restrictions prevent use of Alias records.
 	ARecordAWSPrivateLinkDNSRecordType AWSPrivateLinkDNSRecordType = "ARecord"

--- a/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
@@ -170,7 +170,32 @@ type AWSPrivateLinkConfig struct {
 	//
 	// This list should at minimum include the VPC where the current Hive controller is running.
 	AssociatedVPCs []AWSAssociatedVPC `json:"associatedVPCs,omitempty"`
+
+	// DNSRecordType defines what type of DNS record should be created in Private Hosted Zone
+	// for the customer clusters API endpoint (which is the VPC Endpoint's regional DNS name).
+	//
+	// +kubebuilder:default=Alias
+	// +optional
+	DNSRecordType AWSPrivateLinkDNSRecordType `json:"dnsRecordType,omitempty"`
 }
+
+// AWSPrivateLinkDNSRecordType defines what type of DNS record should be created in Private Hosted Zone
+// for the customer clusters API endpoint (which is the VPC Endpoint's regional DNS name).
+// +kubebuilder:validation:Enum=Alias;ARecord
+type AWSPrivateLinkDNSRecordType string
+
+const (
+	// AliasAWSPrivateLinkDNSRecordType uses Route53 Alias record type for pointing the customer clusters
+	// API DNS name to the DNS name of the VPC endpoint. This is the default and should be used for most
+	// cases as it is provided at no extra cost in terms of DNS queries and usually resolves faster in AWS
+	// environments.
+	AliasAWSPrivateLinkDNSRecordType AWSPrivateLinkDNSRecordType = "Alias"
+
+	// ARecordAWSPrivateLinkDNSRecordType uses Route53 A record type for pointing the customer clusters
+	// API DNS name to the DNS name of the VPC endpoint. This should be used when Alias record type cannot
+	// be used or other restrictions prevent use of Alias records.
+	ARecordAWSPrivateLinkDNSRecordType AWSPrivateLinkDNSRecordType = "ARecord"
+)
 
 // AWSPrivateLinkInventory is a VPC and its corresponding subnets in an AWS region.
 // This VPC will be used to create an AWS VPC Endpoint whenever there is a VPC Endpoint Service


### PR DESCRIPTION
Currently the private link controller creates an ALIAS record in the PHZ
created for customer's cluster. This record points enables the dns
resolution of customer clsuters k8s API to the VPC endpoint, therefore
allowing hive to transparently accessing the cluster over the private
link.

In some cases the ALIAS record cannot be used. For example, in GovCloud
environments the Route53 private hosted zones do not support ALIAS
record type and therefore we have to use A records.

CNAME records would have been more suitable replacement for ALIAS
records, but
CNAME records cannot be created at the apex of a DNS zone like ALIAS
records. see https://stackoverflow.com/a/20230670
The private link architecture uses a DNS zone like
`api.<clustername>.<clusterdomain>`
so that there is no conflicts with authority on DNS resolution. Since
CNAME
records are not supported on the apex, we use A records pointing the
cluster's
API DNS name to the IP addresses of the VPC endpoint directly. Since
these IP
addresses do not change as they are backed by Elastic Network Interfaces
in the
corresponding subnets of the VPC endpoint, this DNS record should remain
stable.

When in A record mode, the controller extracts the ip addresses of the
vpc endpoint attached elastic networking interfaces and uses those ips
to create A record for the cluster's api dns name in the private hosted
zone.

For simplicity and current desired use-case, the dns record type can be
configured globally for all clusters managed by privatelink controller.

```yaml
spec:
  awsPrivateLink:
    dnsRecordType: (Alias | ARecord)
```

xref: https://issues.redhat.com/browse/HIVE-1572

/assign @dgoodwin 