### PR TITLE
Hide internal crs

### DIFF
--- a/config/templates/hive-csv-template.yaml
+++ b/config/templates/hive-csv-template.yaml
@@ -14,6 +14,7 @@ metadata:
     support: Hive Team
     alm-examples: |-
       [{"apiVersion":"hive.openshift.io/v1","kind":"HiveConfig","metadata":{"name":"hive"},"spec":{"managedDomains":[{"aws":{"credentialsSecretRef":{"name":"my-route53-creds"}},"domains":["my-base-domain.example.com"]}]}}]
+    operators.operatorframework.io/internal-objects: '["checkpoints.hive.openshift.io","clusterdeprovisions.hive.openshift.io","clusterprovisions.hive.openshift.io","clusterstates.hive.openshift.io","machinepoolnameleases.hive.openshift.io","clustersyncleases.hiveinternal.openshift.io","clustersyncs.hiveinternal.openshift.io","fakeclusterinstalls.hiveinternal.openshift.io"]'
 spec:
   displayName: Hive for Red Hat OpenShift
   icon:

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -210,7 +210,11 @@ We use a hiveutil subcommand for the install-manager, in pods and thus in an ima
 
 While a community Hive operator bundle is now published weekly to OperatorHub (see above), in rare cases developers may want to build a bundle from source.  You can run or work off the test script below to generate a ClusterServiceVersion, OLM bundle+package, registry image, catalog source, and subscription. (WARNING: this is seldom used and may not always be working)
 
-`$ REGISTRY_IMG="quay.io/dgoodwin/hive-registry" DEPLOY_IMG="quay.io/dgoodwin/hive:latest" hack/olm-registry-deploy.sh`
+`hack/generate-operator-bundle-operatorhub.py operatorhub --previous-version 1.1.11 --new-version 1.1.12 --hive-image "quay.io/dgoodwin/hive:latest"`
+
+You can also generate the OSD version via
+
+`$ REGISTRY_IMG="quay.io/dgoodwin/hive-registry" HIVE_IMAGE="quay.io/dgoodwin/hive:latest" hack/olm-registry-deploy.sh`
 
 ## Enable Debug Logging In Hive Controllers
 


### PR DESCRIPTION
This commit adds the annotation to the CSV generated for OperatorHub,
that would hide the following Hive CRs from the UI
- ClusterSync
- ClusterSyncLease
- FakeClusterInstall
- Checkpoints
- ClusterDeprovision
- ClusterProvision
- ClusterState
- MachinePoolLease

The annotation added is
`operators.operatorframework.io/internal-objects` as per [OpenShift Docs](https://docs.openshift.com/container-platform/4.7/operators/operator_sdk/osdk-generating-csvs.html#osdk-hiding-internal-objects_osdk-generating-csvs)

xref: https://issues.redhat.com/browse/HIVE-1575

/assign @dgoodwin 
/cc @2uasimojo 