### PR TITLE
add NoWorkerNodes to install-log-regexes-configmap

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -72,6 +72,11 @@ data:
       - "InvalidClientTokenId: The security token included in the request is invalid."
       installFailingReason: InvalidCredentials
       installFailingMessage: Credentials are invalid
+    - name: NoWorkerNodes
+      searchRegexStrings:
+      - "Got 0 worker nodes, 3 master nodes"
+      installFailingReason: NoWorkerNodes
+      installFailingMessage: No worker nodes could be created. Check that your machine-api role is correct and try again.
     # GCP Specific
     - name: GCPInvalidProjectID
       searchRegexStrings:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1612,6 +1612,11 @@ data:
       - "InvalidClientTokenId: The security token included in the request is invalid."
       installFailingReason: InvalidCredentials
       installFailingMessage: Credentials are invalid
+    - name: NoWorkerNodes
+      searchRegexStrings:
+      - "Got 0 worker nodes, 3 master nodes"
+      installFailingReason: NoWorkerNodes
+      installFailingMessage: No worker nodes could be created. Check that your machine-api role is correct and try again.
     # GCP Specific
     - name: GCPInvalidProjectID
       searchRegexStrings:


### PR DESCRIPTION
It is a common problem that STS-mode clusters have something
wrong with the operator roles -- typically they're bound to
the wrong (old) OIDC provider. The first place an install notices
that is when machine-api tries to create the workers.

/assign @abutcher 