### PR TITLE
Clear SyncSetsNotApplied Hibernating Reason

### DIFF
--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -467,6 +467,10 @@ const (
 	// SyncSetsNotAppliedReason is used as the reason when SyncSets have not yet been applied
 	// for the cluster based on ClusterSync.Status.FirstSucessTime
 	SyncSetsNotAppliedReason = "SyncSetsNotApplied"
+	// SyncSetsAppliedReason means SyncSets have been successfully applied at some point.
+	// (It does not necessarily mean they are currently copacetic -- check ClusterSync status
+	// for that.)
+	SyncSetsAppliedReason = "SyncSetsApplied"
 )
 
 // Provisioned status condition reasons

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -467,6 +467,10 @@ const (
 	// SyncSetsNotAppliedReason is used as the reason when SyncSets have not yet been applied
 	// for the cluster based on ClusterSync.Status.FirstSucessTime
 	SyncSetsNotAppliedReason = "SyncSetsNotApplied"
+	// SyncSetsAppliedReason means SyncSets have been successfully applied at some point.
+	// (It does not necessarily mean they are currently copacetic -- check ClusterSync status
+	// for that.)
+	SyncSetsAppliedReason = "SyncSetsApplied"
 )
 
 // Provisioned status condition reasons


### PR DESCRIPTION
For a newly-created ClusterDeployment, the hibernation controller can
hit the window where the ClusterSync has been created by the clustersync
controller, but it has not yet succeeded. In this case the hibernation
controller sets the Hibernating condition's Reason to
SyncSetsNotApplied. However, when the ClusterSync does go green, we
weren't resetting that condition, so it stayed that way indefinitely
until the next time the cluster hibernated.

With this commit, we check for that and set the condition to a new
SyncSetsApplied state. The subsequent reconcile does the checks for
Running and sets that state if appropriate.

We also close a latent gap whereby we would silently ignore the case
where the ClusterSync hadn't yet been created. Now we requeue in that
case so we can wait for it to exist.

[HIVE-1657](https://issues.redhat.com/browse/HIVE-1657)