### PR TITLE
Slowly delete stale pool clusters

### DIFF
--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -392,7 +392,7 @@ func (r *ReconcileClusterPool) Reconcile(ctx context.Context, request reconcile.
 			logger.WithError(err).Error("error deleting cluster deployment")
 			return reconcile.Result{}, err
 		}
-
+		metricStaleClusterDeploymentsDeleted.WithLabelValues(clp.Namespace, clp.Name).Inc()
 	}
 
 	// One more (possible) status update: wait until the end to detect whether all unassigned CDs

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -285,7 +285,9 @@ func (r *ReconcileClusterPool) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, nil
 	}
 
-	cds, err := getAllClusterDeploymentsForPool(r.Client, clp, logger)
+	poolVersion := calculatePoolVersion(clp)
+
+	cds, err := getAllClusterDeploymentsForPool(r.Client, clp, poolVersion, logger)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -355,8 +357,6 @@ func (r *ReconcileClusterPool) Reconcile(ctx context.Context, request reconcile.
 	}
 	availableCurrent -= toDel
 
-	poolVersion := calculatePoolVersion(clp)
-
 	switch drift := reserveSize - int(clp.Spec.Size); {
 	// activity quota exceeded, so no action
 	case availableCurrent <= 0:
@@ -383,6 +383,16 @@ func (r *ReconcileClusterPool) Reconcile(ctx context.Context, request reconcile.
 			log.WithError(err).Error("error adding clusters")
 			return reconcile.Result{}, err
 		}
+	// Special case for stale CDs: allow deleting one if all CDs are installed.
+	case drift == 0 && len(cds.Installing()) == 0 && len(cds.Stale()) > 0:
+		toDelete := cds.Stale()[0]
+		logger := logger.WithField("cluster", toDelete.Name)
+		logger.Info("deleting cluster deployment")
+		if err := cds.Delete(r.Client, toDelete.Name); err != nil {
+			logger.WithError(err).Error("error deleting cluster deployment")
+			return reconcile.Result{}, err
+		}
+
 	}
 
 	// One more (possible) status update: wait until the end to detect whether all unassigned CDs
@@ -704,7 +714,8 @@ func (r *ReconcileClusterPool) reconcileDeletedPool(pool *hivev1.ClusterPool, lo
 	if !controllerutils.HasFinalizer(pool, finalizer) {
 		return nil
 	}
-	cds, err := getAllClusterDeploymentsForPool(r.Client, pool, logger)
+	// Don't care about the poolVersion here since we're deleting everything.
+	cds, err := getAllClusterDeploymentsForPool(r.Client, pool, "", logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/clusterpool/metrics.go
+++ b/pkg/controller/clusterpool/metrics.go
@@ -1,0 +1,22 @@
+package clusterpool
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// metricStaleClusterDeploymentsDeleted tracks the total number of CDs we delete because they
+	// became "stale". That is, the ClusterPool was modified in a substantive way such that these
+	// CDs no longer match its spec. Note that this only counts stale CDs we've *deleted* -- there
+	// may be other stale CDs we haven't gotten around to deleting yet.
+	metricStaleClusterDeploymentsDeleted = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "hive_clusterpool_stale_clusterdeployments_deleted",
+		Help: "The number of ClusterDeployments deleted because they no longer match the spec of their ClusterPool.",
+	}, []string{"clusterpool_namespace", "clusterpool_name"})
+)
+
+func init() {
+	metrics.Registry.MustRegister()
+}

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -385,7 +385,7 @@ func processJobs(jobs []batchv1.Job) (runningTotal, succeededTotal, failedTotal 
 }
 
 // clusterAccumulator is an object used to process cluster deployments and sort them so we can
-// increment the appropriate metrics counter based on it's type, installed state, length of time
+// increment the appropriate metrics counter based on its type, installed state, length of time
 // it has been uninstalled, and the conditions it has.
 type clusterAccumulator struct {
 	// ageFilter can optionally be specified to skip processing clusters older than this duration. If this is not desired,


### PR DESCRIPTION
3dc3c3c7c / #1484 added setting and discovery of a version marker for ClusterPool and ClusterDeployment so we could tell whether they match. This commit goes a step further and uses that information to replace stale CDs such that the pool will eventually be consistent.

The algorithm we use is as follows:
If the pool is in steady state -- i.e. we're at capacity and all unclaimed CDs are finished installing -- delete *one* stale CD. This triggers another reconcile wherein the deleted CD is replaced. We're no longer in steady state until (at least) that CD finishes installing, whereupon we're eligible to repeat.

Reasoning:
- We don't want to immediately trash all stale CDs, as this could result in significant downtime following a pool edit.
- We don't want to exceed capacity (size or maxSize) to do this rotation, so we go "down" instead of "up".
- It would have been nice to just wait for the *replacement* CDs to finish installing; but that would have entailed tracking those somehow as being distinct from CDs added through other code paths. That could get tricky, especially across multiple pool edits.

TODO:
- As written, we'll even wait for *stale* CDs to finish installing before we start deleting. We should figure out a way to discount those when checking whether we're eligible for a deletion.
- Consider exposing a knob allowing the consumer to tune how aggressively stale CDs are replaced.

[HIVE-1058](https://issues.redhat.com/browse/HIVE-1058)