### PR TITLE
Make owned CRD order deterministic in CSV

### DIFF
--- a/hack/generate-operator-bundle-operatorhub.py
+++ b/hack/generate-operator-bundle-operatorhub.py
@@ -90,7 +90,7 @@ def generate_csv_base(version, prev_version, hive_image):
     owned_crds = []
 
     # Copy all CSV files over to the bundle output dir:
-    crd_files = os.listdir(crds_dir)
+    crd_files = sorted(os.listdir(crds_dir))
     for file_name in crd_files:
         full_path = os.path.join(crds_dir, file_name)
         if os.path.isfile(os.path.join(crds_dir, file_name)):

--- a/hack/generate-operator-bundle.py
+++ b/hack/generate-operator-bundle.py
@@ -43,7 +43,7 @@ if not os.path.exists(version_dir):
 owned_crds = []
 
 # Copy all CSV files over to the bundle output dir:
-crd_files = os.listdir('config/crds/')
+crd_files = sorted(os.listdir('config/crds/'))
 for file_name in crd_files:
     full_path = os.path.join('config/crds', file_name)
     if (os.path.isfile(os.path.join('config/crds', file_name))):


### PR DESCRIPTION
Sort the list of CRDs when generating the CSV for the operator bundle, for easier diffing from one version to the next.