### PR TITLE
ErrorScrub message in setHibernatingCondition to remove AWS request_id.

### DIFF
--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -445,7 +445,7 @@ func (r *hibernationReconciler) setHibernatingCondition(cd *hivev1.ClusterDeploy
 		hivev1.ClusterHibernatingCondition,
 		status,
 		reason,
-		message,
+		controllerutils.ErrorScrub(errors.New(message)),
 		controllerutils.UpdateConditionIfReasonOrMessageChange,
 	)
 


### PR DESCRIPTION
Scrub condition message to exclude the request id:

```
- lastProbeTime: "2021-08-04T19:45:34Z"
    lastTransitionTime: "2021-08-04T14:48:13Z"
    message: "Failed to start machines: AuthFailure: AWS was not able to validate
      the provided access credentials\n\tstatus code: 401, request id: 5cf337cf-c70d-4a8a-87e0-4a08d3cca2f0"
    reason: FailedToStart
    status: "True"
    type: Hibernating
```