### PR TITLE
Scrub errors for clusters unreachable due to cert dates.

### DIFF
--- a/pkg/controller/utils/errorscrub.go
+++ b/pkg/controller/utils/errorscrub.go
@@ -5,7 +5,8 @@ import (
 )
 
 var (
-	newlineTabRE = regexp.MustCompile(`\n\t`)
+	newlineTabRE           = regexp.MustCompile(`\n\t`)
+	certificateTimeErrorRE = regexp.MustCompile(`: current time \S+ is after \S+`)
 	// aws
 	awsRequestIDRE = regexp.MustCompile(`(, )*(?i)(request id: )(?:[-[:xdigit:]]+)`)
 	// azure
@@ -20,6 +21,7 @@ func ErrorScrub(err error) string {
 	}
 	s := newlineTabRE.ReplaceAllString(err.Error(), ", ")
 	s = awsRequestIDRE.ReplaceAllString(s, "")
+	s = certificateTimeErrorRE.ReplaceAllString(s, "")
 	// if Azure error, return just the error description
 	match := azureErrorDescriptionRE.FindStringSubmatch(s)
 	if len(match) > 0 {

--- a/pkg/controller/utils/errorscrub_test.go
+++ b/pkg/controller/utils/errorscrub_test.go
@@ -39,6 +39,11 @@ func TestErrorScrubber(t *testing.T) {
 			input:    errors.New("azure.BearerAuthorizer#WithAuthorization: Failed to refresh the Token for request to https://management.azure.com/subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourceGroups/os4-common/providers/Microsoft.Network/dnsZones/hive-managed.qe.azure.devcluster.openshift.com?api-version=2018-05-01: StatusCode=401 -- Original Error: adal: Refresh request failed. Status Code = '401'. Response body: {\"error\":\"invalid_client\",\"error_description\":\"AADSTS7000215: Invalid client secret is provided.\\r\\nTrace ID: 9a06fe2e-c2af-44eb-b3ec-036929a15701\\r\\nCorrelation ID: ae4130a3-7160-40d5-b67e-b6f4a0dd18a5\\r\\nTimestamp: 2021-07-02 09:28:53Z\",\"error_codes\":[7000215],\"timestamp\":\"2021-07-02 09:28:53Z\",\"trace_id\":\"9a06fe2e-c2af-44eb-b3ec-036929a15701\",\"correlation_id\":\"ae4130a3-7160-40d5-b67e-b6f4a0dd18a5\",\"error_uri\":\"https://login.microsoftonline.com/error?code=7000215"),
 			expected: "AADSTS7000215: Invalid client secret is provided.",
 		},
+		{
+			name:     "invalid certificate date",
+			input:    errors.New(`[an error on the server ("") has prevented the request from succeeding, Get "https://api.foobar.openshiftapps.com:6443/api?timeout=32s": x509: certificate has expired or is not yet valid: current time 2021-08-06T11:54:02Z is after 2021-07-26T09:26:41Z]`),
+			expected: `[an error on the server ("") has prevented the request from succeeding, Get "https://api.foobar.openshiftapps.com:6443/api?timeout=32s": x509: certificate has expired or is not yet valid`,
+		},
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/remoteclient/remoteclient.go
+++ b/pkg/remoteclient/remoteclient.go
@@ -168,7 +168,7 @@ func SetUnreachableCondition(cd *hivev1.ClusterDeployment, connectionError error
 	if connectionError != nil {
 		status = corev1.ConditionTrue
 		reason = "ErrorConnectingToCluster"
-		message = connectionError.Error()
+		message = utils.ErrorScrub(connectionError)
 		updateCheck = utils.UpdateConditionIfReasonOrMessageChange
 	}
 	cd.Status.Conditions, changed = utils.SetClusterDeploymentConditionWithChangeCheck(


### PR DESCRIPTION
Still lightly hotlooping because of the current time in this error message. 

We need to look into Abhinav's don't update if the reason hasn't changed for more controllers, but this should be a quick fix today for Monday's push.