### PR TITLE
HiveConfig.Spec.FailedProvisionConfig.RetryReasons

### DIFF
--- a/apis/hive/v1/hiveconfig_types.go
+++ b/apis/hive/v1/hiveconfig_types.go
@@ -390,6 +390,11 @@ type FailedProvisionConfig struct {
 	// DEPRECATED: This flag is no longer respected and will be removed in the future.
 	SkipGatherLogs bool                      `json:"skipGatherLogs,omitempty"`
 	AWS            *FailedProvisionAWSConfig `json:"aws,omitempty"`
+	// RetryReasons is a list of installFailingReason strings from the [additional-]install-log-regexes ConfigMaps.
+	// If specified, Hive will only retry a failed installation if it results in one of the listed reasons. If
+	// omitted (not the same thing as empty!), Hive will retry regardless of the failure reason. (The total number
+	// of install attempts is still constrained by ClusterDeployment.Spec.InstallAttemptsLimit.)
+	RetryReasons *[]string `json:"retryReasons,omitempty"`
 }
 
 // ManageDNSConfig contains the domain being managed, and the cloud-specific

--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -378,6 +378,16 @@ spec:
                     required:
                     - credentialsSecretRef
                     type: object
+                  retryReasons:
+                    description: RetryReasons is a list of installFailingReason strings
+                      from the [additional-]install-log-regexes ConfigMaps. If specified,
+                      Hive will only retry a failed installation if it results in
+                      one of the listed reasons. If omitted (not the same thing as
+                      empty!), Hive will retry regardless of the failure reason. (The
+                      total number of install attempts is still constrained by ClusterDeployment.Spec.InstallAttemptsLimit.)
+                    items:
+                      type: string
+                    type: array
                   skipGatherLogs:
                     description: 'DEPRECATED: This flag is no longer respected and
                       will be removed in the future.'

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -3760,6 +3760,17 @@ objects:
                       required:
                       - credentialsSecretRef
                       type: object
+                    retryReasons:
+                      description: RetryReasons is a list of installFailingReason
+                        strings from the [additional-]install-log-regexes ConfigMaps.
+                        If specified, Hive will only retry a failed installation if
+                        it results in one of the listed reasons. If omitted (not the
+                        same thing as empty!), Hive will retry regardless of the failure
+                        reason. (The total number of install attempts is still constrained
+                        by ClusterDeployment.Spec.InstallAttemptsLimit.)
+                      items:
+                        type: string
+                      type: array
                     skipGatherLogs:
                       description: 'DEPRECATED: This flag is no longer respected and
                         will be removed in the future.'

--- a/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
@@ -390,6 +390,11 @@ type FailedProvisionConfig struct {
 	// DEPRECATED: This flag is no longer respected and will be removed in the future.
 	SkipGatherLogs bool                      `json:"skipGatherLogs,omitempty"`
 	AWS            *FailedProvisionAWSConfig `json:"aws,omitempty"`
+	// RetryReasons is a list of installFailingReason strings from the [additional-]install-log-regexes ConfigMaps.
+	// If specified, Hive will only retry a failed installation if it results in one of the listed reasons. If
+	// omitted (not the same thing as empty!), Hive will retry regardless of the failure reason. (The total number
+	// of install attempts is still constrained by ClusterDeployment.Spec.InstallAttemptsLimit.)
+	RetryReasons *[]string `json:"retryReasons,omitempty"`
 }
 
 // ManageDNSConfig contains the domain being managed, and the cloud-specific


### PR DESCRIPTION
Add support for a list of strings in HiveConfig which correspond to
`installFailingReason`s from [additional-]install-log-regexes.

- If the list is present and the most recent ClusterProvision has failed
with a matching reason, we will retry (assuming not otherwise blocked,
e.g. by `InstallAttemptsLimit`).
- If the list is present and the reason is _not_ in the list, we will
fail immediately (`ProvisionStopped`) even if `InstallAttemptsLimit` is
not reached.
- If the list is absent, the previous behavior is observed: we will
ignore the failure reason and proceed or stop based solely on factors
such as `InstallAttemptsLimit`.

[HIVE-1662](https://issues.redhat.com/browse/HIVE-1662)