### PR TITLE
Fix transfer of PreserveOnDelete to DNSZone for installed clusters.

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -765,7 +765,25 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testSecret(corev1.SecretTypeDockerConfigJson, constants.GetMergedPullSecretName(testClusterDeployment()), corev1.DockerConfigJsonKey, "{}"),
 				testDNSZone(),
 			},
-			expectedRequeueAfter: defaultDNSNotReadyTimeout + defaultRequeueTime,
+			validate: func(c client.Client, t *testing.T) {
+				zone := getDNSZone(c)
+				require.NotNil(t, zone, "dns zone should exist")
+				assert.True(t, zone.Spec.PreserveOnDelete, "PreserveOnDelete was not updated")
+			},
+		},
+		{
+			name: "Update DNSZone when PreserveOnDelete changes for installed cluster",
+			existing: []runtime.Object{
+				func() *hivev1.ClusterDeployment {
+					cd := testClusterDeploymentWithInitializedConditions(testInstalledClusterDeployment(time.Now()))
+					cd.Spec.ManageDNS = true
+					cd.Spec.PreserveOnDelete = true
+					return cd
+				}(),
+				testSecret(corev1.SecretTypeDockerConfigJson, pullSecretSecret, corev1.DockerConfigJsonKey, "{}"),
+				testSecret(corev1.SecretTypeDockerConfigJson, constants.GetMergedPullSecretName(testClusterDeployment()), corev1.DockerConfigJsonKey, "{}"),
+				testDNSZone(),
+			},
 			validate: func(c client.Client, t *testing.T) {
 				zone := getDNSZone(c)
 				require.NotNil(t, zone, "dns zone should exist")


### PR DESCRIPTION
Previous attempt only tested against installing clusters, which is
bypassed if the cluster is already installed.

Move the sync of PreserveOnDelete prior to both portions of the
reconcile loop.

x-ref: https://issues.redhat.com/browse/HIVE-1594