### PR TITLE
ClusterPool: running clusters for excess claims

### DIFF
--- a/pkg/controller/clusterpool/clusterpool_controller_test.go
+++ b/pkg/controller/clusterpool/clusterpool_controller_test.go
@@ -1169,6 +1169,8 @@ func TestReconcileClusterPool(t *testing.T) {
 			expectedTotalClusters: 5,
 			// The assignments don't happen until a subsequent reconcile after the CDs are ready
 			expectedUnassignedClaims: 3,
+			// Even though runningCount is zero, we run enough clusters to fulfill the excess claims
+			expectedRunning: 3,
 		},
 		{
 			name: "zero size pool",
@@ -1179,6 +1181,8 @@ func TestReconcileClusterPool(t *testing.T) {
 			expectedTotalClusters: 1,
 			// The assignments don't happen until a subsequent reconcile after the CDs are ready
 			expectedUnassignedClaims: 1,
+			// Even though runningCount is zero, we run enough clusters to fulfill the excess claims
+			expectedRunning: 1,
 		},
 		{
 			name: "no CDs match pool version",
@@ -1364,10 +1368,8 @@ func TestReconcileClusterPool(t *testing.T) {
 			expectedTotalClusters: 9,
 			// The four original pool CDs got claimed. Two were already running; we started the other two.
 			// We create five new CDs to satisfy the pool size plus the additional claim.
-			// Of those, we start two for runningCount, and hibernate the rest.
-			// (Intuitively, perhaps the one for the excess claim should start off in running state.
-			// But that's not how the logic works today. Should it?)
-			expectedRunning:          6,
+			// Of those, we start two for runningCount, and one more for the excess claim.
+			expectedRunning:          7,
 			expectedAssignedCDs:      4,
 			expectedAssignedClaims:   4,
 			expectedUnassignedClaims: 1,


### PR DESCRIPTION
In #1434, we added the paradigm of keeping some number of ClusterPool
clusters in Running state, so they don't have to suffer Resuming time
when claimed. However, that work was narrowly focussed on conforming to
the ClusterPool.Spec.RunningCount.

This commit expands the concept to try to make sure we're always running
enough clusters to satisfy claims. In particular, when we are servicing
a number of claims in excess of the pool's capacity, we create that
excess number of clusters... but we previously didn't account for that
number when calculating how many should be Running.

Now we do.

To explain via a corner case: If your pool has a zero Size and you
create a claim, we will create a cluster and immediately assign it. But
because RunningCount is zero, prior to this commit, we would create the
cluster with `PowerState=Hibernating`, and then kick it over to
`Running` when we assigned the claim. Now we'll create it with
`PowerState=Running` in the first place.

[HIVE-1651](https://issues.redhat.com/browse/HIVE-1651)