### PR TITLE
add addl missing quota check

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -168,3 +168,8 @@ data:
       - "Quota '[A-Z_]*' exceeded"
       installFailingReason: GeneralQuotaExceeded
       installFailingMessage: Quota exceeded
+    - name: PlatformQuotaCheck
+      searchRegexStrings:
+      - "\\\"Platform Quota Check\\\": error(MissingQuota): .* is not available in .* because the required number of resources .* is more than the limit"
+      installFailingReason: PlatformQuotaCheckExceeded
+      installFailingMessage: Platform Quota exceeded


### PR DESCRIPTION
Checking https://redhat.pagerduty.com/incidents/PQ2YJKV , it had an unexpected quota exceeded msg.

the full log line from the cluster prov delay was:

level=fatal msg=failed to fetch Cluster: failed to fetch dependency of "Cluster": failed to generate asset "Platform Quota Check": error(MissingQuota): ec2/... is not available in eu-central-1 because the required number of resources (32) is more than the limit of 8