### PR TITLE
e2e-pool: Move AllClustersCurrent check into wait_for_pool_to_be_ready

### DIFF
--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -67,7 +67,7 @@ function wait_for_pool_to_be_ready() {
   local poolname=$1
   local i=0
   # NOTE: This will need to change if we add a test with a zero-size pool.
-  while [[ $(oc get clusterpool $poolname -o json | jq '.status.size != 0 and .status.ready == .status.size') != "true" ]]; do
+  while [[ $(oc get clusterpool $poolname -o json | jq '.status.size != 0 and .status.ready == .status.size') != "true" ]] || ! expect_all_clusters_current $poolname True; do
     i=$((i+1))
     if [[ $i -gt $max_cluster_deployment_status_checks ]]; then
       echo "Timed out waiting for clusterpool $poolname to be ready."
@@ -143,7 +143,6 @@ oc get clusterpool ${REAL_POOL_NAME} -o json \
 wait_for_pool_to_be_ready $FAKE_POOL_NAME
 
 # Test stale cluster replacement (HIVE-1058)
-expect_all_clusters_current $FAKE_POOL_NAME True
 verify_pool_cd_imagesets $FAKE_POOL_NAME $IMAGESET_NAME
 # Create another cluster image set so we can edit a relevant pool field.
 # The cis is identical except for the name, but the pool doesn't know that.


### PR DESCRIPTION
We've started seeing flakes where the pool's ready/size statuses are copacetic before the conditions settle. This commit moves the check for AllClustersCurrent into the same loop that checks the ready/size statuses so we get a chance to retry in this case.