### PR TITLE
Fix azure e2e

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -123,6 +123,9 @@ case "${CLOUD}" in
 "azure")
 	CREDS_FILE="${CLUSTER_PROFILE_DIR}/osServicePrincipal.json"
 	BASE_DOMAIN="${BASE_DOMAIN:-ci.azure.devcluster.openshift.com}"
+	# For azure we set managedDNS=false as we are facing issues with this feature currently.
+	# This is a temporary workaround to fix the e2e
+	USE_MANAGED_DNS=false
 	;;
 "gcp")
 	CREDS_FILE="${CLUSTER_PROFILE_DIR}/gce.json"

--- a/test/e2e/postdeploy/operator/operator_test.go
+++ b/test/e2e/postdeploy/operator/operator_test.go
@@ -125,7 +125,7 @@ func TestHiveConfig(t *testing.T) {
 		return
 	}
 	for _, md := range hiveConfig.Spec.ManagedDomains {
-		if md.AWS == nil && md.GCP == nil {
+		if md.AWS == nil && md.GCP == nil && md.Azure == nil {
 			t.Errorf("managed domain entry found without cloud configuration")
 			return
 		}
@@ -146,6 +146,14 @@ func TestHiveConfig(t *testing.T) {
 				return
 			}
 			secretName = md.GCP.CredentialsSecretRef.Name
+		}
+
+		if md.Azure != nil {
+			if len(md.Azure.CredentialsSecretRef.Name) == 0 {
+				t.Errorf("Azure managed DNS configured, but no credentials secret specified")
+				return
+			}
+			secretName = md.Azure.CredentialsSecretRef.Name
 		}
 
 		secret := &corev1.Secret{}


### PR DESCRIPTION
Currently, the test to verify HiveConfig CR does not validate
managed domains for azure. This PR fixes it and the e2e

x-ref: https://issues.redhat.com/browse/HIVE-1710