### PR TITLE
csr approve fix

### DIFF
--- a/pkg/controller/hibernation/csr_utility.go
+++ b/pkg/controller/hibernation/csr_utility.go
@@ -82,6 +82,7 @@ func (u *csrUtility) Approve(client kubeclient.Interface, csr *certificatesv1.Ce
 	csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
 		Type:           certificatesv1.CertificateApproved,
 		Reason:         "KubectlApprove",
+		Status:         corev1.ConditionTrue,
 		Message:        "This CSR was automatically approved by Hive",
 		LastUpdateTime: metav1.Now(),
 	})


### PR DESCRIPTION
- Fix issue with CSR approval and status being mandatory.
This surfaced with my quite old 4.8.0rc1 cluster which happened to expire certs, CSR updates are failing in hive due to status being mandatory. Could be broader for all 4.8 clusters. Nodes land NotReady when this happens.

x-ref: https://issues.redhat.com/browse/HIVE-1633