### PR TITLE
Install logs: NoWorkerNodes => (AWS|GCP)NoWorkerNodes

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -88,11 +88,12 @@ data:
       - "InvalidClientTokenId: The security token included in the request is invalid."
       installFailingReason: InvalidCredentials
       installFailingMessage: Credentials are invalid
-    - name: NoWorkerNodes
+    # cf. GCPNoWorkerNodes
+    - name: AWSNoWorkerNodes
       searchRegexStrings:
-      - "Got 0 worker nodes, 3 master nodes"
-      installFailingReason: NoWorkerNodes
-      installFailingMessage: No worker nodes could be created. Check that your machine-api role is correct and try again.
+      - "(?s)terraform-provider-aws.*Got 0 worker nodes, \\d+ master nodes"
+      installFailingReason: AWSNoWorkerNodes
+      installFailingMessage: No worker nodes could be created. Check the machine-api logs.
     - name: InvalidAWSTags
       searchRegexStrings:
       - "platform\\.aws\\.userTags.*: Invalid value:.*value contains invalid characters"
@@ -163,6 +164,12 @@ data:
       - "iam\\.googleapis\\.com/quota/service-account-count is not available in global because the required number of resources \\([0-9]*\\) is more than remaining quota"
       installFailingReason: GCPServiceAccountQuotaExceeded
       installFailingMessage: GCP Service Account quota exceeded
+    # cf. AWSNoWorkerNodes
+    - name: GCPNoWorkerNodes
+      searchRegexStrings:
+      - "(?s)terraform-provider-gcp.*Got 0 worker nodes, \\d+ master nodes"
+      installFailingReason: GCPNoWorkerNodes
+      installFailingMessage: No worker nodes could be created. Check the machine-api logs.
 
     
     # Bare Metal

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -1,6 +1,7 @@
 package clusterprovision
 
 import (
+	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -46,7 +47,10 @@ const (
 	loadBalancerLimitExceeded = "blahblah\ntime=\"2021-01-06T03:35:44Z\" level=info msg=\"Cluster operator ingress Available is False with IngressUnavailable: The \"default\" ingress controller reports Available=False: IngressControllerUnavailable: One or more status	conditions indicate unavailable: LoadBalancerReady=False (SyncLoadBalancerFailed: The service-controller component is reporting SyncLoadBalancerFailed events like: Error syncing load balancer: failed to ensure load balancer: TooManyLoadBalancers: Exceeded quota of account 1234567890\n\tstatus code: 400, request id: f0cb17ec-68b6-4f32-8997-cce5049a6a1e\nThe kube-controller-manager logs may contain more details.)"
 	proxyTimeoutLog           = "time=\"2021-11-17T03:56:25Z\" level=info msg=\"[pull.q1w2.quay.rhcloud.com/openshift-release-dev/ocp-release@sha256:53576e4df71a5f00f77718f25aec6ac7946eaaab998d99d3e3f03fcb403364db: error pinging docker registry pull.q1w2.quay.rhcloud.com: Get \\\"https://pull.q1w2.quay.rhcloud.com/v2/\\\": proxyconnect tcp: dial tcp 10.0.125.189:8080: i/o timeout]): quay.io/openshift-release-dev/ocp-release@sha256:53576e4df71a5f00f77718f25aec6ac7946eaaab998d99d3e3f03fcb403364db: error pinging docker registry quay.io: Get \\\"https://quay.io/v2/\\\": proxyconnect tcp: dial tcp 10.0.125.189:8080: i/o timeout"
 	proxyInvalidCABundleLog   = "time=\"2021-08-27T05:56:50Z\" level=info msg=\"[pull.q1w2.quay.rhcloud.com/openshift-release-dev/ocp-release@sha256:7047acb946649cc1f54d98a1c28dd7b487fe91479aa52c13c971ea014a66c8a8: error pinging docker registry pull.q1w2.quay.rhcloud.com: Get \\\"https://pull.q1w2.quay.rhcloud.com/v2/\\\": proxyconnect tcp: x509: certificate signed by unknown authority]): quay.io/openshift-release-dev/ocp-release@sha256:7047acb946649cc1f54d98a1c28dd7b487fe91479aa52c13c971ea014a66c8a8: error pinging docker registry quay.io: Get \\\"https://quay.io/v2/\\\": proxyconnect tcp: x509: certificate signed by unknown authority"
-	noMatchLog                = "an example of something that doesn't match the log regexes"
+	// NOTE: This embedded newline matters: our regex must be able to match the two chunks of the message on separate lines.
+	noWorkerNodesFmt = `time="2021-12-09T10:51:06Z" level=debug msg="Symlinking plugin terraform-provider-%s src: \"/usr/bin/openshift-install\" dst: \"/tmp/openshift-install-cluster-723469510/plugins/terraform-provider-%s\""
+time="2021-12-09T10:53:06Z" level=error msg="blahblah. Got 0 worker nodes, 3 master nodes blah"`
+	noMatchLog = "an example of something that doesn't match the log regexes"
 )
 
 func TestParseInstallLog(t *testing.T) {
@@ -313,6 +317,16 @@ func TestParseInstallLog(t *testing.T) {
 			name:           "LoadBalancerLimitExceeded",
 			log:            pointer.StringPtr(loadBalancerLimitExceeded),
 			expectedReason: "LoadBalancerLimitExceeded",
+		},
+		{
+			name:           "AWSNoWorkerNodes",
+			log:            pointer.StringPtr(fmt.Sprintf(noWorkerNodesFmt, "aws", "aws")),
+			expectedReason: "AWSNoWorkerNodes",
+		},
+		{
+			name:           "GCPNoWorkerNodes",
+			log:            pointer.StringPtr(fmt.Sprintf(noWorkerNodesFmt, "gcp", "gcp")),
+			expectedReason: "GCPNoWorkerNodes",
 		},
 	}
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1650,11 +1650,12 @@ data:
       - "InvalidClientTokenId: The security token included in the request is invalid."
       installFailingReason: InvalidCredentials
       installFailingMessage: Credentials are invalid
-    - name: NoWorkerNodes
+    # cf. GCPNoWorkerNodes
+    - name: AWSNoWorkerNodes
       searchRegexStrings:
-      - "Got 0 worker nodes, 3 master nodes"
-      installFailingReason: NoWorkerNodes
-      installFailingMessage: No worker nodes could be created. Check that your machine-api role is correct and try again.
+      - "(?s)terraform-provider-aws.*Got 0 worker nodes, \\d+ master nodes"
+      installFailingReason: AWSNoWorkerNodes
+      installFailingMessage: No worker nodes could be created. Check the machine-api logs.
     - name: InvalidAWSTags
       searchRegexStrings:
       - "platform\\.aws\\.userTags.*: Invalid value:.*value contains invalid characters"
@@ -1725,6 +1726,12 @@ data:
       - "iam\\.googleapis\\.com/quota/service-account-count is not available in global because the required number of resources \\([0-9]*\\) is more than remaining quota"
       installFailingReason: GCPServiceAccountQuotaExceeded
       installFailingMessage: GCP Service Account quota exceeded
+    # cf. AWSNoWorkerNodes
+    - name: GCPNoWorkerNodes
+      searchRegexStrings:
+      - "(?s)terraform-provider-gcp.*Got 0 worker nodes, \\d+ master nodes"
+      installFailingReason: GCPNoWorkerNodes
+      installFailingMessage: No worker nodes could be created. Check the machine-api logs.
 
     
     # Bare Metal


### PR DESCRIPTION
Replace the `NoWorkerNodes` regex/reason with cloud-specific versions
`AWSNoWorkerNodes` and `GCPNoWorkerNodes`.

[HIVE-1722](https://issues.redhat.com/browse/HIVE-1722)