### PR TITLE
Expand RBAC for ClusterPool CD namespaces

### DIFF
--- a/config/rbac/hive_clusterpool_admin.yaml
+++ b/config/rbac/hive_clusterpool_admin.yaml
@@ -29,10 +29,14 @@ rules:
   resources:
   - clusterdeployments
   - clusterprovisions
+  - clusterdeprovisions
   verbs:
   - get
   - list
   - watch
+  - update
+  - patch
+  - delete
 - apiGroups:
   - hive.openshift.io
   resources:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1251,10 +1251,14 @@ rules:
   resources:
   - clusterdeployments
   - clusterprovisions
+  - clusterdeprovisions
   verbs:
   - get
   - list
   - watch
+  - update
+  - patch
+  - delete
 - apiGroups:
   - hive.openshift.io
   resources:


### PR DESCRIPTION
Subjects with a RoleBinding to the hive-cluster-pool-admin ClusterRole
have that RoleBinding copied into the namespaces of ClusterDeployments
created under a ClusterPool. Previously that ClusterRole only included
read (`get`/`list`/`watch`) access to ClusterDeployments and
ClusterProvisions. This change adds write (`update` and `patch`, but
notably not `create`) access, and extends the role to include
ClusterDeprovisions as well.

[HIVE-1664](https://issues.redhat.com/browse/HIVE-1664)