### PR TITLE
CD.Spec.Provisioning.InstallerImageOverride

### DIFF
--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -182,6 +182,11 @@ type Provisioning struct {
 	// is the primary and best way to specify what specific version of OpenShift you wish to install.
 	ReleaseImage string `json:"releaseImage,omitempty"`
 
+	// InstallerImageOverride allows specifying a URI for the installer image, normally gleaned from
+	// the metadata within the ReleaseImage.
+	// +optional
+	InstallerImageOverride string `json:"installerImageOverride,omitempty"`
+
 	// ImageSetRef is a reference to a ClusterImageSet. If a value is specified for ReleaseImage,
 	// that will take precedence over the one from the ClusterImageSet.
 	ImageSetRef *ClusterImageSetReference `json:"imageSetRef,omitempty"`

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -867,6 +867,11 @@ spec:
                       - name
                       type: object
                     type: array
+                  installerImageOverride:
+                    description: InstallerImageOverride allows specifying a URI for
+                      the installer image, normally gleaned from the metadata within
+                      the ReleaseImage.
+                    type: string
                   manifestsConfigMapRef:
                     description: ManifestsConfigMapRef is a reference to user-provided
                       manifests to add to or replace manifests that are generated

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -1131,6 +1131,11 @@ objects:
                         - name
                         type: object
                       type: array
+                    installerImageOverride:
+                      description: InstallerImageOverride allows specifying a URI
+                        for the installer image, normally gleaned from the metadata
+                        within the ReleaseImage.
+                      type: string
                     manifestsConfigMapRef:
                       description: ManifestsConfigMapRef is a reference to user-provided
                         manifests to add to or replace manifests that are generated

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -182,6 +182,11 @@ type Provisioning struct {
 	// is the primary and best way to specify what specific version of OpenShift you wish to install.
 	ReleaseImage string `json:"releaseImage,omitempty"`
 
+	// InstallerImageOverride allows specifying a URI for the installer image, normally gleaned from
+	// the metadata within the ReleaseImage.
+	// +optional
+	InstallerImageOverride string `json:"installerImageOverride,omitempty"`
+
 	// ImageSetRef is a reference to a ClusterImageSet. If a value is specified for ReleaseImage,
 	// that will take precedence over the one from the ClusterImageSet.
 	ImageSetRef *ClusterImageSetReference `json:"imageSetRef,omitempty"`


### PR DESCRIPTION
Add a field to ClusterDeployment.Spec.Provisioning allowing
specification of an image URI to use in place of the installer image
gleaned from the ReleaseImage metadata.

[HIVE-1698](https://issues.redhat.com/browse/HIVE-1698)