### PR TITLE
e2e-pool: test stale cluster replacement

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -140,8 +140,10 @@ else
 	CLUSTER_DOMAIN="${BASE_DOMAIN}"
 fi
 
-
 echo "Using cluster base domain: ${CLUSTER_DOMAIN}"
+
+# NOTE: This is needed in order for the short form (cd) to work
+oc get clusterdeployment > /dev/null
 
 function capture_manifests() {
     oc get clusterdeployment -A -o yaml &> "${ARTIFACT_DIR}/hive_clusterdeployment.yaml" || true

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -54,9 +54,6 @@ go run "${SRC_ROOT}/contrib/cmd/hiveutil/main.go" create-cluster "${CLUSTER_NAME
 	${MANAGED_DNS_ARG} \
 	${EXTRA_CREATE_CLUSTER_ARGS}
 
-# NOTE: This is needed in order for the short form (cd) to work
-oc get clusterdeployment > /dev/null
-
 # Sanity check the cluster deployment printer
 i=1
 while [ $i -le ${max_tries} ]; do


### PR DESCRIPTION
Add a fake pool to e2e-pool-test.sh and use it to validate the replacement of ClusterDeployments when the pool spec is modified, per the linked jira.

[HIVE-1058](https://issues.redhat.com/browse/HIVE-1058)