### PR TITLE
hibernation: Backoff delay checking clustersync

### DIFF
--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -469,6 +469,33 @@ func (r *hibernationReconciler) checkClusterRunning(cd *hivev1.ClusterDeployment
 	return r.setHibernatingCondition(cd, hivev1.RunningHibernationReason, "All machines are started and nodes are ready", corev1.ConditionFalse, logger)
 }
 
+// timeBeforeClusterSyncCheck returns a duration for requeue use when we find that (Selector)SyncSets
+// haven't yet been applied. The idea is to use increasing delays, starting short to account for
+// cases of few/no syncsets, but to a maximum total delay of `hibernateAfterSyncSetsNotApplied` from
+// the installation time of the CD, because after that point we want to hibernate anyway.
+func timeBeforeClusterSyncCheck(cd *hivev1.ClusterDeployment) time.Duration {
+	if cd.Status.InstalledTimestamp == nil {
+		// This should never happen... but future proof.
+		return 2 * time.Minute
+	}
+	expiry := cd.Status.InstalledTimestamp.Time.Add(hibernateAfterSyncSetsNotApplied)
+	maxDelay := time.Until(expiry)
+	if maxDelay <= 0 {
+		return 0
+	}
+	elapsed := hibernateAfterSyncSetsNotApplied - maxDelay
+	if elapsed < 30*time.Second {
+		return 10 * time.Second
+	}
+	if elapsed < 3*time.Minute {
+		return time.Minute
+	}
+	if maxDelay > 3*time.Minute {
+		return 3 * time.Minute
+	}
+	return maxDelay
+}
+
 func (r *hibernationReconciler) setHibernatingCondition(cd *hivev1.ClusterDeployment, reason, message string, status corev1.ConditionStatus, logger log.FieldLogger) (result reconcile.Result, returnErr error) {
 	changed := false
 	cd.Status.Conditions, changed = controllerutils.SetClusterDeploymentConditionWithChangeCheck(
@@ -482,8 +509,7 @@ func (r *hibernationReconciler) setHibernatingCondition(cd *hivev1.ClusterDeploy
 
 	if reason == hivev1.SyncSetsNotAppliedReason {
 		defer func() {
-			expiry := cd.Status.InstalledTimestamp.Time.Add(hibernateAfterSyncSetsNotApplied)
-			requeueAfter := time.Until(expiry)
+			requeueAfter := timeBeforeClusterSyncCheck(cd)
 			logger.Infof("cluster will reconcile due to syncsets not applied in: %v", requeueAfter)
 			result.RequeueAfter = requeueAfter
 			result.Requeue = true


### PR DESCRIPTION
Previously, if the hibernation controller encountered a CD that was new
and due for hibernation whose syncsets had not yet been applied, it
would arbitrarily wait until the CD was 10m old before checking again,
at which point it would hibernate regardless of syncset status.

This commit leaves that 10m cap in place, but implements a more granular
requeue delay sequence for rechecking the syncset status, starting short
(10s when the CD is "young") and increasing to a max of 3m, but bounded
by the time remaining until the 10m expiry.