### PR TITLE
dedicated-admin ClusterRole aggregation for direct deploy

### DIFF
--- a/hack/app-sre/kustomization.yaml
+++ b/hack/app-sre/kustomization.yaml
@@ -37,3 +37,11 @@ images:
 - name: registry.ci.openshift.org/openshift/hive-v4.0:hive
   newName: ${REGISTRY_IMG}
   newTag: ${IMAGE_TAG}
+patchesStrategicMerge:
+- |-
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: hive-operator-role
+    labels:
+      managed.openshift.io/aggregate-to-dedicated-admins: cluster

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -6246,7 +6246,8 @@ objects:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:
-    creationTimestamp: null
+    labels:
+      managed.openshift.io/aggregate-to-dedicated-admins: cluster
     name: hive-operator-role
   rules:
   - apiGroups:


### PR DESCRIPTION
Previously, our app-sre deploys were getting aggregated into the [`dedicated-cluster-admins` ClusterRole](https://github.com/openshift/managed-cluster-config/blob/adc42a02ece09d52b852882b1ef26d9cb22bd717/deploy/rbac-permissions-operator-config/03-dedicated-admins-cluster.ClusterRole.yaml) via a [rule intended for "customer installed" operators](https://github.com/openshift/managed-cluster-config/blob/adc42a02ece09d52b852882b1ef26d9cb22bd717/deploy/rbac-permissions-operator-config/03-dedicated-admins-cluster.ClusterRole.yaml#L17-L22) due to our ClusterRole getting labeled by OLM with:

```json
{
  "olm.owner": "hive-og",
  "olm.owner.kind": "OperatorGroup",
  "olm.owner.namespace": "hive"
}
```

With direct-deploy, that label is no longer present on our ClusterRole. Replace it with the [label intended for this purpose](https://github.com/openshift/managed-cluster-config/blob/adc42a02ece09d52b852882b1ef26d9cb22bd717/deploy/rbac-permissions-operator-config/03-dedicated-admins-cluster.ClusterRole.yaml#L3-L8), which is arguably what we should have been doing in the first place.

[HIVE-1588](https://issues.redhat.com/browse/HIVE-1588)