### PR TITLE
More updates for k8s 1.22

### DIFF
--- a/config/hiveadmission/clusterdeployment-webhook.yaml
+++ b/config/hiveadmission/clusterdeployment-webhook.yaml
@@ -1,10 +1,12 @@
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: clusterdeploymentvalidators.admission.hive.openshift.io
 webhooks:
 - name: clusterdeploymentvalidators.admission.hive.openshift.io
+  admissionReviewVersions:
+  - v1beta1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/config/hiveadmission/clusterimageset-webhook.yaml
+++ b/config/hiveadmission/clusterimageset-webhook.yaml
@@ -1,10 +1,12 @@
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: clusterimagesetvalidators.admission.hive.openshift.io
 webhooks:
 - name: clusterimagesetvalidators.admission.hive.openshift.io
+  admissionReviewVersions:
+  - v1beta1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/config/hiveadmission/clusterprovision-webhook.yaml
+++ b/config/hiveadmission/clusterprovision-webhook.yaml
@@ -1,10 +1,12 @@
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: clusterprovisionvalidators.admission.hive.openshift.io
 webhooks:
 - name: clusterprovisionvalidators.admission.hive.openshift.io
+  admissionReviewVersions:
+  - v1beta1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/config/hiveadmission/dnszones-webhook.yaml
+++ b/config/hiveadmission/dnszones-webhook.yaml
@@ -1,11 +1,13 @@
 ---
 # register to intercept DNSZone object creates and updates
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: dnszonevalidators.admission.hive.openshift.io
 webhooks:
 - name: dnszonevalidators.admission.hive.openshift.io
+  admissionReviewVersions:
+  - v1beta1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/config/hiveadmission/machinepool-webhook.yaml
+++ b/config/hiveadmission/machinepool-webhook.yaml
@@ -1,10 +1,12 @@
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: machinepoolvalidators.admission.hive.openshift.io
 webhooks:
 - name: machinepoolvalidators.admission.hive.openshift.io
+  admissionReviewVersions:
+  - v1beta1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/config/hiveadmission/selectorsyncset-webhook.yaml
+++ b/config/hiveadmission/selectorsyncset-webhook.yaml
@@ -1,10 +1,12 @@
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: selectorsyncsetvalidators.admission.hive.openshift.io
 webhooks:
 - name: selectorsyncsetvalidators.admission.hive.openshift.io
+  admissionReviewVersions:
+  - v1beta1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/config/hiveadmission/syncset-webhook.yaml
+++ b/config/hiveadmission/syncset-webhook.yaml
@@ -1,10 +1,12 @@
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: syncsetvalidators.admission.hive.openshift.io
 webhooks:
 - name: syncsetvalidators.admission.hive.openshift.io
+  admissionReviewVersions:
+  - v1beta1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/pkg/controller/hibernation/csr_helper.go
+++ b/pkg/controller/hibernation/csr_helper.go
@@ -3,7 +3,7 @@ package hibernation
 import (
 	"crypto/x509"
 
-	certsv1beta1 "k8s.io/api/certificates/v1beta1"
+	certsv1 "k8s.io/api/certificates/v1"
 	kubeclient "k8s.io/client-go/kubernetes"
 
 	machineapi "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
@@ -11,8 +11,8 @@ import (
 
 //go:generate mockgen -source=./csr_helper.go -destination=./mock/csr_helper_generated.go -package=mock
 type csrHelper interface {
-	IsApproved(csr *certsv1beta1.CertificateSigningRequest) bool
-	Parse(obj *certsv1beta1.CertificateSigningRequest) (*x509.CertificateRequest, error)
-	Authorize(machines []machineapi.Machine, nodes kubeclient.Interface, req *certsv1beta1.CertificateSigningRequest, csr *x509.CertificateRequest) error
-	Approve(client kubeclient.Interface, csr *certsv1beta1.CertificateSigningRequest) error
+	IsApproved(csr *certsv1.CertificateSigningRequest) bool
+	Parse(obj *certsv1.CertificateSigningRequest) (*x509.CertificateRequest, error)
+	Authorize(machines []machineapi.Machine, nodes kubeclient.Interface, req *certsv1.CertificateSigningRequest, csr *x509.CertificateRequest) error
+	Approve(client kubeclient.Interface, csr *certsv1.CertificateSigningRequest) error
 }

--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -539,7 +539,7 @@ func (r *hibernationReconciler) checkCSRs(cd *hivev1.ClusterDeployment, remoteCl
 		logger.WithError(err).Log(controllerutils.LogLevel(err), "Failed to list machines")
 		return reconcile.Result{}, errors.Wrap(err, "failed to list machines")
 	}
-	csrList, err := kubeClient.CertificatesV1beta1().CertificateSigningRequests().List(context.TODO(), metav1.ListOptions{})
+	csrList, err := kubeClient.CertificatesV1().CertificateSigningRequests().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		logger.WithError(err).Log(controllerutils.LogLevel(err), "Failed to list CSRs")
 		return reconcile.Result{}, errors.Wrap(err, "failed to list CSRs")

--- a/pkg/controller/hibernation/hibernation_controller_test.go
+++ b/pkg/controller/hibernation/hibernation_controller_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	batchv1 "k8s.io/api/batch/v1"
-	certsv1beta1 "k8s.io/api/certificates/v1beta1"
+	certsv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -789,7 +789,7 @@ func unreadyNode() []runtime.Object {
 func csrs() []runtime.Object {
 	result := make([]runtime.Object, 5)
 	for i := 0; i < len(result); i++ {
-		csr := &certsv1beta1.CertificateSigningRequest{}
+		csr := &certsv1.CertificateSigningRequest{}
 		csr.Name = fmt.Sprintf("csr-%d", i)
 		result[i] = csr
 	}

--- a/pkg/controller/hibernation/mock/csr_helper_generated.go
+++ b/pkg/controller/hibernation/mock/csr_helper_generated.go
@@ -8,7 +8,7 @@ import (
 	x509 "crypto/x509"
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
-	v1beta10 "k8s.io/api/certificates/v1beta1"
+	v1 "k8s.io/api/certificates/v1"
 	kubernetes "k8s.io/client-go/kubernetes"
 	reflect "reflect"
 )
@@ -37,7 +37,7 @@ func (m *MockcsrHelper) EXPECT() *MockcsrHelperMockRecorder {
 }
 
 // IsApproved mocks base method
-func (m *MockcsrHelper) IsApproved(csr *v1beta10.CertificateSigningRequest) bool {
+func (m *MockcsrHelper) IsApproved(csr *v1.CertificateSigningRequest) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsApproved", csr)
 	ret0, _ := ret[0].(bool)
@@ -51,7 +51,7 @@ func (mr *MockcsrHelperMockRecorder) IsApproved(csr interface{}) *gomock.Call {
 }
 
 // Parse mocks base method
-func (m *MockcsrHelper) Parse(obj *v1beta10.CertificateSigningRequest) (*x509.CertificateRequest, error) {
+func (m *MockcsrHelper) Parse(obj *v1.CertificateSigningRequest) (*x509.CertificateRequest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Parse", obj)
 	ret0, _ := ret[0].(*x509.CertificateRequest)
@@ -66,7 +66,7 @@ func (mr *MockcsrHelperMockRecorder) Parse(obj interface{}) *gomock.Call {
 }
 
 // Authorize mocks base method
-func (m *MockcsrHelper) Authorize(machines []v1beta1.Machine, nodes kubernetes.Interface, req *v1beta10.CertificateSigningRequest, csr *x509.CertificateRequest) error {
+func (m *MockcsrHelper) Authorize(machines []v1beta1.Machine, nodes kubernetes.Interface, req *v1.CertificateSigningRequest, csr *x509.CertificateRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Authorize", machines, nodes, req, csr)
 	ret0, _ := ret[0].(error)
@@ -80,7 +80,7 @@ func (mr *MockcsrHelperMockRecorder) Authorize(machines, nodes, req, csr interfa
 }
 
 // Approve mocks base method
-func (m *MockcsrHelper) Approve(client kubernetes.Interface, csr *v1beta10.CertificateSigningRequest) error {
+func (m *MockcsrHelper) Approve(client kubernetes.Interface, csr *v1.CertificateSigningRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Approve", client, csr)
 	ret0, _ := ret[0].(error)

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -253,12 +253,14 @@ func configHiveadmissionApiserviceYaml() (*asset, error) {
 }
 
 var _configHiveadmissionClusterdeploymentWebhookYaml = []byte(`---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: clusterdeploymentvalidators.admission.hive.openshift.io
 webhooks:
 - name: clusterdeploymentvalidators.admission.hive.openshift.io
+  admissionReviewVersions:
+  - v1beta1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
@@ -296,12 +298,14 @@ func configHiveadmissionClusterdeploymentWebhookYaml() (*asset, error) {
 }
 
 var _configHiveadmissionClusterimagesetWebhookYaml = []byte(`---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: clusterimagesetvalidators.admission.hive.openshift.io
 webhooks:
 - name: clusterimagesetvalidators.admission.hive.openshift.io
+  admissionReviewVersions:
+  - v1beta1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
@@ -338,12 +342,14 @@ func configHiveadmissionClusterimagesetWebhookYaml() (*asset, error) {
 }
 
 var _configHiveadmissionClusterprovisionWebhookYaml = []byte(`---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: clusterprovisionvalidators.admission.hive.openshift.io
 webhooks:
 - name: clusterprovisionvalidators.admission.hive.openshift.io
+  admissionReviewVersions:
+  - v1beta1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
@@ -456,12 +462,14 @@ func configHiveadmissionDeploymentYaml() (*asset, error) {
 
 var _configHiveadmissionDnszonesWebhookYaml = []byte(`---
 # register to intercept DNSZone object creates and updates
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: dnszonevalidators.admission.hive.openshift.io
 webhooks:
 - name: dnszonevalidators.admission.hive.openshift.io
+  admissionReviewVersions:
+  - v1beta1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
@@ -590,12 +598,14 @@ func configHiveadmissionHiveadmission_rbac_role_bindingYaml() (*asset, error) {
 }
 
 var _configHiveadmissionMachinepoolWebhookYaml = []byte(`---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: machinepoolvalidators.admission.hive.openshift.io
 webhooks:
 - name: machinepoolvalidators.admission.hive.openshift.io
+  admissionReviewVersions:
+  - v1beta1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
@@ -632,12 +642,14 @@ func configHiveadmissionMachinepoolWebhookYaml() (*asset, error) {
 }
 
 var _configHiveadmissionSelectorsyncsetWebhookYaml = []byte(`---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: selectorsyncsetvalidators.admission.hive.openshift.io
 webhooks:
 - name: selectorsyncsetvalidators.admission.hive.openshift.io
+  admissionReviewVersions:
+  - v1beta1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
@@ -729,12 +741,14 @@ func configHiveadmissionServiceYaml() (*asset, error) {
 }
 
 var _configHiveadmissionSyncsetWebhookYaml = []byte(`---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: syncsetvalidators.admission.hive.openshift.io
 webhooks:
 - name: syncsetvalidators.admission.hive.openshift.io
+  admissionReviewVersions:
+  - v1beta1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -25,7 +25,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 
-	admregv1 "k8s.io/api/admissionregistration/v1beta1"
+	admregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -140,7 +140,7 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h resour
 	validatingWebhooks := make([]*admregv1.ValidatingWebhookConfiguration, len(webhookAssets))
 	for i, yaml := range webhookAssets {
 		asset = assets.MustAsset(yaml)
-		wh := util.ReadValidatingWebhookConfigurationV1Beta1OrDie(asset, scheme.Scheme)
+		wh := util.ReadValidatingWebhookConfigurationV1OrDie(asset, scheme.Scheme)
 		validatingWebhooks[i] = wh
 	}
 

--- a/pkg/operator/util/admissionregistration.go
+++ b/pkg/operator/util/admissionregistration.go
@@ -1,14 +1,14 @@
 package util
 
 import (
-	admregv1 "k8s.io/api/admissionregistration/v1beta1"
+	admregv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
-// ReadValidatingWebhookConfigurationV1Beta1OrDie reads a ValidatingWebhookConfiguration,
+// ReadValidatingWebhookConfigurationV1OrDie reads a ValidatingWebhookConfiguration,
 // as this is not yet added to library-go.
-func ReadValidatingWebhookConfigurationV1Beta1OrDie(objBytes []byte, scheme *runtime.Scheme) *admregv1.ValidatingWebhookConfiguration {
+func ReadValidatingWebhookConfigurationV1OrDie(objBytes []byte, scheme *runtime.Scheme) *admregv1.ValidatingWebhookConfiguration {
 	apiExtensionsCodecs := serializer.NewCodecFactory(scheme)
 
 	requiredObj, err := runtime.Decode(apiExtensionsCodecs.UniversalDecoder(admregv1.SchemeGroupVersion), objBytes)

--- a/test/e2e/common/client.go
+++ b/test/e2e/common/client.go
@@ -7,7 +7,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/dynamic"
 	kclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -21,7 +21,7 @@ import (
 )
 
 func init() {
-	apiextv1beta1.AddToScheme(scheme.Scheme)
+	apiextv1.AddToScheme(scheme.Scheme)
 	hiveapis.AddToScheme(scheme.Scheme)
 	admissionv1beta1.AddToScheme(scheme.Scheme)
 	autoscalingv1.SchemeBuilder.AddToScheme(scheme.Scheme)

--- a/test/e2e/postdeploy/operator/operator_test.go
+++ b/test/e2e/postdeploy/operator/operator_test.go
@@ -12,7 +12,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -51,12 +51,12 @@ func TestOperatorDeployment(t *testing.T) {
 	}
 }
 
-func readHiveCRDs(t *testing.T) []*apiextv1beta1.CustomResourceDefinition {
+func readHiveCRDs(t *testing.T) []*apiextv1.CustomResourceDefinition {
 	files, err := ioutil.ReadDir(crdDirectory)
 	if err != nil {
 		t.Fatalf("cannot read crd directory: %v", err)
 	}
-	result := []*apiextv1beta1.CustomResourceDefinition{}
+	result := []*apiextv1.CustomResourceDefinition{}
 	for _, file := range files {
 		if !strings.HasSuffix(file.Name(), ".yaml") {
 			continue
@@ -65,7 +65,7 @@ func readHiveCRDs(t *testing.T) []*apiextv1beta1.CustomResourceDefinition {
 		if err != nil {
 			t.Fatalf("cannot read crd file %s: %v", file.Name(), err)
 		}
-		crd := &apiextv1beta1.CustomResourceDefinition{}
+		crd := &apiextv1.CustomResourceDefinition{}
 		if err = yaml.Unmarshal(b, crd); err != nil {
 			t.Fatalf("failed to unmarshall crd from %s: %v", file.Name(), err)
 		}
@@ -81,7 +81,7 @@ func TestHiveCRDs(t *testing.T) {
 	c := common.MustGetClient()
 	hiveCRDs := readHiveCRDs(t)
 	for _, crd := range hiveCRDs {
-		serverCRD := &apiextv1beta1.CustomResourceDefinition{}
+		serverCRD := &apiextv1.CustomResourceDefinition{}
 		err := c.Get(context.TODO(), types.NamespacedName{Name: crd.Name}, serverCRD)
 		if err != nil {
 			t.Errorf("cannot fetch expected crd (%s): %v", crd.Name, err)
@@ -99,7 +99,7 @@ func TestHiveCRDs(t *testing.T) {
 			continue
 		}
 
-		lastAppliedCRD := &apiextv1beta1.CustomResourceDefinition{}
+		lastAppliedCRD := &apiextv1.CustomResourceDefinition{}
 		if err = yaml.Unmarshal([]byte(lastApplied), lastAppliedCRD); err != nil {
 			t.Fatalf("Unable to unmarshal last applied CRD for %s", serverCRD.Name)
 		}


### PR DESCRIPTION
OCP 4.9 uses k8s 1.22, where several deprecated objects have been removed [1]. We got partway via previous commits [2][3]. This hopefully finishes the job, addressing:
- ValidatingWebhookConfiguration
- CertificateSigningRequest
- some remaining CustomResourceDefinition references in test code

[1] https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22
[2] openshift#1395
[3] openshift#1468

[HIVE-1626](https://issues.redhat.com/browse/HIVE-1626)
[HIVE-1627](https://issues.redhat.com/browse/HIVE-1627)