### PR TITLE
ClusterDeployment Provisioned condition

### DIFF
--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -400,6 +400,10 @@ const (
 	// ProvisionStoppedCondition is set when cluster provisioning is stopped
 	ProvisionStoppedCondition ClusterDeploymentConditionType = "ProvisionStopped"
 
+	// Provisioned is True when a cluster is installed; False while it is provisioning or deprovisioning.
+	// The Reason indicates where it is in that lifecycle.
+	ProvisionedCondition ClusterDeploymentConditionType = "Provisioned"
+
 	// RequirementsMetCondition is set True when all pre-provision requirements have been met,
 	// and the controllers can begin the cluster install.
 	RequirementsMetCondition ClusterDeploymentConditionType = "RequirementsMet"
@@ -432,6 +436,7 @@ var PositivePolarityClusterDeploymentConditions = []ClusterDeploymentConditionTy
 	ClusterInstallCompletedClusterDeploymentCondition,
 	ClusterInstallRequirementsMetClusterDeploymentCondition,
 	RequirementsMetCondition,
+	ProvisionedCondition,
 }
 
 // Cluster hibernating reasons
@@ -464,6 +469,22 @@ const (
 	SyncSetsNotAppliedReason = "SyncSetsNotApplied"
 )
 
+// Provisioned status condition reasons
+const (
+	// ProvisioningProvisionedReason is set while the cluster is still provisioning.
+	ProvisioningProvisionedReason = "Provisioning"
+	// ProvisionStoppedProvisionedReason means cluster provisioning is stopped. The ProvisionStopped condition may contain more detail.
+	ProvisionStoppedProvisionedReason = "ProvisionStopped"
+	// ProvisionedProvisionedReason is set when the provision is successful.
+	ProvisionedProvisionedReason = "Provisioned"
+	// DeprovisioningProvisionedReason is set when we start to deprovision the cluster.
+	DeprovisioningProvisionedReason = "Deprovisioning"
+	// DeprovisionFailedProvisionedReason means the deprovision failed terminally.
+	DeprovisionFailedProvisionedReason = "DeprovisionFailed"
+	// DeprovisionedProvisionedReason is set when the cluster has been successfully deprovisioned
+	DeprovisionedProvisionedReason = "Deprovisioned"
+)
+
 // InitializedConditionReason is used when a condition is initialized for the first time, and the status of the
 // condition is still Unknown
 const InitializedConditionReason = "Initialized"
@@ -474,12 +495,12 @@ const InitializedConditionReason = "Initialized"
 // ClusterDeployment is the Schema for the clusterdeployments API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="InfraID",type="string",JSONPath=".spec.clusterMetadata.infraID"
 // +kubebuilder:printcolumn:name="Platform",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/cluster-platform"
 // +kubebuilder:printcolumn:name="Region",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/cluster-region"
-// +kubebuilder:printcolumn:name="ClusterType",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/cluster-type"
-// +kubebuilder:printcolumn:name="Installed",type="boolean",JSONPath=".spec.installed"
-// +kubebuilder:printcolumn:name="InfraID",type="string",JSONPath=".spec.clusterMetadata.infraID"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/version-major-minor-patch"
+// +kubebuilder:printcolumn:name="ClusterType",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/cluster-type"
+// +kubebuilder:printcolumn:name="ProvisionStatus",type="string",JSONPath=".status.conditions[?(@.type=='Provisioned')].reason"
 // +kubebuilder:printcolumn:name="PowerState",type="string",JSONPath=".status.conditions[?(@.type=='Hibernating')].reason"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=clusterdeployments,shortName=cd,scope=Namespaced

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -17,23 +17,23 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.clusterMetadata.infraID
+      name: InfraID
+      type: string
     - jsonPath: .metadata.labels.hive\.openshift\.io/cluster-platform
       name: Platform
       type: string
     - jsonPath: .metadata.labels.hive\.openshift\.io/cluster-region
       name: Region
       type: string
+    - jsonPath: .metadata.labels.hive\.openshift\.io/version-major-minor-patch
+      name: Version
+      type: string
     - jsonPath: .metadata.labels.hive\.openshift\.io/cluster-type
       name: ClusterType
       type: string
-    - jsonPath: .spec.installed
-      name: Installed
-      type: boolean
-    - jsonPath: .spec.clusterMetadata.infraID
-      name: InfraID
-      type: string
-    - jsonPath: .metadata.labels.hive\.openshift\.io/version-major-minor-patch
-      name: Version
+    - jsonPath: .status.conditions[?(@.type=='Provisioned')].reason
+      name: ProvisionStatus
       type: string
     - jsonPath: .status.conditions[?(@.type=='Hibernating')].reason
       name: PowerState

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -268,23 +268,23 @@ objects:
     scope: Namespaced
     versions:
     - additionalPrinterColumns:
+      - jsonPath: .spec.clusterMetadata.infraID
+        name: InfraID
+        type: string
       - jsonPath: .metadata.labels.hive\.openshift\.io/cluster-platform
         name: Platform
         type: string
       - jsonPath: .metadata.labels.hive\.openshift\.io/cluster-region
         name: Region
         type: string
+      - jsonPath: .metadata.labels.hive\.openshift\.io/version-major-minor-patch
+        name: Version
+        type: string
       - jsonPath: .metadata.labels.hive\.openshift\.io/cluster-type
         name: ClusterType
         type: string
-      - jsonPath: .spec.installed
-        name: Installed
-        type: boolean
-      - jsonPath: .spec.clusterMetadata.infraID
-        name: InfraID
-        type: string
-      - jsonPath: .metadata.labels.hive\.openshift\.io/version-major-minor-patch
-        name: Version
+      - jsonPath: .status.conditions[?(@.type=='Provisioned')].reason
+        name: ProvisionStatus
         type: string
       - jsonPath: .status.conditions[?(@.type=='Hibernating')].reason
         name: PowerState

--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -165,6 +165,7 @@ if [[ -z "$cd" ]]; then
 fi
 # Patch the CD's ProvisionStopped status condition to make it look "broken".
 # This should cause the clusterpool controller to replace it.
+i=0
 while j=$(oc get cd -n $cd $cd -o json); do
   i=$((i+1))
   if [[ $i -gt $max_tries ]]; then

--- a/pkg/controller/clusterdeployment/clusterinstalls.go
+++ b/pkg/controller/clusterdeployment/clusterinstalls.go
@@ -153,12 +153,27 @@ func (r *ReconcileClusterDeployment) reconcileExistingInstallingClusterInstall(c
 	if updated {
 		statusModified = true
 		provisionFailedTerminal = true
+		conditions = controllerutils.SetClusterDeploymentCondition(conditions,
+			hivev1.ProvisionedCondition,
+			corev1.ConditionFalse,
+			hivev1.ProvisionStoppedProvisionedReason,
+			"Provisioning failed terminally (see the ProvisionStopped condition for details)",
+			controllerutils.UpdateConditionIfReasonOrMessageChange,
+		)
 	}
 
 	completed = controllerutils.FindClusterDeploymentCondition(conditions, hivev1.ClusterInstallCompletedClusterDeploymentCondition)
 	if completed.Status == corev1.ConditionTrue { // the cluster install is complete
 		cd.Spec.Installed = true
 		cd.Status.InstalledTimestamp = &completed.LastTransitionTime
+		cd.Status.Conditions = controllerutils.SetClusterDeploymentCondition(
+			cd.Status.Conditions,
+			hivev1.ProvisionedCondition,
+			corev1.ConditionTrue,
+			hivev1.ProvisionedProvisionedReason,
+			"Cluster is provisioned",
+			controllerutils.UpdateConditionAlways,
+		)
 		specModified = true
 		statusModified = true
 

--- a/pkg/controller/clusterdeployment/clusterprovisions.go
+++ b/pkg/controller/clusterdeployment/clusterprovisions.go
@@ -282,7 +282,7 @@ func (r *ReconcileClusterDeployment) reconcileInitializingProvision(cd *hivev1.C
 	// Set condition on ClusterDeployment when install pod is stuck in pending phase
 	installPodStuckCondition := controllerutils.FindClusterProvisionCondition(provision.Status.Conditions, hivev1.InstallPodStuckCondition)
 	if installPodStuckCondition != nil && installPodStuckCondition.Status == corev1.ConditionTrue {
-		if err := r.setInstallLaunchErrorCondition(cd, corev1.ConditionTrue, installPodStuckCondition.Reason, installPodStuckCondition.Message, cdLog); err != nil {
+		if err := r.updateCondition(cd, hivev1.InstallLaunchErrorCondition, corev1.ConditionTrue, installPodStuckCondition.Reason, installPodStuckCondition.Message, cdLog); err != nil {
 			cdLog.WithError(err).Log(controllerutils.LogLevel(err), "could not update InstallLaunchErrorCondition")
 			return reconcile.Result{}, err
 		}
@@ -292,7 +292,7 @@ func (r *ReconcileClusterDeployment) reconcileInitializingProvision(cd *hivev1.C
 
 func (r *ReconcileClusterDeployment) reconcileProvisioningProvision(cd *hivev1.ClusterDeployment, provision *hivev1.ClusterProvision, cdLog log.FieldLogger) (reconcile.Result, error) {
 	cdLog.Debug("still provisioning")
-	if err := r.setInstallLaunchErrorCondition(cd, corev1.ConditionFalse, "InstallLaunchSuccessful", "Successfully launched install pod", cdLog); err != nil {
+	if err := r.updateCondition(cd, hivev1.InstallLaunchErrorCondition, corev1.ConditionFalse, "InstallLaunchSuccessful", "Successfully launched install pod", cdLog); err != nil {
 		cdLog.WithError(err).Log(controllerutils.LogLevel(err), "could not update InstallLaunchErrorCondition")
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -127,15 +127,15 @@ func SetClusterDeploymentConditionWithChangeCheck(
 		}
 	}
 	if changed {
-		conditions = sortClusterDeploymentConditions(conditions)
+		conditions = SortClusterDeploymentConditions(conditions)
 	}
 	return conditions, changed
 }
 
-// sortClusterDeploymentConditions sorts the cluster deployment conditions such that conditions in their undesired/error
+// SortClusterDeploymentConditions sorts the cluster deployment conditions such that conditions in their undesired/error
 // state are at the top, followed by conditions in their desired/expected state, with conditions that have unknown status
 // at the last. All conditions that are undesired, desired or unknown are sorted in alphabetical order of their type
-func sortClusterDeploymentConditions(conditions []hivev1.ClusterDeploymentCondition) []hivev1.ClusterDeploymentCondition {
+func SortClusterDeploymentConditions(conditions []hivev1.ClusterDeploymentCondition) []hivev1.ClusterDeploymentCondition {
 	sort.SliceStable(conditions, func(i, j int) bool {
 		if conditions[i].Status != corev1.ConditionUnknown && conditions[j].Status == corev1.ConditionUnknown {
 			return true

--- a/pkg/test/assert/assertions.go
+++ b/pkg/test/assert/assertions.go
@@ -64,7 +64,7 @@ func AssertConditionStatus(t *testing.T, cd *hivev1.ClusterDeployment, condType 
 }
 
 // AssertConditions asserts if the expected conditions are present on the cluster deployment.
-// It also asserts if those conditions have the expected status and reason
+// It also asserts if those conditions have the expected status, reason, and (optionally) message.
 func AssertConditions(t *testing.T, cd *hivev1.ClusterDeployment, expectedConditions []hivev1.ClusterDeploymentCondition) {
 	testifyassert.LessOrEqual(t, len(expectedConditions), len(cd.Status.Conditions), "some conditions are not present")
 	for _, expectedCond := range expectedConditions {
@@ -72,6 +72,10 @@ func AssertConditions(t *testing.T, cd *hivev1.ClusterDeployment, expectedCondit
 		if testifyassert.NotNilf(t, condition, "did not find expected condition type: %v", expectedCond.Type) {
 			testifyassert.Equal(t, expectedCond.Status, condition.Status, "condition found with unexpected status")
 			testifyassert.Equal(t, expectedCond.Reason, condition.Reason, "condition found with unexpected reason")
+			// Optionally validate the message
+			if expectedCond.Message != "" {
+				testifyassert.Equal(t, expectedCond.Message, condition.Message, "condition found with unexpected message")
+			}
 		}
 	}
 }

--- a/pkg/test/clusterdeprovision/clusterdeprovision.go
+++ b/pkg/test/clusterdeprovision/clusterdeprovision.go
@@ -1,9 +1,11 @@
 package clusterdeprovision
 
 import (
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/test/generic"
 )
 
@@ -84,5 +86,18 @@ func WithNamespace(namespace string) Option {
 func Completed() Option {
 	return func(clusterDeprovision *hivev1.ClusterDeprovision) {
 		clusterDeprovision.Status.Completed = true
+	}
+}
+
+func WithAuthenticationFailure() Option {
+	return func(clusterDeprovision *hivev1.ClusterDeprovision) {
+		clusterDeprovision.Status.Conditions = controllerutils.SetClusterDeprovisionCondition(
+			clusterDeprovision.Status.Conditions,
+			hivev1.AuthenticationFailureClusterDeprovisionCondition,
+			v1.ConditionTrue,
+			"AReason",
+			"A Message",
+			controllerutils.UpdateConditionAlways,
+		)
 	}
 }

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -400,6 +400,10 @@ const (
 	// ProvisionStoppedCondition is set when cluster provisioning is stopped
 	ProvisionStoppedCondition ClusterDeploymentConditionType = "ProvisionStopped"
 
+	// Provisioned is True when a cluster is installed; False while it is provisioning or deprovisioning.
+	// The Reason indicates where it is in that lifecycle.
+	ProvisionedCondition ClusterDeploymentConditionType = "Provisioned"
+
 	// RequirementsMetCondition is set True when all pre-provision requirements have been met,
 	// and the controllers can begin the cluster install.
 	RequirementsMetCondition ClusterDeploymentConditionType = "RequirementsMet"
@@ -432,6 +436,7 @@ var PositivePolarityClusterDeploymentConditions = []ClusterDeploymentConditionTy
 	ClusterInstallCompletedClusterDeploymentCondition,
 	ClusterInstallRequirementsMetClusterDeploymentCondition,
 	RequirementsMetCondition,
+	ProvisionedCondition,
 }
 
 // Cluster hibernating reasons
@@ -464,6 +469,22 @@ const (
 	SyncSetsNotAppliedReason = "SyncSetsNotApplied"
 )
 
+// Provisioned status condition reasons
+const (
+	// ProvisioningProvisionedReason is set while the cluster is still provisioning.
+	ProvisioningProvisionedReason = "Provisioning"
+	// ProvisionStoppedProvisionedReason means cluster provisioning is stopped. The ProvisionStopped condition may contain more detail.
+	ProvisionStoppedProvisionedReason = "ProvisionStopped"
+	// ProvisionedProvisionedReason is set when the provision is successful.
+	ProvisionedProvisionedReason = "Provisioned"
+	// DeprovisioningProvisionedReason is set when we start to deprovision the cluster.
+	DeprovisioningProvisionedReason = "Deprovisioning"
+	// DeprovisionFailedProvisionedReason means the deprovision failed terminally.
+	DeprovisionFailedProvisionedReason = "DeprovisionFailed"
+	// DeprovisionedProvisionedReason is set when the cluster has been successfully deprovisioned
+	DeprovisionedProvisionedReason = "Deprovisioned"
+)
+
 // InitializedConditionReason is used when a condition is initialized for the first time, and the status of the
 // condition is still Unknown
 const InitializedConditionReason = "Initialized"
@@ -474,12 +495,12 @@ const InitializedConditionReason = "Initialized"
 // ClusterDeployment is the Schema for the clusterdeployments API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="InfraID",type="string",JSONPath=".spec.clusterMetadata.infraID"
 // +kubebuilder:printcolumn:name="Platform",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/cluster-platform"
 // +kubebuilder:printcolumn:name="Region",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/cluster-region"
-// +kubebuilder:printcolumn:name="ClusterType",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/cluster-type"
-// +kubebuilder:printcolumn:name="Installed",type="boolean",JSONPath=".spec.installed"
-// +kubebuilder:printcolumn:name="InfraID",type="string",JSONPath=".spec.clusterMetadata.infraID"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/version-major-minor-patch"
+// +kubebuilder:printcolumn:name="ClusterType",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/cluster-type"
+// +kubebuilder:printcolumn:name="ProvisionStatus",type="string",JSONPath=".status.conditions[?(@.type=='Provisioned')].reason"
 // +kubebuilder:printcolumn:name="PowerState",type="string",JSONPath=".status.conditions[?(@.type=='Hibernating')].reason"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=clusterdeployments,shortName=cd,scope=Namespaced


### PR DESCRIPTION
Add a `Provisioned` status condition to ClusterDeployment that keeps
track of both provisioning and deprovisioning lifecycle states. Use this
to replace the `INSTALLED` output column for `oc get` to provide better
granularity and fill the gap whereby we previously couldn't tell we were
deprovisioning without looking deeply at the object and possessing some
institutional knowledge.

[HIVE-1596](https://issues.redhat.com/browse/HIVE-1596)