### PR TITLE
Add install log regexes for loadbalancer-related failures

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -22,6 +22,11 @@ data:
        - "TooManyBuckets"
       installFailingReason: S3BucketsLimitExceeded
       installFailingMessage: S3 Buckets Limit Exceeded
+    - name: LoadBalancerLimitExceeded
+      searchRegexStrings:
+      - "TooManyLoadBalancers: Exceeded quota of account"
+      installFailingReason: LoadBalancerLimitExceeded
+      installFailingMessage: AWS Load Balancer Limit Exceeded
     - name: EIPAddressLimitExceeded
       searchRegexStrings:
       - "EIP: AddressLimitExceeded"
@@ -106,6 +111,7 @@ data:
     - name: AWSInsufficientPermissions
       searchRegexStrings:
       - "current credentials insufficient for performing cluster installation"
+      - "Error creating network Load Balancer: AccessDenied"
       installFailingReason: AWSInsufficientPermissions
       installFailingMessage: AWS credentials are insufficient for performing cluster installation
     - name: VcpuLimitExceeded

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1584,6 +1584,11 @@ data:
        - "TooManyBuckets"
       installFailingReason: S3BucketsLimitExceeded
       installFailingMessage: S3 Buckets Limit Exceeded
+    - name: LoadBalancerLimitExceeded
+      searchRegexStrings:
+      - "TooManyLoadBalancers: Exceeded quota of account"
+      installFailingReason: LoadBalancerLimitExceeded
+      installFailingMessage: AWS Load Balancer Limit Exceeded
     - name: EIPAddressLimitExceeded
       searchRegexStrings:
       - "EIP: AddressLimitExceeded"
@@ -1668,6 +1673,7 @@ data:
     - name: AWSInsufficientPermissions
       searchRegexStrings:
       - "current credentials insufficient for performing cluster installation"
+      - "Error creating network Load Balancer: AccessDenied"
       installFailingReason: AWSInsufficientPermissions
       installFailingMessage: AWS credentials are insufficient for performing cluster installation
     - name: VcpuLimitExceeded


### PR DESCRIPTION
This PR:

- adds a new search string under the existing OCM error code for `AWSInsufficientPermissions` when a load balancer is failed to be created due to insufficient permissions.
- adds a new search string and OCM error code for when the account has exceeded its load balancer quota.

The full logs from a failed installations which prompted this PR is:

```
time="2021-11-11T22:05:47Z" level=error msg="Error: Error creating network Load Balancer: AccessDenied: User: xxxxxxxxxxx is not authorized to
 perform: iam:CreateServiceLinkedRole on resource: arn:aws:iam::xxxxxxxxxxxxxxx:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing"       
```

and 

```
time="2021-11-12T00:40:07Z" level=info msg="Cluster operator ingress Available is False with IngressUnavailable: The \"default\" ingress controller reports Available=False: IngressControllerUnavailable: One or more status
 conditions indicate unavailable: LoadBalancerReady=False (SyncLoadBalancerFailed: The service-controller component is reporting SyncLoadBalancerFailed events like: Error syncing load balancer: failed to ensure load balan
cer: TooManyLoadBalancers: Exceeded quota of account xxxxxxxxxxxx\n\tstatus code: 400, request id: f0cb17ec-68b6-4f32-8997-cce5049a6a1e\nThe kube-controller-manager logs may contain more details.)" 
```

A separate PR has been raised to add the new `LoadBalancerLimitExceeded` OCM error code:
https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/3442

I feel like the 'AccessDenied' regex could be made a bit more generic to catch a lot more of these IAM-related permissions issues, but don't want it to inadvertently start matching against things it shouldn't and infer them as IAM problems.

cc @gregsheremeta 