### PR TITLE
check clusteroperators

### DIFF
--- a/apis/hive/v1/clusterclaim_types.go
+++ b/apis/hive/v1/clusterclaim_types.go
@@ -68,8 +68,8 @@ type ClusterClaimConditionType string
 const (
 	// ClusterClaimPendingCondition is set when a cluster has not yet been assigned and made ready to the claim.
 	ClusterClaimPendingCondition ClusterClaimConditionType = "Pending"
-	// ClusterRunningCondition is true when a claimed cluster is running and ready for use.
-	ClusterRunningCondition ClusterClaimConditionType = "ClusterRunning"
+	// ClusterClaimRunningCondition is true when a claimed cluster is running and ready for use.
+	ClusterClaimRunningCondition ClusterClaimConditionType = "ClusterRunning"
 )
 
 // +genclient

--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -445,9 +445,10 @@ const (
 	// from a Hibernating state to a Running state.
 	//ResumingHibernationReason = "Resuming"
 
-	WaitingForMachinesRunningReason  = "WaitingForMachines"
-	WaitingForNodesRunningReason     = "WaitingForNodes"
-	WaitingForClusterOperatorsReason = "WaitingForClusterOperators"
+	WaitingForMachinesRunningReason          = "WaitingForMachines"
+	WaitingForNodesRunningReason             = "WaitingForNodes"
+	PausingForClusterOperatorsToSettleReason = "PausingForClusterOperatorsToSettle"
+	WaitingForClusterOperatorsReason         = "WaitingForClusterOperators"
 
 	// RunningHibernationReason is used as the reason when the cluster is running and
 	// the Hibernating condition is false.

--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -384,9 +384,11 @@ const (
 	// RelocationFailedCondition indicates if a relocation to another Hive instance has failed
 	RelocationFailedCondition ClusterDeploymentConditionType = "RelocationFailed"
 
-	// ClusterHibernatingCondition is set when the ClusterDeployment is either
-	// transitioning to/from a hibernating state or is in a hibernating state.
+	// ClusterHibernatingCondition is true when a Cluster is in a Hibernating state.
 	ClusterHibernatingCondition ClusterDeploymentConditionType = "Hibernating"
+
+	// ClusterRunningCondition is true when a cluster is running and ready for use.
+	ClusterRunningCondition ClusterDeploymentConditionType = "Running"
 
 	// InstallLaunchErrorCondition is set when a cluster provision fails to launch an install pod
 	InstallLaunchErrorCondition ClusterDeploymentConditionType = "InstallLaunchError"
@@ -433,9 +435,20 @@ var PositivePolarityClusterDeploymentConditions = []ClusterDeploymentConditionTy
 
 // Cluster hibernating reasons
 const (
+	// ResumingOrRunningHibernationReason is used as the reason for the Hibernating condition when the cluster
+	// is resuming or running. Precise details are available in the Running condition.
+	ResumingOrRunningHibernationReason = "ResumingOrRunning"
+
+	StoppingOrHibernatingRunningReason = "StoppingOrHibernating"
+
 	// ResumingHibernationReason is used as the reason when the cluster is transitioning
 	// from a Hibernating state to a Running state.
-	ResumingHibernationReason = "Resuming"
+	//ResumingHibernationReason = "Resuming"
+
+	WaitingForMachinesRunningReason  = "WaitingForMachines"
+	WaitingForNodesRunningReason     = "WaitingForNodes"
+	WaitingForClusterOperatorsReason = "WaitingForClusterOperators"
+
 	// RunningHibernationReason is used as the reason when the cluster is running and
 	// the Hibernating condition is false.
 	RunningHibernationReason = "Running"

--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -439,16 +439,22 @@ const (
 	// is resuming or running. Precise details are available in the Running condition.
 	ResumingOrRunningHibernationReason = "ResumingOrRunning"
 
+	// StoppingOrHibernatingRunningReason is used as the reason for the Running condition when the cluster
+	// is stopping or hibernating. Precise details are available in the Hibernating condition.
 	StoppingOrHibernatingRunningReason = "StoppingOrHibernating"
 
-	// ResumingHibernationReason is used as the reason when the cluster is transitioning
-	// from a Hibernating state to a Running state.
-	//ResumingHibernationReason = "Resuming"
+	// WaitingForMachinesRunningReason is used on the Running condition when waiting for cloud VMs to start.
+	WaitingForMachinesRunningReason = "WaitingForMachines"
 
-	WaitingForMachinesRunningReason          = "WaitingForMachines"
-	WaitingForNodesRunningReason             = "WaitingForNodes"
-	PausingForClusterOperatorsToSettleReason = "PausingForClusterOperatorsToSettle"
-	WaitingForClusterOperatorsReason         = "WaitingForClusterOperators"
+	// WaitingForNodesRunningReason is used on the Running condition when waiting for nodes to become Ready.
+	WaitingForNodesRunningReason = "WaitingForNodes"
+
+	// PausingForClusterOperatorsToSettleRunningReason is used on the Running condition when pausing to let ClusterOperators start and post new status before we check it.
+	PausingForClusterOperatorsToSettleRunningReason = "PausingForClusterOperatorsToSettle"
+
+	// WaitingForClusterOperatorsRunningReason is used on the Running condition when waiting for ClusterOperators to
+	// get to a good state. (Available=True, Processing=False, Degraded=False)
+	WaitingForClusterOperatorsRunningReason = "WaitingForClusterOperators"
 
 	// RunningHibernationReason is used as the reason when the cluster is running and
 	// the Hibernating condition is false.

--- a/pkg/controller/clusterclaim/clusterclaim_controller.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller.go
@@ -38,7 +38,7 @@ const (
 // clusterClaimConditions are the cluster claim conditions controlled or initialized by cluster claim controller
 var clusterClaimConditions = []hivev1.ClusterClaimConditionType{
 	hivev1.ClusterClaimPendingCondition,
-	hivev1.ClusterRunningCondition,
+	hivev1.ClusterClaimRunningCondition,
 }
 
 // Add creates a new ClusterClaim Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
@@ -275,7 +275,7 @@ func (r *ReconcileClusterClaim) Reconcile(ctx context.Context, request reconcile
 func (r *ReconcileClusterClaim) setDeletingStatus(claim *hivev1.ClusterClaim, logger log.FieldLogger) (reconcile.Result, error) {
 	if conds, changed := controllerutils.SetClusterClaimConditionWithChangeCheck(
 		claim.Status.Conditions,
-		hivev1.ClusterRunningCondition,
+		hivev1.ClusterClaimRunningCondition,
 		corev1.ConditionFalse,
 		"ClusterDeleting",
 		"Assigned cluster has been marked for deletion",
@@ -413,7 +413,7 @@ func (r *ReconcileClusterClaim) reconcileForDeletedCluster(claim *hivev1.Cluster
 	logger.Debug("assigned cluster has been deleted")
 	conds, changed := controllerutils.SetClusterClaimConditionWithChangeCheck(
 		claim.Status.Conditions,
-		hivev1.ClusterRunningCondition,
+		hivev1.ClusterClaimRunningCondition,
 		corev1.ConditionFalse,
 		"ClusterDeleted",
 		"Assigned cluster has been deleted",
@@ -452,7 +452,7 @@ func (r *ReconcileClusterClaim) reconcileForExistingAssignment(claim *hivev1.Clu
 	if hc.Status == corev1.ConditionFalse {
 		conds, changed = controllerutils.SetClusterClaimConditionWithChangeCheck(
 			conds,
-			hivev1.ClusterRunningCondition,
+			hivev1.ClusterClaimRunningCondition,
 			corev1.ConditionTrue,
 			"Running",
 			"Cluster is running",
@@ -463,7 +463,7 @@ func (r *ReconcileClusterClaim) reconcileForExistingAssignment(claim *hivev1.Clu
 		log.Debug("waiting for cluster to be running")
 		conds, changed = controllerutils.SetClusterClaimConditionWithChangeCheck(
 			conds,
-			hivev1.ClusterRunningCondition,
+			hivev1.ClusterClaimRunningCondition,
 			corev1.ConditionFalse,
 			"Resuming",
 			"Waiting for cluster to be running",

--- a/pkg/controller/clusterclaim/clusterclaim_controller_test.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller_test.go
@@ -79,7 +79,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 		}),
 		testclaim.WithCondition(hivev1.ClusterClaimCondition{
 			Status: corev1.ConditionUnknown,
-			Type:   hivev1.ClusterRunningCondition,
+			Type:   hivev1.ClusterClaimRunningCondition,
 		}),
 	)
 	cdBuilder := testcd.FullBuilder(clusterName, clusterName, scheme).Options(
@@ -118,7 +118,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 					Status: corev1.ConditionUnknown,
 				},
 				{
-					Type:   hivev1.ClusterRunningCondition,
+					Type:   hivev1.ClusterClaimRunningCondition,
 					Status: corev1.ConditionUnknown,
 				},
 			},
@@ -139,7 +139,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 					Status: corev1.ConditionUnknown,
 				},
 				{
-					Type:   hivev1.ClusterRunningCondition,
+					Type:   hivev1.ClusterClaimRunningCondition,
 					Status: corev1.ConditionUnknown,
 				},
 			},
@@ -164,7 +164,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 					Message: "Cluster claimed",
 				},
 				{
-					Type:    hivev1.ClusterRunningCondition,
+					Type:    hivev1.ClusterClaimRunningCondition,
 					Status:  corev1.ConditionFalse,
 					Reason:  "Resuming",
 					Message: "Waiting for cluster to be running",
@@ -191,7 +191,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 			),
 			expectCompletedClaim: true,
 			expectedConditions: []hivev1.ClusterClaimCondition{{
-				Type:    hivev1.ClusterRunningCondition,
+				Type:    hivev1.ClusterClaimRunningCondition,
 				Status:  corev1.ConditionFalse,
 				Reason:  "ClusterDeleting",
 				Message: "Assigned cluster has been marked for deletion",
@@ -201,7 +201,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 			name:  "deleted cluster",
 			claim: initializedClaimBuilder.Build(testclaim.WithCluster(clusterName)),
 			expectedConditions: []hivev1.ClusterClaimCondition{{
-				Type:    hivev1.ClusterRunningCondition,
+				Type:    hivev1.ClusterClaimRunningCondition,
 				Status:  corev1.ConditionFalse,
 				Reason:  "ClusterDeleted",
 				Message: "Assigned cluster has been deleted",
@@ -235,7 +235,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 					Message: "Cluster claimed",
 				},
 				{
-					Type:    hivev1.ClusterRunningCondition,
+					Type:    hivev1.ClusterClaimRunningCondition,
 					Status:  corev1.ConditionFalse,
 					Reason:  "Resuming",
 					Message: "Waiting for cluster to be running",
@@ -333,7 +333,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 					Message: "Cluster claimed",
 				},
 				{
-					Type:    hivev1.ClusterRunningCondition,
+					Type:    hivev1.ClusterClaimRunningCondition,
 					Status:  corev1.ConditionFalse,
 					Reason:  "Resuming",
 					Message: "Waiting for cluster to be running",
@@ -367,7 +367,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 					Message: "Cluster claimed",
 				},
 				{
-					Type:    hivev1.ClusterRunningCondition,
+					Type:    hivev1.ClusterClaimRunningCondition,
 					Status:  corev1.ConditionFalse,
 					Reason:  "Resuming",
 					Message: "Waiting for cluster to be running",
@@ -402,7 +402,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 					Message: "Cluster claimed",
 				},
 				{
-					Type:    hivev1.ClusterRunningCondition,
+					Type:    hivev1.ClusterClaimRunningCondition,
 					Status:  corev1.ConditionFalse,
 					Reason:  "Resuming",
 					Message: "Waiting for cluster to be running",
@@ -431,7 +431,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 					Message: "Cluster claimed",
 				},
 				{
-					Type:    hivev1.ClusterRunningCondition,
+					Type:    hivev1.ClusterClaimRunningCondition,
 					Status:  corev1.ConditionFalse,
 					Reason:  "Resuming",
 					Message: "Waiting for cluster to be running",
@@ -608,7 +608,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 					Message: "Cluster claimed",
 				},
 				{
-					Type:    hivev1.ClusterRunningCondition,
+					Type:    hivev1.ClusterClaimRunningCondition,
 					Status:  corev1.ConditionFalse,
 					Reason:  "Resuming",
 					Message: "Waiting for cluster to be running",

--- a/pkg/controller/hibernation/hibernation_controller_test.go
+++ b/pkg/controller/hibernation/hibernation_controller_test.go
@@ -453,7 +453,7 @@ func TestReconcile(t *testing.T) {
 				assert.Equal(t, hivev1.ResumingOrRunningHibernationReason, cond.Reason)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
-				assert.Equal(t, hivev1.PausingForClusterOperatorsToSettleReason, runCond.Reason)
+				assert.Equal(t, hivev1.PausingForClusterOperatorsToSettleRunningReason, runCond.Reason)
 			},
 			expectRequeueAfter: time.Duration(time.Minute * 5),
 		},
@@ -470,7 +470,7 @@ func TestReconcile(t *testing.T) {
 				testcd.WithCondition(hivev1.ClusterDeploymentCondition{
 					Type:               hivev1.ClusterRunningCondition,
 					Status:             corev1.ConditionFalse,
-					Reason:             hivev1.PausingForClusterOperatorsToSettleReason,
+					Reason:             hivev1.PausingForClusterOperatorsToSettleRunningReason,
 					LastProbeTime:      metav1.Time{time.Now().Add(-2 * time.Minute)},
 					LastTransitionTime: metav1.Time{time.Now().Add(-2 * time.Hour)},
 				}),
@@ -493,7 +493,7 @@ func TestReconcile(t *testing.T) {
 				assert.Equal(t, hivev1.ResumingOrRunningHibernationReason, cond.Reason)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
-				assert.Equal(t, hivev1.PausingForClusterOperatorsToSettleReason, runCond.Reason)
+				assert.Equal(t, hivev1.PausingForClusterOperatorsToSettleRunningReason, runCond.Reason)
 			},
 			expectRequeueAfter: time.Duration(time.Minute * 3),
 		},
@@ -510,7 +510,7 @@ func TestReconcile(t *testing.T) {
 				testcd.WithCondition(hivev1.ClusterDeploymentCondition{
 					Type:               hivev1.ClusterRunningCondition,
 					Status:             corev1.ConditionFalse,
-					Reason:             hivev1.PausingForClusterOperatorsToSettleReason,
+					Reason:             hivev1.PausingForClusterOperatorsToSettleRunningReason,
 					LastProbeTime:      metav1.Time{time.Now().Add(-6 * time.Minute)},
 					LastTransitionTime: metav1.Time{time.Now().Add(-2 * time.Hour)},
 				}),
@@ -533,7 +533,7 @@ func TestReconcile(t *testing.T) {
 				assert.Equal(t, hivev1.ResumingOrRunningHibernationReason, cond.Reason)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
-				assert.Equal(t, hivev1.WaitingForClusterOperatorsReason, runCond.Reason)
+				assert.Equal(t, hivev1.WaitingForClusterOperatorsRunningReason, runCond.Reason)
 			},
 			expectRequeueAfter: time.Duration(time.Second * 30),
 		},

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterclaim_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterclaim_types.go
@@ -68,8 +68,8 @@ type ClusterClaimConditionType string
 const (
 	// ClusterClaimPendingCondition is set when a cluster has not yet been assigned and made ready to the claim.
 	ClusterClaimPendingCondition ClusterClaimConditionType = "Pending"
-	// ClusterRunningCondition is true when a claimed cluster is running and ready for use.
-	ClusterRunningCondition ClusterClaimConditionType = "ClusterRunning"
+	// ClusterClaimRunningCondition is true when a claimed cluster is running and ready for use.
+	ClusterClaimRunningCondition ClusterClaimConditionType = "ClusterRunning"
 )
 
 // +genclient

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -445,9 +445,10 @@ const (
 	// from a Hibernating state to a Running state.
 	//ResumingHibernationReason = "Resuming"
 
-	WaitingForMachinesRunningReason  = "WaitingForMachines"
-	WaitingForNodesRunningReason     = "WaitingForNodes"
-	WaitingForClusterOperatorsReason = "WaitingForClusterOperators"
+	WaitingForMachinesRunningReason          = "WaitingForMachines"
+	WaitingForNodesRunningReason             = "WaitingForNodes"
+	PausingForClusterOperatorsToSettleReason = "PausingForClusterOperatorsToSettle"
+	WaitingForClusterOperatorsReason         = "WaitingForClusterOperators"
 
 	// RunningHibernationReason is used as the reason when the cluster is running and
 	// the Hibernating condition is false.

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -384,9 +384,11 @@ const (
 	// RelocationFailedCondition indicates if a relocation to another Hive instance has failed
 	RelocationFailedCondition ClusterDeploymentConditionType = "RelocationFailed"
 
-	// ClusterHibernatingCondition is set when the ClusterDeployment is either
-	// transitioning to/from a hibernating state or is in a hibernating state.
+	// ClusterHibernatingCondition is true when a Cluster is in a Hibernating state.
 	ClusterHibernatingCondition ClusterDeploymentConditionType = "Hibernating"
+
+	// ClusterRunningCondition is true when a cluster is running and ready for use.
+	ClusterRunningCondition ClusterDeploymentConditionType = "Running"
 
 	// InstallLaunchErrorCondition is set when a cluster provision fails to launch an install pod
 	InstallLaunchErrorCondition ClusterDeploymentConditionType = "InstallLaunchError"
@@ -433,9 +435,20 @@ var PositivePolarityClusterDeploymentConditions = []ClusterDeploymentConditionTy
 
 // Cluster hibernating reasons
 const (
+	// ResumingOrRunningHibernationReason is used as the reason for the Hibernating condition when the cluster
+	// is resuming or running. Precise details are available in the Running condition.
+	ResumingOrRunningHibernationReason = "ResumingOrRunning"
+
+	StoppingOrHibernatingRunningReason = "StoppingOrHibernating"
+
 	// ResumingHibernationReason is used as the reason when the cluster is transitioning
 	// from a Hibernating state to a Running state.
-	ResumingHibernationReason = "Resuming"
+	//ResumingHibernationReason = "Resuming"
+
+	WaitingForMachinesRunningReason  = "WaitingForMachines"
+	WaitingForNodesRunningReason     = "WaitingForNodes"
+	WaitingForClusterOperatorsReason = "WaitingForClusterOperators"
+
 	// RunningHibernationReason is used as the reason when the cluster is running and
 	// the Hibernating condition is false.
 	RunningHibernationReason = "Running"

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -439,16 +439,22 @@ const (
 	// is resuming or running. Precise details are available in the Running condition.
 	ResumingOrRunningHibernationReason = "ResumingOrRunning"
 
+	// StoppingOrHibernatingRunningReason is used as the reason for the Running condition when the cluster
+	// is stopping or hibernating. Precise details are available in the Hibernating condition.
 	StoppingOrHibernatingRunningReason = "StoppingOrHibernating"
 
-	// ResumingHibernationReason is used as the reason when the cluster is transitioning
-	// from a Hibernating state to a Running state.
-	//ResumingHibernationReason = "Resuming"
+	// WaitingForMachinesRunningReason is used on the Running condition when waiting for cloud VMs to start.
+	WaitingForMachinesRunningReason = "WaitingForMachines"
 
-	WaitingForMachinesRunningReason          = "WaitingForMachines"
-	WaitingForNodesRunningReason             = "WaitingForNodes"
-	PausingForClusterOperatorsToSettleReason = "PausingForClusterOperatorsToSettle"
-	WaitingForClusterOperatorsReason         = "WaitingForClusterOperators"
+	// WaitingForNodesRunningReason is used on the Running condition when waiting for nodes to become Ready.
+	WaitingForNodesRunningReason = "WaitingForNodes"
+
+	// PausingForClusterOperatorsToSettleRunningReason is used on the Running condition when pausing to let ClusterOperators start and post new status before we check it.
+	PausingForClusterOperatorsToSettleRunningReason = "PausingForClusterOperatorsToSettle"
+
+	// WaitingForClusterOperatorsRunningReason is used on the Running condition when waiting for ClusterOperators to
+	// get to a good state. (Available=True, Processing=False, Degraded=False)
+	WaitingForClusterOperatorsRunningReason = "WaitingForClusterOperators"
 
 	// RunningHibernationReason is used as the reason when the cluster is running and
 	// the Hibernating condition is false.


### PR DESCRIPTION
- Update bmg, remove imagebuilder workaround
- Hack: Hardcode crb subject namespace for app-sre
- save
- tweak
- ClusterPool:ClusterDeployment version & condition
- Add RequirementsMet condition to provision delay metric.
- review updates
- feedback updates
- Clarify resourceApplyMode: Sync when deleting SyncSets
- .gitignore: exclude *.out only in repo root
- dedicated-admin ClusterRole aggregation for direct deploy
- Unhack: Use a patch to set CRB subject ns for direct deploy
- Scrub AWS not authorized message which includes AWS resource ARNs.
- Update pkg/controller/utils/errorscrub.go
- Replace identifiers in not authorized message.
- More updates for k8s 1.22
- Update pkg/controller/utils/errorscrub.go
- Remove spaces from expected.
- Remove unused ReadMutatingWebhookConfigurationV1Beta1OrDie
- Clean up App-SRE OLMisms
- fix GCP CPU quota install log regexp
- add install log regexp for invalid AWS tags
- Remove encoded error message in VPCEndpointServiceReconcileFailed condition.
- [^,]
- Check ClusterOperator state before considering a cluster running.
- Stop updating resource in setHibernatingCondition.
- Complete ClusterOperator checking.
- Introduce Running condition.
- Add pause for ClusterOperators to settle.
- Cleanup and bugs.
