### PR TITLE
ClusterPool: Delete broken (ProvisionStopped) clusters

### DIFF
--- a/pkg/controller/clusterdeployment/clusterprovisions.go
+++ b/pkg/controller/clusterdeployment/clusterprovisions.go
@@ -68,6 +68,7 @@ func (r *ReconcileClusterDeployment) startNewProvision(
 				logger.WithError(err).Log(controllerutils.LogLevel(err), "failed to update cluster deployment status")
 				return reconcile.Result{}, err
 			}
+			incProvisionFailedTerminal(cd)
 		}
 		return reconcile.Result{}, nil
 	}

--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -3,6 +3,7 @@ package clusterdeployment
 import (
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -114,6 +115,14 @@ func WithCondition(cond hivev1.ClusterDeploymentCondition) Option {
 		}
 		clusterDeployment.Status.Conditions = append(clusterDeployment.Status.Conditions, cond)
 	}
+}
+
+// Broken uses ProvisionStopped=True to make the CD be recognized as broken.
+func Broken() Option {
+	return WithCondition(hivev1.ClusterDeploymentCondition{
+		Type:   hivev1.ProvisionStoppedCondition,
+		Status: v1.ConditionTrue,
+	})
 }
 
 func WithUnclaimedClusterPoolReference(namespace, poolName string) Option {


### PR DESCRIPTION
With this PR, the clusterpool controller detects "broken" ClusterDeployments as those whose ProvisionStopped condition is True* and deletes them so they can be replaced and do not continue to consume capacity in the pool.

When adding or deleting clusters to satisfy capacity requirements, we prioritize as follows:
- If we're under capacity, add new clusters before deleting broken clusters. This is in case we hit `maxConcurrent`: we would prefer to use that quota to add clusters to the pool.
- If we're over capacity, delete broken clusters before deleting viable (installing or assignable) clusters.

We also add a metric, `hive_cluster_deployments_provision_failed_terminal_total`, labeled by clusterpool namespace/name (blank if not a pool CD), keeping track of the total number of ClusterDeployments for which we declare provisioning failed for the last time.

*In the future, we may expand this definition to include other definitions of "broken".

[HIVE-1615](https://issues.redhat.com/browse/HIVE-1615)