### PR TITLE
Check clusteroperators

### DIFF
--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -293,6 +293,10 @@ type ClusterDeploymentStatus struct {
 	// InstalledTimestamp is the time we first detected that the cluster has been successfully installed.
 	InstalledTimestamp *metav1.Time `json:"installedTimestamp,omitempty"`
 
+	// PowerState indicates the powerstate of cluster
+	// +optional
+	PowerState string `json:"powerState,omitempty"`
+
 	// ProvisionRef is a reference to the last ClusterProvision created for the deployment
 	// +optional
 	ProvisionRef *corev1.LocalObjectReference `json:"provisionRef,omitempty"`
@@ -484,7 +488,7 @@ const InitializedConditionReason = "Initialized"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/version-major-minor-patch"
 // +kubebuilder:printcolumn:name="ClusterType",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/cluster-type"
 // +kubebuilder:printcolumn:name="ProvisionStatus",type="string",JSONPath=".status.conditions[?(@.type=='Provisioned')].reason"
-// +kubebuilder:printcolumn:name="PowerState",type="string",JSONPath=".status.conditions[?(@.type=='Hibernating')].reason"
+// +kubebuilder:printcolumn:name="PowerState",type="string",JSONPath=".status.powerState"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=clusterdeployments,shortName=cd,scope=Namespaced
 type ClusterDeployment struct {

--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -435,6 +435,8 @@ const (
 	// StoppingHibernationReason is used as the reason when the cluster is transitioning
 	// from a Running state to a Hibernating state.
 	StoppingHibernationReason = "Stopping"
+	// WaitingForMachinesToStopHibernatingReason is used on the Hibernating condition when waiting for cloud VMs to stop
+	WaitingForMachinesToStopHibernatingReason = "WaitingForMachinesToStop"
 	// HibernatingHibernationReason is used as the reason when the cluster is in a
 	// Hibernating state.
 	HibernatingHibernationReason = "Hibernating"
@@ -446,9 +448,6 @@ const (
 	// FailedToStopHibernationReason is used when there was an error stopping machines
 	// to enter hibernation
 	FailedToStopHibernationReason = "FailedToStop"
-	// FailedToStartHibernationReason is used when there was an error starting machines
-	// to leave hibernation
-	FailedToStartHibernationReason = "FailedToStart"
 	// SyncSetsNotAppliedReason is used as the reason when SyncSets have not yet been applied
 	// for the cluster based on ClusterSync.Status.FirstSucessTime
 	SyncSetsNotAppliedReason = "SyncSetsNotApplied"
@@ -460,6 +459,11 @@ const (
 	// StoppingOrHibernatingReadyReason is used as the reason for the Ready condition when the cluster
 	// is stopping or hibernating. Precise details are available in the Hibernating condition.
 	StoppingOrHibernatingReadyReason = "StoppingOrHibernating"
+	// StartingMachinesReadyReason is used to reflect attempt to list and start cloud VMs
+	StartingMachinesReadyReason = "StartingMachines"
+	// FailedToStartMachinesReadyReason is used when there was an error starting machines
+	// to leave hibernation
+	FailedToStartMachinesReadyReason = "FailedToStartMachines"
 	// WaitingForMachinesReadyReason is used on the Ready condition when waiting for cloud VMs to start.
 	WaitingForMachinesReadyReason = "WaitingForMachines"
 	// WaitingForNodesReadyReason is used on the Ready condition when waiting for nodes to become Ready.

--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -372,6 +372,10 @@ const (
 	// transitioning to/from a hibernating state or is in a hibernating state.
 	ClusterHibernatingCondition ClusterDeploymentConditionType = "Hibernating"
 
+	// ClusterReadyCondition works in conjunction with ClusterHibernatingCondition and gives more information
+	// pertaining to the transition status of the cluster and whether it is running and ready
+	ClusterReadyCondition ClusterDeploymentConditionType = "Ready"
+
 	// InstallLaunchErrorCondition is set when a cluster provision fails to launch an install pod
 	InstallLaunchErrorCondition ClusterDeploymentConditionType = "InstallLaunchError"
 
@@ -415,6 +419,7 @@ const (
 var PositivePolarityClusterDeploymentConditions = []ClusterDeploymentConditionType{
 	ActiveAPIURLOverrideCondition,
 	ClusterHibernatingCondition,
+	ClusterReadyCondition,
 	AWSPrivateLinkReadyClusterDeploymentCondition,
 	ClusterInstallCompletedClusterDeploymentCondition,
 	ClusterInstallRequirementsMetClusterDeploymentCondition,
@@ -422,14 +427,11 @@ var PositivePolarityClusterDeploymentConditions = []ClusterDeploymentConditionTy
 	ProvisionedCondition,
 }
 
-// Cluster hibernating reasons
+// Cluster hibernating and ready reasons
 const (
-	// ResumingHibernationReason is used as the reason when the cluster is transitioning
-	// from a Hibernating state to a Running state.
-	ResumingHibernationReason = "Resuming"
-	// RunningHibernationReason is used as the reason when the cluster is running and
-	// the Hibernating condition is false.
-	RunningHibernationReason = "Running"
+	// ResumingOrRunningHibernationReason is used as the reason for the Hibernating condition when the cluster
+	// is resuming or running. Precise details are available in the Ready condition.
+	ResumingOrRunningHibernationReason = "ResumingOrRunning"
 	// StoppingHibernationReason is used as the reason when the cluster is transitioning
 	// from a Running state to a Hibernating state.
 	StoppingHibernationReason = "Stopping"
@@ -454,6 +456,21 @@ const (
 	// (It does not necessarily mean they are currently copacetic -- check ClusterSync status
 	// for that.)
 	SyncSetsAppliedReason = "SyncSetsApplied"
+
+	// StoppingOrHibernatingReadyReason is used as the reason for the Ready condition when the cluster
+	// is stopping or hibernating. Precise details are available in the Hibernating condition.
+	StoppingOrHibernatingReadyReason = "StoppingOrHibernating"
+	// WaitingForMachinesReadyReason is used on the Ready condition when waiting for cloud VMs to start.
+	WaitingForMachinesReadyReason = "WaitingForMachines"
+	// WaitingForNodesReadyReason is used on the Ready condition when waiting for nodes to become Ready.
+	WaitingForNodesReadyReason = "WaitingForNodes"
+	// PausingForClusterOperatorsToSettleReadyReason is used on the Ready condition when pausing to let ClusterOperators start and post new status before we check it.
+	PausingForClusterOperatorsToSettleReadyReason = "PausingForClusterOperatorsToSettle"
+	// WaitingForClusterOperatorsReadyReason is used on the Ready condition when waiting for ClusterOperators to
+	// get to a good state. (Available=True, Processing=False, Degraded=False)
+	WaitingForClusterOperatorsReadyReason = "WaitingForClusterOperators"
+	// RunningReadyReason is used on the Ready condition as the reason when the cluster is running and ready
+	RunningReadyReason = "Running"
 )
 
 // Provisioned status condition reasons

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -35,7 +35,7 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Provisioned')].reason
       name: ProvisionStatus
       type: string
-    - jsonPath: .status.conditions[?(@.type=='Hibernating')].reason
+    - jsonPath: .status.powerState
       name: PowerState
       type: string
     - jsonPath: .metadata.creationTimestamp
@@ -1037,6 +1037,9 @@ spec:
                         type: object
                     type: object
                 type: object
+              powerState:
+                description: PowerState indicates the powerstate of cluster
+                type: string
               provisionRef:
                 description: ProvisionRef is a reference to the last ClusterProvision
                   created for the deployment

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -286,7 +286,7 @@ objects:
       - jsonPath: .status.conditions[?(@.type=='Provisioned')].reason
         name: ProvisionStatus
         type: string
-      - jsonPath: .status.conditions[?(@.type=='Hibernating')].reason
+      - jsonPath: .status.powerState
         name: PowerState
         type: string
       - jsonPath: .metadata.creationTimestamp
@@ -1302,6 +1302,9 @@ objects:
                           type: object
                       type: object
                   type: object
+                powerState:
+                  description: PowerState indicates the powerstate of cluster
+                  type: string
                 provisionRef:
                   description: ProvisionRef is a reference to the last ClusterProvision
                     created for the deployment

--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -1,8 +1,8 @@
-max_tries=60
+max_tries=120
 sleep_between_tries=10
 # Set timeout for the cluster deployment to install
 # timeout = sleep_between_cluster_deployment_status_checks * max_cluster_deployment_status_checks
-max_cluster_deployment_status_checks=90
+max_cluster_deployment_status_checks=180
 sleep_between_cluster_deployment_status_checks="1m"
 
 export CLUSTER_NAMESPACE="${CLUSTER_NAMESPACE:-cluster-test}"

--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -39,8 +39,8 @@ function wait_for_hibernation_state() {
       sleep ${sleep_between_tries}
     fi
 
-    HIB_COND=$(oc get cd -n $CLUSTER_NAME $CLUSTER_NAME -o json | jq -r '.status.conditions[] | select(.type == "Hibernating")')
-    if [[ $(jq -r .reason <<<"${HIB_COND}") == $EXPECTED_STATE ]]; then
+    powerState=$(oc get cd -n $CLUSTER_NAME $CLUSTER_NAME -o json | jq -r '.status.powerState')
+    if [[ "${powerState}" == $EXPECTED_STATE ]]; then
       echo "Success"
       break
     else
@@ -53,8 +53,7 @@ function wait_for_hibernation_state() {
   if [[ $i -ge ${max_tries} ]] ; then
     # Failed the maximum amount of times.
     echo "ClusterDeployment $CLUSTER_NAME still not $EXPECTED_STATE" >&2
-    echo "Reason: $(jq -r .reason <<<"${HIB_COND}")" >&2
-    echo "Message: $(jq -r .message <<<"${HIB_COND}")" >&2
+    echo "Actual state: ${powerState}" >&2
     exit 9
   fi
 }

--- a/pkg/controller/clusterpool/collections.go
+++ b/pkg/controller/clusterpool/collections.go
@@ -228,14 +228,14 @@ func isBroken(cd *hivev1.ClusterDeployment) bool {
 
 func isRunning(cd *hivev1.ClusterDeployment) bool {
 	// TODO: Change this to use the Running condition
-	cond := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ClusterHibernatingCondition)
+	cond := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ClusterReadyCondition)
 	if cond == nil {
 		// Since we should be initializing conditions, this probably means the CD is super fresh
 		// and quite unlikely to be running. (That said, this really should never happen, since we
 		// only check this for Installed clusters.)
 		return false
 	}
-	return cond.Reason == hivev1.RunningHibernationReason
+	return cond.Reason == hivev1.RunningReadyReason
 }
 
 func (cds *cdCollection) sortInstalling() {

--- a/pkg/controller/clusterpool/collections.go
+++ b/pkg/controller/clusterpool/collections.go
@@ -227,7 +227,6 @@ func isBroken(cd *hivev1.ClusterDeployment) bool {
 }
 
 func isRunning(cd *hivev1.ClusterDeployment) bool {
-	// TODO: Change this to use the Running condition
 	cond := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ClusterReadyCondition)
 	if cond == nil {
 		// Since we should be initializing conditions, this probably means the CD is super fresh

--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -498,6 +498,7 @@ func (r *hibernationReconciler) setHibernatingCondition(cd *hivev1.ClusterDeploy
 		controllerutils.ErrorScrub(errors.New(message)),
 		controllerutils.UpdateConditionIfReasonOrMessageChange,
 	)
+	cd.Status.PowerState = reason
 
 	if reason == hivev1.SyncSetsNotAppliedReason {
 		defer func() {

--- a/pkg/controller/hibernation/hibernation_controller_test.go
+++ b/pkg/controller/hibernation/hibernation_controller_test.go
@@ -97,6 +97,7 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
 				assert.Equal(t, hivev1.UnsupportedHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.UnsupportedHibernationReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -108,6 +109,7 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
 				assert.Equal(t, hivev1.UnsupportedHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.UnsupportedHibernationReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -128,6 +130,7 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionTrue, cond.Status)
 				assert.Equal(t, hivev1.StoppingHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.StoppingHibernationReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -139,6 +142,7 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
 				assert.Equal(t, hivev1.SyncSetsNotAppliedReason, cond.Reason)
+				assert.Equal(t, hivev1.SyncSetsNotAppliedReason, cd.Status.PowerState)
 			},
 			expectError: true,
 		},
@@ -159,6 +163,7 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, hivev1.SyncSetsAppliedReason, cond.Reason)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
+				assert.Equal(t, hivev1.SyncSetsAppliedReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -173,6 +178,7 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionTrue, cond.Status)
 				assert.Equal(t, hivev1.StoppingHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.StoppingHibernationReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -187,6 +193,7 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionTrue, cond.Status)
 				assert.Equal(t, hivev1.StoppingHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.StoppingHibernationReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -201,6 +208,7 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
 				assert.Equal(t, hivev1.FailedToStopHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.FailedToStopHibernationReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -215,6 +223,7 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionTrue, cond.Status)
 				assert.Equal(t, hivev1.HibernatingHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.HibernatingHibernationReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -232,6 +241,7 @@ func TestReconcile(t *testing.T) {
 				assert.Equal(t, corev1.ConditionTrue, cond.Status)
 				assert.Equal(t, hivev1.StoppingHibernationReason, cond.Reason)
 				assert.Equal(t, "Stopping cluster machines. Some machines have not yet stopped: pending-1,running-1,stopping-1", cond.Message)
+				assert.Equal(t, hivev1.StoppingHibernationReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -253,6 +263,7 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionTrue, cond.Status)
 				assert.Equal(t, hivev1.StoppingHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.StoppingHibernationReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -267,6 +278,7 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionTrue, cond.Status)
 				assert.Equal(t, hivev1.ResumingHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.ResumingHibernationReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -282,6 +294,7 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionTrue, cond.Status)
 				assert.Equal(t, hivev1.FailedToStartHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.FailedToStartHibernationReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -303,6 +316,7 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionTrue, cond.Status)
 				assert.Equal(t, hivev1.ResumingHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.ResumingHibernationReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -320,6 +334,7 @@ func TestReconcile(t *testing.T) {
 				assert.Equal(t, corev1.ConditionTrue, cond.Status)
 				assert.Equal(t, hivev1.ResumingHibernationReason, cond.Reason)
 				assert.Equal(t, "Starting cluster machines. Some machines are not yet running: pending-1,stopped-1", cond.Message)
+				assert.Equal(t, hivev1.ResumingHibernationReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -338,6 +353,7 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
 				assert.Equal(t, hivev1.RunningHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.RunningHibernationReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -396,6 +412,7 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, hivev1.RunningHibernationReason, cond.Reason)
 				assert.Equal(t, "Hibernation capable", cond.Message)
+				assert.Equal(t, hivev1.RunningHibernationReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -411,6 +428,7 @@ func TestReconcile(t *testing.T) {
 				assert.Equal(t, hivev1.HibernatingHibernationReason, cond.Reason)
 				assert.Equal(t, corev1.ConditionTrue, cond.Status)
 				assert.Equal(t, "Fake cluster is stopped", cond.Message)
+				assert.Equal(t, hivev1.HibernatingHibernationReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -425,6 +443,7 @@ func TestReconcile(t *testing.T) {
 				assert.Equal(t, hivev1.RunningHibernationReason, cond.Reason)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
 				assert.Equal(t, "Fake cluster is running", cond.Message)
+				assert.Equal(t, hivev1.RunningHibernationReason, cd.Status.PowerState)
 			},
 		},
 	}

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -293,6 +293,10 @@ type ClusterDeploymentStatus struct {
 	// InstalledTimestamp is the time we first detected that the cluster has been successfully installed.
 	InstalledTimestamp *metav1.Time `json:"installedTimestamp,omitempty"`
 
+	// PowerState indicates the powerstate of cluster
+	// +optional
+	PowerState string `json:"powerState,omitempty"`
+
 	// ProvisionRef is a reference to the last ClusterProvision created for the deployment
 	// +optional
 	ProvisionRef *corev1.LocalObjectReference `json:"provisionRef,omitempty"`
@@ -484,7 +488,7 @@ const InitializedConditionReason = "Initialized"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/version-major-minor-patch"
 // +kubebuilder:printcolumn:name="ClusterType",type="string",JSONPath=".metadata.labels.hive\\.openshift\\.io/cluster-type"
 // +kubebuilder:printcolumn:name="ProvisionStatus",type="string",JSONPath=".status.conditions[?(@.type=='Provisioned')].reason"
-// +kubebuilder:printcolumn:name="PowerState",type="string",JSONPath=".status.conditions[?(@.type=='Hibernating')].reason"
+// +kubebuilder:printcolumn:name="PowerState",type="string",JSONPath=".status.powerState"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:path=clusterdeployments,shortName=cd,scope=Namespaced
 type ClusterDeployment struct {

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -435,6 +435,8 @@ const (
 	// StoppingHibernationReason is used as the reason when the cluster is transitioning
 	// from a Running state to a Hibernating state.
 	StoppingHibernationReason = "Stopping"
+	// WaitingForMachinesToStopHibernatingReason is used on the Hibernating condition when waiting for cloud VMs to stop
+	WaitingForMachinesToStopHibernatingReason = "WaitingForMachinesToStop"
 	// HibernatingHibernationReason is used as the reason when the cluster is in a
 	// Hibernating state.
 	HibernatingHibernationReason = "Hibernating"
@@ -446,9 +448,6 @@ const (
 	// FailedToStopHibernationReason is used when there was an error stopping machines
 	// to enter hibernation
 	FailedToStopHibernationReason = "FailedToStop"
-	// FailedToStartHibernationReason is used when there was an error starting machines
-	// to leave hibernation
-	FailedToStartHibernationReason = "FailedToStart"
 	// SyncSetsNotAppliedReason is used as the reason when SyncSets have not yet been applied
 	// for the cluster based on ClusterSync.Status.FirstSucessTime
 	SyncSetsNotAppliedReason = "SyncSetsNotApplied"
@@ -460,6 +459,11 @@ const (
 	// StoppingOrHibernatingReadyReason is used as the reason for the Ready condition when the cluster
 	// is stopping or hibernating. Precise details are available in the Hibernating condition.
 	StoppingOrHibernatingReadyReason = "StoppingOrHibernating"
+	// StartingMachinesReadyReason is used to reflect attempt to list and start cloud VMs
+	StartingMachinesReadyReason = "StartingMachines"
+	// FailedToStartMachinesReadyReason is used when there was an error starting machines
+	// to leave hibernation
+	FailedToStartMachinesReadyReason = "FailedToStartMachines"
 	// WaitingForMachinesReadyReason is used on the Ready condition when waiting for cloud VMs to start.
 	WaitingForMachinesReadyReason = "WaitingForMachines"
 	// WaitingForNodesReadyReason is used on the Ready condition when waiting for nodes to become Ready.

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -372,6 +372,10 @@ const (
 	// transitioning to/from a hibernating state or is in a hibernating state.
 	ClusterHibernatingCondition ClusterDeploymentConditionType = "Hibernating"
 
+	// ClusterReadyCondition works in conjunction with ClusterHibernatingCondition and gives more information
+	// pertaining to the transition status of the cluster and whether it is running and ready
+	ClusterReadyCondition ClusterDeploymentConditionType = "Ready"
+
 	// InstallLaunchErrorCondition is set when a cluster provision fails to launch an install pod
 	InstallLaunchErrorCondition ClusterDeploymentConditionType = "InstallLaunchError"
 
@@ -415,6 +419,7 @@ const (
 var PositivePolarityClusterDeploymentConditions = []ClusterDeploymentConditionType{
 	ActiveAPIURLOverrideCondition,
 	ClusterHibernatingCondition,
+	ClusterReadyCondition,
 	AWSPrivateLinkReadyClusterDeploymentCondition,
 	ClusterInstallCompletedClusterDeploymentCondition,
 	ClusterInstallRequirementsMetClusterDeploymentCondition,
@@ -422,14 +427,11 @@ var PositivePolarityClusterDeploymentConditions = []ClusterDeploymentConditionTy
 	ProvisionedCondition,
 }
 
-// Cluster hibernating reasons
+// Cluster hibernating and ready reasons
 const (
-	// ResumingHibernationReason is used as the reason when the cluster is transitioning
-	// from a Hibernating state to a Running state.
-	ResumingHibernationReason = "Resuming"
-	// RunningHibernationReason is used as the reason when the cluster is running and
-	// the Hibernating condition is false.
-	RunningHibernationReason = "Running"
+	// ResumingOrRunningHibernationReason is used as the reason for the Hibernating condition when the cluster
+	// is resuming or running. Precise details are available in the Ready condition.
+	ResumingOrRunningHibernationReason = "ResumingOrRunning"
 	// StoppingHibernationReason is used as the reason when the cluster is transitioning
 	// from a Running state to a Hibernating state.
 	StoppingHibernationReason = "Stopping"
@@ -454,6 +456,21 @@ const (
 	// (It does not necessarily mean they are currently copacetic -- check ClusterSync status
 	// for that.)
 	SyncSetsAppliedReason = "SyncSetsApplied"
+
+	// StoppingOrHibernatingReadyReason is used as the reason for the Ready condition when the cluster
+	// is stopping or hibernating. Precise details are available in the Hibernating condition.
+	StoppingOrHibernatingReadyReason = "StoppingOrHibernating"
+	// WaitingForMachinesReadyReason is used on the Ready condition when waiting for cloud VMs to start.
+	WaitingForMachinesReadyReason = "WaitingForMachines"
+	// WaitingForNodesReadyReason is used on the Ready condition when waiting for nodes to become Ready.
+	WaitingForNodesReadyReason = "WaitingForNodes"
+	// PausingForClusterOperatorsToSettleReadyReason is used on the Ready condition when pausing to let ClusterOperators start and post new status before we check it.
+	PausingForClusterOperatorsToSettleReadyReason = "PausingForClusterOperatorsToSettle"
+	// WaitingForClusterOperatorsReadyReason is used on the Ready condition when waiting for ClusterOperators to
+	// get to a good state. (Available=True, Processing=False, Degraded=False)
+	WaitingForClusterOperatorsReadyReason = "WaitingForClusterOperators"
+	// RunningReadyReason is used on the Ready condition as the reason when the cluster is running and ready
+	RunningReadyReason = "Running"
 )
 
 // Provisioned status condition reasons


### PR DESCRIPTION
Add functionality to check for clusteroperators to settle as we resume a hibernating cluster

To accomplish this, following things were added
- cd.Status.PowerState
- ClusterReady condition for cluster deployment, that expands on transitioning status when a cluster is resuming
- Intermediate reasons to reflect starting (and stopping) if machines, distinct from waiting for the machines to start (or stop)

xref: https://issues.redhat.com/browse/HIVE-1601

/cc @2uasimojo 