### PR TITLE
move to centos:stream base container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,8 @@ WORKDIR /go/src/github.com/openshift/hive
 COPY . .
 RUN make build
 
-FROM quay.io/centos/centos:8
+FROM quay.io/centos/centos:stream
 
-# CentOS images do not get updates as they are meant to mirror ISO content, and thus this update
-# is strongly recommended for security updates.
 RUN dnf -y update && dnf clean all
 
 # ssh-agent required for gathering logs in some situations:

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -6,8 +6,6 @@ RUN make build
 
 FROM registry.access.redhat.com/ubi8/ubi:latest
 
-# CentOS images do not get updates as they are meant to mirror ISO content, and thus this update
-# is strongly recommended for security updates.
 RUN dnf -y update && dnf clean all
 
 # ssh-agent required for gathering logs in some situations:


### PR DESCRIPTION
As CentOS 8 goes out of support on 12/2021, move the base container away
from centos:8.

Choices were:
centos:stream
centos:stream8
centos:stream9

stream9 appears to be still in development, so going with building
against 'stream' (which presently shares the same SHA as 'stream8'. This will likely
start pointing to 'stream9' when that becomes an officially released build.

xref: https://issues.redhat.com/browse/HIVE-1676