### PR TITLE
Actually start hibernated machines

### DIFF
--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -288,8 +288,7 @@ func (r *hibernationReconciler) Reconcile(ctx context.Context, request reconcile
 			if controllerutils.IsFakeCluster(cd) {
 				r.setHibernatingCondition(cd, hivev1.RunningHibernationReason, "Fake cluster is running",
 					corev1.ConditionFalse, cdLog)
-			}
-			if cd.Spec.PowerState != hivev1.RunningClusterPowerState {
+			} else {
 				return r.startMachines(cd, cdLog)
 			}
 			return reconcile.Result{}, nil

--- a/pkg/controller/hibernation/hibernation_controller_test.go
+++ b/pkg/controller/hibernation/hibernation_controller_test.go
@@ -519,6 +519,9 @@ func TestHibernateAfter(t *testing.T) {
 		},
 		{
 			name: "cluster not yet due for hibernate no running condition", // cluster that has never been hibernated
+			setupActuator: func(actuator *mock.MockHibernationActuator) {
+				actuator.EXPECT().StartMachines(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil)
+			},
 			cd: cdBuilder.Build(
 				testcd.WithHibernateAfter(12*time.Hour),
 				testcd.WithPowerState(hivev1.RunningClusterPowerState),


### PR DESCRIPTION
PR #1477 introduced a regression whereby it wouldn't start (non-fake) machines in most cases. Fix.

[HIVE-1606](https://issues.redhat.com/browse/HIVE-1606)