### PR TITLE
Hack: Hardcode crb subject namespace for app-sre

### DIFF
--- a/hack/app-sre/kustomization.yaml
+++ b/hack/app-sre/kustomization.yaml
@@ -7,7 +7,7 @@
 # The other resources should be curated manually.
 resources:
 - ../../config/operator/operator_role.yaml
-- ../../config/operator/operator_role_binding.yaml
+- operator_role_binding.yaml
 - ../../config/operator/operator_deployment.yaml
 - ../../config/crds/hiveinternal.openshift.io_clustersyncleases.yaml
 - ../../config/crds/hiveinternal.openshift.io_clustersyncs.yaml

--- a/hack/app-sre/operator_role_binding.yaml
+++ b/hack/app-sre/operator_role_binding.yaml
@@ -1,0 +1,21 @@
+# HACK: This is the same as config/operator/operator_role_binding.yaml *except*
+# that the subjects[0].namespace is hardcoded. This is because:
+# - `kustomize set namespace` will *set* the subjects[].namespace if absent,
+#   but will not *override* it if present. So we can't just set it in the
+#   original file, or `make deploy` breaks when HIVE_OPERATOR_NS != "hive".
+# - app-sre manages the namespace into which the operator artifacts are to be
+#   deployed ("hive") and sets it on most things (or it's implicit)... but it
+#   can't/won't dig into this CRB to do so.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: hive-operator-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hive-operator-role
+subjects:
+- kind: ServiceAccount
+  name: hive-operator
+  namespace: hive

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -6443,6 +6443,7 @@ objects:
   subjects:
   - kind: ServiceAccount
     name: hive-operator
+    namespace: hive
 - apiVersion: apps/v1
   kind: Deployment
   metadata:


### PR DESCRIPTION
Create an almost-copy of the operator cluster role binding for app-sre to deploy. The difference being that the subject namespace needs to be hardcoded due to kustomize limitations. See inline comments for more.

[HIVE-1588](https://issues.redhat.com/browse/HIVE-1588)