### PR TITLE
ClusterClaim deletion waits for CD, Role[Binding]

### DIFF
--- a/pkg/controller/clusterclaim/clusterclaim_controller_test.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller_test.go
@@ -279,11 +279,10 @@ func TestReconcileClusterClaim(t *testing.T) {
 				testRoleBinding(),
 			},
 			expectCompletedClaim:                   true,
-			expectDeleted:                          true,
 			expectAssignedClusterDeploymentDeleted: true,
 		},
 		{
-			name: "deleted claim with missing clusterdeployment",
+			name: "deleted claim with missing clusterdeployment, role, and rolebinding",
 			claim: initializedClaimBuilder.GenericOptions(
 				testgeneric.WithFinalizer(finalizer),
 				testgeneric.Deleted(),
@@ -304,7 +303,6 @@ func TestReconcileClusterClaim(t *testing.T) {
 				testRoleBinding(),
 			},
 			expectCompletedClaim: true,
-			expectDeleted:        true,
 		},
 		{
 			name: "deleted claim with clusterdeployment assigned to other claim",
@@ -627,7 +625,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 			if test.cd != nil {
 				test.existing = append(test.existing, test.cd)
 			}
-			c := fake.NewFakeClientWithScheme(scheme, test.existing...)
+			c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(test.existing...).Build()
 			logger := log.New()
 			logger.SetLevel(log.DebugLevel)
 			rcp := &ReconcileClusterClaim{

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -1315,7 +1315,8 @@ func (m *InstallManager) cleanupAdminPasswordSecret() error {
 
 // deleteAnyExistingObject will look for any object that exists that matches the passed in 'obj' and will delete it if it exists
 func (m *InstallManager) deleteAnyExistingObject(namespacedName types.NamespacedName, obj hivev1.MetaRuntimeObject) error {
-	return resource.DeleteAnyExistingObject(m.DynamicClient, namespacedName, obj, m.log)
+	_, err := resource.DeleteAnyExistingObject(m.DynamicClient, namespacedName, obj, m.log)
+	return err
 }
 
 func waitForProvisioningStage(provision *hivev1.ClusterProvision, m *InstallManager) error {


### PR DESCRIPTION
Previously deleting an assigned ClusterClaim would cause the
clusterclaim controller to _mark_ the associated ClusterDeployment,
Role, and RoleBinding for deletion, then remove the ClusterClaim's
finalizer so it could be garbage collected.

Per the associated Jira card, this could cause confusion if the claim
was "resurrected" -- i.e. one with the same name was created. The new
claim would take the place of the old one, making it look like it was
"assigned" the existing, deleting ClusterDeployment.

With this change, we wait to remove the ClusterClaim's finalizer until
all the associated resources are actually 404. This should make it
impossible to "resurrect" a ClusterClaim: you won't be able to create a
claim with that name until all the associated resources are gone; so the
new claim will truly behave like a new claim.

[HIVE-1729](https://issues.redhat.com/browse/HIVE-1729)