### PR TITLE
Refactor hibernation

### DIFF
--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -194,11 +194,21 @@ func (r *hibernationReconciler) Reconcile(ctx context.Context, request reconcile
 		return r.setHibernatingCondition(cd, hivev1.RunningHibernationReason, msg, corev1.ConditionFalse, cdLog)
 	}
 
+	isFakeCluster := controllerutils.IsFakeCluster(cd)
+	var clusterSyncExists = true
+
 	clusterSync := &hiveintv1alpha1.ClusterSync{}
 	if err := r.Get(context.Background(), types.NamespacedName{Namespace: cd.Namespace, Name: cd.Name}, clusterSync); err != nil {
-		// This may be NotFound, which means the clustersync controller hasn't created the ClusterSync yet.
-		// Fail and requeue to wait for it to exist.
-		return reconcile.Result{}, fmt.Errorf("could not get ClusterSync: %v", err)
+		if isFakeCluster && apierrors.IsNotFound(err) {
+			// fake clusters don't create clustersync object by default
+			// This check is used further in the code when we check for SyncSetsNotApplied
+			// TODO: fix this when fake clusters create clusterSync by default like real clusters
+			clusterSyncExists = false
+		} else {
+			// This may be NotFound, which means the clustersync controller hasn't created the ClusterSync yet.
+			// Fail and requeue to wait for it to exist.
+			return reconcile.Result{}, fmt.Errorf("could not get ClusterSync: %v", err)
+		}
 	}
 
 	// Check on the SyncSetsNotApplied condition. Usually this is happening on a freshly installed cluster that's
@@ -207,7 +217,6 @@ func (r *hibernationReconciler) Reconcile(ctx context.Context, request reconcile
 		return r.setHibernatingCondition(cd, hivev1.SyncSetsAppliedReason, "SyncSets have been applied", corev1.ConditionFalse, cdLog)
 	}
 
-	isFakeCluster := controllerutils.IsFakeCluster(cd)
 	shouldHibernate := cd.Spec.PowerState == hivev1.HibernatingClusterPowerState
 	// set readyToHibernate if hibernate after is ready to kick in hibernation
 	var readyToHibernate bool
@@ -289,7 +298,7 @@ func (r *hibernationReconciler) Reconcile(ctx context.Context, request reconcile
 
 	if shouldHibernate || readyToHibernate {
 		// Signal a problem if we should be hibernating and the SyncSets have not yet been applied.
-		if clusterSync.Status.FirstSuccessTime == nil {
+		if clusterSyncExists && clusterSync.Status.FirstSuccessTime == nil {
 			// Allow hibernation (do not set condition) if hibernateAfterSyncSetsNotApplied duration has passed since cluster
 			// installed and syncsets still not applied
 			if cd.Status.InstalledTimestamp != nil && time.Now().Sub(cd.Status.InstalledTimestamp.Time) < hibernateAfterSyncSetsNotApplied {

--- a/pkg/controller/hibernation/hibernation_controller_test.go
+++ b/pkg/controller/hibernation/hibernation_controller_test.go
@@ -402,12 +402,11 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
-			name: "hibernate fake cluster",
+			name: "hibernate fake cluster, no clusterSync",
 			cd: cdBuilder.Build(
 				o.shouldHibernate,
 				testcd.InstalledTimestamp(time.Now().Add(-1*time.Hour)),
 				testcd.WithAnnotation(constants.HiveFakeClusterAnnotation, "true")),
-			cs: csBuilder.Build(),
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
 				cond := getHibernatingCondition(cd)
 				require.NotNil(t, cond)
@@ -417,11 +416,10 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
-			name: "start hibernated fake cluster",
+			name: "start hibernated fake cluster, no clusterSync",
 			cd: cdBuilder.Options(o.hibernating,
 				testcd.WithPowerState(hivev1.RunningClusterPowerState),
 				testcd.WithAnnotation(constants.HiveFakeClusterAnnotation, "true")).Build(),
-			cs: csBuilder.Build(),
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
 				cond := getHibernatingCondition(cd)
 				require.NotNil(t, cond)


### PR DESCRIPTION
Simplify the logic of hibernation controller in order to
better support the upcoming changes. Some noteworthy changes are
- streamline hibernateAfter and shouldHibernate logic to have no
  repeating code
- separate out and untangle decisions made on conditions and their
  reasons in order to eliminate haphazard patches and to support adding
  new condition down the line
- eliminate dead code paths
- minor bug fixes and renames

xref: https://issues.redhat.com/browse/HIVE-1672