### PR TITLE
Static name for managed DNS ConfigMap

### DIFF
--- a/pkg/operator/hive/awsprivatelink.go
+++ b/pkg/operator/hive/awsprivatelink.go
@@ -1,8 +1,6 @@
 package hive
 
 import (
-	"crypto/md5"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -55,15 +53,9 @@ func (r *ReconcileHiveConfig) deployAWSPrivateLinkConfigMap(hLog log.FieldLogger
 	hLog.WithField("result", result).Info("aws-private-link configmap applied")
 
 	hLog.Info("Hashing hive-controllers-config data onto a hive deployment annotation")
-	awsPrivateLinkConfigHash := computeAWSPrivateLinkConfigHash(cm)
+	awsPrivateLinkConfigHash := computeHash(cm.Data)
 
 	return awsPrivateLinkConfigHash, nil
-}
-
-func computeAWSPrivateLinkConfigHash(cm *corev1.ConfigMap) string {
-	hasher := md5.New()
-	hasher.Write([]byte(fmt.Sprintf("%v", cm.Data)))
-	return hex.EncodeToString(hasher.Sum(nil))
 }
 
 func addAWSPrivateLinkConfigVolume(podSpec *corev1.PodSpec) {

--- a/pkg/operator/hive/controllersconfig.go
+++ b/pkg/operator/hive/controllersconfig.go
@@ -1,8 +1,6 @@
 package hive
 
 import (
-	"crypto/md5"
-	"encoding/hex"
 	"fmt"
 	"strconv"
 
@@ -61,7 +59,7 @@ func (r *ReconcileHiveConfig) deployHiveControllersConfigMap(hLog log.FieldLogge
 	hLog.WithField("result", result).Info("hive-controllers-config configmap applied")
 
 	hLog.Info("Hashing hive-controllers-config data onto a hive deployment annotation")
-	hiveControllersConfigHash := computeHiveControllersConfigHash(hiveControllersConfigMap, additionalControllerConfigHashes...)
+	hiveControllersConfigHash := computeHash(hiveControllersConfigMap.Data, additionalControllerConfigHashes...)
 
 	return hiveControllersConfigHash, nil
 }
@@ -92,13 +90,4 @@ func setHiveControllersConfig(config *hivev1.ControllerConfig, hiveControllersCo
 	if config.QueueBurst != nil {
 		hiveControllersConfigMap.Data[fmt.Sprintf(utils.QueueBurstEnvVariableFormat, controllerName)] = strconv.Itoa(int(*config.QueueBurst))
 	}
-}
-
-func computeHiveControllersConfigHash(hiveControllersConfigMap *corev1.ConfigMap, additionalControllerConfigHashes ...string) string {
-	hasher := md5.New()
-	hasher.Write([]byte(fmt.Sprintf("%v", hiveControllersConfigMap.Data)))
-	for _, h := range additionalControllerConfigHashes {
-		hasher.Write([]byte(h))
-	}
-	return hex.EncodeToString(hasher.Sum(nil))
 }

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -63,7 +63,7 @@ var (
 	}
 )
 
-func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper, instance *hivev1.HiveConfig, mdConfigMap *corev1.ConfigMap, hiveControllersConfigHash string, namespacesToClean []string) error {
+func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper, instance *hivev1.HiveConfig, namespacesToClean []string, configHashes ...string) error {
 	deploymentAsset := "config/controllers/deployment.yaml"
 	namespacedAssets := []string{
 		"config/controllers/service.yaml",
@@ -138,7 +138,7 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 		hiveContainer.Env = append(hiveContainer.Env, syncsetReapplyIntervalEnvVar)
 	}
 
-	addManagedDomainsVolume(&hiveDeployment.Spec.Template.Spec, mdConfigMap.Name)
+	addManagedDomainsVolume(&hiveDeployment.Spec.Template.Spec, managedDomainsConfigMapName)
 	addAWSPrivateLinkConfigVolume(&hiveDeployment.Spec.Template.Spec)
 
 	hiveNSName := getHiveNamespace(instance)
@@ -275,7 +275,7 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 	if hiveDeployment.Spec.Template.Annotations == nil {
 		hiveDeployment.Spec.Template.Annotations = make(map[string]string, 1)
 	}
-	hiveDeployment.Spec.Template.Annotations[hiveConfigHashAnnotation] = hiveControllersConfigHash
+	hiveDeployment.Spec.Template.Annotations[hiveConfigHashAnnotation] = computeHash("", configHashes...)
 
 	utils.SetProxyEnvVars(&hiveDeployment.Spec.Template.Spec,
 		os.Getenv("HTTP_PROXY"), os.Getenv("HTTPS_PROXY"), os.Getenv("NO_PROXY"))

--- a/pkg/operator/hive/hive_controller.go
+++ b/pkg/operator/hive/hive_controller.go
@@ -459,7 +459,7 @@ func (r *ReconcileHiveConfig) Reconcile(ctx context.Context, request reconcile.R
 		}
 	}
 
-	managedDomainsConfigMap, err := r.configureManagedDomains(hLog, h, instance, namespacesToClean)
+	managedDomainsConfigHash, err := r.configureManagedDomains(hLog, h, instance, namespacesToClean)
 	if err != nil {
 		hLog.WithError(err).Error("error setting up managed domains")
 		instance.Status.Conditions = util.SetHiveConfigCondition(instance.Status.Conditions, hivev1.HiveReadyCondition, corev1.ConditionFalse, "ErrorSettingUpManagedDomains", err.Error())
@@ -498,7 +498,7 @@ func (r *ReconcileHiveConfig) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	err = r.deployHive(hLog, h, instance, managedDomainsConfigMap, confighash, namespacesToClean)
+	err = r.deployHive(hLog, h, instance, namespacesToClean, confighash, managedDomainsConfigHash)
 	if err != nil {
 		hLog.WithError(err).Error("error deploying Hive")
 		instance.Status.Conditions = util.SetHiveConfigCondition(instance.Status.Conditions, hivev1.HiveReadyCondition, corev1.ConditionFalse, "ErrorDeployingHive", err.Error())
@@ -527,7 +527,7 @@ func (r *ReconcileHiveConfig) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	err = r.deployHiveAdmission(hLog, h, instance, namespacesToClean, managedDomainsConfigMap, fgConfigHash, plConfigHash, scConfigHash)
+	err = r.deployHiveAdmission(hLog, h, instance, namespacesToClean, managedDomainsConfigHash, fgConfigHash, plConfigHash, scConfigHash)
 	if err != nil {
 		hLog.WithError(err).Error("error deploying HiveAdmission")
 		instance.Status.Conditions = util.SetHiveConfigCondition(instance.Status.Conditions, hivev1.HiveReadyCondition, corev1.ConditionFalse, "ErrorDeployingHiveAdmission", err.Error())

--- a/pkg/operator/hive/hive_controller.go
+++ b/pkg/operator/hive/hive_controller.go
@@ -2,8 +2,6 @@ package hive
 
 import (
 	"context"
-	"crypto/md5"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"reflect"
@@ -674,12 +672,6 @@ func aggregatorCAConfigMapHandler(o client.Object) []reconcile.Request {
 		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: constants.HiveConfigName}}}
 	}
 	return nil
-}
-
-func computeHash(data map[string]string) string {
-	hasher := md5.New()
-	hasher.Write([]byte(fmt.Sprintf("%v", data)))
-	return hex.EncodeToString(hasher.Sum(nil))
 }
 
 func (r *ReconcileHiveConfig) updateHiveConfigStatus(origHiveConfig, newHiveConfig *hivev1.HiveConfig, logger log.FieldLogger, succeeded bool) error {

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -66,7 +66,7 @@ var webhookAssets = []string{
 	"config/hiveadmission/selectorsyncset-webhook.yaml",
 }
 
-func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h resource.Helper, instance *hivev1.HiveConfig, namespacesToClean []string, mdConfigMap *corev1.ConfigMap, additionalHashes ...string) error {
+func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h resource.Helper, instance *hivev1.HiveConfig, namespacesToClean []string, additionalHashes ...string) error {
 	deploymentAsset := "config/hiveadmission/deployment.yaml"
 	namespacedAssets := []string{
 		"config/hiveadmission/service.yaml",
@@ -140,7 +140,7 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h resour
 	controllerutils.SetProxyEnvVars(&hiveAdmDeployment.Spec.Template.Spec,
 		os.Getenv("HTTP_PROXY"), os.Getenv("HTTPS_PROXY"), os.Getenv("NO_PROXY"))
 
-	addManagedDomainsVolume(&hiveAdmDeployment.Spec.Template.Spec, mdConfigMap.Name)
+	addManagedDomainsVolume(&hiveAdmDeployment.Spec.Template.Spec, managedDomainsConfigMapName)
 	addAWSPrivateLinkConfigVolume(&hiveAdmDeployment.Spec.Template.Spec)
 	addSupportedContractsConfigVolume(&hiveAdmDeployment.Spec.Template.Spec)
 	addReleaseImageVerificationConfigMapEnv(&hiveAdmDeployment.Spec.Template.Spec, instance)

--- a/pkg/operator/hive/operatorutils.go
+++ b/pkg/operator/hive/operatorutils.go
@@ -2,6 +2,9 @@ package hive
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
 
 	log "github.com/sirupsen/logrus"
 
@@ -40,4 +43,13 @@ type gvrNSName struct {
 	resource  string
 	namespace string // empty for global resources
 	name      string
+}
+
+func computeHash(data interface{}, additionalHashes ...string) string {
+	hasher := md5.New()
+	hasher.Write([]byte(fmt.Sprintf("%v", data)))
+	for _, h := range additionalHashes {
+		hasher.Write([]byte(h))
+	}
+	return hex.EncodeToString(hasher.Sum(nil))
 }


### PR DESCRIPTION
When managed DNS is enabled, we copy the relevant data from HiveConfig
to a ConfigMap in the target namespace. Previously this ConfigMap was
dynamically named `managed-domains-XXXXX` and we would find it via a
label. For consistency with other similar ConfigMaps used by Hive, this
commit switches it to use a static name, `hive-managed-domains`,
instead. For upgrade purposes, we have to keep the old lookup mechanism
in place until we can be sure we've flushed out all instances of the old
naming scheme.