### PR TITLE
Add templates, scripts, targets for OLM-less deploy

### DIFF
--- a/hack/app-sre/generate-saas-template.py
+++ b/hack/app-sre/generate-saas-template.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import yaml
+
+usage="""
+Usage: %s saas_template_stub saas_object_file out_file
+
+Collate `saas_object_file` into the objects list in `saas_template_stub` and
+write the result to `out_file`.
+
+Parameters:
+  saas_template_stub: A yaml file defining a Template with an empty `objects`
+        list.
+  saas_object_file: A yaml file containing some number of yaml documents
+        defining kube objects to be injected into the `saas_template_stub`.
+  out_file: Path to which to write the resulting yaml file. If it exists, it
+        will be overwritten.
+"""
+
+if len(sys.argv) != 4 or any('-h' in x for x in sys.argv[1:]):
+    print(usage % sys.argv[0])
+    sys.exit(-1)
+
+saas_template_stub = sys.argv[1]
+saas_object_file = sys.argv[2]
+out_file = sys.argv[3]
+
+for f in (saas_template_stub, saas_object_file):
+    if not os.path.isfile(f):
+        print("%s: No such file" % f)
+
+if os.path.exists(out_file) and not os.path.isfile(out_file):
+    print("%s: Not a file" % out_file)
+    sys.exit(1)
+
+with open(saas_object_file, 'r') as objf:
+    objects = list(yaml.load_all(objf, Loader=yaml.SafeLoader))
+    print("Loaded %d objects from %s" % (len(objects), saas_object_file))
+
+with open(saas_template_stub, 'r') as stubf:
+    template = yaml.load(stubf, Loader=yaml.SafeLoader)
+
+template['objects'] = objects
+
+msg = "Overwriting existing" if os.path.exists(out_file) else "Writing"
+print(msg + " output file %s" % out_file)
+
+with open(out_file, 'w') as outf:
+    yaml.dump(template, outf, default_flow_style=False)

--- a/hack/app-sre/kustomization.yaml
+++ b/hack/app-sre/kustomization.yaml
@@ -1,0 +1,39 @@
+# This kustomize configuration deploys what is required for the hive-operator
+# *without* OLM.
+# Except:
+# It does not contain a Namespace or a HiveConfig. These are created by app-sre.
+
+# The CRD resources are synced automatically by the `build-app-sre-template` make target.
+# The other resources should be curated manually.
+resources:
+- ../../config/operator/operator_role.yaml
+- ../../config/operator/operator_role_binding.yaml
+- ../../config/operator/operator_deployment.yaml
+- ../../config/crds/hiveinternal.openshift.io_clustersyncleases.yaml
+- ../../config/crds/hiveinternal.openshift.io_clustersyncs.yaml
+- ../../config/crds/hiveinternal.openshift.io_fakeclusterinstalls.yaml
+- ../../config/crds/hive.openshift.io_checkpoints.yaml
+- ../../config/crds/hive.openshift.io_clusterclaims.yaml
+- ../../config/crds/hive.openshift.io_clusterdeployments.yaml
+- ../../config/crds/hive.openshift.io_clusterdeprovisions.yaml
+- ../../config/crds/hive.openshift.io_clusterimagesets.yaml
+- ../../config/crds/hive.openshift.io_clusterpools.yaml
+- ../../config/crds/hive.openshift.io_clusterprovisions.yaml
+- ../../config/crds/hive.openshift.io_clusterrelocates.yaml
+- ../../config/crds/hive.openshift.io_clusterstates.yaml
+- ../../config/crds/hive.openshift.io_dnszones.yaml
+- ../../config/crds/hive.openshift.io_hiveconfigs.yaml
+- ../../config/crds/hive.openshift.io_machinepoolnameleases.yaml
+- ../../config/crds/hive.openshift.io_machinepools.yaml
+- ../../config/crds/hive.openshift.io_selectorsyncidentityproviders.yaml
+- ../../config/crds/hive.openshift.io_selectorsyncsets.yaml
+- ../../config/crds/hive.openshift.io_syncidentityproviders.yaml
+- ../../config/crds/hive.openshift.io_syncsets.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Use app-sre-supplied variables to pull the image for the current commit
+# TODO: Pull by digest instead. Don't forget to address Disappearing Digest Syndrome.
+images:
+- name: registry.ci.openshift.org/openshift/hive-v4.0:hive
+  newName: ${REGISTRY_IMG}
+  newTag: ${IMAGE_TAG}

--- a/hack/app-sre/saas-template-stub.yaml
+++ b/hack/app-sre/saas-template-stub.yaml
@@ -1,0 +1,15 @@
+# This is used by generate-saas-template.py to generate saas-template.yaml.
+# Edit this file only to manage parameters.
+apiVersion: v1
+kind: Template
+metadata:
+  name: hive-saas-template
+
+parameters:
+  - name: REGISTRY_IMG
+    required: true
+  - name: IMAGE_TAG
+    required: true
+
+# Populated by generate-saas-template.py with the objects in saas-objects.yaml
+objects: []

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -1,0 +1,6511 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: hive-saas-template
+objects:
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: checkpoints.hive.openshift.io
+  spec:
+    group: hive.openshift.io
+    names:
+      kind: Checkpoint
+      listKind: CheckpointList
+      plural: checkpoints
+      singular: checkpoint
+    scope: Namespaced
+    versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: Checkpoint is the Schema for the backup of Hive objects.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CheckpointSpec defines the metadata around the Hive objects
+                state in the namespace at the time of the last backup.
+              properties:
+                lastBackupChecksum:
+                  description: LastBackupChecksum is the checksum of all Hive objects
+                    in the namespace at the time of the last backup.
+                  type: string
+                lastBackupRef:
+                  description: LastBackupRef is a reference to last backup object
+                    created
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                lastBackupTime:
+                  description: LastBackupTime is the last time we performed a backup
+                    of the namespace
+                  format: date-time
+                  type: string
+              required:
+              - lastBackupChecksum
+              - lastBackupRef
+              - lastBackupTime
+              type: object
+            status:
+              description: CheckpointStatus defines the observed state of Checkpoint
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: clusterclaims.hive.openshift.io
+  spec:
+    group: hive.openshift.io
+    names:
+      kind: ClusterClaim
+      listKind: ClusterClaimList
+      plural: clusterclaims
+      singular: clusterclaim
+    scope: Namespaced
+    versions:
+    - additionalPrinterColumns:
+      - jsonPath: .spec.clusterPoolName
+        name: Pool
+        type: string
+      - jsonPath: .status.conditions[?(@.type=='Pending')].reason
+        name: Pending
+        type: string
+      - jsonPath: .spec.namespace
+        name: ClusterNamespace
+        type: string
+      - jsonPath: .status.conditions[?(@.type=='ClusterRunning')].reason
+        name: ClusterRunning
+        type: string
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterClaim represents a claim to a cluster from a cluster
+            pool.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterClaimSpec defines the desired state of the ClusterClaim.
+              properties:
+                clusterPoolName:
+                  description: ClusterPoolName is the name of the cluster pool from
+                    which to claim a cluster.
+                  type: string
+                lifetime:
+                  description: Lifetime is the maximum lifetime of the claim after
+                    it is assigned a cluster. If the claim still exists when the lifetime
+                    has elapsed, the claim will be deleted by Hive. This is a Duration
+                    value; see https://pkg.go.dev/time#ParseDuration for accepted
+                    formats.
+                  format: duration
+                  type: string
+                namespace:
+                  description: Namespace is the namespace containing the ClusterDeployment
+                    (name will match the namespace) of the claimed cluster. This field
+                    will be set as soon as a suitable cluster can be found, however
+                    that cluster may still be resuming and not yet ready for use.
+                    Wait for the ClusterRunning condition to be true to avoid this
+                    issue.
+                  type: string
+                subjects:
+                  description: Subjects hold references to which to authorize access
+                    to the claimed cluster.
+                  items:
+                    description: Subject contains a reference to the object or user
+                      identities a role binding applies to.  This can either hold
+                      a direct API object reference, or a value for non-objects such
+                      as user and group names.
+                    properties:
+                      apiGroup:
+                        description: APIGroup holds the API group of the referenced
+                          subject. Defaults to "" for ServiceAccount subjects. Defaults
+                          to "rbac.authorization.k8s.io" for User and Group subjects.
+                        type: string
+                      kind:
+                        description: Kind of object being referenced. Values defined
+                          by this API group are "User", "Group", and "ServiceAccount".
+                          If the Authorizer does not recognized the kind value, the
+                          Authorizer should report an error.
+                        type: string
+                      name:
+                        description: Name of the object being referenced.
+                        type: string
+                      namespace:
+                        description: Namespace of the referenced object.  If the object
+                          kind is non-namespace, such as "User" or "Group", and this
+                          value is not empty the Authorizer should report an error.
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                  type: array
+              required:
+              - clusterPoolName
+              type: object
+            status:
+              description: ClusterClaimStatus defines the observed state of ClusterClaim.
+              properties:
+                conditions:
+                  description: Conditions includes more detailed status for the cluster
+                    pool.
+                  items:
+                    description: ClusterClaimCondition contains details for the current
+                      condition of a cluster claim.
+                    properties:
+                      lastProbeTime:
+                        description: LastProbeTime is the last time we probed the
+                          condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about last transition.
+                        type: string
+                      reason:
+                        description: Reason is a unique, one-word, CamelCase reason
+                          for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+                lifetime:
+                  description: Lifetime is the maximum lifetime of the claim after
+                    it is assigned a cluster. If the claim still exists when the lifetime
+                    has elapsed, the claim will be deleted by Hive.
+                  type: string
+              type: object
+          required:
+          - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: clusterdeployments.hive.openshift.io
+  spec:
+    group: hive.openshift.io
+    names:
+      kind: ClusterDeployment
+      listKind: ClusterDeploymentList
+      plural: clusterdeployments
+      shortNames:
+      - cd
+      singular: clusterdeployment
+    scope: Namespaced
+    versions:
+    - additionalPrinterColumns:
+      - jsonPath: .metadata.labels.hive\.openshift\.io/cluster-platform
+        name: Platform
+        type: string
+      - jsonPath: .metadata.labels.hive\.openshift\.io/cluster-region
+        name: Region
+        type: string
+      - jsonPath: .metadata.labels.hive\.openshift\.io/cluster-type
+        name: ClusterType
+        type: string
+      - jsonPath: .spec.installed
+        name: Installed
+        type: boolean
+      - jsonPath: .spec.clusterMetadata.infraID
+        name: InfraID
+        type: string
+      - jsonPath: .metadata.labels.hive\.openshift\.io/version-major-minor-patch
+        name: Version
+        type: string
+      - jsonPath: .status.conditions[?(@.type=='Hibernating')].reason
+        name: PowerState
+        type: string
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterDeployment is the Schema for the clusterdeployments
+            API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterDeploymentSpec defines the desired state of ClusterDeployment
+              properties:
+                baseDomain:
+                  description: BaseDomain is the base domain to which the cluster
+                    should belong.
+                  type: string
+                boundServiceAccountSigningKeySecretRef:
+                  description: BoundServiceAccountSignkingKeySecretRef refers to a
+                    Secret that contains a 'bound-service-account-signing-key.key'
+                    data key pointing to the private key that will be used to sign
+                    ServiceAccount objects. Primarily used to provision AWS clusters
+                    to use Amazon's Security Token Service.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                certificateBundles:
+                  description: CertificateBundles is a list of certificate bundles
+                    associated with this cluster
+                  items:
+                    description: CertificateBundleSpec specifies a certificate bundle
+                      associated with a cluster deployment
+                    properties:
+                      certificateSecretRef:
+                        description: CertificateSecretRef is the reference to the
+                          secret that contains the certificate bundle. If the certificate
+                          bundle is to be generated, it will be generated with the
+                          name in this reference. Otherwise, it is expected that the
+                          secret should exist in the same namespace as the ClusterDeployment
+                        properties:
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                        type: object
+                      generate:
+                        description: Generate indicates whether this bundle should
+                          have real certificates generated for it.
+                        type: boolean
+                      name:
+                        description: Name is an identifier that must be unique within
+                          the bundle and must be referenced by an ingress or by the
+                          control plane serving certs
+                        type: string
+                    required:
+                    - certificateSecretRef
+                    - name
+                    type: object
+                  type: array
+                clusterInstallRef:
+                  description: ClusterInstallLocalReference provides reference to
+                    an object that implements the hivecontract ClusterInstall. The
+                    namespace of the object is same as the ClusterDeployment. This
+                    cannot be set when Provisioning is also set.
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - group
+                  - kind
+                  - name
+                  - version
+                  type: object
+                clusterMetadata:
+                  description: ClusterMetadata contains metadata information about
+                    the installed cluster.
+                  properties:
+                    adminKubeconfigSecretRef:
+                      description: AdminKubeconfigSecretRef references the secret
+                        containing the admin kubeconfig for this cluster.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    adminPasswordSecretRef:
+                      description: AdminPasswordSecretRef references the secret containing
+                        the admin username/password which can be used to login to
+                        this cluster.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    clusterID:
+                      description: ClusterID is a globally unique identifier for this
+                        cluster generated during installation. Used for reporting
+                        metrics among other places.
+                      type: string
+                    infraID:
+                      description: InfraID is an identifier for this cluster generated
+                        during installation and used for tagging/naming resources
+                        in cloud providers.
+                      type: string
+                  required:
+                  - adminKubeconfigSecretRef
+                  - clusterID
+                  - infraID
+                  type: object
+                clusterName:
+                  description: ClusterName is the friendly name of the cluster. It
+                    is used for subdomains, some resource tagging, and other instances
+                    where a friendly name for the cluster is useful.
+                  type: string
+                clusterPoolRef:
+                  description: ClusterPoolRef is a reference to the ClusterPool that
+                    this ClusterDeployment originated from.
+                  properties:
+                    claimName:
+                      description: ClaimName is the name of the ClusterClaim that
+                        claimed the cluster from the pool.
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the ClusterPool
+                        resides.
+                      type: string
+                    poolName:
+                      description: PoolName is the name of the ClusterPool for which
+                        the cluster was created.
+                      type: string
+                  required:
+                  - namespace
+                  - poolName
+                  type: object
+                controlPlaneConfig:
+                  description: ControlPlaneConfig contains additional configuration
+                    for the target cluster's control plane
+                  properties:
+                    apiURLOverride:
+                      description: APIURLOverride is the optional URL override to
+                        which Hive will transition for communication with the API
+                        server of the remote cluster. When a remote cluster is created,
+                        Hive will initially communicate using the API URL established
+                        during installation. If an API URL Override is specified,
+                        Hive will periodically attempt to connect to the remote cluster
+                        using the override URL. Once Hive has determined that the
+                        override URL is active, Hive will use the override URL for
+                        further communications with the API server of the remote cluster.
+                      type: string
+                    servingCertificates:
+                      description: ServingCertificates specifies serving certificates
+                        for the control plane
+                      properties:
+                        additional:
+                          description: Additional is a list of additional domains
+                            and certificates that are also associated with the control
+                            plane's api endpoint.
+                          items:
+                            description: ControlPlaneAdditionalCertificate defines
+                              an additional serving certificate for a control plane
+                            properties:
+                              domain:
+                                description: Domain is the domain of the additional
+                                  control plane certificate
+                                type: string
+                              name:
+                                description: Name references a CertificateBundle in
+                                  the ClusterDeployment.Spec that should be used for
+                                  this additional certificate.
+                                type: string
+                            required:
+                            - domain
+                            - name
+                            type: object
+                          type: array
+                        default:
+                          description: Default references the name of a CertificateBundle
+                            in the ClusterDeployment that should be used for the control
+                            plane's default endpoint.
+                          type: string
+                      type: object
+                  type: object
+                hibernateAfter:
+                  description: HibernateAfter will transition a cluster to hibernating
+                    power state after it has been running for the given duration.
+                    The time that a cluster has been running is the time since the
+                    cluster was installed or the time since the cluster last came
+                    out of hibernation. This is a Duration value; see https://pkg.go.dev/time#ParseDuration
+                    for accepted formats.
+                  format: duration
+                  type: string
+                ingress:
+                  description: Ingress allows defining desired clusteringress/shards
+                    to be configured on the cluster.
+                  items:
+                    description: ClusterIngress contains the configurable pieces for
+                      any ClusterIngress objects that should exist on the cluster.
+                    properties:
+                      domain:
+                        description: Domain (sometimes referred to as shard) is the
+                          full DNS suffix that the resulting IngressController object
+                          will service (eg abcd.mycluster.mydomain.com).
+                        type: string
+                      name:
+                        description: Name of the ClusterIngress object to create.
+                        type: string
+                      namespaceSelector:
+                        description: NamespaceSelector allows filtering the list of
+                          namespaces serviced by the ingress controller.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      routeSelector:
+                        description: RouteSelector allows filtering the set of Routes
+                          serviced by the ingress controller
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      servingCertificate:
+                        description: ServingCertificate references a CertificateBundle
+                          in the ClusterDeployment.Spec that should be used for this
+                          Ingress
+                        type: string
+                    required:
+                    - domain
+                    - name
+                    type: object
+                  type: array
+                installAttemptsLimit:
+                  description: InstallAttemptsLimit is the maximum number of times
+                    Hive will attempt to install the cluster.
+                  format: int32
+                  type: integer
+                installed:
+                  description: Installed is true if the cluster has been installed
+                  type: boolean
+                machineManagement:
+                  description: MachineManagement contains machine management settings
+                    including the strategy that will be used when provisioning worker
+                    machines.
+                  properties:
+                    central:
+                      description: Central contains settings for central machine management.
+                        If set Central indicates that central machine management will
+                        be used as opposed to management on the spoke cluster.
+                      type: object
+                    targetNamespace:
+                      description: TargetNamespace is the namespace in which we will
+                        create worker machineset resources. Resources required to
+                        create machines will be copied to the TargetNamespace. TargetNamespace
+                        is created for you and cannot be set during creation. TargetNamespace
+                        is also immutable once set.
+                      type: string
+                  type: object
+                manageDNS:
+                  description: ManageDNS specifies whether a DNSZone should be created
+                    and managed automatically for this ClusterDeployment
+                  type: boolean
+                platform:
+                  description: Platform is the configuration for the specific platform
+                    upon which to perform the installation.
+                  properties:
+                    agentBareMetal:
+                      description: AgentBareMetal is the configuration used when performing
+                        an Assisted Agent based installation to bare metal.
+                      properties:
+                        agentSelector:
+                          description: AgentSelector is a label selector used for
+                            associating relevant custom resources with this cluster.
+                            (Agent, BareMetalHost, etc)
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      required:
+                      - agentSelector
+                      type: object
+                    aws:
+                      description: AWS is the configuration used when installing on
+                        AWS.
+                      properties:
+                        credentialsAssumeRole:
+                          description: CredentialsAssumeRole refers to the IAM role
+                            that must be assumed to obtain AWS account access for
+                            the cluster operations.
+                          properties:
+                            externalID:
+                              description: 'ExternalID is random string generated
+                                by platform so that assume role is protected from
+                                confused deputy problem. more info: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html'
+                              type: string
+                            roleARN:
+                              type: string
+                          required:
+                          - roleARN
+                          type: object
+                        credentialsSecretRef:
+                          description: CredentialsSecretRef refers to a secret that
+                            contains the AWS account access credentials.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        privateLink:
+                          description: PrivateLink allows uses to enable access to
+                            the cluster's API server using AWS PrivateLink. AWS PrivateLink
+                            includes a pair of VPC Endpoint Service and VPC Endpoint
+                            accross AWS accounts and allows clients to connect to
+                            services using AWS's internal networking instead of the
+                            Internet.
+                          properties:
+                            enabled:
+                              type: boolean
+                          required:
+                          - enabled
+                          type: object
+                        region:
+                          description: Region specifies the AWS region where the cluster
+                            will be created.
+                          type: string
+                        userTags:
+                          additionalProperties:
+                            type: string
+                          description: UserTags specifies additional tags for AWS
+                            resources created for the cluster.
+                          type: object
+                      required:
+                      - region
+                      type: object
+                    azure:
+                      description: Azure is the configuration used when installing
+                        on Azure.
+                      properties:
+                        baseDomainResourceGroupName:
+                          description: BaseDomainResourceGroupName specifies the resource
+                            group where the azure DNS zone for the base domain is
+                            found
+                          type: string
+                        credentialsSecretRef:
+                          description: CredentialsSecretRef refers to a secret that
+                            contains the Azure account access credentials.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        region:
+                          description: Region specifies the Azure region where the
+                            cluster will be created.
+                          type: string
+                      required:
+                      - credentialsSecretRef
+                      - region
+                      type: object
+                    baremetal:
+                      description: BareMetal is the configuration used when installing
+                        on bare metal.
+                      properties:
+                        libvirtSSHPrivateKeySecretRef:
+                          description: LibvirtSSHPrivateKeySecretRef is the reference
+                            to the secret that contains the private SSH key to use
+                            for access to the libvirt provisioning host. The SSH private
+                            key is expected to be in the secret data under the "ssh-privatekey"
+                            key.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                      required:
+                      - libvirtSSHPrivateKeySecretRef
+                      type: object
+                    gcp:
+                      description: GCP is the configuration used when installing on
+                        Google Cloud Platform.
+                      properties:
+                        credentialsSecretRef:
+                          description: CredentialsSecretRef refers to a secret that
+                            contains the GCP account access credentials.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        region:
+                          description: Region specifies the GCP region where the cluster
+                            will be created.
+                          type: string
+                      required:
+                      - credentialsSecretRef
+                      - region
+                      type: object
+                    openstack:
+                      description: OpenStack is the configuration used when installing
+                        on OpenStack
+                      properties:
+                        certificatesSecretRef:
+                          description: "CertificatesSecretRef refers to a secret that\
+                            \ contains CA certificates necessary for communicating\
+                            \ with the OpenStack. There is additional configuration\
+                            \ required for the OpenShift cluster to trust the certificates\
+                            \ provided in this secret. The \"clouds.yaml\" file included\
+                            \ in the credentialsSecretRef Secret must also include\
+                            \ a reference to the certificate bundle file for the OpenShift\
+                            \ cluster being created to trust the OpenStack endpoints.\
+                            \ The \"clouds.yaml\" file must set the \"cacert\" field\
+                            \ to either \"/etc/openstack-ca/<key name containing the\
+                            \ trust bundle in credentialsSecretRef Secret>\" or \"\
+                            /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem\". \n\
+                            \ For example, \"\"\"clouds.yaml clouds:   shiftstack:\
+                            \     auth: ...     cacert: \"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem\"\
+                            \ \"\"\""
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        cloud:
+                          description: Cloud will be used to indicate the OS_CLOUD
+                            value to use the right section from the clouds.yaml in
+                            the CredentialsSecretRef.
+                          type: string
+                        credentialsSecretRef:
+                          description: CredentialsSecretRef refers to a secret that
+                            contains the OpenStack account access credentials.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        trunkSupport:
+                          description: TrunkSupport indicates whether or not to use
+                            trunk ports in your OpenShift cluster.
+                          type: boolean
+                      required:
+                      - cloud
+                      - credentialsSecretRef
+                      type: object
+                    ovirt:
+                      description: Ovirt is the configuration used when installing
+                        on oVirt
+                      properties:
+                        certificatesSecretRef:
+                          description: CertificatesSecretRef refers to a secret that
+                            contains the oVirt CA certificates necessary for communicating
+                            with oVirt.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        credentialsSecretRef:
+                          description: 'CredentialsSecretRef refers to a secret that
+                            contains the oVirt account access credentials with fields:
+                            ovirt_url, ovirt_username, ovirt_password, ovirt_ca_bundle'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        ovirt_cluster_id:
+                          description: The target cluster under which all VMs will
+                            run
+                          type: string
+                        ovirt_network_name:
+                          description: The target network of all the network interfaces
+                            of the nodes. Omitting defaults to ovirtmgmt network which
+                            is a default network for evert ovirt cluster.
+                          type: string
+                        storage_domain_id:
+                          description: The target storage domain under which all VM
+                            disk would be created.
+                          type: string
+                      required:
+                      - certificatesSecretRef
+                      - credentialsSecretRef
+                      - ovirt_cluster_id
+                      - storage_domain_id
+                      type: object
+                    vsphere:
+                      description: VSphere is the configuration used when installing
+                        on vSphere
+                      properties:
+                        certificatesSecretRef:
+                          description: CertificatesSecretRef refers to a secret that
+                            contains the vSphere CA certificates necessary for communicating
+                            with the VCenter.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        cluster:
+                          description: Cluster is the name of the cluster virtual
+                            machines will be cloned into.
+                          type: string
+                        credentialsSecretRef:
+                          description: 'CredentialsSecretRef refers to a secret that
+                            contains the vSphere account access credentials: GOVC_USERNAME,
+                            GOVC_PASSWORD fields.'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        datacenter:
+                          description: Datacenter is the name of the datacenter to
+                            use in the vCenter.
+                          type: string
+                        defaultDatastore:
+                          description: DefaultDatastore is the default datastore to
+                            use for provisioning volumes.
+                          type: string
+                        folder:
+                          description: Folder is the name of the folder that will
+                            be used and/or created for virtual machines.
+                          type: string
+                        network:
+                          description: Network specifies the name of the network to
+                            be used by the cluster.
+                          type: string
+                        vCenter:
+                          description: VCenter is the domain name or IP address of
+                            the vCenter.
+                          type: string
+                      required:
+                      - certificatesSecretRef
+                      - credentialsSecretRef
+                      - datacenter
+                      - defaultDatastore
+                      - vCenter
+                      type: object
+                  type: object
+                powerState:
+                  description: PowerState indicates whether a cluster should be running
+                    or hibernating. When omitted, PowerState defaults to the Running
+                    state.
+                  enum:
+                  - ''
+                  - Running
+                  - Hibernating
+                  type: string
+                preserveOnDelete:
+                  description: PreserveOnDelete allows the user to disconnect a cluster
+                    from Hive without deprovisioning it. This can also be used to
+                    abandon ongoing cluster deprovision.
+                  type: boolean
+                provisioning:
+                  description: Provisioning contains settings used only for initial
+                    cluster provisioning. May be unset in the case of adopted clusters.
+                  properties:
+                    imageSetRef:
+                      description: ImageSetRef is a reference to a ClusterImageSet.
+                        If a value is specified for ReleaseImage, that will take precedence
+                        over the one from the ClusterImageSet.
+                      properties:
+                        name:
+                          description: Name is the name of the ClusterImageSet that
+                            this refers to
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    installConfigSecretRef:
+                      description: InstallConfigSecretRef is the reference to a secret
+                        that contains an openshift-install InstallConfig. This file
+                        will be passed through directly to the installer. Any version
+                        of InstallConfig can be used, provided it can be parsed by
+                        the openshift-install version for the release you are provisioning.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    installerEnv:
+                      description: InstallerEnv are extra environment variables to
+                        pass through to the installer. This may be used to enable
+                        additional features of the installer.
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                              using the previous defined environment variables in
+                              the container and any service environment variables.
+                              If a variable cannot be resolved, the reference in the
+                              input string will be unchanged. The $(VAR_NAME) syntax
+                              can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                              references will never be expanded, regardless of whether
+                              the variable exists or not. Defaults to "".'
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                              fieldRef:
+                                description: 'Selects a field of the pod: supports
+                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                  spec.serviceAccountName, status.hostIP, status.podIP,
+                                  status.podIPs.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                              resourceFieldRef:
+                                description: 'Selects a resource of the container:
+                                  only resources limits and requests (limits.cpu,
+                                  limits.memory, limits.ephemeral-storage, requests.cpu,
+                                  requests.memory and requests.ephemeral-storage)
+                                  are currently supported.'
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    manifestsConfigMapRef:
+                      description: ManifestsConfigMapRef is a reference to user-provided
+                        manifests to add to or replace manifests that are generated
+                        by the installer.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    releaseImage:
+                      description: ReleaseImage is the image containing metadata for
+                        all components that run in the cluster, and is the primary
+                        and best way to specify what specific version of OpenShift
+                        you wish to install.
+                      type: string
+                    sshKnownHosts:
+                      description: SSHKnownHosts are known hosts to be configured
+                        in the hive install manager pod to avoid ssh prompts. Use
+                        of ssh in the install pod is somewhat limited today (failure
+                        log gathering from cluster, some bare metal provisioning scenarios),
+                        so this setting is often not needed.
+                      items:
+                        type: string
+                      type: array
+                    sshPrivateKeySecretRef:
+                      description: SSHPrivateKeySecretRef is the reference to the
+                        secret that contains the private SSH key to use for access
+                        to compute instances. This private key should correspond to
+                        the public key included in the InstallConfig. The private
+                        key is used by Hive to gather logs on the target cluster if
+                        there are install failures. The SSH private key is expected
+                        to be in the secret data under the "ssh-privatekey" key.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                  type: object
+                pullSecretRef:
+                  description: PullSecretRef is the reference to the secret to use
+                    when pulling images.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+              required:
+              - baseDomain
+              - clusterName
+              - platform
+              type: object
+            status:
+              description: ClusterDeploymentStatus defines the observed state of ClusterDeployment
+              properties:
+                apiURL:
+                  description: APIURL is the URL where the cluster's API can be accessed.
+                  type: string
+                certificateBundles:
+                  description: CertificateBundles contains of the status of the certificate
+                    bundles associated with this cluster deployment.
+                  items:
+                    description: CertificateBundleStatus specifies whether a certificate
+                      bundle was generated for this cluster deployment.
+                    properties:
+                      generated:
+                        description: Generated indicates whether the certificate bundle
+                          was generated
+                        type: boolean
+                      name:
+                        description: Name of the certificate bundle
+                        type: string
+                    required:
+                    - generated
+                    - name
+                    type: object
+                  type: array
+                cliImage:
+                  description: CLIImage is the name of the oc cli image to use when
+                    installing the target cluster
+                  type: string
+                conditions:
+                  description: Conditions includes more detailed status for the cluster
+                    deployment
+                  items:
+                    description: ClusterDeploymentCondition contains details for the
+                      current condition of a cluster deployment
+                    properties:
+                      lastProbeTime:
+                        description: LastProbeTime is the last time we probed the
+                          condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about last transition.
+                        type: string
+                      reason:
+                        description: Reason is a unique, one-word, CamelCase reason
+                          for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+                installRestarts:
+                  description: InstallRestarts is the total count of container restarts
+                    on the clusters install job.
+                  type: integer
+                installStartedTimestamp:
+                  description: InstallStartedTimestamp is the time when all pre-requisites
+                    were met and cluster installation was launched.
+                  format: date-time
+                  type: string
+                installVersion:
+                  description: InstallVersion is the version of OpenShift as reported
+                    by the release image resolved for the installation.
+                  type: string
+                installedTimestamp:
+                  description: InstalledTimestamp is the time we first detected that
+                    the cluster has been successfully installed.
+                  format: date-time
+                  type: string
+                installerImage:
+                  description: InstallerImage is the name of the installer image to
+                    use when installing the target cluster
+                  type: string
+                platformStatus:
+                  description: Platform contains the observed state for the specific
+                    platform upon which to perform the installation.
+                  properties:
+                    aws:
+                      description: AWS is the observed state on AWS.
+                      properties:
+                        privateLink:
+                          description: PrivateLinkAccessStatus contains the observed
+                            state for PrivateLinkAccess resources.
+                          properties:
+                            hostedZoneID:
+                              type: string
+                            vpcEndpointID:
+                              type: string
+                            vpcEndpointService:
+                              properties:
+                                id:
+                                  type: string
+                                name:
+                                  type: string
+                              type: object
+                          type: object
+                      type: object
+                  type: object
+                provisionRef:
+                  description: ProvisionRef is a reference to the last ClusterProvision
+                    created for the deployment
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                webConsoleURL:
+                  description: WebConsoleURL is the URL for the cluster's web console
+                    UI.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: clusterdeprovisions.hive.openshift.io
+  spec:
+    group: hive.openshift.io
+    names:
+      kind: ClusterDeprovision
+      listKind: ClusterDeprovisionList
+      plural: clusterdeprovisions
+      shortNames:
+      - cdr
+      singular: clusterdeprovision
+    scope: Namespaced
+    versions:
+    - additionalPrinterColumns:
+      - jsonPath: .spec.infraID
+        name: InfraID
+        type: string
+      - jsonPath: .spec.clusterID
+        name: ClusterID
+        type: string
+      - jsonPath: .status.completed
+        name: Completed
+        type: boolean
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterDeprovision is the Schema for the clusterdeprovisions
+            API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterDeprovisionSpec defines the desired state of ClusterDeprovision
+              properties:
+                clusterID:
+                  description: ClusterID is a globally unique identifier for the cluster
+                    to deprovision. It will be used if specified.
+                  type: string
+                infraID:
+                  description: InfraID is the identifier generated during installation
+                    for a cluster. It is used for tagging/naming resources in cloud
+                    providers.
+                  type: string
+                platform:
+                  description: Platform contains platform-specific configuration for
+                    a ClusterDeprovision
+                  properties:
+                    aws:
+                      description: AWS contains AWS-specific deprovision settings
+                      properties:
+                        credentialsAssumeRole:
+                          description: CredentialsAssumeRole refers to the IAM role
+                            that must be assumed to obtain AWS account access for
+                            deprovisioning the cluster.
+                          properties:
+                            externalID:
+                              description: 'ExternalID is random string generated
+                                by platform so that assume role is protected from
+                                confused deputy problem. more info: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html'
+                              type: string
+                            roleARN:
+                              type: string
+                          required:
+                          - roleARN
+                          type: object
+                        credentialsSecretRef:
+                          description: CredentialsSecretRef is the AWS account credentials
+                            to use for deprovisioning the cluster
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        region:
+                          description: Region is the AWS region for this deprovisioning
+                          type: string
+                      required:
+                      - region
+                      type: object
+                    azure:
+                      description: Azure contains Azure-specific deprovision settings
+                      properties:
+                        credentialsSecretRef:
+                          description: CredentialsSecretRef is the Azure account credentials
+                            to use for deprovisioning the cluster
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                      type: object
+                    gcp:
+                      description: GCP contains GCP-specific deprovision settings
+                      properties:
+                        credentialsSecretRef:
+                          description: CredentialsSecretRef is the GCP account credentials
+                            to use for deprovisioning the cluster
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        region:
+                          description: Region is the GCP region for this deprovision
+                          type: string
+                      required:
+                      - region
+                      type: object
+                    openstack:
+                      description: OpenStack contains OpenStack-specific deprovision
+                        settings
+                      properties:
+                        certificatesSecretRef:
+                          description: CertificatesSecretRef refers to a secret that
+                            contains CA certificates necessary for communicating with
+                            the OpenStack.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        cloud:
+                          description: Cloud is the secion in the clouds.yaml secret
+                            below to use for auth/connectivity.
+                          type: string
+                        credentialsSecretRef:
+                          description: CredentialsSecretRef is the OpenStack account
+                            credentials to use for deprovisioning the cluster
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                      required:
+                      - cloud
+                      type: object
+                    ovirt:
+                      description: Ovirt contains oVirt-specific deprovision settings
+                      properties:
+                        certificatesSecretRef:
+                          description: CertificatesSecretRef refers to a secret that
+                            contains the oVirt CA certificates necessary for communicating
+                            with the oVirt.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        clusterID:
+                          description: The oVirt cluster ID
+                          type: string
+                        credentialsSecretRef:
+                          description: 'CredentialsSecretRef is the oVirt account
+                            credentials to use for deprovisioning the cluster secret
+                            fields: ovirt_url, ovirt_username, ovirt_password, ovirt_ca_bundle'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                      required:
+                      - certificatesSecretRef
+                      - clusterID
+                      - credentialsSecretRef
+                      type: object
+                    vsphere:
+                      description: VSphere contains VMWare vSphere-specific deprovision
+                        settings
+                      properties:
+                        certificatesSecretRef:
+                          description: CertificatesSecretRef refers to a secret that
+                            contains the vSphere CA certificates necessary for communicating
+                            with the VCenter.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        credentialsSecretRef:
+                          description: CredentialsSecretRef is the vSphere account
+                            credentials to use for deprovisioning the cluster
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        vCenter:
+                          description: VCenter is the vSphere vCenter hostname.
+                          type: string
+                      required:
+                      - certificatesSecretRef
+                      - credentialsSecretRef
+                      - vCenter
+                      type: object
+                  type: object
+              required:
+              - infraID
+              type: object
+            status:
+              description: ClusterDeprovisionStatus defines the observed state of
+                ClusterDeprovision
+              properties:
+                completed:
+                  description: Completed is true when the uninstall has completed
+                    successfully
+                  type: boolean
+                conditions:
+                  description: Conditions includes more detailed status for the cluster
+                    deprovision
+                  items:
+                    description: ClusterDeprovisionCondition contains details for
+                      the current condition of a ClusterDeprovision
+                    properties:
+                      lastProbeTime:
+                        description: LastProbeTime is the last time we probed the
+                          condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about last transition.
+                        type: string
+                      reason:
+                        description: Reason is a unique, one-word, CamelCase reason
+                          for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: clusterimagesets.hive.openshift.io
+  spec:
+    group: hive.openshift.io
+    names:
+      kind: ClusterImageSet
+      listKind: ClusterImageSetList
+      plural: clusterimagesets
+      shortNames:
+      - imgset
+      singular: clusterimageset
+    scope: Cluster
+    versions:
+    - additionalPrinterColumns:
+      - jsonPath: .spec.releaseImage
+        name: Release
+        type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterImageSet is the Schema for the clusterimagesets API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterImageSetSpec defines the desired state of ClusterImageSet
+              properties:
+                releaseImage:
+                  description: ReleaseImage is the image that contains the payload
+                    to use when installing a cluster.
+                  type: string
+              required:
+              - releaseImage
+              type: object
+            status:
+              description: ClusterImageSetStatus defines the observed state of ClusterImageSet
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: clusterpools.hive.openshift.io
+  spec:
+    group: hive.openshift.io
+    names:
+      kind: ClusterPool
+      listKind: ClusterPoolList
+      plural: clusterpools
+      shortNames:
+      - cp
+      singular: clusterpool
+    scope: Namespaced
+    versions:
+    - additionalPrinterColumns:
+      - jsonPath: .status.ready
+        name: Ready
+        type: string
+      - jsonPath: .spec.size
+        name: Size
+        type: string
+      - jsonPath: .spec.baseDomain
+        name: BaseDomain
+        type: string
+      - jsonPath: .spec.imageSetRef.name
+        name: ImageSet
+        type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterPool represents a pool of clusters that should be kept
+            ready to be given out to users. Clusters are removed from the pool once
+            claimed and then automatically replaced with a new one.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterPoolSpec defines the desired state of the ClusterPool.
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  description: Annotations to be applied to new ClusterDeployments
+                    created for the pool. ClusterDeployments that have already been
+                    claimed will not be affected when this value is modified.
+                  type: object
+                baseDomain:
+                  description: BaseDomain is the base domain to use for all clusters
+                    created in this pool.
+                  type: string
+                claimLifetime:
+                  description: ClaimLifetime defines the lifetimes for claims for
+                    the cluster pool.
+                  properties:
+                    default:
+                      description: Default is the default lifetime of the claim when
+                        no lifetime is set on the claim itself. This is a Duration
+                        value; see https://pkg.go.dev/time#ParseDuration for accepted
+                        formats.
+                      format: duration
+                      type: string
+                    maximum:
+                      description: Maximum is the maximum lifetime of the claim after
+                        it is assigned a cluster. If the claim still exists when the
+                        lifetime has elapsed, the claim will be deleted by Hive. The
+                        lifetime of a claim is the mimimum of the lifetimes set by
+                        the cluster pool and the claim itself. This is a Duration
+                        value; see https://pkg.go.dev/time#ParseDuration for accepted
+                        formats.
+                      format: duration
+                      type: string
+                  type: object
+                hibernateAfter:
+                  description: HibernateAfter will be applied to new ClusterDeployments
+                    created for the pool. HibernateAfter will transition clusters
+                    in the clusterpool to hibernating power state after it has been
+                    running for the given duration. The time that a cluster has been
+                    running is the time since the cluster was installed or the time
+                    since the cluster last came out of hibernation. This is a Duration
+                    value; see https://pkg.go.dev/time#ParseDuration for accepted
+                    formats.
+                  format: duration
+                  type: string
+                imageSetRef:
+                  description: ImageSetRef is a reference to a ClusterImageSet. The
+                    release image specified in the ClusterImageSet will be used by
+                    clusters created for this cluster pool.
+                  properties:
+                    name:
+                      description: Name is the name of the ClusterImageSet that this
+                        refers to
+                      type: string
+                  required:
+                  - name
+                  type: object
+                installConfigSecretTemplateRef:
+                  description: InstallConfigSecretTemplateRef is a secret with the
+                    key install-config.yaml consisting of the content of the install-config.yaml
+                    to be used as a template for all clusters in this pool. Cluster
+                    specific settings (name, basedomain) will be injected dynamically
+                    when the ClusterDeployment install-config Secret is generated.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: Labels to be applied to new ClusterDeployments created
+                    for the pool. ClusterDeployments that have already been claimed
+                    will not be affected when this value is modified.
+                  type: object
+                maxConcurrent:
+                  description: MaxConcurrent is the maximum number of clusters that
+                    will be provisioned or deprovisioned at an time. This includes
+                    the claimed clusters being deprovisioned. By default there is
+                    no limit.
+                  format: int32
+                  type: integer
+                maxSize:
+                  description: MaxSize is the maximum number of clusters that will
+                    be provisioned including clusters that have been claimed and ones
+                    waiting to be used. By default there is no limit.
+                  format: int32
+                  type: integer
+                platform:
+                  description: Platform encompasses the desired platform for the cluster.
+                  properties:
+                    agentBareMetal:
+                      description: AgentBareMetal is the configuration used when performing
+                        an Assisted Agent based installation to bare metal.
+                      properties:
+                        agentSelector:
+                          description: AgentSelector is a label selector used for
+                            associating relevant custom resources with this cluster.
+                            (Agent, BareMetalHost, etc)
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      required:
+                      - agentSelector
+                      type: object
+                    aws:
+                      description: AWS is the configuration used when installing on
+                        AWS.
+                      properties:
+                        credentialsAssumeRole:
+                          description: CredentialsAssumeRole refers to the IAM role
+                            that must be assumed to obtain AWS account access for
+                            the cluster operations.
+                          properties:
+                            externalID:
+                              description: 'ExternalID is random string generated
+                                by platform so that assume role is protected from
+                                confused deputy problem. more info: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html'
+                              type: string
+                            roleARN:
+                              type: string
+                          required:
+                          - roleARN
+                          type: object
+                        credentialsSecretRef:
+                          description: CredentialsSecretRef refers to a secret that
+                            contains the AWS account access credentials.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        privateLink:
+                          description: PrivateLink allows uses to enable access to
+                            the cluster's API server using AWS PrivateLink. AWS PrivateLink
+                            includes a pair of VPC Endpoint Service and VPC Endpoint
+                            accross AWS accounts and allows clients to connect to
+                            services using AWS's internal networking instead of the
+                            Internet.
+                          properties:
+                            enabled:
+                              type: boolean
+                          required:
+                          - enabled
+                          type: object
+                        region:
+                          description: Region specifies the AWS region where the cluster
+                            will be created.
+                          type: string
+                        userTags:
+                          additionalProperties:
+                            type: string
+                          description: UserTags specifies additional tags for AWS
+                            resources created for the cluster.
+                          type: object
+                      required:
+                      - region
+                      type: object
+                    azure:
+                      description: Azure is the configuration used when installing
+                        on Azure.
+                      properties:
+                        baseDomainResourceGroupName:
+                          description: BaseDomainResourceGroupName specifies the resource
+                            group where the azure DNS zone for the base domain is
+                            found
+                          type: string
+                        credentialsSecretRef:
+                          description: CredentialsSecretRef refers to a secret that
+                            contains the Azure account access credentials.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        region:
+                          description: Region specifies the Azure region where the
+                            cluster will be created.
+                          type: string
+                      required:
+                      - credentialsSecretRef
+                      - region
+                      type: object
+                    baremetal:
+                      description: BareMetal is the configuration used when installing
+                        on bare metal.
+                      properties:
+                        libvirtSSHPrivateKeySecretRef:
+                          description: LibvirtSSHPrivateKeySecretRef is the reference
+                            to the secret that contains the private SSH key to use
+                            for access to the libvirt provisioning host. The SSH private
+                            key is expected to be in the secret data under the "ssh-privatekey"
+                            key.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                      required:
+                      - libvirtSSHPrivateKeySecretRef
+                      type: object
+                    gcp:
+                      description: GCP is the configuration used when installing on
+                        Google Cloud Platform.
+                      properties:
+                        credentialsSecretRef:
+                          description: CredentialsSecretRef refers to a secret that
+                            contains the GCP account access credentials.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        region:
+                          description: Region specifies the GCP region where the cluster
+                            will be created.
+                          type: string
+                      required:
+                      - credentialsSecretRef
+                      - region
+                      type: object
+                    openstack:
+                      description: OpenStack is the configuration used when installing
+                        on OpenStack
+                      properties:
+                        certificatesSecretRef:
+                          description: "CertificatesSecretRef refers to a secret that\
+                            \ contains CA certificates necessary for communicating\
+                            \ with the OpenStack. There is additional configuration\
+                            \ required for the OpenShift cluster to trust the certificates\
+                            \ provided in this secret. The \"clouds.yaml\" file included\
+                            \ in the credentialsSecretRef Secret must also include\
+                            \ a reference to the certificate bundle file for the OpenShift\
+                            \ cluster being created to trust the OpenStack endpoints.\
+                            \ The \"clouds.yaml\" file must set the \"cacert\" field\
+                            \ to either \"/etc/openstack-ca/<key name containing the\
+                            \ trust bundle in credentialsSecretRef Secret>\" or \"\
+                            /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem\". \n\
+                            \ For example, \"\"\"clouds.yaml clouds:   shiftstack:\
+                            \     auth: ...     cacert: \"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem\"\
+                            \ \"\"\""
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        cloud:
+                          description: Cloud will be used to indicate the OS_CLOUD
+                            value to use the right section from the clouds.yaml in
+                            the CredentialsSecretRef.
+                          type: string
+                        credentialsSecretRef:
+                          description: CredentialsSecretRef refers to a secret that
+                            contains the OpenStack account access credentials.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        trunkSupport:
+                          description: TrunkSupport indicates whether or not to use
+                            trunk ports in your OpenShift cluster.
+                          type: boolean
+                      required:
+                      - cloud
+                      - credentialsSecretRef
+                      type: object
+                    ovirt:
+                      description: Ovirt is the configuration used when installing
+                        on oVirt
+                      properties:
+                        certificatesSecretRef:
+                          description: CertificatesSecretRef refers to a secret that
+                            contains the oVirt CA certificates necessary for communicating
+                            with oVirt.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        credentialsSecretRef:
+                          description: 'CredentialsSecretRef refers to a secret that
+                            contains the oVirt account access credentials with fields:
+                            ovirt_url, ovirt_username, ovirt_password, ovirt_ca_bundle'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        ovirt_cluster_id:
+                          description: The target cluster under which all VMs will
+                            run
+                          type: string
+                        ovirt_network_name:
+                          description: The target network of all the network interfaces
+                            of the nodes. Omitting defaults to ovirtmgmt network which
+                            is a default network for evert ovirt cluster.
+                          type: string
+                        storage_domain_id:
+                          description: The target storage domain under which all VM
+                            disk would be created.
+                          type: string
+                      required:
+                      - certificatesSecretRef
+                      - credentialsSecretRef
+                      - ovirt_cluster_id
+                      - storage_domain_id
+                      type: object
+                    vsphere:
+                      description: VSphere is the configuration used when installing
+                        on vSphere
+                      properties:
+                        certificatesSecretRef:
+                          description: CertificatesSecretRef refers to a secret that
+                            contains the vSphere CA certificates necessary for communicating
+                            with the VCenter.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        cluster:
+                          description: Cluster is the name of the cluster virtual
+                            machines will be cloned into.
+                          type: string
+                        credentialsSecretRef:
+                          description: 'CredentialsSecretRef refers to a secret that
+                            contains the vSphere account access credentials: GOVC_USERNAME,
+                            GOVC_PASSWORD fields.'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        datacenter:
+                          description: Datacenter is the name of the datacenter to
+                            use in the vCenter.
+                          type: string
+                        defaultDatastore:
+                          description: DefaultDatastore is the default datastore to
+                            use for provisioning volumes.
+                          type: string
+                        folder:
+                          description: Folder is the name of the folder that will
+                            be used and/or created for virtual machines.
+                          type: string
+                        network:
+                          description: Network specifies the name of the network to
+                            be used by the cluster.
+                          type: string
+                        vCenter:
+                          description: VCenter is the domain name or IP address of
+                            the vCenter.
+                          type: string
+                      required:
+                      - certificatesSecretRef
+                      - credentialsSecretRef
+                      - datacenter
+                      - defaultDatastore
+                      - vCenter
+                      type: object
+                  type: object
+                pullSecretRef:
+                  description: PullSecretRef is the reference to the secret to use
+                    when pulling images.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                size:
+                  description: Size is the default number of clusters that we should
+                    keep provisioned and waiting for use.
+                  format: int32
+                  minimum: 0
+                  type: integer
+                skipMachinePools:
+                  description: SkipMachinePools allows creating clusterpools where
+                    the machinepools are not managed by hive after cluster creation
+                  type: boolean
+              required:
+              - baseDomain
+              - imageSetRef
+              - platform
+              - size
+              type: object
+            status:
+              description: ClusterPoolStatus defines the observed state of ClusterPool
+              properties:
+                conditions:
+                  description: Conditions includes more detailed status for the cluster
+                    pool
+                  items:
+                    description: ClusterPoolCondition contains details for the current
+                      condition of a cluster pool
+                    properties:
+                      lastProbeTime:
+                        description: LastProbeTime is the last time we probed the
+                          condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about last transition.
+                        type: string
+                      reason:
+                        description: Reason is a unique, one-word, CamelCase reason
+                          for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+                ready:
+                  description: Ready is the number of unclaimed clusters that have
+                    been installed and are ready to be claimed.
+                  format: int32
+                  type: integer
+                size:
+                  description: Size is the number of unclaimed clusters that have
+                    been created for the pool.
+                  format: int32
+                  type: integer
+              required:
+              - ready
+              - size
+              type: object
+          required:
+          - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        scale:
+          specReplicasPath: .spec.size
+          statusReplicasPath: .status.size
+        status: {}
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    labels:
+      contracts.hive.openshift.io/clusterinstall: 'false'
+    name: clusterprovisions.hive.openshift.io
+  spec:
+    group: hive.openshift.io
+    names:
+      kind: ClusterProvision
+      listKind: ClusterProvisionList
+      plural: clusterprovisions
+      singular: clusterprovision
+    scope: Namespaced
+    versions:
+    - additionalPrinterColumns:
+      - jsonPath: .spec.clusterDeploymentRef.name
+        name: ClusterDeployment
+        type: string
+      - jsonPath: .spec.stage
+        name: Stage
+        type: string
+      - jsonPath: .spec.infraID
+        name: InfraID
+        type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterProvision is the Schema for the clusterprovisions API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterProvisionSpec defines the results of provisioning
+                a cluster.
+              properties:
+                adminKubeconfigSecretRef:
+                  description: AdminKubeconfigSecretRef references the secret containing
+                    the admin kubeconfig for this cluster.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                adminPasswordSecretRef:
+                  description: AdminPasswordSecretRef references the secret containing
+                    the admin username/password which can be used to login to this
+                    cluster.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                attempt:
+                  description: Attempt is which attempt number of the cluster deployment
+                    that this ClusterProvision is
+                  type: integer
+                clusterDeploymentRef:
+                  description: ClusterDeploymentRef references the cluster deployment
+                    provisioned.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                clusterID:
+                  description: ClusterID is a globally unique identifier for this
+                    cluster generated during installation. Used for reporting metrics
+                    among other places.
+                  type: string
+                infraID:
+                  description: InfraID is an identifier for this cluster generated
+                    during installation and used for tagging/naming resources in cloud
+                    providers.
+                  type: string
+                installLog:
+                  description: InstallLog is the log from the installer.
+                  type: string
+                metadata:
+                  description: Metadata is the metadata.json generated by the installer,
+                    providing metadata information about the cluster created.
+                  type: object
+                prevClusterID:
+                  description: PrevClusterID is the cluster ID of the previous failed
+                    provision attempt.
+                  type: string
+                prevInfraID:
+                  description: PrevInfraID is the infra ID of the previous failed
+                    provision attempt.
+                  type: string
+                stage:
+                  description: Stage is the stage of provisioning that the cluster
+                    deployment has reached.
+                  type: string
+              required:
+              - attempt
+              - clusterDeploymentRef
+              - podSpec
+              - stage
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              description: ClusterProvisionStatus defines the observed state of ClusterProvision.
+              properties:
+                conditions:
+                  description: Conditions includes more detailed status for the cluster
+                    provision
+                  items:
+                    description: ClusterProvisionCondition contains details for the
+                      current condition of a cluster provision
+                    properties:
+                      lastProbeTime:
+                        description: LastProbeTime is the last time we probed the
+                          condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about last transition.
+                        type: string
+                      reason:
+                        description: Reason is a unique, one-word, CamelCase reason
+                          for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+                jobRef:
+                  description: JobRef is the reference to the job performing the provision.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: clusterrelocates.hive.openshift.io
+  spec:
+    group: hive.openshift.io
+    names:
+      kind: ClusterRelocate
+      listKind: ClusterRelocateList
+      plural: clusterrelocates
+      singular: clusterrelocate
+    scope: Namespaced
+    versions:
+    - additionalPrinterColumns:
+      - jsonPath: .spec.clusterDeploymentSelector
+        name: Selector
+        type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterRelocate is the Schema for the ClusterRelocates API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterRelocateSpec defines the relocation of clusters
+                from one Hive instance to another.
+              properties:
+                clusterDeploymentSelector:
+                  description: ClusterDeploymentSelector is a LabelSelector indicating
+                    which clusters will be relocated.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                kubeconfigSecretRef:
+                  description: KubeconfigSecretRef is a reference to the secret containing
+                    the kubeconfig for the destination Hive instance. The kubeconfig
+                    must be in a data field where the key is "kubeconfig".
+                  properties:
+                    name:
+                      description: Name is the name of the secret.
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace where the secret lives.
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+              required:
+              - clusterDeploymentSelector
+              - kubeconfigSecretRef
+              type: object
+            status:
+              description: ClusterRelocateStatus defines the observed state of ClusterRelocate.
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: clusterstates.hive.openshift.io
+  spec:
+    group: hive.openshift.io
+    names:
+      kind: ClusterState
+      listKind: ClusterStateList
+      plural: clusterstates
+      singular: clusterstate
+    scope: Namespaced
+    versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterState is the Schema for the clusterstates API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterStateSpec defines the desired state of ClusterState
+              type: object
+            status:
+              description: ClusterStateStatus defines the observed state of ClusterState
+              properties:
+                clusterOperators:
+                  description: ClusterOperators contains the state for every cluster
+                    operator in the target cluster
+                  items:
+                    description: ClusterOperatorState summarizes the status of a single
+                      cluster operator
+                    properties:
+                      conditions:
+                        description: Conditions is the set of conditions in the status
+                          of the cluster operator on the target cluster
+                        items:
+                          description: ClusterOperatorStatusCondition represents the
+                            state of the operator's managed and monitored components.
+                          properties:
+                            lastTransitionTime:
+                              description: lastTransitionTime is the time of the last
+                                update to the current status property.
+                              format: date-time
+                              type: string
+                            message:
+                              description: message provides additional information
+                                about the current condition. This is only to be consumed
+                                by humans.  It may contain Line Feed characters (U+000A),
+                                which should be rendered as new lines.
+                              type: string
+                            reason:
+                              description: reason is the CamelCase reason for the
+                                condition's current status.
+                              type: string
+                            status:
+                              description: status of the condition, one of True, False,
+                                Unknown.
+                              type: string
+                            type:
+                              description: type specifies the aspect reported by this
+                                condition.
+                              type: string
+                          required:
+                          - lastTransitionTime
+                          - status
+                          - type
+                          type: object
+                        type: array
+                      name:
+                        description: Name is the name of the cluster operator
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+                lastUpdated:
+                  description: LastUpdated is the last time that operator state was
+                    updated
+                  format: date-time
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: clustersyncleases.hiveinternal.openshift.io
+  spec:
+    group: hiveinternal.openshift.io
+    names:
+      kind: ClusterSyncLease
+      listKind: ClusterSyncLeaseList
+      plural: clustersyncleases
+      shortNames:
+      - csl
+      singular: clustersynclease
+    scope: Namespaced
+    versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ClusterSyncLease is a record of the last time that SyncSets
+            and SelectorSyncSets were applied to a cluster.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterSyncLeaseSpec is the specification of a ClusterSyncLease.
+              properties:
+                renewTime:
+                  description: RenewTime is the time when SyncSets and SelectorSyncSets
+                    were last applied to the cluster.
+                  format: date-time
+                  type: string
+              required:
+              - renewTime
+              type: object
+          type: object
+      served: true
+      storage: true
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: clustersyncs.hiveinternal.openshift.io
+  spec:
+    group: hiveinternal.openshift.io
+    names:
+      kind: ClusterSync
+      listKind: ClusterSyncList
+      plural: clustersyncs
+      shortNames:
+      - csync
+      singular: clustersync
+    scope: Namespaced
+    versions:
+    - additionalPrinterColumns:
+      - jsonPath: .status.conditions[0].reason
+        name: Status
+        type: string
+      - jsonPath: .status.conditions[?(@.type=="Failed")].message
+        name: Message
+        priority: 1
+        type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ClusterSync is the status of all of the SelectorSyncSets and
+            SyncSets that apply to a ClusterDeployment.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterSyncSpec defines the desired state of ClusterSync
+              type: object
+            status:
+              description: ClusterSyncStatus defines the observed state of ClusterSync
+              properties:
+                conditions:
+                  description: Conditions is a list of conditions associated with
+                    syncing to the cluster.
+                  items:
+                    description: ClusterSyncCondition contains details for the current
+                      condition of a ClusterSync
+                    properties:
+                      lastProbeTime:
+                        description: LastProbeTime is the last time we probed the
+                          condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about the last transition.
+                        type: string
+                      reason:
+                        description: Reason is a unique, one-word, CamelCase reason
+                          for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+                firstSuccessTime:
+                  description: FirstSuccessTime is the time we first successfully
+                    applied all (selector)syncsets to a cluster.
+                  format: date-time
+                  type: string
+                selectorSyncSets:
+                  description: SelectorSyncSets is the sync status of all of the SelectorSyncSets
+                    for the cluster.
+                  items:
+                    description: SyncStatus is the status of applying a specific SyncSet
+                      or SelectorSyncSet to the cluster.
+                    properties:
+                      failureMessage:
+                        description: FailureMessage is a message describing why the
+                          SyncSet or SelectorSyncSet could not be applied. This is
+                          only set when Result is Failure.
+                        type: string
+                      firstSuccessTime:
+                        description: FirstSuccessTime is the time when the SyncSet
+                          or SelectorSyncSet was first successfully applied to the
+                          cluster.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: LastTransitionTime is the time when this status
+                          last changed.
+                        format: date-time
+                        type: string
+                      name:
+                        description: Name is the name of the SyncSet or SelectorSyncSet.
+                        type: string
+                      observedGeneration:
+                        description: ObservedGeneration is the generation of the SyncSet
+                          or SelectorSyncSet that was last observed.
+                        format: int64
+                        type: integer
+                      resourcesToDelete:
+                        description: ResourcesToDelete is the list of resources in
+                          the cluster that should be deleted when the SyncSet or SelectorSyncSet
+                          is deleted or is no longer matched to the cluster.
+                        items:
+                          description: SyncResourceReference is a reference to a resource
+                            that is synced to a cluster via a SyncSet or SelectorSyncSet.
+                          properties:
+                            apiVersion:
+                              description: APIVersion is the Group and Version of
+                                the resource.
+                              type: string
+                            kind:
+                              description: Kind is the Kind of the resource.
+                              type: string
+                            name:
+                              description: Name is the name of the resource.
+                              type: string
+                            namespace:
+                              description: Namespace is the namespace of the resource.
+                              type: string
+                          required:
+                          - apiVersion
+                          - name
+                          type: object
+                        type: array
+                      result:
+                        description: Result is the result of the last attempt to apply
+                          the SyncSet or SelectorSyncSet to the cluster.
+                        enum:
+                        - Success
+                        - Failure
+                        type: string
+                    required:
+                    - lastTransitionTime
+                    - name
+                    - observedGeneration
+                    - result
+                    type: object
+                  type: array
+                syncSets:
+                  description: SyncSets is the sync status of all of the SyncSets
+                    for the cluster.
+                  items:
+                    description: SyncStatus is the status of applying a specific SyncSet
+                      or SelectorSyncSet to the cluster.
+                    properties:
+                      failureMessage:
+                        description: FailureMessage is a message describing why the
+                          SyncSet or SelectorSyncSet could not be applied. This is
+                          only set when Result is Failure.
+                        type: string
+                      firstSuccessTime:
+                        description: FirstSuccessTime is the time when the SyncSet
+                          or SelectorSyncSet was first successfully applied to the
+                          cluster.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: LastTransitionTime is the time when this status
+                          last changed.
+                        format: date-time
+                        type: string
+                      name:
+                        description: Name is the name of the SyncSet or SelectorSyncSet.
+                        type: string
+                      observedGeneration:
+                        description: ObservedGeneration is the generation of the SyncSet
+                          or SelectorSyncSet that was last observed.
+                        format: int64
+                        type: integer
+                      resourcesToDelete:
+                        description: ResourcesToDelete is the list of resources in
+                          the cluster that should be deleted when the SyncSet or SelectorSyncSet
+                          is deleted or is no longer matched to the cluster.
+                        items:
+                          description: SyncResourceReference is a reference to a resource
+                            that is synced to a cluster via a SyncSet or SelectorSyncSet.
+                          properties:
+                            apiVersion:
+                              description: APIVersion is the Group and Version of
+                                the resource.
+                              type: string
+                            kind:
+                              description: Kind is the Kind of the resource.
+                              type: string
+                            name:
+                              description: Name is the name of the resource.
+                              type: string
+                            namespace:
+                              description: Namespace is the namespace of the resource.
+                              type: string
+                          required:
+                          - apiVersion
+                          - name
+                          type: object
+                        type: array
+                      result:
+                        description: Result is the result of the last attempt to apply
+                          the SyncSet or SelectorSyncSet to the cluster.
+                        enum:
+                        - Success
+                        - Failure
+                        type: string
+                    required:
+                    - lastTransitionTime
+                    - name
+                    - observedGeneration
+                    - result
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: dnszones.hive.openshift.io
+  spec:
+    group: hive.openshift.io
+    names:
+      kind: DNSZone
+      listKind: DNSZoneList
+      plural: dnszones
+      singular: dnszone
+    scope: Namespaced
+    versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: DNSZone is the Schema for the dnszones API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DNSZoneSpec defines the desired state of DNSZone
+              properties:
+                aws:
+                  description: AWS specifies AWS-specific cloud configuration
+                  properties:
+                    additionalTags:
+                      description: AdditionalTags is a set of additional tags to set
+                        on the DNS hosted zone. In addition to these tags,the DNS
+                        Zone controller will set a hive.openhsift.io/hostedzone tag
+                        identifying the HostedZone record that it belongs to.
+                      items:
+                        description: AWSResourceTag represents a tag that is applied
+                          to an AWS cloud resource
+                        properties:
+                          key:
+                            description: Key is the key for the tag
+                            type: string
+                          value:
+                            description: Value is the value for the tag
+                            type: string
+                        required:
+                        - key
+                        - value
+                        type: object
+                      type: array
+                    credentialsAssumeRole:
+                      description: CredentialsAssumeRole refers to the IAM role that
+                        must be assumed to obtain AWS account access for the DNS CRUD
+                        operations.
+                      properties:
+                        externalID:
+                          description: 'ExternalID is random string generated by platform
+                            so that assume role is protected from confused deputy
+                            problem. more info: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html'
+                          type: string
+                        roleARN:
+                          type: string
+                      required:
+                      - roleARN
+                      type: object
+                    credentialsSecretRef:
+                      description: CredentialsSecretRef contains a reference to a
+                        secret that contains AWS credentials for CRUD operations
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    region:
+                      description: Region is the AWS region to use for route53 operations.
+                        This defaults to us-east-1. For AWS China, use cn-northwest-1.
+                      type: string
+                  type: object
+                azure:
+                  description: Azure specifes Azure-specific cloud configuration
+                  properties:
+                    credentialsSecretRef:
+                      description: CredentialsSecretRef references a secret that will
+                        be used to authenticate with Azure CloudDNS. It will need
+                        permission to create and manage CloudDNS Hosted Zones. Secret
+                        should have a key named 'osServicePrincipal.json'. The credentials
+                        must specify the project to use.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    resourceGroupName:
+                      description: ResourceGroupName specifies the Azure resource
+                        group in which the Hosted Zone should be created.
+                      type: string
+                  required:
+                  - credentialsSecretRef
+                  - resourceGroupName
+                  type: object
+                gcp:
+                  description: GCP specifies GCP-specific cloud configuration
+                  properties:
+                    credentialsSecretRef:
+                      description: CredentialsSecretRef references a secret that will
+                        be used to authenticate with GCP CloudDNS. It will need permission
+                        to create and manage CloudDNS Hosted Zones. Secret should
+                        have a key named 'osServiceAccount.json'. The credentials
+                        must specify the project to use.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                  required:
+                  - credentialsSecretRef
+                  type: object
+                linkToParentDomain:
+                  description: LinkToParentDomain specifies whether DNS records should
+                    be automatically created to link this DNSZone with a parent domain.
+                  type: boolean
+                preserveOnDelete:
+                  description: PreserveOnDelete allows the user to disconnect a DNSZone
+                    from Hive without deprovisioning it. This can also be used to
+                    abandon ongoing DNSZone deprovision. Typically set automatically
+                    due to PreserveOnDelete being set on a ClusterDeployment.
+                  type: boolean
+                zone:
+                  description: Zone is the DNS zone to host
+                  type: string
+              required:
+              - zone
+              type: object
+            status:
+              description: DNSZoneStatus defines the observed state of DNSZone
+              properties:
+                aws:
+                  description: AWSDNSZoneStatus contains status information specific
+                    to AWS
+                  properties:
+                    zoneID:
+                      description: ZoneID is the ID of the zone in AWS
+                      type: string
+                  type: object
+                azure:
+                  description: AzureDNSZoneStatus contains status information specific
+                    to Azure
+                  type: object
+                conditions:
+                  description: Conditions includes more detailed status for the DNSZone
+                  items:
+                    description: DNSZoneCondition contains details for the current
+                      condition of a DNSZone
+                    properties:
+                      lastProbeTime:
+                        description: LastProbeTime is the last time we probed the
+                          condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about last transition.
+                        type: string
+                      reason:
+                        description: Reason is a unique, one-word, CamelCase reason
+                          for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+                gcp:
+                  description: GCPDNSZoneStatus contains status information specific
+                    to GCP
+                  properties:
+                    zoneName:
+                      description: ZoneName is the name of the zone in GCP Cloud DNS
+                      type: string
+                  type: object
+                lastSyncGeneration:
+                  description: LastSyncGeneration is the generation of the zone resource
+                    that was last sync'd. This is used to know if the Object has changed
+                    and we should sync immediately.
+                  format: int64
+                  type: integer
+                lastSyncTimestamp:
+                  description: LastSyncTimestamp is the time that the zone was last
+                    sync'd.
+                  format: date-time
+                  type: string
+                nameServers:
+                  description: NameServers is a list of nameservers for this DNS zone
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    labels:
+      contracts.hive.openshift.io/clusterinstall: 'true'
+    name: fakeclusterinstalls.hiveinternal.openshift.io
+  spec:
+    group: hiveinternal.openshift.io
+    names:
+      kind: FakeClusterInstall
+      listKind: FakeClusterInstallList
+      plural: fakeclusterinstalls
+      singular: fakeclusterinstall
+    scope: Namespaced
+    versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: FakeClusterInstall represents a fake request to provision an
+            agent based cluster.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: FakeClusterInstallSpec defines the desired state of the
+                FakeClusterInstall.
+              properties:
+                clusterDeploymentRef:
+                  description: ClusterDeploymentRef is a reference to the ClusterDeployment
+                    associated with this AgentClusterInstall.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                clusterMetadata:
+                  description: ClusterMetadata contains metadata information about
+                    the installed cluster. It should be populated once the cluster
+                    install is completed. (it can be populated sooner if desired,
+                    but Hive will not copy back to ClusterDeployment until the Installed
+                    condition goes True.
+                  properties:
+                    adminKubeconfigSecretRef:
+                      description: AdminKubeconfigSecretRef references the secret
+                        containing the admin kubeconfig for this cluster.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    adminPasswordSecretRef:
+                      description: AdminPasswordSecretRef references the secret containing
+                        the admin username/password which can be used to login to
+                        this cluster.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    clusterID:
+                      description: ClusterID is a globally unique identifier for this
+                        cluster generated during installation. Used for reporting
+                        metrics among other places.
+                      type: string
+                    infraID:
+                      description: InfraID is an identifier for this cluster generated
+                        during installation and used for tagging/naming resources
+                        in cloud providers.
+                      type: string
+                  required:
+                  - adminKubeconfigSecretRef
+                  - clusterID
+                  - infraID
+                  type: object
+                imageSetRef:
+                  description: ImageSetRef is a reference to a ClusterImageSet. The
+                    release image specified in the ClusterImageSet will be used to
+                    install the cluster.
+                  properties:
+                    name:
+                      description: Name is the name of the ClusterImageSet that this
+                        refers to
+                      type: string
+                  required:
+                  - name
+                  type: object
+              required:
+              - clusterDeploymentRef
+              - imageSetRef
+              type: object
+            status:
+              description: FakeClusterInstallStatus defines the observed state of
+                the FakeClusterInstall.
+              properties:
+                conditions:
+                  description: Conditions includes more detailed status for the cluster
+                    install.
+                  items:
+                    description: ClusterInstallCondition contains details for the
+                      current condition of a cluster install.
+                    properties:
+                      lastProbeTime:
+                        description: LastProbeTime is the last time we probed the
+                          condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about last transition.
+                        type: string
+                      reason:
+                        description: Reason is a unique, one-word, CamelCase reason
+                          for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+              type: object
+          required:
+          - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: hiveconfigs.hive.openshift.io
+  spec:
+    group: hive.openshift.io
+    names:
+      kind: HiveConfig
+      listKind: HiveConfigList
+      plural: hiveconfigs
+      singular: hiveconfig
+    scope: Cluster
+    versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: HiveConfig is the Schema for the hives API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HiveConfigSpec defines the desired state of Hive
+              properties:
+                additionalCertificateAuthoritiesSecretRef:
+                  description: AdditionalCertificateAuthoritiesSecretRef is a list
+                    of references to secrets in the TargetNamespace that contain an
+                    additional Certificate Authority to use when communicating with
+                    target clusters. These certificate authorities will be used in
+                    addition to any self-signed CA generated by each cluster on installation.
+                  items:
+                    description: LocalObjectReference contains enough information
+                      to let you locate the referenced object inside the same namespace.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                  type: array
+                argoCDConfig:
+                  description: ArgoCD specifies configuration for ArgoCD integration.
+                    If enabled, Hive will automatically add provisioned clusters to
+                    ArgoCD, and remove them when they are deprovisioned.
+                  properties:
+                    enabled:
+                      description: Enabled dictates if ArgoCD gitops integration is
+                        enabled. If not specified, the default is disabled.
+                      type: boolean
+                    namespace:
+                      description: Namespace specifies the namespace where ArgoCD
+                        is installed. Used for the location of cluster secrets. Defaults
+                        to "argocd"
+                      type: string
+                  required:
+                  - enabled
+                  type: object
+                awsPrivateLink:
+                  description: AWSPrivateLink defines the configuration for the aws-private-link
+                    controller. It provides 3 major pieces of information required
+                    by the controller, 1. The Credentials that should be used to create
+                    AWS PrivateLink resources other than     what exist in the customer's
+                    account. 2. A list of VPCs that can be used by the controller
+                    to choose one to create AWS VPC Endpoints     for the AWS VPC
+                    Endpoint Services created for ClusterDeployments in their     corresponding
+                    regions. 3. A list of VPCs that should be able to resolve the
+                    DNS addresses setup for Private Link.
+                  properties:
+                    associatedVPCs:
+                      description: "AssociatedVPCs is the list of VPCs that should\
+                        \ be able to resolve the DNS addresses setup for Private Link.\
+                        \ This allows clients in VPC to resolve the AWS PrivateLink\
+                        \ address using AWS's default DNS resolver for Private Route53\
+                        \ Hosted Zones. \n This list should at minimum include the\
+                        \ VPC where the current Hive controller is running."
+                      items:
+                        description: AWSAssociatedVPC defines a VPC that should be
+                          able to resolve the DNS addresses setup for Private Link.
+                        properties:
+                          credentialsSecretRef:
+                            description: CredentialsSecretRef references a secret
+                              in the TargetNamespace that will be used to authenticate
+                              with AWS for associating the VPC with the Private HostedZone
+                              created for PrivateLink. When not provided, the common
+                              credentials for the controller should be used.
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                            type: object
+                          region:
+                            type: string
+                          vpcID:
+                            type: string
+                        required:
+                        - region
+                        - vpcID
+                        type: object
+                      type: array
+                    credentialsSecretRef:
+                      description: CredentialsSecretRef references a secret in the
+                        TargetNamespace that will be used to authenticate with AWS
+                        for creating the resources for AWS PrivateLink.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    dnsRecordType:
+                      default: Alias
+                      description: DNSRecordType defines what type of DNS record should
+                        be created in Private Hosted Zone for the customer cluster's
+                        API endpoint (which is the VPC Endpoint's regional DNS name).
+                      enum:
+                      - Alias
+                      - ARecord
+                      type: string
+                    endpointVPCInventory:
+                      description: EndpointVPCInventory is a list of VPCs and the
+                        corresponding subnets in various AWS regions. The controller
+                        uses this list to choose a VPC for creating AWS VPC Endpoints.
+                        Since the VPC Endpoints must be in the same region as the
+                        ClusterDeployment, we must have VPCs in that region to be
+                        able to setup Private Link.
+                      items:
+                        description: AWSPrivateLinkInventory is a VPC and its corresponding
+                          subnets in an AWS region. This VPC will be used to create
+                          an AWS VPC Endpoint whenever there is a VPC Endpoint Service
+                          created for a ClusterDeployment.
+                        properties:
+                          region:
+                            type: string
+                          subnets:
+                            items:
+                              description: AWSPrivateLinkSubnet defines a subnet in
+                                the an AWS VPC.
+                              properties:
+                                availabilityZone:
+                                  type: string
+                                subnetID:
+                                  type: string
+                              required:
+                              - availabilityZone
+                              - subnetID
+                              type: object
+                            type: array
+                          vpcID:
+                            type: string
+                        required:
+                        - region
+                        - subnets
+                        - vpcID
+                        type: object
+                      type: array
+                  required:
+                  - credentialsSecretRef
+                  type: object
+                backup:
+                  description: Backup specifies configuration for backup integration.
+                    If absent, backup integration will be disabled.
+                  properties:
+                    minBackupPeriodSeconds:
+                      description: MinBackupPeriodSeconds specifies that a minimum
+                        of MinBackupPeriodSeconds will occur in between each backup.
+                        This is used to rate limit backups. This potentially batches
+                        together multiple changes into 1 backup. No backups will be
+                        lost as changes that happen during this interval are queued
+                        up and will result in a backup happening once the interval
+                        has been completed.
+                      type: integer
+                    velero:
+                      description: Velero specifies configuration for the Velero backup
+                        integration.
+                      properties:
+                        enabled:
+                          description: Enabled dictates if Velero backup integration
+                            is enabled. If not specified, the default is disabled.
+                          type: boolean
+                        namespace:
+                          description: Namespace specifies in which namespace velero
+                            backup objects should be created. If not specified, the
+                            default is a namespace named "velero".
+                          type: string
+                      type: object
+                  type: object
+                controllersConfig:
+                  description: ControllersConfig is used to configure different hive
+                    controllers
+                  properties:
+                    controllers:
+                      description: Controllers contains a list of configurations for
+                        different controllers
+                      items:
+                        description: SpecificControllerConfig contains the configuration
+                          for a specific controller
+                        properties:
+                          config:
+                            description: ControllerConfig contains the configuration
+                              for the controller specified by Name field
+                            properties:
+                              clientBurst:
+                                description: ClientBurst specifies client rate limiter
+                                  burst for a controller
+                                format: int32
+                                type: integer
+                              clientQPS:
+                                description: ClientQPS specifies client rate limiter
+                                  QPS for a controller
+                                format: int32
+                                type: integer
+                              concurrentReconciles:
+                                description: ConcurrentReconciles specifies number
+                                  of concurrent reconciles for a controller
+                                format: int32
+                                type: integer
+                              queueBurst:
+                                description: QueueBurst specifies workqueue rate limiter
+                                  burst for a controller
+                                format: int32
+                                type: integer
+                              queueQPS:
+                                description: QueueQPS specifies workqueue rate limiter
+                                  QPS for a controller
+                                format: int32
+                                type: integer
+                              replicas:
+                                description: Replicas specifies the number of replicas
+                                  the specific controller pod should use. This is
+                                  ONLY for controllers that have been split out into
+                                  their own pods. This is ignored for all others.
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            description: Name specifies the name of the controller
+                            enum:
+                            - clusterDeployment
+                            - clusterrelocate
+                            - clusterstate
+                            - clusterversion
+                            - controlPlaneCerts
+                            - dnsendpoint
+                            - dnszone
+                            - remoteingress
+                            - remotemachineset
+                            - syncidentityprovider
+                            - unreachable
+                            - velerobackup
+                            - clusterprovision
+                            - clusterDeprovision
+                            - clusterpool
+                            - clusterpoolnamespace
+                            - hibernation
+                            - clusterclaim
+                            - metrics
+                            - clustersync
+                            type: string
+                        required:
+                        - config
+                        - name
+                        type: object
+                      type: array
+                    default:
+                      description: Default specifies default configuration for all
+                        the controllers, can be used to override following coded defaults
+                        default for concurrent reconciles is 5 default for client
+                        qps is 5 default for client burst is 10 default for queue
+                        qps is 10 default for queue burst is 100
+                      properties:
+                        clientBurst:
+                          description: ClientBurst specifies client rate limiter burst
+                            for a controller
+                          format: int32
+                          type: integer
+                        clientQPS:
+                          description: ClientQPS specifies client rate limiter QPS
+                            for a controller
+                          format: int32
+                          type: integer
+                        concurrentReconciles:
+                          description: ConcurrentReconciles specifies number of concurrent
+                            reconciles for a controller
+                          format: int32
+                          type: integer
+                        queueBurst:
+                          description: QueueBurst specifies workqueue rate limiter
+                            burst for a controller
+                          format: int32
+                          type: integer
+                        queueQPS:
+                          description: QueueQPS specifies workqueue rate limiter QPS
+                            for a controller
+                          format: int32
+                          type: integer
+                        replicas:
+                          description: Replicas specifies the number of replicas the
+                            specific controller pod should use. This is ONLY for controllers
+                            that have been split out into their own pods. This is
+                            ignored for all others.
+                          format: int32
+                          type: integer
+                      type: object
+                  type: object
+                deleteProtection:
+                  description: DeleteProtection can be set to "enabled" to turn on
+                    automatic delete protection for ClusterDeployments. When enabled,
+                    Hive will add the "hive.openshift.io/protected-delete" annotation
+                    to new ClusterDeployments. Once a ClusterDeployment has been installed,
+                    a user must remove the annotation from a ClusterDeployment prior
+                    to deleting it.
+                  enum:
+                  - enabled
+                  type: string
+                deprovisionsDisabled:
+                  description: DeprovisionsDisabled can be set to true to block deprovision
+                    jobs from running.
+                  type: boolean
+                disabledControllers:
+                  description: DisabledControllers allows selectively disabling Hive
+                    controllers by name. The name of an individual controller matches
+                    the name of the controller as seen in the Hive logging output.
+                  items:
+                    type: string
+                  type: array
+                failedProvisionConfig:
+                  description: FailedProvisionConfig is used to configure settings
+                    related to handling provision failures.
+                  properties:
+                    aws:
+                      description: FailedProvisionAWSConfig contains AWS-specific
+                        info to upload log files.
+                      properties:
+                        bucket:
+                          description: Bucket is the S3 bucket to store the logs in.
+                          type: string
+                        credentialsSecretRef:
+                          description: 'CredentialsSecretRef references a secret in
+                            the TargetNamespace that will be used to authenticate
+                            with AWS S3. It will need permission to upload logs to
+                            S3. Secret should have keys named aws_access_key_id and
+                            aws_secret_access_key that contain the AWS credentials.
+                            Example Secret:   data:     aws_access_key_id: minio     aws_secret_access_key:
+                            minio123'
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                        region:
+                          description: Region is the AWS region to use for S3 operations.
+                            This defaults to us-east-1. For AWS China, use cn-northwest-1.
+                          type: string
+                        serviceEndpoint:
+                          description: ServiceEndpoint is the url to connect to an
+                            S3 compatible provider.
+                          type: string
+                      required:
+                      - credentialsSecretRef
+                      type: object
+                    skipGatherLogs:
+                      description: 'DEPRECATED: This flag is no longer respected and
+                        will be removed in the future.'
+                      type: boolean
+                  type: object
+                featureGates:
+                  description: FeatureGateSelection allows selecting feature gates
+                    for the controller.
+                  properties:
+                    custom:
+                      description: custom allows the enabling or disabling of any
+                        feature. Because of its nature, this setting cannot be validated.  If
+                        you have any typos or accidentally apply invalid combinations
+                        might cause unknown behavior. featureSet must equal "Custom"
+                        must be set to use this field.
+                      nullable: true
+                      properties:
+                        enabled:
+                          description: enabled is a list of all feature gates that
+                            you want to force on
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    featureSet:
+                      description: featureSet changes the list of features in the
+                        cluster.  The default is empty.  Be very careful adjusting
+                        this setting.
+                      enum:
+                      - ''
+                      - Custom
+                      type: string
+                  type: object
+                globalPullSecretRef:
+                  description: GlobalPullSecretRef is used to specify a pull secret
+                    that will be used globally by all of the cluster deployments.
+                    For each cluster deployment, the contents of GlobalPullSecret
+                    will be merged with the specific pull secret for a cluster deployment(if
+                    specified), with precedence given to the contents of the pull
+                    secret for the cluster deployment. The global pull secret is assumed
+                    to be in the TargetNamespace.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                logLevel:
+                  description: LogLevel is the level of logging to use for the Hive
+                    controllers. Acceptable levels, from coarsest to finest, are panic,
+                    fatal, error, warn, info, debug, and trace. The default level
+                    is info.
+                  type: string
+                maintenanceMode:
+                  description: MaintenanceMode can be set to true to disable the hive
+                    controllers in situations where we need to ensure nothing is running
+                    that will add or act upon finalizers on Hive types. This should
+                    rarely be needed. Sets replicas to 0 for the hive-controllers
+                    deployment to accomplish this.
+                  type: boolean
+                managedDomains:
+                  description: 'ManagedDomains is the list of DNS domains that are
+                    managed by the Hive cluster When specifying ''manageDNS: true''
+                    in a ClusterDeployment, the ClusterDeployment''s baseDomain should
+                    be a direct child of one of these domains, otherwise the ClusterDeployment
+                    creation will result in a validation error.'
+                  items:
+                    description: ManageDNSConfig contains the domain being managed,
+                      and the cloud-specific details for accessing/managing the domain.
+                    properties:
+                      aws:
+                        description: AWS contains AWS-specific settings for external
+                          DNS
+                        properties:
+                          credentialsSecretRef:
+                            description: CredentialsSecretRef references a secret
+                              in the TargetNamespace that will be used to authenticate
+                              with AWS Route53. It will need permission to manage
+                              entries for the domain listed in the parent ManageDNSConfig
+                              object. Secret should have AWS keys named 'aws_access_key_id'
+                              and 'aws_secret_access_key'.
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                            type: object
+                          region:
+                            description: Region is the AWS region to use for route53
+                              operations. This defaults to us-east-1. For AWS China,
+                              use cn-northwest-1.
+                            type: string
+                        required:
+                        - credentialsSecretRef
+                        type: object
+                      azure:
+                        description: Azure contains Azure-specific settings for external
+                          DNS
+                        properties:
+                          credentialsSecretRef:
+                            description: CredentialsSecretRef references a secret
+                              in the TargetNamespace that will be used to authenticate
+                              with Azure DNS. It wil need permission to manage entries
+                              in each of the managed domains listed in the parent
+                              ManageDNSConfig object. Secret should have a key named
+                              'osServicePrincipal.json'
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                            type: object
+                          resourceGroupName:
+                            description: ResourceGroupName specifies the Azure resource
+                              group containing the DNS zones for the domains being
+                              managed.
+                            type: string
+                        required:
+                        - credentialsSecretRef
+                        - resourceGroupName
+                        type: object
+                      domains:
+                        description: Domains is the list of domains that hive will
+                          be managing entries for with the provided credentials.
+                        items:
+                          type: string
+                        type: array
+                      gcp:
+                        description: GCP contains GCP-specific settings for external
+                          DNS
+                        properties:
+                          credentialsSecretRef:
+                            description: CredentialsSecretRef references a secret
+                              in the TargetNamespace that will be used to authenticate
+                              with GCP DNS. It will need permission to manage entries
+                              in each of the managed domains for this cluster. listed
+                              in the parent ManageDNSConfig object. Secret should
+                              have a key named 'osServiceAccount.json'. The credentials
+                              must specify the project to use.
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                            type: object
+                        required:
+                        - credentialsSecretRef
+                        type: object
+                    required:
+                    - domains
+                    type: object
+                  type: array
+                releaseImageVerificationConfigMapRef:
+                  description: "ReleaseImageVerificationConfigMapRef is a reference\
+                    \ to the ConfigMap that will be used to verify release images.\
+                    \ \n The config map structure is exactly the same as the config\
+                    \ map used for verification of release images for OpenShift 4\
+                    \ during upgrades. Therefore you can usually set this to the config\
+                    \ map shipped as part of OpenShift (openshift-config-managed/release-verification).\
+                    \ \n See https://github.com/openshift/cluster-update-keys for\
+                    \ more details. The keys within the config map in the data field\
+                    \ define how verification is performed: \n verifier-public-key-*:\
+                    \ One or more GPG public keys in ASCII form that must have signed\
+                    \ the                        release image by digest. \n store-*:\
+                    \ A URL (scheme file://, http://, or https://) location that contains\
+                    \ signatures. These          signatures are in the atomic container\
+                    \ signature format. The URL will have the digest          of the\
+                    \ image appended to it as \"<STORE>/<ALGO>=<DIGEST>/signature-<NUMBER>\"\
+                    \ as described          in the container image signing format.\
+                    \ The docker-image-manifest section of the          signature\
+                    \ must match the release image digest. Signatures are searched\
+                    \ starting at          NUMBER 1 and incrementing if the signature\
+                    \ exists but is not valid. The signature is a          GPG signed\
+                    \ and encrypted JSON message. The file store is provided for testing\
+                    \ only at          the current time, although future versions\
+                    \ of the CVO might allow host mounting of          signatures.\
+                    \ \n See https://github.com/containers/image/blob/ab49b0a48428c623a8f03b41b9083d48966b34a9/docs/signature-protocols.md\
+                    \ for a description of the signature store \n The returned verifier\
+                    \ will require that any new release image will only be considered\
+                    \ verified if each provided public key has signed the release\
+                    \ image digest. The signature may be in any store and the lookup\
+                    \ order is internally defined. \n If not set, no verification\
+                    \ will be performed."
+                  properties:
+                    name:
+                      description: Name of the ConfigMap
+                      type: string
+                    namespace:
+                      description: Namespace of the ConfigMap
+                      type: string
+                  required:
+                  - name
+                  - namespace
+                  type: object
+                serviceProviderCredentialsConfig:
+                  description: ServiceProviderCredentialsConfig is used to configure
+                    credentials related to being a service provider on various cloud
+                    platforms.
+                  properties:
+                    aws:
+                      description: AWS is used to configure credentials related to
+                        being a service provider on AWS.
+                      properties:
+                        credentialsSecretRef:
+                          description: CredentialsSecretRef references a secret in
+                            the TargetNamespace that will be used to authenticate
+                            with AWS to become the Service Provider. Being a Service
+                            Provider allows the controllers to assume the role in
+                            customer AWS accounts to manager clusters.
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                syncSetReapplyInterval:
+                  description: SyncSetReapplyInterval is a string duration indicating
+                    how much time must pass before SyncSet resources will be reapplied.
+                    The default reapply interval is two hours.
+                  type: string
+                targetNamespace:
+                  description: TargetNamespace is the namespace where the core Hive
+                    components should be run. Defaults to "hive". Will be created
+                    if it does not already exist. All resource references in HiveConfig
+                    can be assumed to be in the TargetNamespace.
+                  type: string
+              type: object
+            status:
+              description: HiveConfigStatus defines the observed state of Hive
+              properties:
+                aggregatorClientCAHash:
+                  description: AggregatorClientCAHash keeps an md5 hash of the aggregator
+                    client CA configmap data from the openshift-config-managed namespace.
+                    When the configmap changes, admission is redeployed.
+                  type: string
+                conditions:
+                  description: Conditions includes more detailed status for the HiveConfig
+                  items:
+                    description: HiveConfigCondition contains details for the current
+                      condition of a HiveConfig
+                    properties:
+                      lastProbeTime:
+                        description: LastProbeTime is the last time we probed the
+                          condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about last transition.
+                        type: string
+                      reason:
+                        description: Reason is a unique, one-word, CamelCase reason
+                          for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+                configApplied:
+                  description: ConfigApplied will be set by the hive operator to indicate
+                    whether or not the LastGenerationObserved was successfully reconciled.
+                  type: boolean
+                observedGeneration:
+                  description: ObservedGeneration will record the most recently processed
+                    HiveConfig object's generation.
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: machinepoolnameleases.hive.openshift.io
+  spec:
+    group: hive.openshift.io
+    names:
+      kind: MachinePoolNameLease
+      listKind: MachinePoolNameLeaseList
+      plural: machinepoolnameleases
+      singular: machinepoolnamelease
+    scope: Namespaced
+    versions:
+    - additionalPrinterColumns:
+      - jsonPath: .metadata.labels.hive\.openshift\.io/machine-pool-name
+        name: MachinePool
+        type: string
+      - jsonPath: .metadata.labels.hive\.openshift\.io/cluster-deployment-name
+        name: Cluster
+        type: string
+      - jsonPath: .metadata.creationTimestamp
+        name: Age
+        type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: MachinePoolNameLease is the Schema for the MachinePoolNameLeases
+            API. This resource is mostly empty as we're primarily relying on the name
+            to determine if a lease is available. Note that not all cloud providers
+            require the use of a lease for naming, at present this is only required
+            for GCP where we're extremely restricted on name lengths.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: MachinePoolNameLeaseSpec is a minimal resource for obtaining
+                unique machine pool names of a limited length.
+              type: object
+            status:
+              description: MachinePoolNameLeaseStatus defines the observed state of
+                MachinePoolNameLease.
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: machinepools.hive.openshift.io
+  spec:
+    group: hive.openshift.io
+    names:
+      kind: MachinePool
+      listKind: MachinePoolList
+      plural: machinepools
+      singular: machinepool
+    scope: Namespaced
+    versions:
+    - additionalPrinterColumns:
+      - jsonPath: .spec.name
+        name: PoolName
+        type: string
+      - jsonPath: .spec.clusterDeploymentRef.name
+        name: ClusterDeployment
+        type: string
+      - jsonPath: .spec.replicas
+        name: Replicas
+        type: integer
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: MachinePool is the Schema for the machinepools API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: MachinePoolSpec defines the desired state of MachinePool
+              properties:
+                autoscaling:
+                  description: Autoscaling is the details for auto-scaling the machine
+                    pool. Replicas and autoscaling cannot be used together.
+                  properties:
+                    maxReplicas:
+                      description: MaxReplicas is the maximum number of replicas for
+                        the machine pool.
+                      format: int32
+                      type: integer
+                    minReplicas:
+                      description: MinReplicas is the minimum number of replicas for
+                        the machine pool.
+                      format: int32
+                      type: integer
+                  required:
+                  - maxReplicas
+                  - minReplicas
+                  type: object
+                clusterDeploymentRef:
+                  description: ClusterDeploymentRef references the cluster deployment
+                    to which this machine pool belongs.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: Map of label string keys and values that will be applied
+                    to the created MachineSet's MachineSpec. This list will overwrite
+                    any modifications made to Node labels on an ongoing basis.
+                  type: object
+                name:
+                  description: Name is the name of the machine pool.
+                  type: string
+                platform:
+                  description: Platform is configuration for machine pool specific
+                    to the platform.
+                  properties:
+                    aws:
+                      description: AWS is the configuration used when installing on
+                        AWS.
+                      properties:
+                        rootVolume:
+                          description: EC2RootVolume defines the storage for ec2 instance.
+                          properties:
+                            iops:
+                              description: IOPS defines the iops for the storage.
+                              type: integer
+                            kmsKeyARN:
+                              description: The KMS key that will be used to encrypt
+                                the EBS volume. If no key is provided the default
+                                KMS key for the account will be used. https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetEbsDefaultKmsKeyId.html
+                              type: string
+                            size:
+                              description: Size defines the size of the storage.
+                              type: integer
+                            type:
+                              description: Type defines the type of the storage.
+                              type: string
+                          required:
+                          - iops
+                          - size
+                          - type
+                          type: object
+                        spotMarketOptions:
+                          description: SpotMarketOptions allows users to configure
+                            instances to be run using AWS Spot instances.
+                          properties:
+                            maxPrice:
+                              description: 'The maximum price the user is willing
+                                to pay for their instances Default: On-Demand price'
+                              type: string
+                          type: object
+                        subnets:
+                          description: Subnets is the list of subnets to which to
+                            attach the machines. There must be exactly one private
+                            subnet for each availability zone used. If public subnets
+                            are specified, there must be exactly one private and one
+                            public subnet specified for each availability zone.
+                          items:
+                            type: string
+                          type: array
+                        type:
+                          description: InstanceType defines the ec2 instance type.
+                            eg. m4-large
+                          type: string
+                        zones:
+                          description: Zones is list of availability zones that can
+                            be used.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - rootVolume
+                      - type
+                      type: object
+                    azure:
+                      description: Azure is the configuration used when installing
+                        on Azure.
+                      properties:
+                        osDisk:
+                          description: OSDisk defines the storage for instance.
+                          properties:
+                            diskSizeGB:
+                              description: DiskSizeGB defines the size of disk in
+                                GB.
+                              format: int32
+                              type: integer
+                          required:
+                          - diskSizeGB
+                          type: object
+                        type:
+                          description: InstanceType defines the azure instance type.
+                            eg. Standard_DS_V2
+                          type: string
+                        zones:
+                          description: Zones is list of availability zones that can
+                            be used. eg. ["1", "2", "3"]
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - osDisk
+                      - type
+                      type: object
+                    gcp:
+                      description: GCP is the configuration used when installing on
+                        GCP.
+                      properties:
+                        osDisk:
+                          description: OSDisk defines the storage for instances.
+                          properties:
+                            diskSizeGB:
+                              description: DiskSizeGB defines the size of disk in
+                                GB. Defaulted internally to 128.
+                              format: int64
+                              maximum: 65536
+                              minimum: 16
+                              type: integer
+                            diskType:
+                              description: DiskType defines the type of disk. The
+                                valid values are pd-standard and pd-ssd. Defaulted
+                                internally to pd-ssd.
+                              enum:
+                              - pd-ssd
+                              - pd-standard
+                              type: string
+                            encryptionKey:
+                              description: EncryptionKey defines the KMS key to be
+                                used to encrypt the disk.
+                              properties:
+                                kmsKey:
+                                  description: KMSKey is a reference to a KMS Key
+                                    to use for the encryption.
+                                  properties:
+                                    keyRing:
+                                      description: KeyRing is the name of the KMS
+                                        Key Ring which the KMS Key belongs to.
+                                      type: string
+                                    location:
+                                      description: Location is the GCP location in
+                                        which the Key Ring exists.
+                                      type: string
+                                    name:
+                                      description: Name is the name of the customer
+                                        managed encryption key to be used for the
+                                        disk encryption.
+                                      type: string
+                                    projectID:
+                                      description: ProjectID is the ID of the Project
+                                        in which the KMS Key Ring exists. Defaults
+                                        to the VM ProjectID if not set.
+                                      type: string
+                                  required:
+                                  - keyRing
+                                  - location
+                                  - name
+                                  type: object
+                                kmsKeyServiceAccount:
+                                  description: KMSKeyServiceAccount is the service
+                                    account being used for the encryption request
+                                    for the given KMS key. If absent, the Compute
+                                    Engine default service account is used. See https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_service_account
+                                    for details on the default service account.
+                                  type: string
+                              type: object
+                          type: object
+                        type:
+                          description: InstanceType defines the GCP instance type.
+                            eg. n1-standard-4
+                          type: string
+                        zones:
+                          description: Zones is list of availability zones that can
+                            be used.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - type
+                      type: object
+                    openstack:
+                      description: OpenStack is the configuration used when installing
+                        on OpenStack.
+                      properties:
+                        flavor:
+                          description: Flavor defines the OpenStack Nova flavor. eg.
+                            m1.large The json key here differs from the installer
+                            which uses both "computeFlavor" and type "type" depending
+                            on which type you're looking at, and the resulting field
+                            on the MachineSet is "flavor". We are opting to stay consistent
+                            with the end result.
+                          type: string
+                        rootVolume:
+                          description: RootVolume defines the root volume for instances
+                            in the machine pool. The instances use ephemeral disks
+                            if not set.
+                          properties:
+                            size:
+                              description: Size defines the size of the volume in
+                                gibibytes (GiB). Required
+                              type: integer
+                            type:
+                              description: Type defines the type of the volume. Required
+                              type: string
+                          required:
+                          - size
+                          - type
+                          type: object
+                      required:
+                      - flavor
+                      type: object
+                    ovirt:
+                      description: Ovirt is the configuration used when installing
+                        on oVirt.
+                      properties:
+                        cpu:
+                          description: CPU defines the VM CPU.
+                          properties:
+                            cores:
+                              description: Cores is the number of cores per socket.
+                                Total CPUs is (Sockets * Cores)
+                              format: int32
+                              type: integer
+                            sockets:
+                              description: Sockets is the number of sockets for a
+                                VM. Total CPUs is (Sockets * Cores)
+                              format: int32
+                              type: integer
+                          required:
+                          - cores
+                          - sockets
+                          type: object
+                        memoryMB:
+                          description: MemoryMB is the size of a VM's memory in MiBs.
+                          format: int32
+                          type: integer
+                        osDisk:
+                          description: OSDisk is the the root disk of the node.
+                          properties:
+                            sizeGB:
+                              description: SizeGB size of the bootable disk in GiB.
+                              format: int64
+                              type: integer
+                          required:
+                          - sizeGB
+                          type: object
+                        vmType:
+                          description: VMType defines the workload type of the VM.
+                          enum:
+                          - ''
+                          - desktop
+                          - server
+                          - high_performance
+                          type: string
+                      type: object
+                    vsphere:
+                      description: VSphere is the configuration used when installing
+                        on vSphere
+                      properties:
+                        coresPerSocket:
+                          description: NumCoresPerSocket is the number of cores per
+                            socket in a vm. The number of vCPUs on the vm will be
+                            NumCPUs/NumCoresPerSocket.
+                          format: int32
+                          type: integer
+                        cpus:
+                          description: NumCPUs is the total number of virtual processor
+                            cores to assign a vm.
+                          format: int32
+                          type: integer
+                        memoryMB:
+                          description: Memory is the size of a VM's memory in MB.
+                          format: int64
+                          type: integer
+                        osDisk:
+                          description: OSDisk defines the storage for instance.
+                          properties:
+                            diskSizeGB:
+                              description: DiskSizeGB defines the size of disk in
+                                GB.
+                              format: int32
+                              type: integer
+                          required:
+                          - diskSizeGB
+                          type: object
+                      required:
+                      - coresPerSocket
+                      - cpus
+                      - memoryMB
+                      - osDisk
+                      type: object
+                  type: object
+                replicas:
+                  description: Replicas is the count of machines for this machine
+                    pool. Replicas and autoscaling cannot be used together. Default
+                    is 1, if autoscaling is not used.
+                  format: int64
+                  type: integer
+                taints:
+                  description: List of taints that will be applied to the created
+                    MachineSet's MachineSpec. This list will overwrite any modifications
+                    made to Node taints on an ongoing basis.
+                  items:
+                    description: The node this Taint is attached to has the "effect"
+                      on any pod that does not tolerate the Taint.
+                    properties:
+                      effect:
+                        description: Required. The effect of the taint on pods that
+                          do not tolerate the taint. Valid effects are NoSchedule,
+                          PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Required. The taint key to be applied to a node.
+                        type: string
+                      timeAdded:
+                        description: TimeAdded represents the time at which the taint
+                          was added. It is only written for NoExecute taints.
+                        format: date-time
+                        type: string
+                      value:
+                        description: The taint value corresponding to the taint key.
+                        type: string
+                    required:
+                    - effect
+                    - key
+                    type: object
+                  type: array
+              required:
+              - clusterDeploymentRef
+              - name
+              - platform
+              type: object
+            status:
+              description: MachinePoolStatus defines the observed state of MachinePool
+              properties:
+                conditions:
+                  description: Conditions includes more detailed status for the cluster
+                    deployment
+                  items:
+                    description: MachinePoolCondition contains details for the current
+                      condition of a machine pool
+                    properties:
+                      lastProbeTime:
+                        description: LastProbeTime is the last time we probed the
+                          condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition
+                          transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Message is a human-readable message indicating
+                          details about last transition.
+                        type: string
+                      reason:
+                        description: Reason is a unique, one-word, CamelCase reason
+                          for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status is the status of the condition.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    required:
+                    - status
+                    - type
+                    type: object
+                  type: array
+                machineSets:
+                  description: MachineSets is the status of the machine sets for the
+                    machine pool on the remote cluster.
+                  items:
+                    description: MachineSetStatus is the status of a machineset in
+                      the remote cluster.
+                    properties:
+                      errorMessage:
+                        type: string
+                      errorReason:
+                        description: In the event that there is a terminal problem
+                          reconciling the replicas, both ErrorReason and ErrorMessage
+                          will be set. ErrorReason will be populated with a succinct
+                          value suitable for machine interpretation, while ErrorMessage
+                          will contain a more verbose string suitable for logging
+                          and human consumption.
+                        type: string
+                      maxReplicas:
+                        description: MaxReplicas is the maximum number of replicas
+                          for the machine set.
+                        format: int32
+                        type: integer
+                      minReplicas:
+                        description: MinReplicas is the minimum number of replicas
+                          for the machine set.
+                        format: int32
+                        type: integer
+                      name:
+                        description: Name is the name of the machine set.
+                        type: string
+                      readyReplicas:
+                        description: The number of ready replicas for this MachineSet.
+                          A machine is considered ready when the node has been created
+                          and is "Ready". It is transferred as-is from the MachineSet
+                          from remote cluster.
+                        format: int32
+                        type: integer
+                      replicas:
+                        description: Replicas is the current number of replicas for
+                          the machine set.
+                        format: int32
+                        type: integer
+                    required:
+                    - maxReplicas
+                    - minReplicas
+                    - name
+                    - replicas
+                    type: object
+                  type: array
+                replicas:
+                  description: Replicas is the current number of replicas for the
+                    machine pool.
+                  format: int32
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        scale:
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.replicas
+        status: {}
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: selectorsyncidentityproviders.hive.openshift.io
+  spec:
+    group: hive.openshift.io
+    names:
+      kind: SelectorSyncIdentityProvider
+      listKind: SelectorSyncIdentityProviderList
+      plural: selectorsyncidentityproviders
+      singular: selectorsyncidentityprovider
+    scope: Cluster
+    versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: SelectorSyncIdentityProvider is the Schema for the SelectorSyncSet
+            API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SelectorSyncIdentityProviderSpec defines the SyncIdentityProviderCommonSpec
+                to sync to ClusterDeploymentSelector indicating which clusters the
+                SelectorSyncIdentityProvider applies to in any namespace.
+              properties:
+                clusterDeploymentSelector:
+                  description: ClusterDeploymentSelector is a LabelSelector indicating
+                    which clusters the SelectorIdentityProvider applies to in any
+                    namespace.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                identityProviders:
+                  description: IdentityProviders is an ordered list of ways for a
+                    user to identify themselves
+                  items:
+                    description: IdentityProvider provides identities for users authenticating
+                      using credentials
+                    properties:
+                      basicAuth:
+                        description: basicAuth contains configuration options for
+                          the BasicAuth IdP
+                        properties:
+                          ca:
+                            description: ca is an optional reference to a config map
+                              by name containing the PEM-encoded CA bundle. It is
+                              used as a trust anchor to validate the TLS certificate
+                              presented by the remote server. The key "ca.crt" is
+                              used to locate the data. If specified and the config
+                              map or expected key is not found, the identity provider
+                              is not honored. If the specified ca data is not valid,
+                              the identity provider is not honored. If empty, the
+                              default system roots are used. The namespace for this
+                              config map is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  config map
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          tlsClientCert:
+                            description: tlsClientCert is an optional reference to
+                              a secret by name that contains the PEM-encoded TLS client
+                              certificate to present when connecting to the server.
+                              The key "tls.crt" is used to locate the data. If specified
+                              and the secret or expected key is not found, the identity
+                              provider is not honored. If the specified certificate
+                              data is not valid, the identity provider is not honored.
+                              The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          tlsClientKey:
+                            description: tlsClientKey is an optional reference to
+                              a secret by name that contains the PEM-encoded TLS private
+                              key for the client certificate referenced in tlsClientCert.
+                              The key "tls.key" is used to locate the data. If specified
+                              and the secret or expected key is not found, the identity
+                              provider is not honored. If the specified certificate
+                              data is not valid, the identity provider is not honored.
+                              The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          url:
+                            description: url is the remote URL to connect to
+                            type: string
+                        type: object
+                      github:
+                        description: github enables user authentication using GitHub
+                          credentials
+                        properties:
+                          ca:
+                            description: ca is an optional reference to a config map
+                              by name containing the PEM-encoded CA bundle. It is
+                              used as a trust anchor to validate the TLS certificate
+                              presented by the remote server. The key "ca.crt" is
+                              used to locate the data. If specified and the config
+                              map or expected key is not found, the identity provider
+                              is not honored. If the specified ca data is not valid,
+                              the identity provider is not honored. If empty, the
+                              default system roots are used. This can only be configured
+                              when hostname is set to a non-empty value. The namespace
+                              for this config map is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  config map
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          clientID:
+                            description: clientID is the oauth client ID
+                            type: string
+                          clientSecret:
+                            description: clientSecret is a required reference to the
+                              secret by name containing the oauth client secret. The
+                              key "clientSecret" is used to locate the data. If the
+                              secret or expected key is not found, the identity provider
+                              is not honored. The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          hostname:
+                            description: hostname is the optional domain (e.g. "mycompany.com")
+                              for use with a hosted instance of GitHub Enterprise.
+                              It must match the GitHub Enterprise settings value configured
+                              at /setup/settings#hostname.
+                            type: string
+                          organizations:
+                            description: organizations optionally restricts which
+                              organizations are allowed to log in
+                            items:
+                              type: string
+                            type: array
+                          teams:
+                            description: teams optionally restricts which teams are
+                              allowed to log in. Format is <org>/<team>.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      gitlab:
+                        description: gitlab enables user authentication using GitLab
+                          credentials
+                        properties:
+                          ca:
+                            description: ca is an optional reference to a config map
+                              by name containing the PEM-encoded CA bundle. It is
+                              used as a trust anchor to validate the TLS certificate
+                              presented by the remote server. The key "ca.crt" is
+                              used to locate the data. If specified and the config
+                              map or expected key is not found, the identity provider
+                              is not honored. If the specified ca data is not valid,
+                              the identity provider is not honored. If empty, the
+                              default system roots are used. The namespace for this
+                              config map is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  config map
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          clientID:
+                            description: clientID is the oauth client ID
+                            type: string
+                          clientSecret:
+                            description: clientSecret is a required reference to the
+                              secret by name containing the oauth client secret. The
+                              key "clientSecret" is used to locate the data. If the
+                              secret or expected key is not found, the identity provider
+                              is not honored. The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          url:
+                            description: url is the oauth server base URL
+                            type: string
+                        type: object
+                      google:
+                        description: google enables user authentication using Google
+                          credentials
+                        properties:
+                          clientID:
+                            description: clientID is the oauth client ID
+                            type: string
+                          clientSecret:
+                            description: clientSecret is a required reference to the
+                              secret by name containing the oauth client secret. The
+                              key "clientSecret" is used to locate the data. If the
+                              secret or expected key is not found, the identity provider
+                              is not honored. The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          hostedDomain:
+                            description: hostedDomain is the optional Google App domain
+                              (e.g. "mycompany.com") to restrict logins to
+                            type: string
+                        type: object
+                      htpasswd:
+                        description: htpasswd enables user authentication using an
+                          HTPasswd file to validate credentials
+                        properties:
+                          fileData:
+                            description: fileData is a required reference to a secret
+                              by name containing the data to use as the htpasswd file.
+                              The key "htpasswd" is used to locate the data. If the
+                              secret or expected key is not found, the identity provider
+                              is not honored. If the specified htpasswd data is not
+                              valid, the identity provider is not honored. The namespace
+                              for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        type: object
+                      keystone:
+                        description: keystone enables user authentication using keystone
+                          password credentials
+                        properties:
+                          ca:
+                            description: ca is an optional reference to a config map
+                              by name containing the PEM-encoded CA bundle. It is
+                              used as a trust anchor to validate the TLS certificate
+                              presented by the remote server. The key "ca.crt" is
+                              used to locate the data. If specified and the config
+                              map or expected key is not found, the identity provider
+                              is not honored. If the specified ca data is not valid,
+                              the identity provider is not honored. If empty, the
+                              default system roots are used. The namespace for this
+                              config map is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  config map
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          domainName:
+                            description: domainName is required for keystone v3
+                            type: string
+                          tlsClientCert:
+                            description: tlsClientCert is an optional reference to
+                              a secret by name that contains the PEM-encoded TLS client
+                              certificate to present when connecting to the server.
+                              The key "tls.crt" is used to locate the data. If specified
+                              and the secret or expected key is not found, the identity
+                              provider is not honored. If the specified certificate
+                              data is not valid, the identity provider is not honored.
+                              The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          tlsClientKey:
+                            description: tlsClientKey is an optional reference to
+                              a secret by name that contains the PEM-encoded TLS private
+                              key for the client certificate referenced in tlsClientCert.
+                              The key "tls.key" is used to locate the data. If specified
+                              and the secret or expected key is not found, the identity
+                              provider is not honored. If the specified certificate
+                              data is not valid, the identity provider is not honored.
+                              The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          url:
+                            description: url is the remote URL to connect to
+                            type: string
+                        type: object
+                      ldap:
+                        description: ldap enables user authentication using LDAP credentials
+                        properties:
+                          attributes:
+                            description: attributes maps LDAP attributes to identities
+                            properties:
+                              email:
+                                description: email is the list of attributes whose
+                                  values should be used as the email address. Optional.
+                                  If unspecified, no email is set for the identity
+                                items:
+                                  type: string
+                                type: array
+                              id:
+                                description: id is the list of attributes whose values
+                                  should be used as the user ID. Required. First non-empty
+                                  attribute is used. At least one attribute is required.
+                                  If none of the listed attribute have a value, authentication
+                                  fails. LDAP standard identity attribute is "dn"
+                                items:
+                                  type: string
+                                type: array
+                              name:
+                                description: name is the list of attributes whose
+                                  values should be used as the display name. Optional.
+                                  If unspecified, no display name is set for the identity
+                                  LDAP standard display name attribute is "cn"
+                                items:
+                                  type: string
+                                type: array
+                              preferredUsername:
+                                description: preferredUsername is the list of attributes
+                                  whose values should be used as the preferred username.
+                                  LDAP standard login attribute is "uid"
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          bindDN:
+                            description: bindDN is an optional DN to bind with during
+                              the search phase.
+                            type: string
+                          bindPassword:
+                            description: bindPassword is an optional reference to
+                              a secret by name containing a password to bind with
+                              during the search phase. The key "bindPassword" is used
+                              to locate the data. If specified and the secret or expected
+                              key is not found, the identity provider is not honored.
+                              The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          ca:
+                            description: ca is an optional reference to a config map
+                              by name containing the PEM-encoded CA bundle. It is
+                              used as a trust anchor to validate the TLS certificate
+                              presented by the remote server. The key "ca.crt" is
+                              used to locate the data. If specified and the config
+                              map or expected key is not found, the identity provider
+                              is not honored. If the specified ca data is not valid,
+                              the identity provider is not honored. If empty, the
+                              default system roots are used. The namespace for this
+                              config map is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  config map
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          insecure:
+                            description: 'insecure, if true, indicates the connection
+                              should not use TLS WARNING: Should not be set to `true`
+                              with the URL scheme "ldaps://" as "ldaps://" URLs always          attempt
+                              to connect using TLS, even when `insecure` is set to
+                              `true` When `true`, "ldap://" URLS connect insecurely.
+                              When `false`, "ldap://" URLs are upgraded to a TLS connection
+                              using StartTLS as specified in https://tools.ietf.org/html/rfc2830.'
+                            type: boolean
+                          url:
+                            description: 'url is an RFC 2255 URL which specifies the
+                              LDAP search parameters to use. The syntax of the URL
+                              is: ldap://host:port/basedn?attribute?scope?filter'
+                            type: string
+                        type: object
+                      mappingMethod:
+                        description: mappingMethod determines how identities from
+                          this provider are mapped to users Defaults to "claim"
+                        type: string
+                      name:
+                        description: 'name is used to qualify the identities returned
+                          by this provider. - It MUST be unique and not shared by
+                          any other identity provider used - It MUST be a valid path
+                          segment: name cannot equal "." or ".." or contain "/" or
+                          "%" or ":"   Ref: https://godoc.org/github.com/openshift/origin/pkg/user/apis/user/validation#ValidateIdentityProviderName'
+                        type: string
+                      openID:
+                        description: openID enables user authentication using OpenID
+                          credentials
+                        properties:
+                          ca:
+                            description: ca is an optional reference to a config map
+                              by name containing the PEM-encoded CA bundle. It is
+                              used as a trust anchor to validate the TLS certificate
+                              presented by the remote server. The key "ca.crt" is
+                              used to locate the data. If specified and the config
+                              map or expected key is not found, the identity provider
+                              is not honored. If the specified ca data is not valid,
+                              the identity provider is not honored. If empty, the
+                              default system roots are used. The namespace for this
+                              config map is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  config map
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          claims:
+                            description: claims mappings
+                            properties:
+                              email:
+                                description: email is the list of claims whose values
+                                  should be used as the email address. Optional. If
+                                  unspecified, no email is set for the identity
+                                items:
+                                  type: string
+                                type: array
+                              name:
+                                description: name is the list of claims whose values
+                                  should be used as the display name. Optional. If
+                                  unspecified, no display name is set for the identity
+                                items:
+                                  type: string
+                                type: array
+                              preferredUsername:
+                                description: preferredUsername is the list of claims
+                                  whose values should be used as the preferred username.
+                                  If unspecified, the preferred username is determined
+                                  from the value of the sub claim
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          clientID:
+                            description: clientID is the oauth client ID
+                            type: string
+                          clientSecret:
+                            description: clientSecret is a required reference to the
+                              secret by name containing the oauth client secret. The
+                              key "clientSecret" is used to locate the data. If the
+                              secret or expected key is not found, the identity provider
+                              is not honored. The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          extraAuthorizeParameters:
+                            additionalProperties:
+                              type: string
+                            description: extraAuthorizeParameters are any custom parameters
+                              to add to the authorize request.
+                            type: object
+                          extraScopes:
+                            description: extraScopes are any scopes to request in
+                              addition to the standard "openid" scope.
+                            items:
+                              type: string
+                            type: array
+                          issuer:
+                            description: issuer is the URL that the OpenID Provider
+                              asserts as its Issuer Identifier. It must use the https
+                              scheme with no query or fragment component.
+                            type: string
+                        type: object
+                      requestHeader:
+                        description: requestHeader enables user authentication using
+                          request header credentials
+                        properties:
+                          ca:
+                            description: ca is a required reference to a config map
+                              by name containing the PEM-encoded CA bundle. It is
+                              used as a trust anchor to validate the TLS certificate
+                              presented by the remote server. Specifically, it allows
+                              verification of incoming requests to prevent header
+                              spoofing. The key "ca.crt" is used to locate the data.
+                              If the config map or expected key is not found, the
+                              identity provider is not honored. If the specified ca
+                              data is not valid, the identity provider is not honored.
+                              The namespace for this config map is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  config map
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          challengeURL:
+                            description: challengeURL is a URL to redirect unauthenticated
+                              /authorize requests to Unauthenticated requests from
+                              OAuth clients which expect WWW-Authenticate challenges
+                              will be redirected here. ${url} is replaced with the
+                              current URL, escaped to be safe in a query parameter   https://www.example.com/sso-login?then=${url}
+                              ${query} is replaced with the current query string   https://www.example.com/auth-proxy/oauth/authorize?${query}
+                              Required when challenge is set to true.
+                            type: string
+                          clientCommonNames:
+                            description: clientCommonNames is an optional list of
+                              common names to require a match from. If empty, any
+                              client certificate validated against the clientCA bundle
+                              is considered authoritative.
+                            items:
+                              type: string
+                            type: array
+                          emailHeaders:
+                            description: emailHeaders is the set of headers to check
+                              for the email address
+                            items:
+                              type: string
+                            type: array
+                          headers:
+                            description: headers is the set of headers to check for
+                              identity information
+                            items:
+                              type: string
+                            type: array
+                          loginURL:
+                            description: loginURL is a URL to redirect unauthenticated
+                              /authorize requests to Unauthenticated requests from
+                              OAuth clients which expect interactive logins will be
+                              redirected here ${url} is replaced with the current
+                              URL, escaped to be safe in a query parameter   https://www.example.com/sso-login?then=${url}
+                              ${query} is replaced with the current query string   https://www.example.com/auth-proxy/oauth/authorize?${query}
+                              Required when login is set to true.
+                            type: string
+                          nameHeaders:
+                            description: nameHeaders is the set of headers to check
+                              for the display name
+                            items:
+                              type: string
+                            type: array
+                          preferredUsernameHeaders:
+                            description: preferredUsernameHeaders is the set of headers
+                              to check for the preferred username
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      type:
+                        description: type identifies the identity provider type for
+                          this entry.
+                        type: string
+                    type: object
+                  type: array
+              required:
+              - identityProviders
+              type: object
+            status:
+              description: IdentityProviderStatus defines the observed state of SyncSet
+              type: object
+          type: object
+      served: true
+      storage: true
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: selectorsyncsets.hive.openshift.io
+  spec:
+    group: hive.openshift.io
+    names:
+      kind: SelectorSyncSet
+      listKind: SelectorSyncSetList
+      plural: selectorsyncsets
+      shortNames:
+      - sss
+      singular: selectorsyncset
+    scope: Cluster
+    versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: SelectorSyncSet is the Schema for the SelectorSyncSet API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SelectorSyncSetSpec defines the SyncSetCommonSpec resources
+                and patches to sync along with a ClusterDeploymentSelector indicating
+                which clusters the SelectorSyncSet applies to in any namespace.
+              properties:
+                applyBehavior:
+                  description: ApplyBehavior indicates how resources in this syncset
+                    will be applied to the target cluster. The default value of "Apply"
+                    indicates that resources should be applied using the 'oc apply'
+                    command. If no value is set, "Apply" is assumed. A value of "CreateOnly"
+                    indicates that the resource will only be created if it does not
+                    already exist in the target cluster. Otherwise, it will be left
+                    alone. A value of "CreateOrUpdate" indicates that the resource
+                    will be created/updated without the use of the 'oc apply' command,
+                    allowing larger resources to be synced, but losing some functionality
+                    of the 'oc apply' command such as the ability to remove annotations,
+                    labels, and other map entries in general.
+                  enum:
+                  - ''
+                  - Apply
+                  - CreateOnly
+                  - CreateOrUpdate
+                  type: string
+                clusterDeploymentSelector:
+                  description: ClusterDeploymentSelector is a LabelSelector indicating
+                    which clusters the SelectorSyncSet applies to in any namespace.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
+                      items:
+                        description: A label selector requirement is a selector that
+                          contains values, a key, and an operator that relates the
+                          key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: operator represents a key's relationship
+                              to a set of values. Valid operators are In, NotIn, Exists
+                              and DoesNotExist.
+                            type: string
+                          values:
+                            description: values is an array of string values. If the
+                              operator is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels is a map of {key,value} pairs. A single
+                        {key,value} in the matchLabels map is equivalent to an element
+                        of matchExpressions, whose key field is "key", the operator
+                        is "In", and the values array contains only "value". The requirements
+                        are ANDed.
+                      type: object
+                  type: object
+                patches:
+                  description: Patches is the list of patches to apply.
+                  items:
+                    description: SyncObjectPatch represents a patch to be applied
+                      to a specific object
+                    properties:
+                      apiVersion:
+                        description: APIVersion is the Group and Version of the object
+                          to be patched.
+                        type: string
+                      kind:
+                        description: Kind is the Kind of the object to be patched.
+                        type: string
+                      name:
+                        description: Name is the name of the object to be patched.
+                        type: string
+                      namespace:
+                        description: Namespace is the Namespace in which the object
+                          to patch exists. Defaults to the SyncSet's Namespace.
+                        type: string
+                      patch:
+                        description: Patch is the patch to apply.
+                        type: string
+                      patchType:
+                        description: PatchType indicates the PatchType as "strategic"
+                          (default), "json", or "merge".
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - patch
+                    type: object
+                  type: array
+                resourceApplyMode:
+                  description: ResourceApplyMode indicates if the Resource apply mode
+                    is "Upsert" (default) or "Sync". ApplyMode "Upsert" indicates
+                    create and update. ApplyMode "Sync" indicates create, update and
+                    delete.
+                  type: string
+                resources:
+                  description: Resources is the list of objects to sync from RawExtension
+                    definitions.
+                  items:
+                    type: object
+                    x-kubernetes-embedded-resource: true
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                secretMappings:
+                  description: Secrets is the list of secrets to sync along with their
+                    respective destinations.
+                  items:
+                    description: SecretMapping defines a source and destination for
+                      a secret to be synced by a SyncSet
+                    properties:
+                      sourceRef:
+                        description: SourceRef specifies the name and namespace of
+                          a secret on the management cluster
+                        properties:
+                          name:
+                            description: Name is the name of the secret
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace where the secret
+                              lives. If not present for the source secret reference,
+                              it is assumed to be the same namespace as the syncset
+                              with the reference.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      targetRef:
+                        description: TargetRef specifies the target name and namespace
+                          of the secret on the target cluster
+                        properties:
+                          name:
+                            description: Name is the name of the secret
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace where the secret
+                              lives. If not present for the source secret reference,
+                              it is assumed to be the same namespace as the syncset
+                              with the reference.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - sourceRef
+                    - targetRef
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: SelectorSyncSetStatus defines the observed state of a SelectorSyncSet
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: syncidentityproviders.hive.openshift.io
+  spec:
+    group: hive.openshift.io
+    names:
+      kind: SyncIdentityProvider
+      listKind: SyncIdentityProviderList
+      plural: syncidentityproviders
+      singular: syncidentityprovider
+    scope: Namespaced
+    versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: SyncIdentityProvider is the Schema for the SyncIdentityProvider
+            API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SyncIdentityProviderSpec defines the SyncIdentityProviderCommonSpec
+                identity providers to sync along with ClusterDeploymentRefs indicating
+                which clusters the SyncIdentityProvider applies to in the SyncIdentityProvider's
+                namespace.
+              properties:
+                clusterDeploymentRefs:
+                  description: ClusterDeploymentRefs is the list of LocalObjectReference
+                    indicating which clusters the SyncSet applies to in the SyncSet's
+                    namespace.
+                  items:
+                    description: LocalObjectReference contains enough information
+                      to let you locate the referenced object inside the same namespace.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                  type: array
+                identityProviders:
+                  description: IdentityProviders is an ordered list of ways for a
+                    user to identify themselves
+                  items:
+                    description: IdentityProvider provides identities for users authenticating
+                      using credentials
+                    properties:
+                      basicAuth:
+                        description: basicAuth contains configuration options for
+                          the BasicAuth IdP
+                        properties:
+                          ca:
+                            description: ca is an optional reference to a config map
+                              by name containing the PEM-encoded CA bundle. It is
+                              used as a trust anchor to validate the TLS certificate
+                              presented by the remote server. The key "ca.crt" is
+                              used to locate the data. If specified and the config
+                              map or expected key is not found, the identity provider
+                              is not honored. If the specified ca data is not valid,
+                              the identity provider is not honored. If empty, the
+                              default system roots are used. The namespace for this
+                              config map is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  config map
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          tlsClientCert:
+                            description: tlsClientCert is an optional reference to
+                              a secret by name that contains the PEM-encoded TLS client
+                              certificate to present when connecting to the server.
+                              The key "tls.crt" is used to locate the data. If specified
+                              and the secret or expected key is not found, the identity
+                              provider is not honored. If the specified certificate
+                              data is not valid, the identity provider is not honored.
+                              The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          tlsClientKey:
+                            description: tlsClientKey is an optional reference to
+                              a secret by name that contains the PEM-encoded TLS private
+                              key for the client certificate referenced in tlsClientCert.
+                              The key "tls.key" is used to locate the data. If specified
+                              and the secret or expected key is not found, the identity
+                              provider is not honored. If the specified certificate
+                              data is not valid, the identity provider is not honored.
+                              The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          url:
+                            description: url is the remote URL to connect to
+                            type: string
+                        type: object
+                      github:
+                        description: github enables user authentication using GitHub
+                          credentials
+                        properties:
+                          ca:
+                            description: ca is an optional reference to a config map
+                              by name containing the PEM-encoded CA bundle. It is
+                              used as a trust anchor to validate the TLS certificate
+                              presented by the remote server. The key "ca.crt" is
+                              used to locate the data. If specified and the config
+                              map or expected key is not found, the identity provider
+                              is not honored. If the specified ca data is not valid,
+                              the identity provider is not honored. If empty, the
+                              default system roots are used. This can only be configured
+                              when hostname is set to a non-empty value. The namespace
+                              for this config map is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  config map
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          clientID:
+                            description: clientID is the oauth client ID
+                            type: string
+                          clientSecret:
+                            description: clientSecret is a required reference to the
+                              secret by name containing the oauth client secret. The
+                              key "clientSecret" is used to locate the data. If the
+                              secret or expected key is not found, the identity provider
+                              is not honored. The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          hostname:
+                            description: hostname is the optional domain (e.g. "mycompany.com")
+                              for use with a hosted instance of GitHub Enterprise.
+                              It must match the GitHub Enterprise settings value configured
+                              at /setup/settings#hostname.
+                            type: string
+                          organizations:
+                            description: organizations optionally restricts which
+                              organizations are allowed to log in
+                            items:
+                              type: string
+                            type: array
+                          teams:
+                            description: teams optionally restricts which teams are
+                              allowed to log in. Format is <org>/<team>.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      gitlab:
+                        description: gitlab enables user authentication using GitLab
+                          credentials
+                        properties:
+                          ca:
+                            description: ca is an optional reference to a config map
+                              by name containing the PEM-encoded CA bundle. It is
+                              used as a trust anchor to validate the TLS certificate
+                              presented by the remote server. The key "ca.crt" is
+                              used to locate the data. If specified and the config
+                              map or expected key is not found, the identity provider
+                              is not honored. If the specified ca data is not valid,
+                              the identity provider is not honored. If empty, the
+                              default system roots are used. The namespace for this
+                              config map is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  config map
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          clientID:
+                            description: clientID is the oauth client ID
+                            type: string
+                          clientSecret:
+                            description: clientSecret is a required reference to the
+                              secret by name containing the oauth client secret. The
+                              key "clientSecret" is used to locate the data. If the
+                              secret or expected key is not found, the identity provider
+                              is not honored. The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          url:
+                            description: url is the oauth server base URL
+                            type: string
+                        type: object
+                      google:
+                        description: google enables user authentication using Google
+                          credentials
+                        properties:
+                          clientID:
+                            description: clientID is the oauth client ID
+                            type: string
+                          clientSecret:
+                            description: clientSecret is a required reference to the
+                              secret by name containing the oauth client secret. The
+                              key "clientSecret" is used to locate the data. If the
+                              secret or expected key is not found, the identity provider
+                              is not honored. The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          hostedDomain:
+                            description: hostedDomain is the optional Google App domain
+                              (e.g. "mycompany.com") to restrict logins to
+                            type: string
+                        type: object
+                      htpasswd:
+                        description: htpasswd enables user authentication using an
+                          HTPasswd file to validate credentials
+                        properties:
+                          fileData:
+                            description: fileData is a required reference to a secret
+                              by name containing the data to use as the htpasswd file.
+                              The key "htpasswd" is used to locate the data. If the
+                              secret or expected key is not found, the identity provider
+                              is not honored. If the specified htpasswd data is not
+                              valid, the identity provider is not honored. The namespace
+                              for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        type: object
+                      keystone:
+                        description: keystone enables user authentication using keystone
+                          password credentials
+                        properties:
+                          ca:
+                            description: ca is an optional reference to a config map
+                              by name containing the PEM-encoded CA bundle. It is
+                              used as a trust anchor to validate the TLS certificate
+                              presented by the remote server. The key "ca.crt" is
+                              used to locate the data. If specified and the config
+                              map or expected key is not found, the identity provider
+                              is not honored. If the specified ca data is not valid,
+                              the identity provider is not honored. If empty, the
+                              default system roots are used. The namespace for this
+                              config map is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  config map
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          domainName:
+                            description: domainName is required for keystone v3
+                            type: string
+                          tlsClientCert:
+                            description: tlsClientCert is an optional reference to
+                              a secret by name that contains the PEM-encoded TLS client
+                              certificate to present when connecting to the server.
+                              The key "tls.crt" is used to locate the data. If specified
+                              and the secret or expected key is not found, the identity
+                              provider is not honored. If the specified certificate
+                              data is not valid, the identity provider is not honored.
+                              The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          tlsClientKey:
+                            description: tlsClientKey is an optional reference to
+                              a secret by name that contains the PEM-encoded TLS private
+                              key for the client certificate referenced in tlsClientCert.
+                              The key "tls.key" is used to locate the data. If specified
+                              and the secret or expected key is not found, the identity
+                              provider is not honored. If the specified certificate
+                              data is not valid, the identity provider is not honored.
+                              The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          url:
+                            description: url is the remote URL to connect to
+                            type: string
+                        type: object
+                      ldap:
+                        description: ldap enables user authentication using LDAP credentials
+                        properties:
+                          attributes:
+                            description: attributes maps LDAP attributes to identities
+                            properties:
+                              email:
+                                description: email is the list of attributes whose
+                                  values should be used as the email address. Optional.
+                                  If unspecified, no email is set for the identity
+                                items:
+                                  type: string
+                                type: array
+                              id:
+                                description: id is the list of attributes whose values
+                                  should be used as the user ID. Required. First non-empty
+                                  attribute is used. At least one attribute is required.
+                                  If none of the listed attribute have a value, authentication
+                                  fails. LDAP standard identity attribute is "dn"
+                                items:
+                                  type: string
+                                type: array
+                              name:
+                                description: name is the list of attributes whose
+                                  values should be used as the display name. Optional.
+                                  If unspecified, no display name is set for the identity
+                                  LDAP standard display name attribute is "cn"
+                                items:
+                                  type: string
+                                type: array
+                              preferredUsername:
+                                description: preferredUsername is the list of attributes
+                                  whose values should be used as the preferred username.
+                                  LDAP standard login attribute is "uid"
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          bindDN:
+                            description: bindDN is an optional DN to bind with during
+                              the search phase.
+                            type: string
+                          bindPassword:
+                            description: bindPassword is an optional reference to
+                              a secret by name containing a password to bind with
+                              during the search phase. The key "bindPassword" is used
+                              to locate the data. If specified and the secret or expected
+                              key is not found, the identity provider is not honored.
+                              The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          ca:
+                            description: ca is an optional reference to a config map
+                              by name containing the PEM-encoded CA bundle. It is
+                              used as a trust anchor to validate the TLS certificate
+                              presented by the remote server. The key "ca.crt" is
+                              used to locate the data. If specified and the config
+                              map or expected key is not found, the identity provider
+                              is not honored. If the specified ca data is not valid,
+                              the identity provider is not honored. If empty, the
+                              default system roots are used. The namespace for this
+                              config map is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  config map
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          insecure:
+                            description: 'insecure, if true, indicates the connection
+                              should not use TLS WARNING: Should not be set to `true`
+                              with the URL scheme "ldaps://" as "ldaps://" URLs always          attempt
+                              to connect using TLS, even when `insecure` is set to
+                              `true` When `true`, "ldap://" URLS connect insecurely.
+                              When `false`, "ldap://" URLs are upgraded to a TLS connection
+                              using StartTLS as specified in https://tools.ietf.org/html/rfc2830.'
+                            type: boolean
+                          url:
+                            description: 'url is an RFC 2255 URL which specifies the
+                              LDAP search parameters to use. The syntax of the URL
+                              is: ldap://host:port/basedn?attribute?scope?filter'
+                            type: string
+                        type: object
+                      mappingMethod:
+                        description: mappingMethod determines how identities from
+                          this provider are mapped to users Defaults to "claim"
+                        type: string
+                      name:
+                        description: 'name is used to qualify the identities returned
+                          by this provider. - It MUST be unique and not shared by
+                          any other identity provider used - It MUST be a valid path
+                          segment: name cannot equal "." or ".." or contain "/" or
+                          "%" or ":"   Ref: https://godoc.org/github.com/openshift/origin/pkg/user/apis/user/validation#ValidateIdentityProviderName'
+                        type: string
+                      openID:
+                        description: openID enables user authentication using OpenID
+                          credentials
+                        properties:
+                          ca:
+                            description: ca is an optional reference to a config map
+                              by name containing the PEM-encoded CA bundle. It is
+                              used as a trust anchor to validate the TLS certificate
+                              presented by the remote server. The key "ca.crt" is
+                              used to locate the data. If specified and the config
+                              map or expected key is not found, the identity provider
+                              is not honored. If the specified ca data is not valid,
+                              the identity provider is not honored. If empty, the
+                              default system roots are used. The namespace for this
+                              config map is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  config map
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          claims:
+                            description: claims mappings
+                            properties:
+                              email:
+                                description: email is the list of claims whose values
+                                  should be used as the email address. Optional. If
+                                  unspecified, no email is set for the identity
+                                items:
+                                  type: string
+                                type: array
+                              name:
+                                description: name is the list of claims whose values
+                                  should be used as the display name. Optional. If
+                                  unspecified, no display name is set for the identity
+                                items:
+                                  type: string
+                                type: array
+                              preferredUsername:
+                                description: preferredUsername is the list of claims
+                                  whose values should be used as the preferred username.
+                                  If unspecified, the preferred username is determined
+                                  from the value of the sub claim
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          clientID:
+                            description: clientID is the oauth client ID
+                            type: string
+                          clientSecret:
+                            description: clientSecret is a required reference to the
+                              secret by name containing the oauth client secret. The
+                              key "clientSecret" is used to locate the data. If the
+                              secret or expected key is not found, the identity provider
+                              is not honored. The namespace for this secret is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          extraAuthorizeParameters:
+                            additionalProperties:
+                              type: string
+                            description: extraAuthorizeParameters are any custom parameters
+                              to add to the authorize request.
+                            type: object
+                          extraScopes:
+                            description: extraScopes are any scopes to request in
+                              addition to the standard "openid" scope.
+                            items:
+                              type: string
+                            type: array
+                          issuer:
+                            description: issuer is the URL that the OpenID Provider
+                              asserts as its Issuer Identifier. It must use the https
+                              scheme with no query or fragment component.
+                            type: string
+                        type: object
+                      requestHeader:
+                        description: requestHeader enables user authentication using
+                          request header credentials
+                        properties:
+                          ca:
+                            description: ca is a required reference to a config map
+                              by name containing the PEM-encoded CA bundle. It is
+                              used as a trust anchor to validate the TLS certificate
+                              presented by the remote server. Specifically, it allows
+                              verification of incoming requests to prevent header
+                              spoofing. The key "ca.crt" is used to locate the data.
+                              If the config map or expected key is not found, the
+                              identity provider is not honored. If the specified ca
+                              data is not valid, the identity provider is not honored.
+                              The namespace for this config map is openshift-config.
+                            properties:
+                              name:
+                                description: name is the metadata.name of the referenced
+                                  config map
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          challengeURL:
+                            description: challengeURL is a URL to redirect unauthenticated
+                              /authorize requests to Unauthenticated requests from
+                              OAuth clients which expect WWW-Authenticate challenges
+                              will be redirected here. ${url} is replaced with the
+                              current URL, escaped to be safe in a query parameter   https://www.example.com/sso-login?then=${url}
+                              ${query} is replaced with the current query string   https://www.example.com/auth-proxy/oauth/authorize?${query}
+                              Required when challenge is set to true.
+                            type: string
+                          clientCommonNames:
+                            description: clientCommonNames is an optional list of
+                              common names to require a match from. If empty, any
+                              client certificate validated against the clientCA bundle
+                              is considered authoritative.
+                            items:
+                              type: string
+                            type: array
+                          emailHeaders:
+                            description: emailHeaders is the set of headers to check
+                              for the email address
+                            items:
+                              type: string
+                            type: array
+                          headers:
+                            description: headers is the set of headers to check for
+                              identity information
+                            items:
+                              type: string
+                            type: array
+                          loginURL:
+                            description: loginURL is a URL to redirect unauthenticated
+                              /authorize requests to Unauthenticated requests from
+                              OAuth clients which expect interactive logins will be
+                              redirected here ${url} is replaced with the current
+                              URL, escaped to be safe in a query parameter   https://www.example.com/sso-login?then=${url}
+                              ${query} is replaced with the current query string   https://www.example.com/auth-proxy/oauth/authorize?${query}
+                              Required when login is set to true.
+                            type: string
+                          nameHeaders:
+                            description: nameHeaders is the set of headers to check
+                              for the display name
+                            items:
+                              type: string
+                            type: array
+                          preferredUsernameHeaders:
+                            description: preferredUsernameHeaders is the set of headers
+                              to check for the preferred username
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      type:
+                        description: type identifies the identity provider type for
+                          this entry.
+                        type: string
+                    type: object
+                  type: array
+              required:
+              - clusterDeploymentRefs
+              - identityProviders
+              type: object
+            status:
+              description: IdentityProviderStatus defines the observed state of SyncSet
+              type: object
+          type: object
+      served: true
+      storage: true
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: apiextensions.k8s.io/v1
+  kind: CustomResourceDefinition
+  metadata:
+    annotations:
+      controller-gen.kubebuilder.io/version: v0.6.0
+    creationTimestamp: null
+    name: syncsets.hive.openshift.io
+  spec:
+    group: hive.openshift.io
+    names:
+      kind: SyncSet
+      listKind: SyncSetList
+      plural: syncsets
+      shortNames:
+      - ss
+      singular: syncset
+    scope: Namespaced
+    versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: SyncSet is the Schema for the SyncSet API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SyncSetSpec defines the SyncSetCommonSpec resources and
+                patches to sync along with ClusterDeploymentRefs indicating which
+                clusters the SyncSet applies to in the SyncSet's namespace.
+              properties:
+                applyBehavior:
+                  description: ApplyBehavior indicates how resources in this syncset
+                    will be applied to the target cluster. The default value of "Apply"
+                    indicates that resources should be applied using the 'oc apply'
+                    command. If no value is set, "Apply" is assumed. A value of "CreateOnly"
+                    indicates that the resource will only be created if it does not
+                    already exist in the target cluster. Otherwise, it will be left
+                    alone. A value of "CreateOrUpdate" indicates that the resource
+                    will be created/updated without the use of the 'oc apply' command,
+                    allowing larger resources to be synced, but losing some functionality
+                    of the 'oc apply' command such as the ability to remove annotations,
+                    labels, and other map entries in general.
+                  enum:
+                  - ''
+                  - Apply
+                  - CreateOnly
+                  - CreateOrUpdate
+                  type: string
+                clusterDeploymentRefs:
+                  description: ClusterDeploymentRefs is the list of LocalObjectReference
+                    indicating which clusters the SyncSet applies to in the SyncSet's
+                    namespace.
+                  items:
+                    description: LocalObjectReference contains enough information
+                      to let you locate the referenced object inside the same namespace.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                  type: array
+                patches:
+                  description: Patches is the list of patches to apply.
+                  items:
+                    description: SyncObjectPatch represents a patch to be applied
+                      to a specific object
+                    properties:
+                      apiVersion:
+                        description: APIVersion is the Group and Version of the object
+                          to be patched.
+                        type: string
+                      kind:
+                        description: Kind is the Kind of the object to be patched.
+                        type: string
+                      name:
+                        description: Name is the name of the object to be patched.
+                        type: string
+                      namespace:
+                        description: Namespace is the Namespace in which the object
+                          to patch exists. Defaults to the SyncSet's Namespace.
+                        type: string
+                      patch:
+                        description: Patch is the patch to apply.
+                        type: string
+                      patchType:
+                        description: PatchType indicates the PatchType as "strategic"
+                          (default), "json", or "merge".
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - patch
+                    type: object
+                  type: array
+                resourceApplyMode:
+                  description: ResourceApplyMode indicates if the Resource apply mode
+                    is "Upsert" (default) or "Sync". ApplyMode "Upsert" indicates
+                    create and update. ApplyMode "Sync" indicates create, update and
+                    delete.
+                  type: string
+                resources:
+                  description: Resources is the list of objects to sync from RawExtension
+                    definitions.
+                  items:
+                    type: object
+                    x-kubernetes-embedded-resource: true
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                secretMappings:
+                  description: Secrets is the list of secrets to sync along with their
+                    respective destinations.
+                  items:
+                    description: SecretMapping defines a source and destination for
+                      a secret to be synced by a SyncSet
+                    properties:
+                      sourceRef:
+                        description: SourceRef specifies the name and namespace of
+                          a secret on the management cluster
+                        properties:
+                          name:
+                            description: Name is the name of the secret
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace where the secret
+                              lives. If not present for the source secret reference,
+                              it is assumed to be the same namespace as the syncset
+                              with the reference.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      targetRef:
+                        description: TargetRef specifies the target name and namespace
+                          of the secret on the target cluster
+                        properties:
+                          name:
+                            description: Name is the name of the secret
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace where the secret
+                              lives. If not present for the source secret reference,
+                              it is assumed to be the same namespace as the syncset
+                              with the reference.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - sourceRef
+                    - targetRef
+                    type: object
+                  type: array
+              required:
+              - clusterDeploymentRefs
+              type: object
+            status:
+              description: SyncSetStatus defines the observed state of a SyncSet
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  status:
+    acceptedNames:
+      kind: ''
+      plural: ''
+    conditions: []
+    storedVersions: []
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: hive-operator
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    name: hive-operator-role
+  rules:
+  - apiGroups:
+    - hive.openshift.io
+    resources:
+    - '*'
+    verbs:
+    - '*'
+  - apiGroups:
+    - hiveinternal.openshift.io
+    resources:
+    - '*'
+    verbs:
+    - '*'
+  - apiGroups:
+    - extensions.hive.openshift.io
+    resources:
+    - '*'
+    verbs:
+    - '*'
+  - apiGroups:
+    - velero.io
+    resources:
+    - backups
+    verbs:
+    - create
+  - apiGroups:
+    - ''
+    resources:
+    - serviceaccounts
+    - serviceaccounts/finalizers
+    - secrets
+    - secrets/finalizers
+    - services
+    - services/finalizers
+    - events
+    - configmaps
+    - namespaces
+    - persistentvolumeclaims
+    verbs:
+    - '*'
+  - apiGroups:
+    - apiregistration.k8s.io
+    resources:
+    - apiservices
+    - apiservices/finalizers
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - admissionregistration.k8s.io
+    resources:
+    - validatingwebhookconfigurations
+    - mutatingwebhookconfigurations
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    - deployments/finalizers
+    - daemonsets
+    - daemonsets/finalizers
+    - statefulsets
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - apiextensions.k8s.io
+    resources:
+    - customresourcedefinitions
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+    - clusterroles
+    - clusterrolebindings
+    - roles
+    - rolebindings
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - apps.openshift.io
+    resources:
+    - deploymentconfigs
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - authorization.openshift.io
+    resources:
+    - clusterroles
+    - clusterrolebindings
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - batch
+    resources:
+    - jobs
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+  - apiGroups:
+    - ''
+    resources:
+    - pods
+    - pods/log
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - admission.hive.openshift.io
+    resources:
+    - dnszones
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - authorization.k8s.io
+    resources:
+    - subjectaccessreviews
+    verbs:
+    - create
+  - apiGroups:
+    - admission.hive.openshift.io
+    resources:
+    - clusterdeployments
+    - clusterimagesets
+    - clusterprovisions
+    - dnszones
+    - machinepools
+    - selectorsyncsets
+    - syncsets
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    name: hive-operator-rolebinding
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: hive-operator-role
+  subjects:
+  - kind: ServiceAccount
+    name: hive-operator
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      control-plane: hive-operator
+      controller-tools.k8s.io: '1.0'
+    name: hive-operator
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 4
+    selector:
+      matchLabels:
+        control-plane: hive-operator
+        controller-tools.k8s.io: '1.0'
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          control-plane: hive-operator
+          controller-tools.k8s.io: '1.0'
+      spec:
+        containers:
+        - command:
+          - /opt/services/hive-operator
+          - --log-level
+          - info
+          env:
+          - name: CLI_CACHE_DIR
+            value: /var/cache/kubectl
+          - name: HIVE_OPERATOR_NS
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          image: ${REGISTRY_IMG}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          name: hive-operator
+          ports:
+          - containerPort: 2112
+            name: metrics
+            protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+          - mountPath: /var/cache/kubectl
+            name: kubectl-cache
+        serviceAccountName: hive-operator
+        terminationGracePeriodSeconds: 10
+        volumes:
+        - emptyDir: {}
+          name: kubectl-cache
+parameters:
+- name: REGISTRY_IMG
+  required: true
+- name: IMAGE_TAG
+  required: true


### PR DESCRIPTION
New `make` targets:
- `build-app-sre-template`: Makes sure hack/app-sre/saas-template.yaml is up to date with the current state of the repo. More below.
- `verify-app-sre-template`: Added to the `verify` chain. Makes sure the above has been run.

The `build-app-sre-template` target
- Syncs the resources in the new `kustomization.yaml` to make sure we're picking up all the CRDs under config/crds. The kustomization makes sure the template will contain variables, which will be substituted by app-sre via `oc process`, for the URI of the container image in the deployment.
- Uses that kustomization to generate/overwrite the new `saas-objects.yaml` to contain all the objects we wish to deploy via
app-sre.
- Runs the new `generate-saas-template.py` script, which melds the `saas-objects.yaml` with the new `saas-template-stub.yaml` to generate/overwrite the new `saas-template.yaml`.

This `saas-template.yaml` file is what app-sre uses for direct deploy.

The other new artifact is `hack/app-sre/build-push.sh`. This is the script that will eventually be run by app-sre's ci-int job for direct deploy. It is a subset of `hack/app_sre_build_deploy.sh`: it only builds the hive operator image and pushes it to quay. (Note that this script will not be used by appsre until all environments are migrated to direct deploy.)

[HIVE-1588](https://issues.redhat.com/browse/HIVE-1588)