### PR TITLE
e2e: Fix disappearing logs

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -92,9 +92,14 @@ export HIVE_OPERATOR_NS="hive-operator"
 IMG="${HIVE_IMAGE}" make deploy
 
 function save_hive_logs() {
-  oc logs -n "${HIVE_NS}" deployment/hive-controllers > "${ARTIFACT_DIR}/hive-controllers.log" || true
-  oc logs -n "${HIVE_NS}" deployment/hiveadmission > "${ARTIFACT_DIR}/hiveadmission.log" || true
-  oc logs -n "${HIVE_NS}" deployment/hive-operator > "${ARTIFACT_DIR}/hive-operator.log" || true
+  tmpf=$(mktemp)
+  for x in "hive-controllers ${HIVE_NS}" "hiveadmission ${HIVE_NS}" "hive-operator ${HIVE_OPERATOR_NS}"; do
+    read d n <<<$x
+    # Don't save/overwrite the file unless log extraction succeeds
+    if oc logs -n $n deployment/$d > $tmpf; then
+      mv $tmpf "${ARTIFACT_DIR}/${d}.log"
+    fi
+  done
 }
 
 SRC_ROOT=$(git rev-parse --show-toplevel)


### PR DESCRIPTION
We're saving deployment logs as part of an exit trap to ensure we get
the latest, most complete picture on failure. However, the way we were
doing it previously would truncate the log files if the deployments were
gone -- which they would be if the script didn't exit early, because we
uninstall the operator as the last part of the test.

Fix the log saving logic to only overwrite the log files if the log
extraction command succeeds.