### PR TITLE
Register hive_clusterpool_stale_clusterdeployments_deleted metric

### DIFF
--- a/pkg/controller/clusterpool/metrics.go
+++ b/pkg/controller/clusterpool/metrics.go
@@ -18,5 +18,5 @@ var (
 )
 
 func init() {
-	metrics.Registry.MustRegister()
+	metrics.Registry.MustRegister(metricStaleClusterDeploymentsDeleted)
 }


### PR DESCRIPTION
This was missed in #1512 / f3e437e.

[HIVE-1058](https://issues.redhat.com/browse/HIVE-1058)
[HIVE-1645](https://issues.redhat.com/browse/HIVE-1645)