### PR TITLE
Fix some bugs identified by code inspection

### DIFF
--- a/pkg/client/fake/overrideable_client.go
+++ b/pkg/client/fake/overrideable_client.go
@@ -1,0 +1,82 @@
+package fake
+
+import (
+	"context"
+
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// FakeClientWithCustomErrors overrides some of the fake client's methods, allowing them to (not
+// actually run and) throw specific errors. Use it like this:
+//   realFakeClient := NewFakeClient(...)
+//   c := FakeClientWithCustomErrors{
+//       Client: realFakeClient,
+//       DeleteBehavior: []error{nil, fmt.Errorf("Error on the second call"), nil}
+//       UpdateBehavior: []error(fmt.Errorf("Error on the first call"))
+//   }
+//   c.Delete(...) // runs the real fake Delete
+//   c.Delete(...) // skips the real fake Delete and returns the first error
+//   c.Delete(...) // runs the real fake Delete
+//   c.Delete(...) // runs the real fake Delete, even though we ran off the end of the array
+//   c.Update(...) // returns the error
+//   c.Get(...)    // runs the real fake Get, because no overrides
+type FakeClientWithCustomErrors struct {
+	// The "Real" fake client
+	crclient.Client
+	// Entries in this list affect each successive call to Get(). Using `nil` causes the "real"
+	// Get to be called. Using a non-nil error causes the "real" Get to be skipped, and that
+	// error to be returned instead.
+	GetBehavior []error
+	// Private tracker of calls to Get, used to determine which GetBehavior to use.
+	numGetCalls int
+	// Ditto Delete
+	DeleteBehavior []error
+	// Private tracker of calls to Delete, used to determine which DeleteBehavior to use.
+	numDeleteCalls int
+	// Ditto Update
+	UpdateBehavior []error
+	// Private tracker of calls to Update, used to determine which UpdateBehavior to use.
+	numUpdateCalls int
+	// TODO(efried): Add the other methods. Propose upstream.
+}
+
+func clientOverride(behavior []error, numCalls int) error {
+	if len(behavior) > numCalls {
+		return behavior[numCalls] // which might be nil
+	}
+	// If we ran off the end, assume default behavior
+	return nil
+}
+
+// Get overrides the fake client's Get, conditionally bypassing it and returning an error instead.
+func (f FakeClientWithCustomErrors) Get(ctx context.Context, key crclient.ObjectKey, obj crclient.Object) error {
+	// Always increment the call count, but not until we're done.
+	defer func() { f.numGetCalls++ }()
+	if err := clientOverride(f.GetBehavior, f.numGetCalls); err != nil {
+		return err
+	}
+	// Otherwise run the real Get
+	return f.Client.Get(ctx, key, obj)
+}
+
+// Delete overrides the fake client's Delete, conditionally bypassing it and returning an error instead.
+func (f FakeClientWithCustomErrors) Delete(ctx context.Context, obj crclient.Object, opts ...crclient.DeleteOption) error {
+	// Always increment the call count, but not until we're done.
+	defer func() { f.numDeleteCalls++ }()
+	if err := clientOverride(f.DeleteBehavior, f.numDeleteCalls); err != nil {
+		return err
+	}
+	// Otherwise run the real Delete
+	return f.Client.Delete(ctx, obj, opts...)
+}
+
+// Update overrides the fake client's Update, conditionally bypassing it and returning an error instead.
+func (f FakeClientWithCustomErrors) Update(ctx context.Context, obj crclient.Object, opts ...crclient.UpdateOption) error {
+	// Always increment the call count, but not until we're done.
+	defer func() { f.numUpdateCalls++ }()
+	if err := clientOverride(f.UpdateBehavior, f.numUpdateCalls); err != nil {
+		return err
+	}
+	// Otherwise run the real Update
+	return f.Client.Update(ctx, obj, opts...)
+}

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
@@ -401,9 +401,10 @@ func (r *ReconcileClusterDeprovision) Reconcile(ctx context.Context, request rec
 			err := r.Delete(context.TODO(), existingJob, client.PropagationPolicy(metav1.DeletePropagationForeground))
 			if err != nil {
 				rLog.WithError(err).Log(controllerutils.LogLevel(err), "error deleting outdated deprovision job")
+				return reconcile.Result{}, err
 			}
 		}
-		return reconcile.Result{}, err
+		return reconcile.Result{}, nil
 	}
 
 	rLog.Infof("uninstall job not yet successful")


### PR DESCRIPTION
- A missed error return in the Reconcile loop if Delete() fails.
- Incomplete error path coverage in the unit test driver.

Adding unit test for the former entailed beefing up the fake controller-runtime client to allow overriding behavior for specific calls without mocking the whole thing. For this I stole/adapted a [solution](https://github.com/openshift/aws-efs-operator/blob/043676e0d01fc41279715ad740145c7ab22a2379/pkg/test/client.go) from 2020 Eric.