### PR TITLE
Update bmg, remove imagebuilder workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,12 @@
 all: vendor update test build
 
 # Include the library makefile
-# TODO: Get rid of the imagebuilder.mk include once
-# https://github.com/openshift/build-machinery-go/pull/50 is merged and
-# vendored.
 include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	golang.mk \
 	targets/openshift/controller-gen.mk \
 	targets/openshift/yq.mk \
 	targets/openshift/bindata.mk \
 	targets/openshift/deps.mk \
-	targets/openshift/imagebuilder.mk \
 	targets/openshift/images.mk \
 	targets/openshift/kustomize.mk \
 )

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
-	github.com/openshift/build-machinery-go v0.0.0-20210701182933-efa47ed39f2e
+	github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37
 	github.com/openshift/cluster-api v0.0.0-20191129101638-b09907ac6668 // indirect
 	github.com/openshift/cluster-api-provider-gcp v0.0.1-0.20201203141909-4dc702fd57a5
 	github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20200504092944-27473ea1ae43

--- a/go.sum
+++ b/go.sum
@@ -1451,8 +1451,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mo
 github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
-github.com/openshift/build-machinery-go v0.0.0-20210701182933-efa47ed39f2e h1:/1to3fmWP80/eZqBuF99jpNjTDOKHzt7J5Xzeq3dFGM=
-github.com/openshift/build-machinery-go v0.0.0-20210701182933-efa47ed39f2e/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
+github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37 h1:40Nw4fwP1tXx0g1UgIGoLA9eoSdLm7jBUXFH5uVYjBA=
+github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20190923180330-3b6373338c9b/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/client-go v0.0.0-20191125132246-f6563a70e19a/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/version.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/version.mk
@@ -5,7 +5,7 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 
 .empty-golang-versions-files:
 	@rm -f "$(PERMANENT_TMP)/golang-versions" "$(PERMANENT_TMP)/named-golang-versions"
-.PHONE: .empty-golang-versions-files
+.PHONY: .empty-golang-versions-files
 
 verify-golang-versions:
 	@if [ -f "$(PERMANENT_TMP)/golang-versions" ]; then \

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/controller-gen.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/controller-gen.mk
@@ -17,7 +17,7 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 # e.g.
 # 	/home/efried/.gvm/pkgsets/go1.16/global/bin/darwin_amd64/controller-gen
 CONTROLLER_GEN_VERSION ?=v0.6.0
-CONTROLLER_GEN ?=$(PERMANENT_TMP_GOPATH)/bin/controller-gen
+CONTROLLER_GEN ?=$(PERMANENT_TMP_GOPATH)/bin/controller-gen-$(CONTROLLER_GEN_VERSION)
 ifneq "" "$(wildcard $(CONTROLLER_GEN))"
 _controller_gen_installed_version = $(shell $(CONTROLLER_GEN) --version | awk '{print $$2}')
 endif
@@ -37,7 +37,7 @@ endif
 .PHONY: ensure-controller-gen
 
 clean-controller-gen:
-	$(RM) '$(CONTROLLER_GEN)'
+	$(RM) $(controller_gen_dir)controller-gen*
 	if [ -d '$(controller_gen_dir)' ]; then rmdir --ignore-fail-on-non-empty -p '$(controller_gen_dir)'; fi
 .PHONY: clean-controller-gen
 

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/images.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/images.mk
@@ -1,3 +1,7 @@
+include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
+	imagebuilder.mk \
+)
+
 # IMAGE_BUILD_EXTRA_FLAGS lets you add extra flags for imagebuilder
 # e.g. to mount secrets and repo information into base image like:
 # make images IMAGE_BUILD_EXTRA_FLAGS='-mount ~/projects/origin-repos/4.2/:/etc/yum.repos.d/'

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/kustomize.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/kustomize.mk
@@ -5,22 +5,27 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 )
 
 KUSTOMIZE_VERSION ?= 4.1.3
-KUSTOMIZE ?= $(PERMANENT_TMP_GOPATH)/bin/kustomize
+KUSTOMIZE ?= $(PERMANENT_TMP_GOPATH)/bin/kustomize-$(KUSTOMIZE_VERSION)
 kustomize_dir := $(dir $(KUSTOMIZE))
 
 ensure-kustomize:
 ifeq "" "$(wildcard $(KUSTOMIZE))"
 	$(info Installing kustomize into '$(KUSTOMIZE)')
 	mkdir -p '$(kustomize_dir)'
+	@# install_kustomize.sh lays down the binary as `kustomize`, and will
+	@# also fail if a file of that name already exists. Remove it for
+	@# backward compatibility (older b-m-gs used the raw file name).
+	rm -f $(kustomize_dir)/kustomize
 	@# NOTE: Pinning script to a tag rather than `master` for security reasons
 	curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/kustomize/v$(KUSTOMIZE_VERSION)/hack/install_kustomize.sh"  | bash -s $(KUSTOMIZE_VERSION) $(kustomize_dir)
+	mv $(kustomize_dir)/kustomize $(KUSTOMIZE)
 else
 	$(info Using existing kustomize from "$(KUSTOMIZE)")
 endif
 .PHONY: ensure-kustomize
 
 clean-kustomize:
-	$(RM) '$(KUSTOMIZE)'
+	$(RM) $(kustomize_dir)kustomize*
 	if [ -d '$(kustomize_dir)' ]; then rmdir --ignore-fail-on-non-empty -p '$(kustomize_dir)'; fi
 .PHONY: clean-kustomize
 

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yaml-patch.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yaml-patch.mk
@@ -6,7 +6,8 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 	../../lib/tmp.mk \
 )
 
-YAML_PATCH ?=$(PERMANENT_TMP_GOPATH)/bin/yaml-patch
+YAML_PATCH_VERSION ?=v0.0.10
+YAML_PATCH ?=$(PERMANENT_TMP_GOPATH)/bin/yaml-patch-$(YAML_PATCH_VERSION)
 yaml_patch_dir :=$(dir $(YAML_PATCH))
 
 
@@ -14,7 +15,7 @@ ensure-yaml-patch:
 ifeq "" "$(wildcard $(YAML_PATCH))"
 	$(info Installing yaml-patch into '$(YAML_PATCH)')
 	mkdir -p '$(yaml_patch_dir)'
-	curl -s -f -L https://github.com/krishicks/yaml-patch/releases/download/v0.0.10/yaml_patch_$(GOHOSTOS) -o '$(YAML_PATCH)'
+	curl -s -f -L https://github.com/krishicks/yaml-patch/releases/download/$(YAML_PATCH_VERSION)/yaml_patch_$(GOHOSTOS) -o '$(YAML_PATCH)'
 	chmod +x '$(YAML_PATCH)';
 else
 	$(info Using existing yaml-patch from "$(YAML_PATCH)")
@@ -22,7 +23,7 @@ endif
 .PHONY: ensure-yaml-patch
 
 clean-yaml-patch:
-	$(RM) '$(YAML_PATCH)'
+	$(RM) $(yaml_patch_dir)yaml-patch*
 	if [ -d '$(yaml_patch_dir)' ]; then rmdir --ignore-fail-on-non-empty -p '$(yaml_patch_dir)'; fi
 .PHONY: clean-yaml-patch
 

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yq.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yq.mk
@@ -6,7 +6,8 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 	../../lib/tmp.mk \
 )
 
-YQ ?=$(PERMANENT_TMP_GOPATH)/bin/yq
+YQ_VERSION ?=2.4.0
+YQ ?=$(PERMANENT_TMP_GOPATH)/bin/yq-$(YQ_VERSION)
 yq_dir :=$(dir $(YQ))
 
 
@@ -14,7 +15,7 @@ ensure-yq:
 ifeq "" "$(wildcard $(YQ))"
 	$(info Installing yq into '$(YQ)')
 	mkdir -p '$(yq_dir)'
-	curl -s -f -L https://github.com/mikefarah/yq/releases/download/2.4.0/yq_$(GOHOSTOS)_$(GOHOSTARCH) -o '$(YQ)'
+	curl -s -f -L https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(GOHOSTOS)_$(GOHOSTARCH) -o '$(YQ)'
 	chmod +x '$(YQ)';
 else
 	$(info Using existing yq from "$(YQ)")
@@ -22,7 +23,7 @@ endif
 .PHONY: ensure-yq
 
 clean-yq:
-	$(RM) '$(YQ)'
+	$(RM) $(yq_dir)yq*
 	if [ -d '$(yq_dir)' ]; then rmdir --ignore-fail-on-non-empty -p '$(yq_dir)'; fi
 .PHONY: clean-yq
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -541,7 +541,7 @@ github.com/openshift/api/image/v1
 github.com/openshift/api/operator/v1
 github.com/openshift/api/pkg/serialization
 github.com/openshift/api/route/v1
-# github.com/openshift/build-machinery-go v0.0.0-20210701182933-efa47ed39f2e
+# github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37
 ## explicit
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make


### PR DESCRIPTION
Update our vendored build-machinery-go dep to pick up https://github.com/openshift/build-machinery-go/pull/50, and resolve the TODO that was waiting on it.