### PR TITLE
e2e: Increase node wait timeout

### DIFF
--- a/test/e2e/postinstall/machinesets/infra_test.go
+++ b/test/e2e/postinstall/machinesets/infra_test.go
@@ -418,7 +418,7 @@ func waitForNodes(logger log.FieldLogger, cfg *rest.Config, cd *hivev1.ClusterDe
 		}
 
 		return true
-	}, 10*time.Minute)
+	}, 15*time.Minute)
 }
 
 func machineNamePrefix(cd *hivev1.ClusterDeployment, poolName string) (string, error) {


### PR DESCRIPTION
Been seeing frequent flakes on this. Increasing the timeout,
understanding that it may be a deeper flake and we're just wasting more
time.