### PR TITLE
fail on error to push container image

### DIFF
--- a/hack/bundle-gen.py
+++ b/hack/bundle-gen.py
@@ -139,14 +139,14 @@ def build_and_push_image(registry_auth_file, hive_version, dry_run):
         print("Building container {}".format(container_name))
 
         cmd = "buildah bud --tag {} -f ./Dockerfile".format(container_name).split()
-        subprocess.run(cmd)
+        subprocess.run(cmd, check=True)
 
     print("Pushing container")
     cmd = "buildah push "
     if registry_auth_file != None:
         cmd = cmd + " --authfile={} ".format(registry_auth_file)
     cmd = cmd + " {}".format(container_name)
-    subprocess.run(cmd.split())
+    subprocess.run(cmd.split(), check=True)
 
 
 # gen_hive_version generates and returns the hive version eg. "1.2.3187-18827f6"


### PR DESCRIPTION
Saw the error message because I had bad creds.

```
Pushing container
Getting image source signatures
error pushing image "quay.io/openshift-hive/hive:v1.2.3254-512b7f4" to "docker://quay.io/openshift-hive/hive:v1.2.3254-512b7f4": trying to reuse blob sha256:74ddd0ec08fa43d09f32636ba91a0a3053b02cb4627c35051aff89f853606b59 at destination: unable to retrieve auth token: invalid username/password: unauthorized: Could not find robot with username: XXXXXXXX and supplied password.
ERRO[0000] exit status 125
Writing bundle files to directory: /tmp/hive-operator-bundle-d14jkjza
Generating CSV for version: 1.2.3254-512b7f4
Wrote ClusterServiceVersion:
/tmp/hive-operator-bundle-d14jkjza/1.2.3254-512b7f4/hive-operator.v1.2.3254-512b7f4.clusterserviceversion.yaml
Wrote package: /tmp/hive-operator-bundle-d14jkjza/hive.package.yaml
```

And it just kept going and going. Treat the failure to push the
container as a reason to stop.