### PR TITLE
ProvisionDelay metric shouldn't log unknown conds

### DIFF
--- a/pkg/controller/metrics/provision_underway_collector_test.go
+++ b/pkg/controller/metrics/provision_underway_collector_test.go
@@ -59,16 +59,35 @@ func TestProvisioningUnderwayCollector(t *testing.T) {
 			"cluster_deployment = cd-2 cluster_type = unspecified condition = Unknown image_set = none namespace = cd-2 platform =  reason = Unknown",
 		},
 	}, {
-		name: "provisioning with other conditions",
+		name: "provisioning with other conditions in desired state",
 		existing: []runtime.Object{
 			cdBuilder("cd-1").Build(testcd.Installed()),
 			cdBuilder("cd-2").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
-				Type:   hivev1.ClusterHibernatingCondition,
+				Type:   hivev1.ProvisionStoppedCondition,
+				Status: corev1.ConditionFalse,
+			})),
+		},
+	}, {
+		name: "provisioning with other conditions in undesired state",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ProvisionStoppedCondition,
 				Status: corev1.ConditionTrue,
 			})),
 		},
 		expected: []string{
 			"cluster_deployment = cd-2 cluster_type = unspecified condition = Unknown image_set = none namespace = cd-2 platform =  reason = Unknown",
+		},
+	}, {
+		name: "provisioning with Initialized condition",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ProvisionFailedCondition,
+				Status: corev1.ConditionUnknown,
+				Reason: hivev1.InitializedConditionReason,
+			})),
 		},
 	}, {
 		name: "provisioning with ProvisionFailed condition",
@@ -130,7 +149,7 @@ func TestProvisioningUnderwayCollector(t *testing.T) {
 		existing: []runtime.Object{
 			cdBuilder("cd-1").Build(testcd.Installed()),
 			cdBuilder("cd-2").Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
-				Type:   hivev1.ClusterHibernatingCondition,
+				Type:   hivev1.ProvisionStoppedCondition,
 				Status: corev1.ConditionTrue,
 			})),
 		},
@@ -334,11 +353,20 @@ func TestProvisioningUnderwayInstallRestartsCollector(t *testing.T) {
 			"cluster_deployment = cd-2 cluster_type = unspecified condition = Unknown image_set = none namespace = cd-2 platform =  reason = Unknown 2",
 		},
 	}, {
-		name: "provisioning with other conditions",
+		name: "provisioning with other conditions in desired state",
 		existing: []runtime.Object{
 			cdBuilder("cd-1").Build(testcd.Installed()),
 			cdBuilder("cd-2").Build(testcd.InstallRestarts(2), testcd.WithCondition(hivev1.ClusterDeploymentCondition{
-				Type:   hivev1.ClusterHibernatingCondition,
+				Type:   hivev1.ProvisionStoppedCondition,
+				Status: corev1.ConditionFalse,
+			})),
+		},
+	}, {
+		name: "provisioning with other conditions in undesired state",
+		existing: []runtime.Object{
+			cdBuilder("cd-1").Build(testcd.Installed()),
+			cdBuilder("cd-2").Build(testcd.InstallRestarts(2), testcd.WithCondition(hivev1.ClusterDeploymentCondition{
+				Type:   hivev1.ProvisionStoppedCondition,
 				Status: corev1.ConditionTrue,
 			})),
 		},
@@ -392,7 +420,7 @@ func TestProvisioningUnderwayInstallRestartsCollector(t *testing.T) {
 		existing: []runtime.Object{
 			cdBuilder("cd-1").Build(testcd.Installed()),
 			cdBuilder("cd-2").Build(testcd.InstallRestarts(2), testcd.WithCondition(hivev1.ClusterDeploymentCondition{
-				Type:   hivev1.ClusterHibernatingCondition,
+				Type:   hivev1.ProvisionStoppedCondition,
 				Status: corev1.ConditionTrue,
 			})),
 		},

--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -798,3 +798,12 @@ func IsConditionInDesiredState(condition hivev1.ClusterDeploymentCondition) bool
 	return (IsConditionWithPositivePolarity(condition.Type) && condition.Status == corev1.ConditionTrue) ||
 		(!IsConditionWithPositivePolarity(condition.Type) && condition.Status == corev1.ConditionFalse)
 }
+
+// AreAllConditionsInDesiredState checks if all cluster deployment conditions are in their desired state
+func AreAllConditionsInDesiredState(conditions []hivev1.ClusterDeploymentCondition) bool {
+	// cluster deployment conditions are sorted to have error conditions at the top
+	if conditions[0].Status == corev1.ConditionUnknown || IsConditionInDesiredState(conditions[0]) {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Provision underway metric logged conditions even if they were of unknown status. Since we are initializing all the conditions now, it doesn't seem appropriate to do so anymore.

This commit ensures the provision underway metric is logged if and only if there are conditions present on the cluster deployment in undesired state. For conditions that are not part of the predetermined [list](https://github.com/openshift/hive/blob/master/pkg/controller/metrics/provision_underway_collector.go#L19-L26) of provision delay conditions, if there are conditions in error/undesired state, we would log the metric but condition and reason would be unknown. This should help with better alerts.

[HIVE-1660](https://issues.redhat.com/browse/HIVE-1660)

/assign @2uasimojo 