### PR TITLE
ClusterPool RunningCount

### DIFF
--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -252,6 +252,9 @@ type ClusterPoolReference struct {
 	// ClaimName is the name of the ClusterClaim that claimed the cluster from the pool.
 	// +optional
 	ClaimName string `json:"claimName,omitempty"`
+	// ClaimedTimestamp is the time this cluster was assigned to a ClusterClaim. This is only used for
+	// ClusterDeployments belonging to ClusterPools.
+	ClaimedTimestamp *metav1.Time `json:"claimedTimestamp,omitempty"`
 }
 
 // ClusterMetadata contains metadata information about the installed cluster.

--- a/apis/hive/v1/clusterpool_types.go
+++ b/apis/hive/v1/clusterpool_types.go
@@ -21,6 +21,12 @@ type ClusterPoolSpec struct {
 	// +required
 	Size int32 `json:"size"`
 
+	// RunningCount is the number of clusters we should keep running. The remainder will be kept hibernated until claimed.
+	// By default no clusters will be kept running (all will be hibernated).
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	RunningCount int32 `json:"runningCount,omitempty"`
+
 	// MaxSize is the maximum number of clusters that will be provisioned including clusters that have been claimed
 	// and ones waiting to be used.
 	// By default there is no limit.

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -181,6 +181,12 @@ spec:
                     description: ClaimName is the name of the ClusterClaim that claimed
                       the cluster from the pool.
                     type: string
+                  claimedTimestamp:
+                    description: ClaimedTimestamp is the time this cluster was assigned
+                      to a ClusterClaim. This is only used for ClusterDeployments
+                      belonging to ClusterPools.
+                    format: date-time
+                    type: string
                   namespace:
                     description: Namespace is the namespace where the ClusterPool
                       resides.

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -463,6 +463,13 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+              runningCount:
+                description: RunningCount is the number of clusters we should keep
+                  running. The remainder will be kept hibernated until claimed. By
+                  default no clusters will be kept running (all will be hibernated).
+                format: int32
+                minimum: 0
+                type: integer
               size:
                 description: Size is the default number of clusters that we should
                   keep provisioned and waiting for use.

--- a/docs/clusterpools.md
+++ b/docs/clusterpools.md
@@ -24,12 +24,12 @@ the pool. `ClusterClaims` must be created in the same namespace as their
 The user who claims a cluster can be given RBAC to their clusters namespace to
 prevent anyone else from being able to access it.
 
-Presently once a `ClusterDeployment` is ready, it will be
+By default once a `ClusterDeployment` is ready, it will be
 [hibernated](./hibernating-clusters.md) automatically. Once claimed it will be
 automatically resumed, meaning that the typical time to claim a cluster and be
-ready to go is in the 2-5 minute range while the cluster starts up. An option
-to keep the clusters in the pool always running so they can instantly be used
-may be added in the future.
+ready to go is in the 2-5 minute range while the cluster starts up. You can
+keep a subset of clusters active by setting `ClusterPool.Spec.RunningCount`;
+such clusters will be ready immediately when claimed.
 
 When done with a cluster, users can just delete their `ClusterClaim` and the
 `ClusterDeployment` will be automatically deprovisioned. An optional
@@ -67,7 +67,8 @@ spec:
       region: us-east-1
   pullSecretRef:
     name: hive-team-pull-secret
-  size: 1
+  runningCount: 1
+  size: 3
 ```
 
 ## Sample Cluster Claim

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -434,6 +434,12 @@ objects:
                       description: ClaimName is the name of the ClusterClaim that
                         claimed the cluster from the pool.
                       type: string
+                    claimedTimestamp:
+                      description: ClaimedTimestamp is the time this cluster was assigned
+                        to a ClusterClaim. This is only used for ClusterDeployments
+                        belonging to ClusterPools.
+                      format: date-time
+                      type: string
                     namespace:
                       description: Namespace is the namespace where the ClusterPool
                         resides.
@@ -2143,6 +2149,13 @@ objects:
                         TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
+                runningCount:
+                  description: RunningCount is the number of clusters we should keep
+                    running. The remainder will be kept hibernated until claimed.
+                    By default no clusters will be kept running (all will be hibernated).
+                  format: int32
+                  minimum: 0
+                  type: integer
                 size:
                   description: Size is the default number of clusters that we should
                     keep provisioned and waiting for use.

--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -136,6 +136,8 @@ func WithClusterPoolReference(namespace, poolName, claimName string) Option {
 			PoolName:  poolName,
 			ClaimName: claimName,
 		}
+		now := metav1.Now()
+		clusterDeployment.Spec.ClusterPoolRef.ClaimedTimestamp = &now
 	}
 }
 

--- a/pkg/test/clusterpool/clusterpool.go
+++ b/pkg/test/clusterpool/clusterpool.go
@@ -172,3 +172,9 @@ func WithCondition(cond hivev1.ClusterPoolCondition) Option {
 		clusterPool.Status.Conditions = append(clusterPool.Status.Conditions, cond)
 	}
 }
+
+func WithRunningCount(size int) Option {
+	return func(clusterPool *hivev1.ClusterPool) {
+		clusterPool.Spec.RunningCount = int32(size)
+	}
+}

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -252,6 +252,9 @@ type ClusterPoolReference struct {
 	// ClaimName is the name of the ClusterClaim that claimed the cluster from the pool.
 	// +optional
 	ClaimName string `json:"claimName,omitempty"`
+	// ClaimedTimestamp is the time this cluster was assigned to a ClusterClaim. This is only used for
+	// ClusterDeployments belonging to ClusterPools.
+	ClaimedTimestamp *metav1.Time `json:"claimedTimestamp,omitempty"`
 }
 
 // ClusterMetadata contains metadata information about the installed cluster.

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
@@ -21,6 +21,12 @@ type ClusterPoolSpec struct {
 	// +required
 	Size int32 `json:"size"`
 
+	// RunningCount is the number of clusters we should keep running. The remainder will be kept hibernated until claimed.
+	// By default no clusters will be kept running (all will be hibernated).
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	RunningCount int32 `json:"runningCount,omitempty"`
+
 	// MaxSize is the maximum number of clusters that will be provisioned including clusters that have been claimed
 	// and ones waiting to be used.
 	// By default there is no limit.


### PR DESCRIPTION
Adds ClusterPool.Spec.RunningCount, the number of pool clusters to try to keep active at any time.

Note that when ClusterPool.Spec.HibernateAfter is set, we count from when it was claimed rather than when it was started so it doesn't hibernate early.

[HIVE-1576](https://issues.redhat.com/browse/HIVE-1576)