### PR TITLE
OCM-2.4: Backport HIVE-1465

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -651,14 +651,9 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 		return *result, err
 	}
 
-	// Sanity check the platform/cloud credentials.
-	validCreds, err := r.validatePlatformCreds(cd, cdLog)
-	if err != nil {
-		cdLog.WithError(err).Error("unable to validate platform credentials")
-		return reconcile.Result{}, err
-	}
-	// Make sure the condition is set properly.
-	_, err = r.setAuthenticationFailure(cd, validCreds, cdLog)
+	// Sanity check the platform/cloud credentials and set hivev1.AuthenticationFailureClusterDeploymentCondition
+	validCreds, authError := r.validatePlatformCreds(cd, cdLog)
+	_, err := r.setAuthenticationFailure(cd, validCreds, authError, cdLog)
 	if err != nil {
 		cdLog.WithError(err).Error("unable to update clusterdeployment")
 		return reconcile.Result{}, err
@@ -1062,7 +1057,7 @@ func (r *ReconcileClusterDeployment) setDNSNotReadyCondition(cd *hivev1.ClusterD
 	return r.Status().Update(context.TODO(), cd)
 }
 
-func (r *ReconcileClusterDeployment) setAuthenticationFailure(cd *hivev1.ClusterDeployment, authSuccessful bool, cdLog log.FieldLogger) (bool, error) {
+func (r *ReconcileClusterDeployment) setAuthenticationFailure(cd *hivev1.ClusterDeployment, authSuccessful bool, authError error, cdLog log.FieldLogger) (bool, error) {
 
 	var status corev1.ConditionStatus
 	var reason, message string
@@ -1074,7 +1069,7 @@ func (r *ReconcileClusterDeployment) setAuthenticationFailure(cd *hivev1.Cluster
 	} else {
 		status = corev1.ConditionTrue
 		reason = platformAuthFailureReason
-		message = "Platform credentials failed authentication check"
+		message = fmt.Sprintf("Platform credentials failed authentication check: %s", authError)
 	}
 
 	conditions, changed := controllerutils.SetClusterDeploymentConditionWithChangeCheck(

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1883,7 +1884,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testClusterDeploymentWithInitializedConditions(testClusterDeployment()),
 			},
 			platformCredentialsValidation: func(client.Client, *hivev1.ClusterDeployment, log.FieldLogger) (bool, error) {
-				return false, nil
+				return false, errors.New("Post \"https://xxx.xxx.xxx.xxx/sdk\": x509: cannot validate certificate for xxx.xxx.xxx.xxx because it doesn't contain any IP SANs")
 			},
 			expectErr: true,
 			validate: func(c client.Client, t *testing.T) {
@@ -1891,6 +1892,16 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				require.NotNil(t, cd, "could not get ClusterDeployment")
 
 				testassert.AssertConditionStatus(t, cd, hivev1.AuthenticationFailureClusterDeploymentCondition, corev1.ConditionTrue)
+
+				// Preflight check happens before we declare provisioning
+				testassert.AssertConditions(t, cd, []hivev1.ClusterDeploymentCondition{
+					{
+						Type:    hivev1.AuthenticationFailureClusterDeploymentCondition,
+						Status:  corev1.ConditionTrue,
+						Reason:  platformAuthFailureReason,
+						Message: "Platform credentials failed authentication check: Post \"https://xxx.xxx.xxx.xxx/sdk\": x509: cannot validate certificate for xxx.xxx.xxx.xxx because it doesn't contain any IP SANs",
+					},
+				})
 			},
 		},
 		{


### PR DESCRIPTION
Backports https://github.com/openshift/hive/pull/1645.
xref: https://issues.redhat.com/browse/HIVE-1465

This backport was created manually because there were merge conflicts to resolve in the tests related to initialized conditions.