### PR TITLE
OSD: Pull operator/controller images by digest

### DIFF
--- a/hack/app-sre/kustomization.yaml
+++ b/hack/app-sre/kustomization.yaml
@@ -34,9 +34,9 @@ kind: Kustomization
 # Use app-sre-supplied variables to pull the image for the current commit
 # TODO: Pull by digest instead. Don't forget to address Disappearing Digest Syndrome.
 images:
-- name: registry.ci.openshift.org/openshift/hive-v4.0:hive
+- digest: ${IMAGE_DIGEST}
+  name: registry.ci.openshift.org/openshift/hive-v4.0:hive
   newName: ${REGISTRY_IMG}
-  newTag: ${IMAGE_TAG}
 patchesStrategicMerge:
 - |-
   apiVersion: rbac.authorization.k8s.io/v1

--- a/hack/app-sre/saas-template-stub.yaml
+++ b/hack/app-sre/saas-template-stub.yaml
@@ -8,7 +8,7 @@ metadata:
 parameters:
   - name: REGISTRY_IMG
     required: true
-  - name: IMAGE_TAG
+  - name: IMAGE_DIGEST
     required: true
 
 # Populated by generate-saas-template.py with the objects in saas-objects.yaml

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -6549,7 +6549,7 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          image: ${REGISTRY_IMG}:${IMAGE_TAG}
+          image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
           imagePullPolicy: Always
           livenessProbe:
             httpGet:
@@ -6579,5 +6579,5 @@ objects:
 parameters:
 - name: REGISTRY_IMG
   required: true
-- name: IMAGE_TAG
+- name: IMAGE_DIGEST
   required: true

--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -12,6 +12,71 @@ IMG="${BASE_IMG}:latest"
 
 GIT_HASH=`git rev-parse --short=7 HEAD`
 
+## image_exits_in_repo IMAGE_URI
+#
+# Checks whether IMAGE_URI -- e.g. quay.io/app-sre/osd-metrics-exporter:abcd123
+# -- exists in the remote repository.
+# If so, returns success.
+# If the image does not exist, but the query was otherwise successful, returns
+# failure.
+# If the query fails for any reason, prints an error and *exits* nonzero.
+image_exists_in_repo() {
+    local image_uri=$1
+    local output
+    local rc
+
+    local skopeo_stderr=$(mktemp)
+
+    output=$(skopeo inspect docker://${image_uri} 2>$skopeo_stderr)
+    rc=$?
+    # So we can delete the temp file right away...
+    stderr=$(cat $skopeo_stderr)
+    rm -f $skopeo_stderr
+    if [[ $rc -eq 0 ]]; then
+        # The image exists. Sanity check the output.
+        local digest=$(echo $output | jq -r .Digest)
+        if [[ -z "$digest" ]]; then
+            echo "Unexpected error: skopeo inspect succeeded, but output contained no .Digest"
+            echo "Here's the output:"
+            echo "$output"
+            echo "...and stderr:"
+            echo "$stderr"
+            exit 1
+        fi
+        echo "Image ${image_uri} exists with digest $digest."
+        return 0
+    elif [[ "$stderr" == *"manifest unknown"* ]]; then
+        # We were able to talk to the repository, but the tag doesn't exist.
+        # This is the normal "green field" case.
+        echo "Image ${image_uri} does not exist in the repository."
+        return 1
+    elif [[ "$stderr" == *"was deleted or has expired"* ]]; then
+        # This should be rare, but accounts for cases where we had to
+        # manually delete an image.
+        echo "Image ${image_uri} was deleted from the repository."
+        echo "Proceeding as if it never existed."
+        return 1
+    else
+        # Any other error. For example:
+        #   - "unauthorized: access to the requested resource is not
+        #     authorized". This happens not just on auth errors, but if we
+        #     reference a repository that doesn't exist.
+        #   - "no such host".
+        #   - Network or other infrastructure failures.
+        # In all these cases, we want to bail, because we don't know whether
+        # the image exists (and we'd likely fail to push it anyway).
+        echo "Error querying the repository for ${image_uri}:"
+        echo "stdout: $output"
+        echo "stderr: $stderr"
+        exit 1
+    fi
+}
+
+if image_exists_in_repo "${QUAY_IMAGE}:${GIT_HASH}"; then
+    echo "Skipping image build/push for ${QUAY_IMAGE}:${GIT_HASH}"
+    exit 0
+fi
+
 # build the image
 BUILD_CMD="docker build" IMG="$IMG" make GO_REQUIRED_MIN_VERSION:= docker-build
 


### PR DESCRIPTION
To accommodate ICSP, guarding against a quay outage, pull the operator images by digest for OSD, causing the operator to pull the (same) image for the controllers by digest as well.

OperatorHub is not affected.

[HIVE-1504](https://issues.redhat.com/browse/HIVE-1504)