### PR TITLE
fix DNSZone docs permissions

### DIFF
--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -795,10 +795,10 @@ To use this feature:
        route53:CreateHostedZone
        route53:DeleteHostedZone
        route53:GetHostedZone
-       route53:GetResourcesPages
-       route53:ListHostedZoneByName
+       route53:ListHostedZonesByName
        route53:ListResourceRecordSets
        route53:ListTagsForResource
+       tag:GetResources
        ```
      - GCP
        ```yaml


### PR DESCRIPTION
Permission route53:GetResourcesPages is not a route53 API at all, it
should be tag:GetResources.

Permission route53:ListHostedZoneByName has a typo as it should be Zones
(plural).

xref: https://issues.redhat.com/browse/HIVE-1681