### PR TITLE
ClusterClaim delay histogram metric

### DIFF
--- a/pkg/controller/clusterpool/metrics.go
+++ b/pkg/controller/clusterpool/metrics.go
@@ -15,8 +15,25 @@ var (
 		Name: "hive_clusterpool_stale_clusterdeployments_deleted",
 		Help: "The number of ClusterDeployments deleted because they no longer match the spec of their ClusterPool.",
 	}, []string{"clusterpool_namespace", "clusterpool_name"})
+	// metricClaimDelaySeconds tracks how long it takes for a claim to be assigned, labeled by
+	// cluster pool.
+	metricClaimDelaySeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "hive_clusterclaim_assignment_delay_seconds",
+		Help: "Time between ClusterClaim creation and fulfillment by a ClusterDeployment",
+		// USUALLY:
+		// - <10m indicates claims of *running* clusters. Bias toward the high end of that range
+		//   may indicate that we can optimize the controller logic.
+		// - ~10m is CDs waking up from hibernation. Lots of hits here indicate a pool using a
+		//   runningCount that is too low (or zero).
+		// - ~40m is CDs being provisioned on demand to satisfy claims. Probably indicates pool
+		//   Size is too low.
+		// - <1h either means CDs are needing multiple install attempts, or MaxSize is too low
+		//   so we're having to wait to create CDs to fulfill claims.
+		Buckets: []float64{1, 30, 120, 600, 1800, 3000, 7200},
+	}, []string{"clusterpool_namespace", "clusterpool_name"})
 )
 
 func init() {
 	metrics.Registry.MustRegister(metricStaleClusterDeploymentsDeleted)
+	metrics.Registry.MustRegister(metricClaimDelaySeconds)
 }


### PR DESCRIPTION
Add a histogram metric, `hive_clusterclaim_assignment_delay_seconds`,
for the number of seconds it takes for a ClusterClaim to be fulfilled by
a ClusterDeployment.

[HIVE-1643](https://issues.redhat.com/browse/HIVE-1643)