### PR TITLE
Add requirements met condition to provision delay metric labels.

### DIFF
--- a/pkg/controller/metrics/provision_underway_collector.go
+++ b/pkg/controller/metrics/provision_underway_collector.go
@@ -18,6 +18,7 @@ var (
 	// ClusterDeployment conditions that could indicate provisioning problems with a cluster
 	// First condition appearing True will be used in the metric labels.
 	provisioningDelayCondition = [...]hivev1.ClusterDeploymentConditionType{
+		hivev1.RequirementsMetCondition,
 		hivev1.DNSNotReadyCondition,
 		hivev1.InstallLaunchErrorCondition,
 		hivev1.ProvisionFailedCondition,


### PR DESCRIPTION
Encountered a cluster today with a missing image set, requirements met false, but the metric did not inform us.