### PR TITLE
ClusterPool:ClusterDeployment version & condition

### DIFF
--- a/apis/hive/v1/clusterpool_types.go
+++ b/apis/hive/v1/clusterpool_types.go
@@ -138,6 +138,9 @@ const (
 	// ClusterPoolCapacityAvailableCondition is set to provide information on whether the cluster pool has capacity
 	// available to create more clusters for the pool.
 	ClusterPoolCapacityAvailableCondition ClusterPoolConditionType = "CapacityAvailable"
+	// ClusterPoolAllClustersCurrentCondition indicates whether all unassigned (installing or ready)
+	// ClusterDeployments in the pool match the current configuration of the ClusterPool.
+	ClusterPoolAllClustersCurrentCondition ClusterPoolConditionType = "AllClustersCurrent"
 )
 
 // +genclient

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go v1.38.41
 	github.com/blang/semver/v4 v4.0.0
 	github.com/davecgh/go-spew v1.1.1
+	github.com/davegardnerisme/deephash v0.0.0-20210406090112-6d072427d830
 	github.com/evanphx/json-patch v4.11.0+incompatible
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-bindata/go-bindata v3.1.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -393,6 +393,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-xdr v0.0.0-20161123171359-e6a2ba005892/go.mod h1:CTDl0pzVzE5DEzZhPfvhY/9sPFMQIxaJ9VAMs9AagrE=
+github.com/davegardnerisme/deephash v0.0.0-20210406090112-6d072427d830 h1:gn7TsPBQ3HoEUaa8oBLbMalIBPf3eeQb7W/8kK3gERk=
+github.com/davegardnerisme/deephash v0.0.0-20210406090112-6d072427d830/go.mod h1:ToGe2SdaElKXzEmYLttAgFHy0exxh0wyq9zG7ZjjjYM=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
 github.com/deislabs/oras v0.8.1/go.mod h1:Mx0rMSbBNaNfY9hjpccEnxkOqJL6KGjtxNHPLC4G4As=
 github.com/denis-tingajkin/go-header v0.3.1 h1:ymEpSiFjeItCy1FOP+x0M2KdCELdEAHUsNa8F+hHc6w=

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -333,6 +333,12 @@ const (
 	// from the pool.
 	ClusterClaimRemoveClusterAnnotation = "hive.openshift.io/remove-claimed-cluster-from-pool"
 
+	// ClusterDeploymentPoolSpecHashAnnotation annotates a ClusterDeployment. It is an opaque value representing
+	// the state of the important (to ClusterDeployments) fields of the ClusterPool at the time this CD was created.
+	// It is used by the clusterpool controller to determine whether its unclaimed ClusterDeployments are current or
+	// stale, allowing it to set the ClusterPool's "ClusterDeploymentsCurrent" status condition.
+	ClusterDeploymentPoolSpecHashAnnotation = "hive.openshift.io/cluster-pool-spec-hash"
+
 	// HiveAWSServiceProviderCredentialsSecretRefEnvVar is the environment variable specifying what secret to use for
 	// assuming the service provider credentials for AWS clusters.
 	HiveAWSServiceProviderCredentialsSecretRefEnvVar = "HIVE_AWS_SERVICE_PROVIDER_CREDENTIALS_SECRET"

--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -98,6 +98,11 @@ func WithAnnotation(key, value string) Option {
 	return Generic(generic.WithAnnotation(key, value))
 }
 
+// WithPoolVersion sets the cluster pool spec hash annotation on the supplied object.
+func WithPoolVersion(poolVersion string) Option {
+	return WithAnnotation(constants.ClusterDeploymentPoolSpecHashAnnotation, poolVersion)
+}
+
 // WithCondition adds the specified condition to the ClusterDeployment
 func WithCondition(cond hivev1.ClusterDeploymentCondition) Option {
 	return func(clusterDeployment *hivev1.ClusterDeployment) {

--- a/pkg/test/clusterpool/clusterpool.go
+++ b/pkg/test/clusterpool/clusterpool.go
@@ -104,6 +104,12 @@ func WithClusterDeploymentLabels(labels map[string]string) Option {
 	}
 }
 
+func WithPlatform(platform hivev1.Platform) Option {
+	return func(clusterPool *hivev1.ClusterPool) {
+		clusterPool.Spec.Platform = platform
+	}
+}
+
 func WithBaseDomain(baseDomain string) Option {
 	return func(clusterPool *hivev1.ClusterPool) {
 		clusterPool.Spec.BaseDomain = baseDomain
@@ -113,6 +119,14 @@ func WithBaseDomain(baseDomain string) Option {
 func WithImageSet(clusterImageSetName string) Option {
 	return func(clusterPool *hivev1.ClusterPool) {
 		clusterPool.Spec.ImageSetRef = hivev1.ClusterImageSetReference{Name: clusterImageSetName}
+	}
+}
+
+func WithInstallConfigSecretTemplateRef(name string) Option {
+	return func(clusterPool *hivev1.ClusterPool) {
+		clusterPool.Spec.InstallConfigSecretTemplateRef = &corev1.LocalObjectReference{
+			Name: name,
+		}
 	}
 }
 

--- a/vendor/github.com/davegardnerisme/deephash/.travis.yml
+++ b/vendor/github.com/davegardnerisme/deephash/.travis.yml
@@ -1,0 +1,2 @@
+language: go
+

--- a/vendor/github.com/davegardnerisme/deephash/LICENSE
+++ b/vendor/github.com/davegardnerisme/deephash/LICENSE
@@ -1,0 +1,18 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/vendor/github.com/davegardnerisme/deephash/README.md
+++ b/vendor/github.com/davegardnerisme/deephash/README.md
@@ -1,0 +1,53 @@
+# Deep hash
+
+[![Build Status](https://travis-ci.org/davegardnerisme/deephash.svg?branch=master)](https://travis-ci.org/davegardnerisme/deephash)
+
+A library for calculating a deterministic hash for simple or nested data structures
+in Go. The traversal algorithm is based on [mergo](https://github.com/imdario/mergo),
+which is in turn based on `reflect/deepequal.go` from the stdlib.
+
+Example:
+
+```
+eg1 := "foo"
+eg2 := example{
+	Foo: "foo",
+	Bar: 43.0,
+}
+eg3 := &example{
+	Foo: "foo",
+	Bar: 43.0,
+}
+
+fmt.Printf("String\t%x\n", deephash.Hash(eg1))
+fmt.Printf("Struct\t%x\n", deephash.Hash(eg2))
+fmt.Printf("Pointer\t%x\n", deephash.Hash(eg3))
+```
+
+Output:
+
+```
+String	dcb27518fed9d577
+Struct	e0979b89bf545866
+Pointer	e0979b89bf545866
+```
+
+It's worth noting that here two structs with the same content (eg: a copy),
+where one is a pointer and one isn't, **both hash to the same value**.
+
+You can run this via:
+
+```
+go run example/example.go
+```
+
+## Key features
+
+ - uses fnv 64a hashing algorithm which is fast with good distribution
+ - deterministic hashing for maps (which don't have any order) by sorting on
+   the hash of the keys
+
+## Docs
+
+http://godoc.org/github.com/davegardnerisme/deephash
+

--- a/vendor/github.com/davegardnerisme/deephash/deephash.go
+++ b/vendor/github.com/davegardnerisme/deephash/deephash.go
@@ -1,0 +1,97 @@
+package deephash
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/fnv"
+	"reflect"
+	"sort"
+)
+
+// During deepHash, must keep track of visited, to avoid circular traversal.
+// The algorithm is based on: https://github.com/imdario/mergo
+type visit struct {
+	ptr  uintptr
+	typ  reflect.Type
+	next *visit
+}
+
+// Traverses recursively hashing each exported value
+func deepHash(src reflect.Value, visited map[uintptr]*visit, depth int) []byte {
+	if !src.IsValid() {
+		return nil
+	}
+	if src.CanAddr() {
+		addr := src.UnsafeAddr()
+		h := 17 * addr
+		seen := visited[h]
+		typ := src.Type()
+		for p := seen; p != nil; p = p.next {
+			if p.ptr == addr && p.typ == typ {
+				return nil
+			}
+		}
+		// Remember, remember...
+		visited[h] = &visit{addr, typ, seen}
+	}
+
+	hash := fnv.New64a()
+
+	// deal with pointers/interfaces
+	for src.Kind() == reflect.Ptr || src.Kind() == reflect.Interface {
+		src = src.Elem()
+	}
+
+	switch src.Kind() {
+	case reflect.Struct:
+		for i, n := 0, src.NumField(); i < n; i++ {
+			if b := deepHash(src.Field(i), visited, depth+1); b != nil {
+				hash.Write(b)
+			}
+		}
+	case reflect.Map:
+		sortedHashedKeys := make([]string, len(src.MapKeys()))
+		indexedByHash := make(map[string]reflect.Value)
+
+		for i, key := range src.MapKeys() {
+			kh := fmt.Sprintf("%x", deepHash(key, visited, depth+1))
+			sortedHashedKeys[i] = kh
+			indexedByHash[kh] = src.MapIndex(key)
+		}
+		sort.Strings(sortedHashedKeys)
+
+		// hash each value, in order
+		for _, kh := range sortedHashedKeys {
+			hash.Write([]byte(kh))
+			hash.Write(deepHash(indexedByHash[kh], visited, depth+1))
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < src.Len(); i++ {
+			hash.Write(deepHash(src.Index(i), visited, depth+1))
+		}
+	case reflect.String:
+		hash.Write([]byte(src.String()))
+	case reflect.Bool:
+		if src.Bool() == true {
+			hash.Write([]byte("1"))
+		} else {
+			hash.Write([]byte("0"))
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		binary.Write(hash, binary.BigEndian, src.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		binary.Write(hash, binary.BigEndian, src.Uint())
+	case reflect.Float32, reflect.Float64:
+		binary.Write(hash, binary.BigEndian, src.Float())
+
+	}
+
+	return hash.Sum(nil)
+}
+
+// Hash returns an fnv64a hash of src, hashing recursively any exported
+// properties, including slices and maps/
+func Hash(src interface{}) []byte {
+	vSrc := reflect.ValueOf(src)
+	return deepHash(vSrc, make(map[uintptr]*visit), 0)
+}

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
@@ -138,6 +138,9 @@ const (
 	// ClusterPoolCapacityAvailableCondition is set to provide information on whether the cluster pool has capacity
 	// available to create more clusters for the pool.
 	ClusterPoolCapacityAvailableCondition ClusterPoolConditionType = "CapacityAvailable"
+	// ClusterPoolAllClustersCurrentCondition indicates whether all unassigned (installing or ready)
+	// ClusterDeployments in the pool match the current configuration of the ClusterPool.
+	ClusterPoolAllClustersCurrentCondition ClusterPoolConditionType = "AllClustersCurrent"
 )
 
 // +genclient

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -153,6 +153,9 @@ github.com/daixiang0/gci/pkg/gci
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
+# github.com/davegardnerisme/deephash v0.0.0-20210406090112-6d072427d830
+## explicit
+github.com/davegardnerisme/deephash
 # github.com/denis-tingajkin/go-header v0.3.1
 github.com/denis-tingajkin/go-header
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible


### PR DESCRIPTION
This commit adds a mechanism for calculating a hash representing the following fields in ClusterPool.Spec:
- Platform
- BaseDomain
- ImageSetRef
- InstallConfigSecretTemplateRef

When creating a new ClusterDeployment for the pool, this hash is stored in a new annotation on the ClusterDeployment.

The clusterpool controller checks all unassigned (installing or ready) ClusterDeployments and sets a new condition on the ClusterPool. This condition is:
- "True" when all CDs are up to date with the pool (including the edge case where there are no CDs);
- "False" when one or more CDs are stale;
- "Unknown" if the annotation is missing from one or more CDs.
- (Also "Unknown" if we haven't had a chance to figure it out yet.)

Of note:
- When "False" or "Unknown", the condition's Message contains a list of the offending CDs (in the spirit of ClusterSync's "Failed" condition).
- "False" takes precedence over "Unknown" (including: we don't try to combine the CD lists in the Message).

[HIVE-1058](https://issues.redhat.com/browse/HIVE-1058)