### PR TITLE
provide a UBI-based Dockerfile

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,0 +1,46 @@
+FROM registry.ci.openshift.org/openshift/release:golang-1.16 as builder
+RUN mkdir -p /go/src/github.com/openshift/hive
+WORKDIR /go/src/github.com/openshift/hive
+COPY . .
+RUN make build
+
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+# CentOS images do not get updates as they are meant to mirror ISO content, and thus this update
+# is strongly recommended for security updates.
+RUN dnf -y update && dnf clean all
+
+# ssh-agent required for gathering logs in some situations:
+RUN if ! rpm -q openssh-clients; then dnf install -y openssh-clients && dnf clean all && rm -rf /var/cache/dnf/*; fi
+
+# libvirt libraries required for running bare metal installer.
+RUN if ! rpm -q libvirt-devel; then dnf install -y libvirt-devel && dnf clean all && rm -rf /var/cache/dnf/*; fi
+
+COPY --from=builder /go/src/github.com/openshift/hive/bin/manager /opt/services/
+COPY --from=builder /go/src/github.com/openshift/hive/bin/hiveadmission /opt/services/
+COPY --from=builder /go/src/github.com/openshift/hive/bin/hiveutil /usr/bin
+COPY --from=builder /go/src/github.com/openshift/hive/bin/operator /opt/services/hive-operator
+
+# Hacks to allow writing known_hosts, homedir is / by default in OpenShift.
+# Bare metal installs need to write to $HOME/.cache, and $HOME/.ssh for as long as
+# we're hitting libvirt over ssh. OpenShift will not let you write these directories
+# by default so we must setup some permissions here.
+ENV HOME /home/hive
+RUN mkdir -p /home/hive && \
+    chgrp -R 0 /home/hive && \
+    chmod -R g=u /home/hive
+
+# This is so that we can write source certificate anchors during container start up.
+RUN mkdir -p /etc/pki/ca-trust/source/anchors && \
+    chgrp -R 0 /etc/pki/ca-trust/source/anchors && \
+    chmod -R g=u /etc/pki/ca-trust/source/anchors
+
+# This is so that we can run update-ca-trust during container start up.
+RUN mkdir -p /etc/pki/ca-trust/extracted/openssl && \
+    mkdir -p /etc/pki/ca-trust/extracted/pem && \
+    mkdir -p /etc/pki/ca-trust/extracted/java && \
+    chgrp -R 0 /etc/pki/ca-trust/extracted && \
+    chmod -R g=u /etc/pki/ca-trust/extracted
+
+# TODO: should this be the operator?
+ENTRYPOINT ["/opt/services/manager"]

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 )
 
 DOCKER_CMD ?= docker
+CONTAINER_BUILD_FLAGS ?= --file ./Dockerfile
 
 # Namespace hive-operator will run:
 HIVE_OPERATOR_NS ?= hive
@@ -269,7 +270,7 @@ $(addprefix generate-submodules-,$(GO_SUB_MODULES)):
 .PHONY: docker-build
 docker-build:
 	@echo "*** DEPRECATED: Use the image-hive target instead ***"
-	$(DOCKER_CMD) build -t ${IMG} .
+	$(DOCKER_CMD) build $(CONTAINER_BUILD_FLAGS) -t ${IMG} .
 
 # Push the image using docker
 .PHONY: docker-push

--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -83,7 +83,7 @@ if image_exists_in_repo "${IMG}"; then
 fi
 
 # build the image
-make IMG="$IMG" GO_REQUIRED_MIN_VERSION:= docker-build
+CONTAINER_BUILD_FLAGS="--file ./Dockerfile.ubi" make IMG="$IMG" GO_REQUIRED_MIN_VERSION:= docker-build
 
 # push the image
 make IMG="$IMG" docker-push


### PR DESCRIPTION
Introduce a new Dockerfile.ubi which will use the RHEL UBI container as
the base/runtime container image.

Add new CONTAINER_BUILD_FLAGS into the Makefile and set it to use the
original 'Dockefile'.

Update hack/app_sre_build_deploy.sh to overide this
CONTAINER_BUILD_FLAGS to use 'Dockerfile.ubi' as the Dockerfile to use.

Remove the unused BUILD_CMD flag from the hack/app_sre_build_deploy.sh
script as it is a no-op in our Makefile.

xref: https://issues.redhat.com/browse/HIVE-1668