### PR TITLE
OSD-9064 add install log handlers for proxy install failures

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -131,6 +131,7 @@ data:
       installFailingReason: UserInitiatedShutdown
       installFailingMessage: User initiated shutdown of instances as the install was running
 
+
     # GCP Specific
     - name: GCPInvalidProjectID
       searchRegexStrings:
@@ -163,6 +164,7 @@ data:
       installFailingReason: GCPServiceAccountQuotaExceeded
       installFailingMessage: GCP Service Account quota exceeded
 
+    
     # Bare Metal
     - name: LibvirtSSHKeyPermissionDenied
       searchRegexStrings:
@@ -174,6 +176,20 @@ data:
       - "could not connect to libvirt"
       installFailingReason: LibvirtConnectionFailed
       installFailingMessage: "Could not connect to libvirt host"
+
+
+    # Proxy-enabled clusters
+    - name: ProxyTimeout
+      searchRegexStrings:
+      - "error pinging docker registry .+ proxyconnect tcp: dial tcp [^ ]+: i/o timeout"
+      installFailingReason: ProxyTimeout
+      installFailingMessage: The cluster is installing via a proxy, however the proxy server is timing out connections. Verify that the proxy is running and would be accessible from the cluster's private subnet(s).
+    - name: ProxyInvalidCABundle
+      searchRegexStrings:
+      - "error pinging docker registry .+ proxyconnect tcp: x509: certificate signed by unknown authority"
+      installFailingReason: ProxyInvalidCABundle
+      installFailingMessage: The cluster is installing via a proxy, but does not trust the signing certificate the proxy is presenting. Verify that the Certificate Authority certificate(s) to verify proxy communications have been supplied at installation time.
+
 
     # Generic OpenShift Install
     - name: KubeAPIWaitTimeout

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -44,6 +44,8 @@ const (
 	insufficientPermissions   = "level=fatal msg=failed to fetch Cluster: failed to fetch dependency of \"Cluster\": failed to generate asset \"Platform Permissions Check\": validate AWS credentials: current credentials insufficient for performing cluster installation"
 	accessDeniedSLR           = "blahblah\nError: Error creating network Load Balancer: AccessDenied: User: arn:aws:sts::123456789:assumed-role/ManagedOpenShift-Installer-Role/123456789 is not authorized to perform: iam:CreateServiceLinkedRole on resource: arn:aws:iam::123456789:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing"
 	loadBalancerLimitExceeded = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=info msg=\"Cluster operator ingress Available is False with IngressUnavailable: The \"default\" ingress controller reports Available=False: IngressControllerUnavailable: One or more status	conditions indicate unavailable: LoadBalancerReady=False (SyncLoadBalancerFailed: The service-controller component is reporting SyncLoadBalancerFailed events like: Error syncing load balancer: failed to ensure load balancer: TooManyLoadBalancers: Exceeded quota of account 1234567890\n\tstatus code: 400, request id: f0cb17ec-68b6-4f32-8997-cce5049a6a1e\nThe kube-controller-manager logs may contain more details.)"
+	proxyTimeoutLog           = "time=\"2021-11-17T03:56:25Z\" level=info msg=\"[pull.q1w2.quay.rhcloud.com/openshift-release-dev/ocp-release@sha256:53576e4df71a5f00f77718f25aec6ac7946eaaab998d99d3e3f03fcb403364db: error pinging docker registry pull.q1w2.quay.rhcloud.com: Get \\\"https://pull.q1w2.quay.rhcloud.com/v2/\\\": proxyconnect tcp: dial tcp 10.0.125.189:8080: i/o timeout]): quay.io/openshift-release-dev/ocp-release@sha256:53576e4df71a5f00f77718f25aec6ac7946eaaab998d99d3e3f03fcb403364db: error pinging docker registry quay.io: Get \\\"https://quay.io/v2/\\\": proxyconnect tcp: dial tcp 10.0.125.189:8080: i/o timeout"
+	proxyInvalidCABundleLog   = "time=\"2021-08-27T05:56:50Z\" level=info msg=\"[pull.q1w2.quay.rhcloud.com/openshift-release-dev/ocp-release@sha256:7047acb946649cc1f54d98a1c28dd7b487fe91479aa52c13c971ea014a66c8a8: error pinging docker registry pull.q1w2.quay.rhcloud.com: Get \\\"https://pull.q1w2.quay.rhcloud.com/v2/\\\": proxyconnect tcp: x509: certificate signed by unknown authority]): quay.io/openshift-release-dev/ocp-release@sha256:7047acb946649cc1f54d98a1c28dd7b487fe91479aa52c13c971ea014a66c8a8: error pinging docker registry quay.io: Get \\\"https://quay.io/v2/\\\": proxyconnect tcp: x509: certificate signed by unknown authority"
 	noMatchLog                = "an example of something that doesn't match the log regexes"
 )
 
@@ -121,6 +123,18 @@ func TestParseInstallLog(t *testing.T) {
 			log:            pointer.StringPtr(kubeAPIWaitFailedLog),
 			existing:       []runtime.Object{buildRegexConfigMap()},
 			expectedReason: "KubeAPIWaitFailed",
+		},
+		{
+			name:           "ProxyTimeout",
+			log:            pointer.StringPtr(proxyTimeoutLog),
+			existing:       []runtime.Object{buildRegexConfigMap()},
+			expectedReason: "ProxyTimeout",
+		},
+		{
+			name:           "ProxyInvalidCABundle",
+			log:            pointer.StringPtr(proxyInvalidCABundleLog),
+			existing:       []runtime.Object{buildRegexConfigMap()},
+			expectedReason: "ProxyInvalidCABundle",
 		},
 		{
 			name: "KubeAPIWaitTimeout from additional regex entries",

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1693,6 +1693,7 @@ data:
       installFailingReason: UserInitiatedShutdown
       installFailingMessage: User initiated shutdown of instances as the install was running
 
+
     # GCP Specific
     - name: GCPInvalidProjectID
       searchRegexStrings:
@@ -1725,6 +1726,7 @@ data:
       installFailingReason: GCPServiceAccountQuotaExceeded
       installFailingMessage: GCP Service Account quota exceeded
 
+    
     # Bare Metal
     - name: LibvirtSSHKeyPermissionDenied
       searchRegexStrings:
@@ -1736,6 +1738,20 @@ data:
       - "could not connect to libvirt"
       installFailingReason: LibvirtConnectionFailed
       installFailingMessage: "Could not connect to libvirt host"
+
+
+    # Proxy-enabled clusters
+    - name: ProxyTimeout
+      searchRegexStrings:
+      - "error pinging docker registry .+ proxyconnect tcp: dial tcp [^ ]+: i/o timeout"
+      installFailingReason: ProxyTimeout
+      installFailingMessage: The cluster is installing via a proxy, however the proxy server is timing out connections. Verify that the proxy is running and would be accessible from the cluster's private subnet(s).
+    - name: ProxyInvalidCABundle
+      searchRegexStrings:
+      - "error pinging docker registry .+ proxyconnect tcp: x509: certificate signed by unknown authority"
+      installFailingReason: ProxyInvalidCABundle
+      installFailingMessage: The cluster is installing via a proxy, but does not trust the signing certificate the proxy is presenting. Verify that the Certificate Authority certificate(s) to verify proxy communications have been supplied at installation time.
+
 
     # Generic OpenShift Install
     - name: KubeAPIWaitTimeout


### PR DESCRIPTION
This PR adds two new installation log handlers, `ProxyTimeout`, and  `ProxyInvalidCABundle`, to cover cases where a cluster installation using a cluster-wide proxy is impacted due to the proxy either being unavailable or serving untrusted certificates.

Refs [OSD-9064](https://issues.redhat.com/browse/OSD-9064) / [SDE-1471](https://issues.redhat.com/browse/SDE-1471)
