### PR TITLE
WIP: ClusterPool Inventory

### DIFF
--- a/apis/hive/v1/clusterpool_types.go
+++ b/apis/hive/v1/clusterpool_types.go
@@ -39,6 +39,11 @@ type ClusterPoolSpec struct {
 	// +optional
 	MaxConcurrent *int32 `json:"maxConcurrent,omitempty"`
 
+	// Inventory is a way to enumerate values unique to each ClusterDeployment in the pool. Today, it can be used exclusively
+	// to provide a list of cluster names. MaxSize is constrained to the size of the Inventory.
+	// +optional
+	Inventory *ClusterDeploymentInventory `json:"inventory,omitempty"`
+
 	// BaseDomain is the base domain to use for all clusters created in this pool.
 	// +required
 	BaseDomain string `json:"baseDomain"`
@@ -80,6 +85,22 @@ type ClusterPoolSpec struct {
 	// ClaimLifetime defines the lifetimes for claims for the cluster pool.
 	// +optional
 	ClaimLifetime *ClusterPoolClaimLifetime `json:"claimLifetime,omitempty"`
+}
+
+// ClusterDeploymentInventory contains information about each unique ClusterDeployment this ClusterPool can create.
+type ClusterDeploymentInventory struct {
+	// ClusterDeployments lists inventory entries for each unique ClusterDeployment this ClusterPool can create.
+	// +required
+	// +kubebuilder:validation:MinItems=1
+	ClusterDeployments []ClusterDeploymentInventoryEntry `json:"clusterDeployments"`
+}
+
+type ClusterDeploymentInventoryEntry struct {
+	// Name is the value to use for the ClusterDeployment.Spec.ClusterName field for a single ClusterDeployment owned
+	// by this ClusterPool. Must be unique within the Inventory.ClusterDeployments list.
+	// +required
+	// +kubebuilder:validation:MinLength=1
+	Name string `json:"name"`
 }
 
 // ClusterPoolClaimLifetime defines the lifetimes for claims for the cluster pool.

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -116,6 +116,32 @@ spec:
                       TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
                 type: object
+              inventory:
+                description: Inventory is a way to enumerate values unique to each
+                  ClusterDeployment in the pool. Today, it can be used exclusively
+                  to provide a list of cluster names. MaxSize is constrained to the
+                  size of the Inventory.
+                properties:
+                  clusterDeployments:
+                    description: ClusterDeployments lists inventory entries for each
+                      unique ClusterDeployment this ClusterPool can create.
+                    items:
+                      properties:
+                        name:
+                          description: Name is the value to use for the ClusterDeployment.Spec.ClusterName
+                            field for a single ClusterDeployment owned by this ClusterPool.
+                            Must be unique within the Inventory.ClusterDeployments
+                            list.
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    minItems: 1
+                    type: array
+                required:
+                - clusterDeployments
+                type: object
               labels:
                 additionalProperties:
                   type: string

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -1820,6 +1820,32 @@ objects:
                         TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
+                inventory:
+                  description: Inventory is a way to enumerate values unique to each
+                    ClusterDeployment in the pool. Today, it can be used exclusively
+                    to provide a list of cluster names. MaxSize is constrained to
+                    the size of the Inventory.
+                  properties:
+                    clusterDeployments:
+                      description: ClusterDeployments lists inventory entries for
+                        each unique ClusterDeployment this ClusterPool can create.
+                      items:
+                        properties:
+                          name:
+                            description: Name is the value to use for the ClusterDeployment.Spec.ClusterName
+                              field for a single ClusterDeployment owned by this ClusterPool.
+                              Must be unique within the Inventory.ClusterDeployments
+                              list.
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                  - clusterDeployments
+                  type: object
                 labels:
                   additionalProperties:
                     type: string

--- a/pkg/controller/clusterpool/inventory.go
+++ b/pkg/controller/clusterpool/inventory.go
@@ -1,0 +1,13 @@
+package clusterpool
+
+const (
+	ClusterNamesAnnotationKey = "hive.openshift.io/cluster-names"
+)
+
+// YOU ARE HERE
+// Struct for the name: namespace dict
+// Methods to:
+// - find an unclaimed name
+// - claim a name: takes "no" args, updates the map (and pushes to server?), returns (name, namespace)
+// - release a name: updates the map (and pushes to server?)
+// - (this is a weird one) reconcile claimed-but-unused names? (Will need the cdCollection.)

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
@@ -39,6 +39,11 @@ type ClusterPoolSpec struct {
 	// +optional
 	MaxConcurrent *int32 `json:"maxConcurrent,omitempty"`
 
+	// Inventory is a way to enumerate values unique to each ClusterDeployment in the pool. Today, it can be used exclusively
+	// to provide a list of cluster names. MaxSize is constrained to the size of the Inventory.
+	// +optional
+	Inventory *ClusterDeploymentInventory `json:"inventory,omitempty"`
+
 	// BaseDomain is the base domain to use for all clusters created in this pool.
 	// +required
 	BaseDomain string `json:"baseDomain"`
@@ -80,6 +85,22 @@ type ClusterPoolSpec struct {
 	// ClaimLifetime defines the lifetimes for claims for the cluster pool.
 	// +optional
 	ClaimLifetime *ClusterPoolClaimLifetime `json:"claimLifetime,omitempty"`
+}
+
+// ClusterDeploymentInventory contains information about each unique ClusterDeployment this ClusterPool can create.
+type ClusterDeploymentInventory struct {
+	// ClusterDeployments lists inventory entries for each unique ClusterDeployment this ClusterPool can create.
+	// +required
+	// +kubebuilder:validation:MinItems=1
+	ClusterDeployments []ClusterDeploymentInventoryEntry `json:"clusterDeployments"`
+}
+
+type ClusterDeploymentInventoryEntry struct {
+	// Name is the value to use for the ClusterDeployment.Spec.ClusterName field for a single ClusterDeployment owned
+	// by this ClusterPool. Must be unique within the Inventory.ClusterDeployments list.
+	// +required
+	// +kubebuilder:validation:MinLength=1
+	Name string `json:"name"`
 }
 
 // ClusterPoolClaimLifetime defines the lifetimes for claims for the cluster pool.


### PR DESCRIPTION
Add a ClusterPool.Spec.Inventory allowing enumeration of the complete
set of allowable `ClusterName`s a pool's ClusterDeployments may have.

[HIVE-1367](https://issues.redhat.com/browse/HIVE-1367)