### PR TITLE
Stop assuming containers[0]

### DIFF
--- a/pkg/operator/hive/clustersync.go
+++ b/pkg/operator/hive/clustersync.go
@@ -44,7 +44,10 @@ func (r *ReconcileHiveConfig) deployClusterSync(hLog log.FieldLogger, h resource
 	asset := assets.MustAsset(ssAsset)
 	hLog.Debug("reading statefulset")
 	newClusterSyncStatefulSet := controllerutils.ReadStatefulsetOrDie(asset)
-	hiveContainer := &newClusterSyncStatefulSet.Spec.Template.Spec.Containers[0]
+	hiveContainer, err := containerByName(&newClusterSyncStatefulSet.Spec.Template.Spec, "clustersync")
+	if err != nil {
+		return err
+	}
 
 	hLog.Infof("hive image: %s", r.hiveImage)
 	if r.hiveImage != "" {

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -114,7 +114,11 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h resour
 	asset := assets.MustAsset(deploymentAsset)
 	hLog.Debug("reading deployment")
 	hiveAdmDeployment := resourceread.ReadDeploymentV1OrDie(asset)
-	hiveAdmContainer := &hiveAdmDeployment.Spec.Template.Spec.Containers[0]
+	hiveAdmContainer, err := containerByName(&hiveAdmDeployment.Spec.Template.Spec, "hiveadmission")
+	if err != nil {
+		return err
+	}
+
 	hiveAdmDeployment.Namespace = hiveNSName
 	if r.hiveImage != "" {
 		hiveAdmContainer.Image = r.hiveImage

--- a/pkg/operator/hive/operatorutils.go
+++ b/pkg/operator/hive/operatorutils.go
@@ -8,6 +8,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -52,4 +53,13 @@ func computeHash(data interface{}, additionalHashes ...string) string {
 		hasher.Write([]byte(h))
 	}
 	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+func containerByName(template *corev1.PodSpec, name string) (*corev1.Container, error) {
+	for i, container := range template.Containers {
+		if container.Name == name {
+			return &template.Containers[i], nil
+		}
+	}
+	return nil, fmt.Errorf("no container named %s", name)
 }


### PR DESCRIPTION
As hive-operator loads and modifies the manifests for the other
controllers, it used to assume that they only had one container. This is
not future-proof: if we added another container, it would be easy to
miss that we're now modifying the wrong one. Guard against this by
instead looking up the container by name.

There should be no functional change.