### PR TITLE
Include CertData, KeyData in TLSClientConfig for ArgoCD cluster.

### DIFF
--- a/pkg/controller/argocdregister/argocdregister_controller.go
+++ b/pkg/controller/argocdregister/argocdregister_controller.go
@@ -361,6 +361,8 @@ func tlsClientConfigBuilderFunc(kubeConfig clientcmd.ClientConfig, cdLog log.Fie
 		Insecure:   cfg.TLSClientConfig.Insecure,
 		ServerName: cfg.TLSClientConfig.ServerName,
 		CAData:     cfg.TLSClientConfig.CAData,
+		CertData:   cfg.TLSClientConfig.CertData,
+		KeyData:    cfg.TLSClientConfig.KeyData,
 	}
 
 	return tlsClientConfig, nil


### PR DESCRIPTION
https://issues.redhat.com/browse/HIVE-1625