### PR TITLE
add ec2:DescribeNetworkInterfaces permission to PrivateLink permissions

### DIFF
--- a/docs/awsprivatelink.md
+++ b/docs/awsprivatelink.md
@@ -195,6 +195,7 @@ expectations of required permissions for these credentials.
     ec2:DescribeVpcEndpoints
     ec2:CreateVpcEndpoint
     ec2:CreateTags
+    ec2:DescribeNetworkInterfaces
     ec2:DescribeVPCs
 
     ec2:DeleteVpcEndpoints


### PR DESCRIPTION
related to FedRamp work and this conversation: https://coreos.slack.com/archives/C027UG79RR9/p1636063266209800?thread_ts=1636043782.182600&cid=C027UG79RR9