### PR TITLE
ClusterPool: Delete broken CDs at MaxSize

### DIFF
--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -380,10 +380,7 @@ func (r *ReconcileClusterPool) Reconcile(ctx context.Context, request reconcile.
 			"Available":     availableCurrent,
 		}).Info("Cannot create/delete clusters as max concurrent quota exceeded.")
 	// If too few, create new InstallConfig and ClusterDeployment.
-	case drift < 0:
-		if availableCapacity <= 0 {
-			break
-		}
+	case drift < 0 && availableCapacity > 0:
 		toAdd := minIntVarible(-drift, availableCapacity, availableCurrent)
 		if err := r.addClusters(clp, poolVersion, cds, toAdd, logger); err != nil {
 			log.WithError(err).Error("error adding clusters")

--- a/pkg/controller/clusterpool/clusterpool_controller_test.go
+++ b/pkg/controller/clusterpool/clusterpool_controller_test.go
@@ -330,6 +330,23 @@ func TestReconcileClusterPool(t *testing.T) {
 			expectedDeletedClusters: []string{"c1"},
 		},
 		{
+			// HIVE-1684
+			name: "broken clusters are deleted at MaxSize",
+			existing: []runtime.Object{
+				initializedPoolBuilder.Build(testcp.WithSize(2), testcp.WithMaxSize(3)),
+				unclaimedCDBuilder("c1").Build(
+					testcd.Broken(),
+				),
+				cdBuilder("c2").Build(testcd.Installed(), testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "aclaim")),
+				cdBuilder("c3").Build(testcd.Installed(), testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "bclaim")),
+			},
+			expectedTotalClusters:   2,
+			expectedObservedSize:    1,
+			expectedObservedReady:   0,
+			expectedAssignedCDs:     2,
+			expectedDeletedClusters: []string{"c1"},
+		},
+		{
 			name: "create all clusters",
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(5), testcp.WithClusterDeploymentLabels(map[string]string{"foo": "bar"})),


### PR DESCRIPTION
Previously a pool at MaxSize with one or more broken CDs would get stuck
rather than deleting the broken CDs. Fix.

[HIVE-1684](https://issues.redhat.com/browse/HIVE-1684)