### PR TITLE
controller/dnszone: add condition to track dns api opt-in required failures

### DIFF
--- a/apis/hive/v1/dnszone_types.go
+++ b/apis/hive/v1/dnszone_types.go
@@ -185,6 +185,9 @@ const (
 	// AuthenticationFailureCondition is true when credentials cannot be used to create a
 	// DNS zone because they fail authentication
 	AuthenticationFailureCondition DNSZoneConditionType = "AuthenticationFailure"
+	// APIOptInRequiredCondition is true when the user account used for managing DNS
+	// needs to enable the DNS apis.
+	APIOptInRequiredCondition DNSZoneConditionType = "APIOptInRequired"
 	// GenericDNSErrorsCondition is true when there's some DNS Zone related error that isn't related to
 	// authentication or credentials, and needs to be bubbled up to ClusterDeployment
 	GenericDNSErrorsCondition DNSZoneConditionType = "DNSError"

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -1504,6 +1504,7 @@ func (r *ReconcileClusterDeployment) ensureManagedDNSZone(cd *hivev1.ClusterDepl
 	availableCondition := controllerutils.FindDNSZoneCondition(dnsZone.Status.Conditions, hivev1.ZoneAvailableDNSZoneCondition)
 	insufficientCredentialsCondition := controllerutils.FindDNSZoneCondition(dnsZone.Status.Conditions, hivev1.InsufficientCredentialsCondition)
 	authenticationFailureCondition := controllerutils.FindDNSZoneCondition(dnsZone.Status.Conditions, hivev1.AuthenticationFailureCondition)
+	apiOptInRequiredCondition := controllerutils.FindDNSZoneCondition(dnsZone.Status.Conditions, hivev1.APIOptInRequiredCondition)
 	dnsErrorCondition := controllerutils.FindDNSZoneCondition(dnsZone.Status.Conditions, hivev1.GenericDNSErrorsCondition)
 	var (
 		status          corev1.ConditionStatus
@@ -1522,6 +1523,10 @@ func (r *ReconcileClusterDeployment) ensureManagedDNSZone(cd *hivev1.ClusterDepl
 		status = corev1.ConditionTrue
 		reason = "AuthenticationFailure"
 		message = authenticationFailureCondition.Message
+	case apiOptInRequiredCondition != nil && apiOptInRequiredCondition.Status == corev1.ConditionTrue:
+		status = corev1.ConditionTrue
+		reason = "APIOptInRequiredForDNS"
+		message = apiOptInRequiredCondition.Message
 	case dnsErrorCondition != nil && dnsErrorCondition.Status == corev1.ConditionTrue:
 		status = corev1.ConditionTrue
 		reason = dnsErrorCondition.Reason

--- a/pkg/controller/dnszone/dnszone_controller.go
+++ b/pkg/controller/dnszone/dnszone_controller.go
@@ -48,6 +48,8 @@ const (
 	accessGrantedReason             = "AccessGranted"
 	authenticationFailedReason      = "AuthenticationFailed"
 	authenticationSucceededReason   = "AuthenticationSucceeded"
+	apiOptInRequiredReason          = "RequiredAPIsNotEnabled"
+	apiOptInNotRequiredReason       = "RequiredAPIsEnabled"
 	dnsCloudErrorReason             = "CloudError"
 	dnsNoErrorReason                = "NoError"
 )

--- a/pkg/controller/dnszone/dnszone_controller_test.go
+++ b/pkg/controller/dnszone/dnszone_controller_test.go
@@ -958,6 +958,19 @@ func TestSetConditionsForErrorForAWS(t *testing.T) {
 			},
 		},
 		{
+			name:    "Set APIOptInRequiredCondition on DNSZone for OptInRequired error",
+			dnsZone: validDNSZone(),
+			error:   testOptInRequiredError(),
+			expectConditions: []hivev1.DNSZoneCondition{
+				{
+					Type:    hivev1.APIOptInRequiredCondition,
+					Status:  corev1.ConditionTrue,
+					Reason:  apiOptInRequiredReason,
+					Message: "The AWS Access Key Id needs a subscription for the service.",
+				},
+			},
+		},
+		{
 			name:    "Set GenericDNSErrorsCondition on DNSZone",
 			dnsZone: validDNSZone(),
 			error:   testCloudError(),
@@ -992,6 +1005,12 @@ func TestSetConditionsForErrorForAWS(t *testing.T) {
 						Status:  corev1.ConditionTrue,
 						Reason:  authenticationFailedReason,
 						Message: "The security token included in the request is invalid.",
+					},
+					{
+						Type:    hivev1.APIOptInRequiredCondition,
+						Status:  corev1.ConditionTrue,
+						Reason:  apiOptInRequiredReason,
+						Message: "The AWS Access Key Id needs a subscription for the service.",
 					},
 				}
 
@@ -1101,4 +1120,11 @@ func testInvalidSignatureExceptionError() error {
 		"The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.",
 		fmt.Errorf("The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details"))
 	return invalidSignatureErr
+}
+
+func testOptInRequiredError() error {
+	optInReqErr := awserr.New("OptInRequired",
+		"The AWS Access Key Id needs a subscription for the service\n\tstatus code: 403, request id: f5afff49-3e3d-46d7-92e5-5f9992757398",
+		fmt.Errorf("The AWS Access Key Id needs a subscription for the service"))
+	return optInReqErr
 }

--- a/vendor/github.com/openshift/hive/apis/hive/v1/dnszone_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/dnszone_types.go
@@ -185,6 +185,9 @@ const (
 	// AuthenticationFailureCondition is true when credentials cannot be used to create a
 	// DNS zone because they fail authentication
 	AuthenticationFailureCondition DNSZoneConditionType = "AuthenticationFailure"
+	// APIOptInRequiredCondition is true when the user account used for managing DNS
+	// needs to enable the DNS apis.
+	APIOptInRequiredCondition DNSZoneConditionType = "APIOptInRequired"
 	// GenericDNSErrorsCondition is true when there's some DNS Zone related error that isn't related to
 	// authentication or credentials, and needs to be bubbled up to ClusterDeployment
 	GenericDNSErrorsCondition DNSZoneConditionType = "DNSError"


### PR DESCRIPTION
Adds a special purpose condition to DNSZone like the
AuthenticationFailure condition to provide details when the controller
requires DNS apis to be enabled for success.

Currently, only the AWS actuator sets this condition based on request
from HIVE-1469.

The clusterdeployment controller tracks the conditions from DNSZone, and
it now also tracks the new condition to update the DNSReady condition on
the clusterdeployment.

/assign @joelddiaz 
/cc @suhanime 