### PR TITLE
move the install log regex for loadbalancer creation failure to its own condition

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -108,10 +108,16 @@ data:
       - "The subnet ID .* does not exist"
       installFailingReason: AWSSubnetDoesNotExist
       installFailingMessage: AWS Subnet Does Not Exist
+    # iam:CreateServiceLinkedRole is a super powerful permission that we don't give to STS clusters. We require it's done as a one-time prereq.
+    # This is the error we see when the prereq step was missed.
+    - name: AWSAccessDeniedSLR
+      searchRegexStrings:
+      - "Error creating network Load Balancer: AccessDenied.*iam:CreateServiceLinkedRole"
+      installFailingReason: AWSAccessDeniedSLR
+      installFailingMessage: Missing prerequisite service role for load balancer
     - name: AWSInsufficientPermissions
       searchRegexStrings:
       - "current credentials insufficient for performing cluster installation"
-      - "Error creating network Load Balancer: AccessDenied"
       installFailingReason: AWSInsufficientPermissions
       installFailingMessage: AWS credentials are insufficient for performing cluster installation
     - name: VcpuLimitExceeded

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -42,7 +42,7 @@ const (
 	awsDeleteRoleFailed       = "time=\"2021-09-22T12:25:40Z\" level=error msg=\"Error: Error deleting IAM Role (my-fake-cluster-hashn0s-bootstrap-role): DeleteConflict: Cannot delete entity, must detach all policies first.\""
 	subnetDoesNotExist        = "blahblah\nlevel=fatal msg=\"failed to fetch Master Machines: failed to load asset \"Install Config\": [platform.aws.subnets: Invalid value: []string{\"subnet-whatever\", \"subnet-whatever2\"}: describing subnets: InvalidSubnetID.NotFound: The subnet ID 'subnet-whatever' does not exist"
 	insufficientPermissions   = "level=fatal msg=failed to fetch Cluster: failed to fetch dependency of \"Cluster\": failed to generate asset \"Platform Permissions Check\": validate AWS credentials: current credentials insufficient for performing cluster installation"
-	insufficientPermissionsLB = "level=error msg=\"Error: Error creating network Load Balancer: AccessDenied: User: xxxxxxxxxxx is not authorized to"
+	accessDeniedSLR           = "blahblah\nError: Error creating network Load Balancer: AccessDenied: User: arn:aws:sts::123456789:assumed-role/ManagedOpenShift-Installer-Role/123456789 is not authorized to perform: iam:CreateServiceLinkedRole on resource: arn:aws:iam::123456789:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing"
 	loadBalancerLimitExceeded = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=info msg=\"Cluster operator ingress Available is False with IngressUnavailable: The \"default\" ingress controller reports Available=False: IngressControllerUnavailable: One or more status	conditions indicate unavailable: LoadBalancerReady=False (SyncLoadBalancerFailed: The service-controller component is reporting SyncLoadBalancerFailed events like: Error syncing load balancer: failed to ensure load balancer: TooManyLoadBalancers: Exceeded quota of account 1234567890\n\tstatus code: 400, request id: f0cb17ec-68b6-4f32-8997-cce5049a6a1e\nThe kube-controller-manager logs may contain more details.)"
 	noMatchLog                = "an example of something that doesn't match the log regexes"
 )
@@ -56,6 +56,12 @@ func TestParseInstallLog(t *testing.T) {
 		expectedReason  string
 		expectedMessage *string
 	}{
+		{
+			name:           "load balancer service linked role prereq",
+			log:            pointer.StringPtr(accessDeniedSLR),
+			existing:       []runtime.Object{buildRegexConfigMap()},
+			expectedReason: "AWSAccessDeniedSLR",
+		},
 		{
 			name:           "DNS already exists",
 			log:            pointer.StringPtr(dnsAlreadyExistsLog),
@@ -343,7 +349,6 @@ func TestParseInstallLog(t *testing.T) {
 - name: InsufficientPermissions
   searchRegexStrings:
   - "current credentials insufficient for performing cluster installation"
-  - "Error creating network Load Balancer: AccessDenied"
   installFailingReason: AWSInsufficientPermissions
   installFailingMessage: AWS credentials are insufficient for performing cluster installation
 `,
@@ -356,12 +361,6 @@ func TestParseInstallLog(t *testing.T) {
 			log:            pointer.StringPtr(loadBalancerLimitExceeded),
 			existing:       []runtime.Object{buildRegexConfigMap()},
 			expectedReason: "LoadBalancerLimitExceeded",
-		},
-		{
-			name:           "AWSInsufficientPermissions",
-			log:            pointer.StringPtr(insufficientPermissionsLB),
-			existing:       []runtime.Object{buildRegexConfigMap()},
-			expectedReason: "AWSInsufficientPermissions",
 		},
 	}
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1670,10 +1670,16 @@ data:
       - "The subnet ID .* does not exist"
       installFailingReason: AWSSubnetDoesNotExist
       installFailingMessage: AWS Subnet Does Not Exist
+    # iam:CreateServiceLinkedRole is a super powerful permission that we don't give to STS clusters. We require it's done as a one-time prereq.
+    # This is the error we see when the prereq step was missed.
+    - name: AWSAccessDeniedSLR
+      searchRegexStrings:
+      - "Error creating network Load Balancer: AccessDenied.*iam:CreateServiceLinkedRole"
+      installFailingReason: AWSAccessDeniedSLR
+      installFailingMessage: Missing prerequisite service role for load balancer
     - name: AWSInsufficientPermissions
       searchRegexStrings:
       - "current credentials insufficient for performing cluster installation"
-      - "Error creating network Load Balancer: AccessDenied"
       installFailingReason: AWSInsufficientPermissions
       installFailingMessage: AWS credentials are insufficient for performing cluster installation
     - name: VcpuLimitExceeded


### PR DESCRIPTION
move the install log regex for loadbalancer creation failure to its own condition

When this happens, the problem is slightly different than just a plain ol'
permission denied, and we need to call it out as such.

/assign @mrbarge @2uasimojo 
/cc @abutcher 