### PR TITLE
Scrub AWS not authorized message which includes AWS resource ARNs

### DIFF
--- a/pkg/controller/awsprivatelink/awsprivatelink_controller.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller.go
@@ -459,7 +459,7 @@ func (r *ReconcileAWSPrivateLink) reconcilePrivateLink(cd *hivev1.ClusterDeploym
 
 		logger.WithField("infraID", clusterMetadata.InfraID).WithError(err).Error("error discovering NLB for the cluster")
 
-		if err := r.setErrCondition(cd, "DiscoveringNLBFailed", err, logger); err != nil {
+		if err := r.setErrCondition(cd, "DiscoveringNLBFailed", errors.New(controllerutils.ErrorScrub(err)), logger); err != nil {
 			logger.WithError(err).Error("failed to update condition on cluster deployment")
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/utils/errorscrub.go
+++ b/pkg/controller/utils/errorscrub.go
@@ -22,7 +22,7 @@ func ErrorScrub(err error) string {
 	}
 	s := newlineTabRE.ReplaceAllString(err.Error(), ", ")
 	s = awsRequestIDRE.ReplaceAllString(s, "")
-	s = awsNotAuthorized.ReplaceAllString(s, `$1 XXX $2 XXX $3 XXX $4`)
+	s = awsNotAuthorized.ReplaceAllString(s, `${1}XXX${2}XXX${3}XXX${4}`)
 	s = certificateTimeErrorRE.ReplaceAllString(s, "")
 	// if Azure error, return just the error description
 	match := azureErrorDescriptionRE.FindStringSubmatch(s)

--- a/pkg/controller/utils/errorscrub.go
+++ b/pkg/controller/utils/errorscrub.go
@@ -8,7 +8,8 @@ var (
 	newlineTabRE           = regexp.MustCompile(`\n\t`)
 	certificateTimeErrorRE = regexp.MustCompile(`: current time \S+ is after \S+`)
 	// aws
-	awsRequestIDRE = regexp.MustCompile(`(, )*(?i)(request id: )(?:[-[:xdigit:]]+)`)
+	awsRequestIDRE   = regexp.MustCompile(`(, )*(?i)(request id: )(?:[-[:xdigit:]]+)`)
+	awsNotAuthorized = regexp.MustCompile(`User\: \S+ is not authorized to perform\: \S+ on resource\: \S+`)
 	// azure
 	azureErrorDescriptionRE = regexp.MustCompile(`\"error_description\":\"(.*?)\\r\\n`)
 )
@@ -21,6 +22,7 @@ func ErrorScrub(err error) string {
 	}
 	s := newlineTabRE.ReplaceAllString(err.Error(), ", ")
 	s = awsRequestIDRE.ReplaceAllString(s, "")
+	s = awsNotAuthorized.ReplaceAllString(s, "")
 	s = certificateTimeErrorRE.ReplaceAllString(s, "")
 	// if Azure error, return just the error description
 	match := azureErrorDescriptionRE.FindStringSubmatch(s)

--- a/pkg/controller/utils/errorscrub.go
+++ b/pkg/controller/utils/errorscrub.go
@@ -9,7 +9,7 @@ var (
 	certificateTimeErrorRE = regexp.MustCompile(`: current time \S+ is after \S+`)
 	// aws
 	awsRequestIDRE   = regexp.MustCompile(`(, )*(?i)(request id: )(?:[-[:xdigit:]]+)`)
-	awsNotAuthorized = regexp.MustCompile(`User\: \S+ is not authorized to perform\: \S+ on resource\: \S+`)
+	awsNotAuthorized = regexp.MustCompile(`User: \S+ is not authorized to perform: \S+ on resource: \S+`)
 	// azure
 	azureErrorDescriptionRE = regexp.MustCompile(`\"error_description\":\"(.*?)\\r\\n`)
 )

--- a/pkg/controller/utils/errorscrub.go
+++ b/pkg/controller/utils/errorscrub.go
@@ -9,7 +9,7 @@ var (
 	certificateTimeErrorRE = regexp.MustCompile(`: current time \S+ is after \S+`)
 	// aws
 	awsRequestIDRE   = regexp.MustCompile(`(, )*(?i)(request id: )(?:[-[:xdigit:]]+)`)
-	awsNotAuthorized = regexp.MustCompile(`User: \S+ is not authorized to perform: \S+ on resource: \S+`)
+	awsNotAuthorized = regexp.MustCompile(`(User: arn:aws:sts::)\S+(:assumed-role/[^/]+/)\S+( is not authorized to perform: \S+ on resource: arn:aws:iam::)[^:]+(:\S+)`)
 	// azure
 	azureErrorDescriptionRE = regexp.MustCompile(`\"error_description\":\"(.*?)\\r\\n`)
 )
@@ -22,7 +22,7 @@ func ErrorScrub(err error) string {
 	}
 	s := newlineTabRE.ReplaceAllString(err.Error(), ", ")
 	s = awsRequestIDRE.ReplaceAllString(s, "")
-	s = awsNotAuthorized.ReplaceAllString(s, "")
+	s = awsNotAuthorized.ReplaceAllString(s, `$1 XXX $2 XXX $3 XXX $4`)
 	s = certificateTimeErrorRE.ReplaceAllString(s, "")
 	// if Azure error, return just the error description
 	match := azureErrorDescriptionRE.FindStringSubmatch(s)

--- a/pkg/controller/utils/errorscrub_test.go
+++ b/pkg/controller/utils/errorscrub_test.go
@@ -44,6 +44,11 @@ func TestErrorScrubber(t *testing.T) {
 			input:    errors.New(`[an error on the server ("") has prevented the request from succeeding, Get "https://api.foobar.openshiftapps.com:6443/api?timeout=32s": x509: certificate has expired or is not yet valid: current time 2021-08-06T11:54:02Z is after 2021-07-26T09:26:41Z]`),
 			expected: `[an error on the server ("") has prevented the request from succeeding, Get "https://api.foobar.openshiftapps.com:6443/api?timeout=32s": x509: certificate has expired or is not yet valid`,
 		},
+		{
+			name:     "aws not authorized arn",
+			input:    errors.New("failed to describe load balancer for the cluster: AccessDenied: User: arn:aws:sts::999999999:assumed-role/RH-Managed-OpenShift-Installer/9999999999999999999 is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::999999999999:role/ManagedOpenShift-Installer-Role\n\tstatus code: 403, request id: be5fed4c-ba78-43a2-82b7-150bab2b10cc"),
+			expected: `failed to describe load balancer for the cluster: AccessDenied:  status code: 403`,
+		},
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/controller/utils/errorscrub_test.go
+++ b/pkg/controller/utils/errorscrub_test.go
@@ -47,7 +47,7 @@ func TestErrorScrubber(t *testing.T) {
 		{
 			name:     "aws not authorized arn",
 			input:    errors.New("failed to describe load balancer for the cluster: AccessDenied: User: arn:aws:sts::999999999:assumed-role/RH-Managed-OpenShift-Installer/9999999999999999999 is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::999999999999:role/ManagedOpenShift-Installer-Role\n\tstatus code: 403, request id: be5fed4c-ba78-43a2-82b7-150bab2b10cc"),
-			expected: `failed to describe load balancer for the cluster: AccessDenied: User: arn:aws:sts:: XXX :assumed-role/RH-Managed-OpenShift-Installer/ XXX  is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam:: XXX :role/ManagedOpenShift-Installer-Role, status code: 403`,
+			expected: `failed to describe load balancer for the cluster: AccessDenied: User: arn:aws:sts::XXX:assumed-role/RH-Managed-OpenShift-Installer/XXX is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::XXX:role/ManagedOpenShift-Installer-Role, status code: 403`,
 		},
 	}
 	for _, test := range cases {

--- a/pkg/controller/utils/errorscrub_test.go
+++ b/pkg/controller/utils/errorscrub_test.go
@@ -47,7 +47,7 @@ func TestErrorScrubber(t *testing.T) {
 		{
 			name:     "aws not authorized arn",
 			input:    errors.New("failed to describe load balancer for the cluster: AccessDenied: User: arn:aws:sts::999999999:assumed-role/RH-Managed-OpenShift-Installer/9999999999999999999 is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::999999999999:role/ManagedOpenShift-Installer-Role\n\tstatus code: 403, request id: be5fed4c-ba78-43a2-82b7-150bab2b10cc"),
-			expected: `failed to describe load balancer for the cluster: AccessDenied:  status code: 403`,
+			expected: `failed to describe load balancer for the cluster: AccessDenied: User: arn:aws:sts:: XXX :assumed-role/RH-Managed-OpenShift-Installer/ XXX  is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam:: XXX :role/ManagedOpenShift-Installer-Role, status code: 403`,
 		},
 	}
 	for _, test := range cases {


### PR DESCRIPTION
I started out trying to hit the AWS resource ARNs with the regex but I think it will be simpler to just target this message. There is a request id and the ARN being updated in the message.