### PR TITLE
Fix Provisioned condition for adopted clusters

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -599,6 +599,18 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 				return reconcile.Result{Requeue: true}, nil
 			}
 		}
+		// Set the Provisioned status condition for adopted clusters (and in case we upgraded to/past where that condition was introduced)
+		if err := r.updateCondition(
+			cd,
+			hivev1.ProvisionedCondition,
+			corev1.ConditionTrue,
+			hivev1.ProvisionedProvisionedReason,
+			"Cluster is provisioned",
+			cdLog,
+		); err != nil {
+			cdLog.WithError(err).Error("Error updating Provisioned status condition")
+			return reconcile.Result{}, err
+		}
 
 		// update SyncSetFailedCondition status condition
 		cdLog.Debug("Check if any syncsets are failing")

--- a/pkg/controller/clusterdeployment/clusterprovisions.go
+++ b/pkg/controller/clusterdeployment/clusterprovisions.go
@@ -65,7 +65,7 @@ func (r *ReconcileClusterDeployment) startNewProvision(
 			controllerutils.UpdateConditionIfReasonOrMessageChange)
 
 		conditions, changed2 = controllerutils.SetClusterDeploymentConditionWithChangeCheck(
-			cd.Status.Conditions,
+			conditions,
 			hivev1.ProvisionedCondition,
 			corev1.ConditionFalse,
 			hivev1.ProvisionStoppedProvisionedReason,


### PR DESCRIPTION
...or clusters that were already provisioned prior to being upgraded
to/past where the Provisioned condition was introduced.

Also address a latent
[buglet](https://github.com/openshift/hive/pull/1546#discussion_r721401994)
that wasn't actually affecting anything (it would have washed out on the
subsequent reconcile).

HIVE-1596