### PR TITLE
DNM: Demonstrate multiline install-log-regex

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -246,3 +246,10 @@ data:
       - "Error waiting for instance .* to become ready"
       installFailingReason: FallbackInstancesFailedToBecomeReady
       installFailingMessage: Unknown error - instances failed to become ready
+
+    - name: MultiLineWorks
+      searchRegexStrings:
+      # The two chunks of this regex need to match content on separate lines. (?s) makes . match \n.
+      - "(?s)a gcp cluster.*quota issue"
+      installFailingReason: MultiLineWorks
+      installFailingMessage: "It works"

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -46,6 +46,7 @@ const (
 	loadBalancerLimitExceeded = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=info msg=\"Cluster operator ingress Available is False with IngressUnavailable: The \"default\" ingress controller reports Available=False: IngressControllerUnavailable: One or more status	conditions indicate unavailable: LoadBalancerReady=False (SyncLoadBalancerFailed: The service-controller component is reporting SyncLoadBalancerFailed events like: Error syncing load balancer: failed to ensure load balancer: TooManyLoadBalancers: Exceeded quota of account 1234567890\n\tstatus code: 400, request id: f0cb17ec-68b6-4f32-8997-cce5049a6a1e\nThe kube-controller-manager logs may contain more details.)"
 	proxyTimeoutLog           = "time=\"2021-11-17T03:56:25Z\" level=info msg=\"[pull.q1w2.quay.rhcloud.com/openshift-release-dev/ocp-release@sha256:53576e4df71a5f00f77718f25aec6ac7946eaaab998d99d3e3f03fcb403364db: error pinging docker registry pull.q1w2.quay.rhcloud.com: Get \\\"https://pull.q1w2.quay.rhcloud.com/v2/\\\": proxyconnect tcp: dial tcp 10.0.125.189:8080: i/o timeout]): quay.io/openshift-release-dev/ocp-release@sha256:53576e4df71a5f00f77718f25aec6ac7946eaaab998d99d3e3f03fcb403364db: error pinging docker registry quay.io: Get \\\"https://quay.io/v2/\\\": proxyconnect tcp: dial tcp 10.0.125.189:8080: i/o timeout"
 	proxyInvalidCABundleLog   = "time=\"2021-08-27T05:56:50Z\" level=info msg=\"[pull.q1w2.quay.rhcloud.com/openshift-release-dev/ocp-release@sha256:7047acb946649cc1f54d98a1c28dd7b487fe91479aa52c13c971ea014a66c8a8: error pinging docker registry pull.q1w2.quay.rhcloud.com: Get \\\"https://pull.q1w2.quay.rhcloud.com/v2/\\\": proxyconnect tcp: x509: certificate signed by unknown authority]): quay.io/openshift-release-dev/ocp-release@sha256:7047acb946649cc1f54d98a1c28dd7b487fe91479aa52c13c971ea014a66c8a8: error pinging docker registry quay.io: Get \\\"https://quay.io/v2/\\\": proxyconnect tcp: x509: certificate signed by unknown authority"
+	multilineLog              = "this is a gcp cluster\nand we ran into a quota issue here"
 	noMatchLog                = "an example of something that doesn't match the log regexes"
 )
 
@@ -58,6 +59,12 @@ func TestParseInstallLog(t *testing.T) {
 		expectedReason  string
 		expectedMessage *string
 	}{
+		{
+			name:           "validate multiline regex",
+			log:            pointer.StringPtr(multilineLog),
+			existing:       []runtime.Object{buildRegexConfigMap()},
+			expectedReason: "MultiLineWorks",
+		},
 		{
 			name:           "load balancer service linked role prereq",
 			log:            pointer.StringPtr(accessDeniedSLR),

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1808,7 +1808,13 @@ data:
       - "Error waiting for instance .* to become ready"
       installFailingReason: FallbackInstancesFailedToBecomeReady
       installFailingMessage: Unknown error - instances failed to become ready
-`)
+
+    - name: MultiLineWorks
+      searchRegexStrings:
+      # The two chunks of this regex need to match content on separate lines. (?s) makes . match \n.
+      - "(?s)a gcp cluster.*quota issue"
+      installFailingReason: MultiLineWorks
+      installFailingMessage: "It works"`)
 
 func configConfigmapsInstallLogRegexesConfigmapYamlBytes() ([]byte, error) {
 	return _configConfigmapsInstallLogRegexesConfigmapYaml, nil


### PR DESCRIPTION
If you need to match chunks on separate lines, add `(?s)`, which causes
`.` to match `\n`, which it normally doesn't.