### PR TITLE
UBI minimal and baremetal RPM dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,15 @@ RUN make build
 
 FROM quay.io/centos/centos:stream
 
-RUN dnf -y update && dnf clean all
+ARG DNF=dnf
+
+RUN $DNF -y update && $DNF clean all
 
 # ssh-agent required for gathering logs in some situations:
-RUN if ! rpm -q openssh-clients; then dnf install -y openssh-clients && dnf clean all && rm -rf /var/cache/dnf/*; fi
+RUN if ! rpm -q openssh-clients; then $DNF install -y openssh-clients && $DNF clean all && rm -rf /var/cache/dnf/*; fi
 
 # libvirt libraries required for running bare metal installer.
-RUN if ! rpm -q libvirt-devel; then dnf install -y libvirt-devel && dnf clean all && rm -rf /var/cache/dnf/*; fi
+RUN if ! rpm -q libvirt-devel; then $DNF install -y libvirt-devel && $DNF clean all && rm -rf /var/cache/dnf/*; fi
 
 COPY --from=builder /go/src/github.com/openshift/hive/bin/manager /opt/services/
 COPY --from=builder /go/src/github.com/openshift/hive/bin/hiveadmission /opt/services/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN $DNF -y update && $DNF clean all
 RUN if ! rpm -q openssh-clients; then $DNF install -y openssh-clients && $DNF clean all && rm -rf /var/cache/dnf/*; fi
 
 # libvirt libraries required for running bare metal installer.
-RUN if ! rpm -q libvirt-devel; then $DNF install -y libvirt-devel && $DNF clean all && rm -rf /var/cache/dnf/*; fi
+RUN if ! rpm -q libvirt-libs; then $DNF install -y libvirt-libs && $DNF clean all && rm -rf /var/cache/dnf/*; fi
 
 COPY --from=builder /go/src/github.com/openshift/hive/bin/manager /opt/services/
 COPY --from=builder /go/src/github.com/openshift/hive/bin/hiveadmission /opt/services/

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -14,7 +14,7 @@ RUN $DNF -y update && $DNF clean all
 RUN if ! rpm -q openssh-clients; then $DNF install -y openssh-clients && $DNF clean all && rm -rf /var/cache/dnf/*; fi
 
 # libvirt libraries required for running bare metal installer.
-RUN if ! rpm -q libvirt-devel; then $DNF install -y libvirt-devel && $DNF clean all && rm -rf /var/cache/dnf/*; fi
+RUN if ! rpm -q libvirt-libs; then $DNF install -y libvirt-libs && $DNF clean all && rm -rf /var/cache/dnf/*; fi
 
 COPY --from=builder /go/src/github.com/openshift/hive/bin/manager /opt/services/
 COPY --from=builder /go/src/github.com/openshift/hive/bin/hiveadmission /opt/services/

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -4,15 +4,17 @@ WORKDIR /go/src/github.com/openshift/hive
 COPY . .
 RUN make build
 
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-RUN dnf -y update && dnf clean all
+ARG DNF=microdnf
+
+RUN $DNF -y update && $DNF clean all
 
 # ssh-agent required for gathering logs in some situations:
-RUN if ! rpm -q openssh-clients; then dnf install -y openssh-clients && dnf clean all && rm -rf /var/cache/dnf/*; fi
+RUN if ! rpm -q openssh-clients; then $DNF install -y openssh-clients && $DNF clean all && rm -rf /var/cache/dnf/*; fi
 
 # libvirt libraries required for running bare metal installer.
-RUN if ! rpm -q libvirt-devel; then dnf install -y libvirt-devel && dnf clean all && rm -rf /var/cache/dnf/*; fi
+RUN if ! rpm -q libvirt-devel; then $DNF install -y libvirt-devel && $DNF clean all && rm -rf /var/cache/dnf/*; fi
 
 COPY --from=builder /go/src/github.com/openshift/hive/bin/manager /opt/services/
 COPY --from=builder /go/src/github.com/openshift/hive/bin/hiveadmission /opt/services/


### PR DESCRIPTION
move to UBI-minimal

Smaller set of packages (105 vs 192) (no python RPMs installed at all).

We do lose standard 'dnf', as 'microdnf' is there in its place.

Adjust both Dockerfiles to minimize differences by defining a DNF
variable that is set to 'microdnf' or 'dnf' as appropriate.


openshift-install baremetal RPM dependencies
    
The openshift-install binary for baremetal really only needs
libvirt-libs at runtime (not the full libvirt-devel).

See differences between build-time dependencies and run-time
dependencies in:
https://github.com/openshift/installer/blob/master/images/baremetal/Dockerfile.ci

xref: https://issues.redhat.com/browse/HIVE-1673