### PR TITLE
Respect azure cloudName set for clusterpool.

### DIFF
--- a/pkg/clusterresource/azure.go
+++ b/pkg/clusterresource/azure.go
@@ -32,6 +32,9 @@ type AzureCloudBuilder struct {
 
 	// Region is the Azure region to which to install the cluster.
 	Region string
+
+	// CloudName is the name of the Azure cloud environment which will be used for the cluster.
+	CloudName hivev1azure.CloudEnvironment
 }
 
 func NewAzureCloudBuilderFromSecret(credsSecret *corev1.Secret) *AzureCloudBuilder {
@@ -66,6 +69,7 @@ func (p *AzureCloudBuilder) GetCloudPlatform(o *Builder) hivev1.Platform {
 			},
 			Region:                      p.Region,
 			BaseDomainResourceGroupName: p.BaseDomainResourceGroupName,
+			CloudName:                   p.CloudName,
 		},
 	}
 }
@@ -86,6 +90,7 @@ func (p *AzureCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installerty
 		Azure: &azureinstallertypes.Platform{
 			Region:                      p.Region,
 			BaseDomainResourceGroupName: p.BaseDomainResourceGroupName,
+			CloudName:                   azureinstallertypes.CloudEnvironment(p.CloudName),
 		},
 	}
 

--- a/pkg/clusterresource/builder_test.go
+++ b/pkg/clusterresource/builder_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/openshift/hive/apis"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	hivev1azure "github.com/openshift/hive/apis/hive/v1/azure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -31,6 +32,7 @@ const (
 	fakeAWSSecretAccessKey           = "fakesecretAccessKey"
 	fakeAzureServicePrincipal        = "fakeSP"
 	fakeAzureBaseDomainResourceGroup = "azure-resource-group"
+	fakeAzureCloudName               = hivev1azure.CloudEnvironment("AzureUSGovernmentCloud")
 	fakeGCPServiceAccount            = "fakeSA"
 	fakeGCPProjectID                 = "gcp-project-id"
 	adoptAdminKubeconfig             = "adopted-admin-kubeconfig"
@@ -115,6 +117,7 @@ func createAzureClusterBuilder() *Builder {
 	b.CloudBuilder = &AzureCloudBuilder{
 		ServicePrincipal:            []byte(fakeAzureServicePrincipal),
 		BaseDomainResourceGroupName: fakeAzureBaseDomainResourceGroup,
+		CloudName:                   fakeAzureCloudName,
 	}
 	return b
 }
@@ -209,6 +212,8 @@ func TestBuildClusterResources(t *testing.T) {
 				assert.Equal(t, credsSecret.Name, cd.Spec.Platform.Azure.CredentialsSecretRef.Name)
 
 				assert.Equal(t, azureInstanceType, workerPool.Spec.Platform.Azure.InstanceType)
+
+				assert.Equal(t, fakeAzureCloudName, cd.Spec.Platform.Azure.CloudName)
 			},
 		},
 		{

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -990,6 +990,7 @@ func (r *ReconcileClusterPool) createCloudBuilder(pool *hivev1.ClusterPool, logg
 		cloudBuilder := clusterresource.NewAzureCloudBuilderFromSecret(credsSecret)
 		cloudBuilder.BaseDomainResourceGroupName = platform.Azure.BaseDomainResourceGroupName
 		cloudBuilder.Region = platform.Azure.Region
+		cloudBuilder.CloudName = platform.Azure.CloudName
 		return cloudBuilder, nil
 	// TODO: OpenStack, VMware, and Ovirt.
 	default:


### PR DESCRIPTION
`CloudName` set within the Azure Platform for `ClusterPool` will be set for created `ClusterDeployments` and within `InstallConfig` platform.