### PR TITLE
Copy NodeSelector/Tolerations from operator to controllers

### DIFF
--- a/pkg/operator/hive/clustersync.go
+++ b/pkg/operator/hive/clustersync.go
@@ -141,6 +141,10 @@ func (r *ReconcileHiveConfig) deployClusterSync(hLog log.FieldLogger, h resource
 		}
 	}
 
+	// Apply nodeSelector and tolerations passed through from the operator deployment
+	newClusterSyncStatefulSet.Spec.Template.Spec.NodeSelector = r.nodeSelector
+	newClusterSyncStatefulSet.Spec.Template.Spec.Tolerations = r.tolerations
+
 	newClusterSyncStatefulSet.Namespace = hiveNSName
 	result, err := util.ApplyRuntimeObjectWithGC(h, newClusterSyncStatefulSet, hiveconfig)
 	if err != nil {

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -310,6 +310,10 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 		hLog.Warn("hive is not running on OpenShift, some optional assets will not be deployed")
 	}
 
+	// Apply nodeSelector and tolerations passed through from the operator deployment
+	hiveDeployment.Spec.Template.Spec.NodeSelector = r.nodeSelector
+	hiveDeployment.Spec.Template.Spec.Tolerations = r.tolerations
+
 	hiveDeployment.Namespace = hiveNSName
 	result, err := util.ApplyRuntimeObjectWithGC(h, hiveDeployment, instance)
 	if err != nil {

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -187,6 +187,10 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h resour
 	}
 	hiveAdmDeployment.Spec.Template.Annotations[servingCertSecretHashAnnotation] = certSecretHash
 
+	// Apply nodeSelector and tolerations passed through from the operator deployment
+	hiveAdmDeployment.Spec.Template.Spec.NodeSelector = r.nodeSelector
+	hiveAdmDeployment.Spec.Template.Spec.Tolerations = r.tolerations
+
 	result, err := util.ApplyRuntimeObjectWithGC(h, hiveAdmDeployment, instance)
 	if err != nil {
 		hLog.WithError(err).Error("error applying deployment")


### PR DESCRIPTION
With this change, the operator will deploy controllers (including clustersync and hiveadmission) with the same NodeSelector and Tolerations as the operator itself was deployed with.

[HIVE-1635](https://issues.redhat.com/browse/HIVE-1635)