### PR TITLE
Add polarity check for Provision Underway metric

### DIFF
--- a/pkg/controller/metrics/provision_underway_collector.go
+++ b/pkg/controller/metrics/provision_underway_collector.go
@@ -7,7 +7,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 
-	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
@@ -209,7 +208,7 @@ func getKnownConditions(conditions []hivev1.ClusterDeploymentCondition) (conditi
 	for _, delayCondition := range provisioningDelayCondition {
 		if cdCondition := controllerutils.FindClusterDeploymentCondition(conditions,
 			delayCondition); cdCondition != nil {
-			if cdCondition.Status == corev1.ConditionTrue {
+			if !controllerutils.IsConditionInDesiredState(*cdCondition) {
 				condition = string(delayCondition)
 				if cdCondition.Reason != "" {
 					reason = cdCondition.Reason

--- a/pkg/controller/metrics/provision_underway_collector_test.go
+++ b/pkg/controller/metrics/provision_underway_collector_test.go
@@ -84,6 +84,19 @@ func TestProvisioningUnderwayCollector(t *testing.T) {
 			"cluster_deployment = cd-2 cluster_type = unspecified condition = ProvisionFailed image_set = none namespace = cd-2 platform =  reason = FailedDueToQuotas",
 		},
 	}, {
+		name: "provisioning with positive polarity condition",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.RequirementsMetCondition,
+				Status: corev1.ConditionFalse,
+				Reason: "ClusterImageSetNotFound",
+			})),
+		},
+		expected: []string{
+			"cluster_deployment = cd-2 cluster_type = unspecified condition = RequirementsMet image_set = none namespace = cd-2 platform =  reason = ClusterImageSetNotFound",
+		},
+	}, {
 		name: "provisioning with ProvisionFailed, DNSNotReadyCondition condition",
 		existing: []runtime.Object{
 			cdBuilder("cd-1").Build(testcd.Installed()),


### PR DESCRIPTION
This commit adds a polarity check of the given cluster deployment
condition before deciding if it is responsible for provision failure or
delay. This fixes the bug where the collector incorrectly interprets the
error status of RequirementsMet condition

/assign @dgoodwin 