### PR TITLE
e2e: Force DNSZone resync on ActuatorNotInitialized flake

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -156,6 +156,10 @@ function capture_manifests() {
     oc get clusterimageset -o yaml &> "${ARTIFACT_DIR}/hive_clusterimagesets.yaml" || true
     oc get clusterprovision -A -o yaml &> "${ARTIFACT_DIR}/hive_clusterprovision.yaml" || true
     oc get clusterstate -A -o yaml &> "${ARTIFACT_DIR}/hive_clusterstate.yaml" || true
+    oc get dnszone -A -o yaml &> "${ARTIFACT_DIR}/hive_dnszones.yaml" || true
+    oc get machinepool -A -o yaml &> "${ARTIFACT_DIR}/hive_machinepools.yaml" || true
+    # Don't get the contents of the secrets, since they're sensitive; hopefully just listing them will be helpful.
+    oc get secrets -A &> "${ARTIFACT_DIR}/secret_list.txt" || true
 }
 
 function capture_cluster_logs() {

--- a/hack/statuspatch
+++ b/hack/statuspatch
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+CMD=${0##*/}
+EDITOR=${EDITOR:-/usr/bin/vi}
+
+RC=0
+
+usage() {
+    cat <<EOF
+Usage: $CMD {oc args to get a single object} [<<< JQ]
+
+Uses oc with the supplied arguments to retrieve a single k8s object for
+editing. But instead of your .status edits being ignored, they are
+applied (and any .spec edits are ignored). Do not include "-o json" --
+we'll do that for you.
+
+In interactive mode, opens an editor like "oc edit" would. Changes are
+applied when the editor is saved and exited.
+
+To use this utility noninteractively, supply a jq command on stdin. That
+command is run on the object and the resulting output is applied.
+NOTE: The jq command must return the whole object, not just the chunk
+that was changed.
+NOTE: Be sure you're using the right version of jq. App-SRE Jenkins
+servers are running v3.
+
+Example:
+  Interactive: 
+    $CMD -n mynamespace clusterdeployment foo
+
+  Noninteractive:
+    $CMD -n mynamespace clusterdeployment foo <<< '(.status.conditions[] | select(.type=="ProvisionStopped") | .status) = "True"'
+EOF
+    exit -1
+}
+
+cleanup() {
+    # Terminate proxy, if any
+    kill %1 2>/dev/null
+    # Clean up the unix socket, if it exists
+    [[ -S "$socket" ]] && rm -f $socket
+    # Clean up the patchfile, unless we failed (and it's nonempty)
+    if [[ $RC -ne 0 ]] && [[ -s "$patchfile" ]]; then
+        echo "Saving patchfile $patchfile"
+    else
+        echo "Cleaning up $patchfile"
+        rm -f $patchfile
+    fi
+}
+trap "cleanup" EXIT
+
+getfield() {
+    local path="$1"
+    local res=$(jq -r "$path" $patchfile)
+    RC=$?
+    if [[ $RC -ne 0 ]] || [[ -z "$res" ]]; then
+        echo "Couldn't get '$path' from retrieved object! What's in $patchfile?"
+        exit 2
+    fi
+    echo $res
+}
+
+# Print usage if no args, or if any arg looks like -h/--help
+[[ $# -eq 0 ]] && usage
+for arg in "$@"; do
+  [[ "$arg" == "-h"* ]] || [[ "$arg" == "--h"* ]] && usage
+done
+
+patchfile=$(mktemp /tmp/$CMD.XXXX)
+
+echo "Retrieving object..."
+oc get "$@" -o json > $patchfile || RC=$?
+[[ $RC -eq 0 ]] || exit 1
+
+kind=$(getfield .kind)
+
+# Only support single objects
+if [[ $kind == "List" ]]; then
+    echo "Can't patch a List! Please refine your command to retrieve a single object."
+    exit 3
+fi
+
+# TODO: This will *usually* work, but the right thing would be to go
+# discover the proper API path.
+kind=$(echo "$kind" | tr '[:upper:]' '[:lower:]')s
+
+apiVersion=$(getfield .apiVersion)
+name=$(getfield .metadata.name)
+namespace=$(getfield .metadata.namespace)
+# Construct the sub-path depending on whether it's a namespaced resource
+if [[ $namespace == "null" ]]; then
+    subpath=$kind/$name
+else
+    subpath=namespaces/$namespace/$kind/$name
+fi
+
+if [[ -t 0 ]]; then
+    # No stdin: interactive mode: allow user to edit
+    # TODO: If $EDITOR launches in the background...
+    $EDITOR $patchfile
+else
+    echo "Noninteractive mode. Applying jq..."
+    read jqcmd
+    # TODO: Better way to edit in place?
+    jq "$jqcmd" < $patchfile > $patchfile.2 || RC=$?
+    # Do this before error checking, for consistency/cleanup purposes
+    mv $patchfile.2 $patchfile
+    if [[ $RC -ne 0 ]]; then
+        echo "jq patch failed"
+        exit 4
+    fi
+fi
+if ! [[ -s $patchfile ]]; then
+    echo "Empty patch file $patchfile! Aborting."
+    exit 5
+fi
+
+# Proxy through a unix socket so we don't have to dork with ports
+socket=$patchfile.sock
+python -c "import os, socket as s; s.socket(s.AF_UNIX).bind('$socket')"
+oc proxy -u $socket &
+# TODO: Better way to wait for the socket to spin up
+sleep 1
+
+# Do the patch. Save the output (which is the object, returned by the
+# server) to the same patchfile so it's preserved if something fails.
+# TODO: Is this the right thing? Should we preserve the original
+# patchfile separately?
+curl -k -s -X PATCH \
+    -H "Accept: application/json, */*" \
+    -H "Content-Type: application/merge-patch+json" \
+    --unix-socket $socket \
+    http://localhost/apis/$apiVersion/$subpath/status \
+    --data @$patchfile -o $patchfile || RC=$?
+if [[ $RC -eq 0 ]]; then
+    echo "Success"
+fi
+
+# Let the trap do the cleanup.


### PR DESCRIPTION
We've seen frequent e2e flakes where the ClusterDeployment times out waiting to install, and it contains a status condition like:

```
   - lastProbeTime: "2021-09-10T00:24:40Z"
      lastTransitionTime: "2021-09-10T00:24:40Z"
      message: 'error instantiating actuator: Secret "hiveci-613aa513-5fd-aws-creds" not found'
      reason: ActuatorNotInitialized
      status: "True"
      type: DNSNotReady
```

This is a timing problem whereby hiveutil create-cluster is creating the secret and the ClusterDeployment in quick succession, and the dnszone controller kicks in before the secret has come to life (or appeared in the cache?). If the dnszone controller doesn't find the secret, it goes to sleep for 2h, during which time the CD doesn't progress; and we time out of the test after ~90m.

Since this is not a situation that could reasonably happen in real life, we can't justify changing the logic of the clusterpool or dnszone controllers. So with this commit we hack the test case: While waiting for the ClusterDeployment to install, if we notice this condition, we reset the `lastSyncGeneration` of the DNSZone object, which forces the dnszone controller to resync it. Hopefully by this time the secret exists and things will proceed as normal.

While we're in here, we do a couple of other small things:
- Send failure and timeout messages to stderr, which (I think?) should make them show up in the CI output in eye-catching red, and not be collapsed.
- On timeout, print the ClusterDeployment's status conditions so we don't have to go hunting through the artifacts directory for them.
- Save dnszones, machinepools, and (a summary of) secrets into the artifacts dir to aid debugging.