### PR TITLE
Use a ConfigMap for FailedProvisionConfig

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -351,6 +351,10 @@ const (
 	// file that includes configuration for aws-private-link-controller
 	AWSPrivateLinkControllerConfigFileEnvVar = "AWS_PRIVATELINK_CONTROLLER_CONFIG_FILE"
 
+	// FailedProvisionConfigFileEnvVar points to a text file containing configuration for
+	// desired behavior when provisions fail. See HiveConfig.Spec.FailedProvisionConfig.
+	FailedProvisionConfigFileEnvVar = "FAILED_PROVISION_CONFIG_FILE"
+
 	// HiveReleaseImageVerificationConfigMapNamespaceEnvVar is used to configure the config map that will be used
 	// to verify the release images being used for cluster deployments.
 	HiveReleaseImageVerificationConfigMapNamespaceEnvVar = "HIVE_RELEASE_IMAGE_VERIFICATION_CONFIGMAP_NS"

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -864,20 +864,6 @@ func isDNSNotReadyConditionSet(cd *hivev1.ClusterDeployment) (bool, *hivev1.Clus
 		dnsNotReadyCondition
 }
 
-func addEnvVarIfFound(name string, envVars []corev1.EnvVar) []corev1.EnvVar {
-	value, found := os.LookupEnv(name)
-	if !found {
-		return envVars
-	}
-
-	tmp := corev1.EnvVar{
-		Name:  name,
-		Value: value,
-	}
-
-	return append(envVars, tmp)
-}
-
 // getReleaseImage looks for a a release image in clusterdeployment or its corresponding imageset in the following order:
 // 1 - specified in the cluster deployment spec.images.releaseImage
 // 2 - referenced in the cluster deployment spec.imageSet

--- a/pkg/operator/hive/failedprovision.go
+++ b/pkg/operator/hive/failedprovision.go
@@ -1,0 +1,80 @@
+package hive
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
+	"github.com/openshift/hive/pkg/operator/util"
+	"github.com/openshift/hive/pkg/resource"
+)
+
+const (
+	failedProvisionConfigMapName      = "hive-failed-provision-config"
+	failedProvisionConfigMapNameKey   = "hive-failed-provision-config"
+	failedProvisionConfigMapMountPath = "/data/failed-provision-config"
+)
+
+func (r *ReconcileHiveConfig) deployFailedProvisionConfigMap(hLog log.FieldLogger, h resource.Helper, instance *hivev1.HiveConfig, namespacesToClean []string) (string, error) {
+	// Delete the configmap from previous target namespaces
+	for _, ns := range namespacesToClean {
+		hLog.Infof("Deleting configmap/%s from old target namespace %s", failedProvisionConfigMapName, ns)
+		// h.Delete already no-ops for IsNotFound
+		// TODO: Something better than hardcoding apiVersion and kind.
+		if err := h.Delete("v1", "ConfigMap", ns, failedProvisionConfigMapName); err != nil {
+			return "", errors.Wrapf(err, "error deleting configmap/%s from old target namespace %s", failedProvisionConfigMapName, ns)
+		}
+	}
+
+	cm := &corev1.ConfigMap{}
+	cm.Name = failedProvisionConfigMapName
+	cm.Namespace = getHiveNamespace(instance)
+	cm.Data = make(map[string]string)
+
+	data, err := json.Marshal(instance.Spec.FailedProvisionConfig)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to marshal failed provision config")
+	}
+	cm.Data[failedProvisionConfigMapNameKey] = string(data)
+
+	result, err := util.ApplyRuntimeObjectWithGC(h, cm, instance)
+	if err != nil {
+		hLog.WithError(err).Error("error applying failed provision configmap")
+		return "", err
+	}
+	hLog.WithField("result", result).Info("failed provision configmap applied")
+
+	hLog.Info("Hashing hive-controllers-config data onto a hive deployment annotation")
+	failedProvisionConfigHash := computeHash(cm.Data)
+
+	return failedProvisionConfigHash, nil
+}
+
+func addFailedProvisionConfigVolume(podSpec *corev1.PodSpec) {
+	optional := true
+	volume := corev1.Volume{}
+	volume.Name = failedProvisionConfigMapName
+	volume.ConfigMap = &corev1.ConfigMapVolumeSource{
+		LocalObjectReference: corev1.LocalObjectReference{
+			Name: failedProvisionConfigMapName,
+		},
+		Optional: &optional,
+	}
+	volumeMount := corev1.VolumeMount{
+		Name:      failedProvisionConfigMapName,
+		MountPath: failedProvisionConfigMapMountPath,
+	}
+	envVar := corev1.EnvVar{
+		Name:  constants.FailedProvisionConfigFileEnvVar,
+		Value: fmt.Sprintf("%s/%s", failedProvisionConfigMapMountPath, failedProvisionConfigMapNameKey),
+	}
+	podSpec.Volumes = append(podSpec.Volumes, volume)
+	podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, volumeMount)
+	podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, envVar)
+}


### PR DESCRIPTION
Create a ConfigMap containing FailedProvisionConfig and use it instead of the existing mechanisms:
- Environment variables for log upload
- Directly reading HiveConfig for RetryReasons

[HIVE-1692](https://issues.redhat.com/browse/HIVE-1692)