### PR TITLE
fix GCP CPU quota install log regexp

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -100,7 +100,7 @@ data:
       installFailingMessage: GCP quota SSD_TOTAL_GB exceeded
     - name: GCPComputeQuota
       searchRegexStrings:
-      - "compute\\.googleapis\\.com/cpus is not available in [a-z0-9-]* because the required number of resources \\([0-9]*\\) is more than remaining quota"
+      - "compute\\.googleapis\\.com/cpus is not available in [a-z0-9-]* because the required number of resources \\([0-9]*\\) is more than"
       installFailingReason: GCPComputeQuotaExceeded
       installFailingMessage: GCP CPUs quota exceeded
     - name: GCPServiceAccountQuota

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1654,7 +1654,7 @@ data:
       installFailingMessage: GCP quota SSD_TOTAL_GB exceeded
     - name: GCPComputeQuota
       searchRegexStrings:
-      - "compute\\.googleapis\\.com/cpus is not available in [a-z0-9-]* because the required number of resources \\([0-9]*\\) is more than remaining quota"
+      - "compute\\.googleapis\\.com/cpus is not available in [a-z0-9-]* because the required number of resources \\([0-9]*\\) is more than"
       installFailingReason: GCPComputeQuotaExceeded
       installFailingMessage: GCP CPUs quota exceeded
     - name: GCPServiceAccountQuota


### PR DESCRIPTION
fix GCP CPU quota install log regexp. GCP CPU quota install log regexp
was too specific, and the tail end of the message in GCP changed.

/assign @dgoodwin 
/cc @abutcher 