### PR TITLE
Fix hiveutil create-cluster --ssh-private-key-file

### DIFF
--- a/contrib/pkg/createcluster/create.go
+++ b/contrib/pkg/createcluster/create.go
@@ -806,7 +806,7 @@ func (o *Options) getSSHPrivateKey() (string, error) {
 			o.log.Error("Cannot read SSH private key file")
 			return "", err
 		}
-		sshPrivateKey := strings.TrimSpace(string(data))
+		sshPrivateKey := strings.TrimSpace(string(data)) + "\n"
 		return sshPrivateKey, nil
 	}
 	o.log.Debug("No private SSH key file provided")


### PR DESCRIPTION
Specifying an SSH private key file to `hiveutil create-cluster` causes
it to parlay the contents into a Secret. However, the code is chomping
whitespace, including the trailing newline, which `ssh-add` seems to
require or it complains the file format is invalid. This commit
explicitly adds the trailing newline. This causes the resulting yaml
block scalar to be introduced with `|` now rather than `|-`, and
`ssh-add` works.