### PR TITLE
ClusterPool: Claim running clusters

### DIFF
--- a/apis/hive/v1/clusterpool_types.go
+++ b/apis/hive/v1/clusterpool_types.go
@@ -110,7 +110,11 @@ type ClusterPoolStatus struct {
 	// Size is the number of unclaimed clusters that have been created for the pool.
 	Size int32 `json:"size"`
 
-	// Ready is the number of unclaimed clusters that have been installed and are ready to be claimed.
+	// Standby is the number of unclaimed clusters that are installed, but not running.
+	// +optional
+	Standby int32 `json:"standby"`
+
+	// Ready is the number of unclaimed clusters that are installed and are running and ready to be claimed.
 	Ready int32 `json:"ready"`
 
 	// Conditions includes more detailed status for the cluster pool
@@ -161,8 +165,9 @@ const (
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.size,statuspath=.status.size
-// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready"
 // +kubebuilder:printcolumn:name="Size",type="string",JSONPath=".spec.size"
+// +kubebuilder:printcolumn:name="Standby",type="string",JSONPath=".status.standby"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready"
 // +kubebuilder:printcolumn:name="BaseDomain",type="string",JSONPath=".spec.baseDomain"
 // +kubebuilder:printcolumn:name="ImageSet",type="string",JSONPath=".spec.imageSetRef.name"
 // +kubebuilder:resource:path=clusterpools,shortName=cp

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -17,11 +17,14 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.ready
-      name: Ready
-      type: string
     - jsonPath: .spec.size
       name: Size
+      type: string
+    - jsonPath: .status.standby
+      name: Standby
+      type: string
+    - jsonPath: .status.ready
+      name: Ready
       type: string
     - jsonPath: .spec.baseDomain
       name: BaseDomain
@@ -541,13 +544,18 @@ spec:
                   type: object
                 type: array
               ready:
-                description: Ready is the number of unclaimed clusters that have been
-                  installed and are ready to be claimed.
+                description: Ready is the number of unclaimed clusters that are installed
+                  and are running and ready to be claimed.
                 format: int32
                 type: integer
               size:
                 description: Size is the number of unclaimed clusters that have been
                   created for the pool.
+                format: int32
+                type: integer
+              standby:
+                description: Standby is the number of unclaimed clusters that are
+                  installed, but not running.
                 format: int32
                 type: integer
             required:

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -1707,11 +1707,14 @@ objects:
     scope: Namespaced
     versions:
     - additionalPrinterColumns:
-      - jsonPath: .status.ready
-        name: Ready
-        type: string
       - jsonPath: .spec.size
         name: Size
+        type: string
+      - jsonPath: .status.standby
+        name: Standby
+        type: string
+      - jsonPath: .status.ready
+        name: Ready
         type: string
       - jsonPath: .spec.baseDomain
         name: BaseDomain
@@ -2243,13 +2246,18 @@ objects:
                     type: object
                   type: array
                 ready:
-                  description: Ready is the number of unclaimed clusters that have
-                    been installed and are ready to be claimed.
+                  description: Ready is the number of unclaimed clusters that are
+                    installed and are running and ready to be claimed.
                   format: int32
                   type: integer
                 size:
                   description: Size is the number of unclaimed clusters that have
                     been created for the pool.
+                  format: int32
+                  type: integer
+                standby:
+                  description: Standby is the number of unclaimed clusters that are
+                    installed, but not running.
                   format: int32
                   type: integer
               required:

--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -98,7 +98,7 @@ function wait_for_pool_to_be_ready() {
   local poolname=$1
   local i=0
   # NOTE: This will need to change if we add a test with a zero-size pool.
-  while [[ $(oc get clusterpool $poolname -o json | jq '.status.size != 0 and .status.ready == .status.size') != "true" ]] || ! expect_all_clusters_current $poolname True; do
+  while [[ $(oc get clusterpool $poolname -o json | jq '.status.size != 0 and .status.ready + .status.standby == .status.size') != "true" ]] || ! expect_all_clusters_current $poolname True; do
     i=$((i+1))
     if [[ $i -gt $max_cluster_deployment_status_checks ]]; then
       echo "Timed out waiting for clusterpool $poolname to be ready."

--- a/pkg/controller/clusterclaim/clusterclaim_controller.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller.go
@@ -465,7 +465,7 @@ func (r *ReconcileClusterClaim) reconcileForExistingAssignment(claim *hivev1.Clu
 	)
 	statusChanged = statusChanged || changed
 
-	if cd.Status.PowerState == hivev1.RunningReadyReason {
+	if cd.Status.PowerState == hivev1.ClusterPowerStateRunning {
 		conds, changed = controllerutils.SetClusterClaimConditionWithChangeCheck(
 			conds,
 			hivev1.ClusterRunningCondition,

--- a/pkg/controller/clusterclaim/clusterclaim_controller_test.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller_test.go
@@ -128,7 +128,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 			claim: initializedClaimBuilder.Build(testclaim.WithCluster(clusterName)),
 			cd: cdBuilder.Build(
 				testcd.WithUnclaimedClusterPoolReference(claimNamespace, "test-pool"),
-				testcd.WithStatusPowerState(hivev1.StartingMachinesReadyReason),
+				testcd.WithStatusPowerState(hivev1.ClusterPowerStateStartingMachines),
 			),
 			expectedConditions: []hivev1.ClusterClaimCondition{
 				{
@@ -146,7 +146,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 			claim: initializedClaimBuilder.Build(testclaim.WithCluster(clusterName)),
 			cd: cdBuilder.Build(
 				testcd.WithClusterPoolReference(claimNamespace, "test-pool", claimName),
-				testcd.WithStatusPowerState(hivev1.StartingMachinesReadyReason),
+				testcd.WithStatusPowerState(hivev1.ClusterPowerStateStartingMachines),
 			),
 			expectCompletedClaim: true,
 			expectRBAC:           true,
@@ -170,7 +170,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 			claim: initializedClaimBuilder.Build(testclaim.WithCluster(clusterName)),
 			cd: cdBuilder.Build(
 				testcd.WithClusterPoolReference(claimNamespace, "test-pool", claimName),
-				testcd.WithStatusPowerState(hivev1.RunningReadyReason),
+				testcd.WithStatusPowerState(hivev1.ClusterPowerStateRunning),
 			),
 			expectCompletedClaim: true,
 			expectRBAC:           true,
@@ -239,7 +239,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 			),
 			cd: cdBuilder.Build(
 				testcd.WithClusterPoolReference(claimNamespace, "test-pool", claimName),
-				testcd.WithStatusPowerState(hivev1.StartingMachinesReadyReason),
+				testcd.WithStatusPowerState(hivev1.ClusterPowerStateStartingMachines),
 			),
 			expectCompletedClaim: true,
 			expectedConditions: []hivev1.ClusterClaimCondition{
@@ -332,7 +332,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 			name:  "no RBAC when no subjects",
 			claim: initializedClaimBuilder.Build(testclaim.WithCluster(clusterName), testclaim.WithSubjects(nil)),
 			cd: cdBuilder.Build(testcd.WithClusterPoolReference(claimNamespace, "test-pool", claimName),
-				testcd.WithStatusPowerState(hivev1.StartingMachinesReadyReason),
+				testcd.WithStatusPowerState(hivev1.ClusterPowerStateStartingMachines),
 			),
 			expectCompletedClaim: true,
 			expectedConditions: []hivev1.ClusterClaimCondition{
@@ -355,7 +355,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 			claim: initializedClaimBuilder.Build(testclaim.WithCluster(clusterName)),
 			cd: cdBuilder.Build(
 				testcd.WithClusterPoolReference(claimNamespace, "test-pool", claimName),
-				testcd.WithStatusPowerState(hivev1.StartingMachinesReadyReason),
+				testcd.WithStatusPowerState(hivev1.ClusterPowerStateStartingMachines),
 			),
 			existing: []runtime.Object{
 				func() runtime.Object {
@@ -386,7 +386,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 			claim: initializedClaimBuilder.Build(testclaim.WithCluster(clusterName)),
 			cd: cdBuilder.Build(
 				testcd.WithClusterPoolReference(claimNamespace, "test-pool", claimName),
-				testcd.WithStatusPowerState(hivev1.StartingMachinesReadyReason),
+				testcd.WithStatusPowerState(hivev1.ClusterPowerStateStartingMachines),
 			),
 			existing: []runtime.Object{
 				func() runtime.Object {
@@ -418,8 +418,8 @@ func TestReconcileClusterClaim(t *testing.T) {
 			claim: initializedClaimBuilder.Build(testclaim.WithCluster(clusterName)),
 			cd: cdBuilder.Build(
 				testcd.WithClusterPoolReference(claimNamespace, "test-pool", claimName),
-				testcd.WithPowerState(hivev1.HibernatingClusterPowerState),
-				testcd.WithStatusPowerState(hivev1.StartingMachinesReadyReason),
+				testcd.WithPowerState(hivev1.ClusterPowerStateHibernating),
+				testcd.WithStatusPowerState(hivev1.ClusterPowerStateStartingMachines),
 			),
 			expectCompletedClaim: true,
 			expectRBAC:           true,
@@ -452,7 +452,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 			),
 			cd: cdBuilder.Build(
 				testcd.WithClusterPoolReference(claimNamespace, "test-pool", claimName),
-				testcd.WithStatusPowerState(hivev1.StartingMachinesReadyReason),
+				testcd.WithStatusPowerState(hivev1.ClusterPowerStateStartingMachines),
 			),
 			expectCompletedClaim: true,
 		},
@@ -469,7 +469,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 			),
 			cd: cdBuilder.Build(
 				testcd.WithClusterPoolReference(claimNamespace, "test-pool", claimName),
-				testcd.WithStatusPowerState(hivev1.StartingMachinesReadyReason),
+				testcd.WithStatusPowerState(hivev1.ClusterPowerStateStartingMachines),
 			),
 			existing: []runtime.Object{
 				poolBuilder.Build(testcp.WithDefaultClaimLifetime(1 * time.Hour)),
@@ -489,7 +489,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 			),
 			cd: cdBuilder.Build(
 				testcd.WithClusterPoolReference(claimNamespace, "test-pool", claimName),
-				testcd.WithStatusPowerState(hivev1.StartingMachinesReadyReason),
+				testcd.WithStatusPowerState(hivev1.ClusterPowerStateStartingMachines),
 			),
 			existing: []runtime.Object{
 				poolBuilder.Build(testcp.WithMaximumClaimLifetime(1 * time.Hour)),
@@ -510,7 +510,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 			),
 			cd: cdBuilder.Build(
 				testcd.WithClusterPoolReference(claimNamespace, "test-pool", claimName),
-				testcd.WithStatusPowerState(hivev1.StartingMachinesReadyReason),
+				testcd.WithStatusPowerState(hivev1.ClusterPowerStateStartingMachines),
 			),
 			existing: []runtime.Object{
 				poolBuilder.Build(testcp.WithMaximumClaimLifetime(1 * time.Hour)),
@@ -530,7 +530,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 			),
 			cd: cdBuilder.Build(
 				testcd.WithClusterPoolReference(claimNamespace, "test-pool", claimName),
-				testcd.WithStatusPowerState(hivev1.StartingMachinesReadyReason),
+				testcd.WithStatusPowerState(hivev1.ClusterPowerStateStartingMachines),
 			),
 			existing: []runtime.Object{
 				poolBuilder.Build(testcp.WithDefaultClaimLifetime(2*time.Hour), testcp.WithMaximumClaimLifetime(1*time.Hour)),
@@ -551,7 +551,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 			),
 			cd: cdBuilder.Build(
 				testcd.WithClusterPoolReference(claimNamespace, "test-pool", claimName),
-				testcd.WithStatusPowerState(hivev1.StartingMachinesReadyReason),
+				testcd.WithStatusPowerState(hivev1.ClusterPowerStateStartingMachines),
 			),
 			existing: []runtime.Object{
 				poolBuilder.Build(testcp.WithMaximumClaimLifetime(2 * time.Hour)),
@@ -573,7 +573,7 @@ func TestReconcileClusterClaim(t *testing.T) {
 			),
 			cd: cdBuilder.Build(
 				testcd.WithClusterPoolReference(claimNamespace, "test-pool", claimName),
-				testcd.WithStatusPowerState(hivev1.StartingMachinesReadyReason),
+				testcd.WithStatusPowerState(hivev1.ClusterPowerStateStartingMachines),
 			),
 			existing: []runtime.Object{
 				testRole(),
@@ -667,9 +667,9 @@ func TestReconcileClusterClaim(t *testing.T) {
 					toRemove := controllerutils.IsClaimedClusterMarkedForRemoval(&cd)
 					assignedClusterDeploymentExists = !toRemove
 					if test.expectHibernating {
-						assert.Equal(t, hivev1.HibernatingClusterPowerState, cd.Spec.PowerState, "expected ClusterDeployment to be hibernating")
+						assert.Equal(t, hivev1.ClusterPowerStateHibernating, cd.Spec.PowerState, "expected ClusterDeployment to be hibernating")
 					} else {
-						assert.NotEqual(t, hivev1.HibernatingClusterPowerState, cd.Spec.PowerState, "expected ClusterDeployment to not be hibernating")
+						assert.NotEqual(t, hivev1.ClusterPowerStateHibernating, cd.Spec.PowerState, "expected ClusterDeployment to not be hibernating")
 					}
 				}
 			}

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -605,7 +605,7 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 			cd,
 			hivev1.ProvisionedCondition,
 			corev1.ConditionTrue,
-			hivev1.ProvisionedProvisionedReason,
+			hivev1.ProvisionedReasonProvisioned,
 			"Cluster is provisioned",
 			cdLog,
 		); err != nil {
@@ -1254,7 +1254,7 @@ func (r *ReconcileClusterDeployment) ensureClusterDeprovisioned(cd *hivev1.Clust
 			return false, r.updateCondition(cd,
 				hivev1.ProvisionedCondition,
 				corev1.ConditionFalse,
-				hivev1.DeprovisioningProvisionedReason,
+				hivev1.ProvisionedReasonDeprovisioning,
 				"Cluster is being deprovisioned",
 				cdLog)
 		}
@@ -1280,7 +1280,7 @@ func (r *ReconcileClusterDeployment) ensureClusterDeprovisioned(cd *hivev1.Clust
 				conds,
 				hivev1.ProvisionedCondition,
 				corev1.ConditionFalse,
-				hivev1.DeprovisionFailedProvisionedReason,
+				hivev1.ProvisionedReasonDeprovisionFailed,
 				"Cluster deprovision failed",
 				controllerutils.UpdateConditionIfReasonOrMessageChange,
 			)
@@ -1301,7 +1301,7 @@ func (r *ReconcileClusterDeployment) ensureClusterDeprovisioned(cd *hivev1.Clust
 			cd,
 			hivev1.ProvisionedCondition,
 			corev1.ConditionFalse,
-			hivev1.DeprovisioningProvisionedReason,
+			hivev1.ProvisionedReasonDeprovisioning,
 			"Cluster is deprovisioning",
 			cdLog,
 		)
@@ -1312,7 +1312,7 @@ func (r *ReconcileClusterDeployment) ensureClusterDeprovisioned(cd *hivev1.Clust
 		cd,
 		hivev1.ProvisionedCondition,
 		corev1.ConditionFalse,
-		hivev1.DeprovisionedProvisionedReason,
+		hivev1.ProvisionedReasonDeprovisioned,
 		"Cluster is deprovisioned",
 		cdLog,
 	)

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -196,7 +196,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testassert.AssertConditions(t, getCD(c), []hivev1.ClusterDeploymentCondition{{
 					Type:    hivev1.ProvisionedCondition,
 					Status:  corev1.ConditionFalse,
-					Reason:  hivev1.ProvisioningProvisionedReason,
+					Reason:  hivev1.ProvisionedReasonProvisioning,
 					Message: "Cluster provision created",
 				}})
 			},
@@ -264,7 +264,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 						*e,
 						hivev1.ProvisionedCondition,
 						corev1.ConditionFalse,
-						hivev1.ProvisioningProvisionedReason,
+						hivev1.ProvisionedReasonProvisioning,
 						"Cluster provision initializing",
 					)
 					sanitizeConditions(e, cd)
@@ -353,7 +353,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 					testassert.AssertConditions(t, cd, []hivev1.ClusterDeploymentCondition{{
 						Type:    hivev1.ProvisionedCondition,
 						Status:  corev1.ConditionTrue,
-						Reason:  hivev1.ProvisionedProvisionedReason,
+						Reason:  hivev1.ProvisionedReasonProvisioned,
 						Message: "Cluster is provisioned",
 					}})
 				}
@@ -381,7 +381,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 					testassert.AssertConditions(t, cd, []hivev1.ClusterDeploymentCondition{{
 						Type:    hivev1.ProvisionedCondition,
 						Status:  corev1.ConditionTrue,
-						Reason:  hivev1.ProvisionedProvisionedReason,
+						Reason:  hivev1.ProvisionedReasonProvisioned,
 						Message: "Cluster is provisioned",
 					}})
 				}
@@ -438,7 +438,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 						*cd,
 						hivev1.ProvisionedCondition,
 						corev1.ConditionTrue,
-						hivev1.ProvisionedProvisionedReason,
+						hivev1.ProvisionedReasonProvisioned,
 						"Cluster is provisioned",
 					)
 					return cd
@@ -454,7 +454,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testassert.AssertConditions(t, cd, []hivev1.ClusterDeploymentCondition{{
 					Type:    hivev1.ProvisionedCondition,
 					Status:  corev1.ConditionTrue,
-					Reason:  hivev1.ProvisionedProvisionedReason,
+					Reason:  hivev1.ProvisionedReasonProvisioned,
 					Message: "Cluster is provisioned",
 				}})
 			},
@@ -1189,7 +1189,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testassert.AssertConditions(t, getCD(c), []hivev1.ClusterDeploymentCondition{{
 					Type:    hivev1.ProvisionedCondition,
 					Status:  corev1.ConditionFalse,
-					Reason:  hivev1.ProvisioningProvisionedReason,
+					Reason:  hivev1.ProvisionedReasonProvisioning,
 					Message: "Cluster provision created",
 				}})
 			},
@@ -1289,7 +1289,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 					testassert.AssertConditions(t, cd, []hivev1.ClusterDeploymentCondition{{
 						Type:    hivev1.ProvisionedCondition,
 						Status:  corev1.ConditionFalse,
-						Reason:  hivev1.ProvisioningProvisionedReason,
+						Reason:  hivev1.ProvisionedReasonProvisioning,
 						Message: "Cluster provision created",
 					}})
 				}
@@ -1379,7 +1379,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 						*cd,
 						hivev1.ProvisionedCondition,
 						corev1.ConditionTrue,
-						hivev1.ProvisionedProvisionedReason,
+						hivev1.ProvisionedReasonProvisioned,
 						"Cluster is provisioned",
 					)
 					return cd
@@ -1398,7 +1398,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testassert.AssertConditions(t, getCD(c), []hivev1.ClusterDeploymentCondition{{
 					Type:    hivev1.ProvisionedCondition,
 					Status:  corev1.ConditionTrue,
-					Reason:  hivev1.ProvisionedProvisionedReason,
+					Reason:  hivev1.ProvisionedReasonProvisioned,
 					Message: "Cluster is provisioned",
 				}})
 			},
@@ -1445,7 +1445,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testassert.AssertConditions(t, getCD(c), []hivev1.ClusterDeploymentCondition{{
 					Type:    hivev1.ProvisionedCondition,
 					Status:  corev1.ConditionFalse,
-					Reason:  hivev1.DeprovisioningProvisionedReason,
+					Reason:  hivev1.ProvisionedReasonDeprovisioning,
 					Message: "Cluster is being deprovisioned",
 				}})
 			},
@@ -1812,7 +1812,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testassert.AssertConditions(t, cd, []hivev1.ClusterDeploymentCondition{{
 					Type:    hivev1.ProvisionedCondition,
 					Status:  corev1.ConditionFalse,
-					Reason:  hivev1.DeprovisionedProvisionedReason,
+					Reason:  hivev1.ProvisionedReasonDeprovisioned,
 					Message: "Cluster is deprovisioned",
 				}})
 			},
@@ -1839,7 +1839,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testassert.AssertConditions(t, cd, []hivev1.ClusterDeploymentCondition{{
 					Type:    hivev1.ProvisionedCondition,
 					Status:  corev1.ConditionFalse,
-					Reason:  hivev1.DeprovisioningProvisionedReason,
+					Reason:  hivev1.ProvisionedReasonDeprovisioning,
 					Message: "Cluster is deprovisioning",
 				}})
 			},
@@ -1867,7 +1867,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testassert.AssertConditions(t, cd, []hivev1.ClusterDeploymentCondition{{
 					Type:    hivev1.ProvisionedCondition,
 					Status:  corev1.ConditionFalse,
-					Reason:  hivev1.DeprovisionFailedProvisionedReason,
+					Reason:  hivev1.ProvisionedReasonDeprovisionFailed,
 					Message: "Cluster deprovision failed",
 				}})
 			},
@@ -1885,7 +1885,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 						*cd,
 						hivev1.ProvisionedCondition,
 						corev1.ConditionFalse,
-						hivev1.DeprovisioningProvisionedReason,
+						hivev1.ProvisionedReasonDeprovisioning,
 						"Cluster is being deprovisioned",
 					)
 					return cd
@@ -1902,7 +1902,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testassert.AssertConditions(t, getCD(c), []hivev1.ClusterDeploymentCondition{{
 					Type:    hivev1.ProvisionedCondition,
 					Status:  corev1.ConditionFalse,
-					Reason:  hivev1.DeprovisioningProvisionedReason,
+					Reason:  hivev1.ProvisionedReasonDeprovisioning,
 					Message: "Cluster is being deprovisioned",
 				}})
 			},
@@ -2011,7 +2011,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 					{
 						Type:    hivev1.ProvisionedCondition,
 						Status:  corev1.ConditionFalse,
-						Reason:  hivev1.ProvisioningProvisionedReason,
+						Reason:  hivev1.ProvisionedReasonProvisioning,
 						Message: "Cluster provision initializing",
 					},
 				})
@@ -2038,7 +2038,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testassert.AssertConditions(t, getCD(c), []hivev1.ClusterDeploymentCondition{{
 					Type:    hivev1.ProvisionedCondition,
 					Status:  corev1.ConditionFalse,
-					Reason:  hivev1.ProvisioningProvisionedReason,
+					Reason:  hivev1.ProvisionedReasonProvisioning,
 					Message: "Cluster provision created",
 				}})
 			},
@@ -2068,7 +2068,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 					{
 						Type:    hivev1.ProvisionedCondition,
 						Status:  corev1.ConditionFalse,
-						Reason:  hivev1.ProvisionStoppedProvisionedReason,
+						Reason:  hivev1.ProvisionedReasonProvisionStopped,
 						Message: "Provisioning failed terminally (see the ProvisionStopped condition for details)",
 					},
 				})
@@ -2099,7 +2099,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 					{
 						Type:    hivev1.ProvisionedCondition,
 						Status:  corev1.ConditionFalse,
-						Reason:  hivev1.ProvisionStoppedProvisionedReason,
+						Reason:  hivev1.ProvisionedReasonProvisionStopped,
 						Message: "Provisioning failed terminally (see the ProvisionStopped condition for details)",
 					},
 				})
@@ -2346,7 +2346,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 					{
 						Type:    hivev1.ProvisionedCondition,
 						Status:  corev1.ConditionFalse,
-						Reason:  hivev1.ProvisionStoppedProvisionedReason,
+						Reason:  hivev1.ProvisionedReasonProvisionStopped,
 						Message: "Provisioning failed terminally (see the ProvisionStopped condition for details)",
 					},
 				})
@@ -2380,7 +2380,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 					{
 						Type:    hivev1.ProvisionedCondition,
 						Status:  corev1.ConditionFalse,
-						Reason:  hivev1.ProvisionStoppedProvisionedReason,
+						Reason:  hivev1.ProvisionedReasonProvisionStopped,
 						Message: "Provisioning failed terminally (see the ProvisionStopped condition for details)",
 					},
 				})
@@ -2487,7 +2487,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testassert.AssertConditions(t, cd, []hivev1.ClusterDeploymentCondition{{
 					Type:    hivev1.ProvisionedCondition,
 					Status:  corev1.ConditionTrue,
-					Reason:  hivev1.ProvisionedProvisionedReason,
+					Reason:  hivev1.ProvisionedReasonProvisioned,
 					Message: "Cluster is provisioned",
 				}})
 			},
@@ -2522,7 +2522,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 					{
 						Type:    hivev1.ProvisionedCondition,
 						Status:  corev1.ConditionTrue,
-						Reason:  hivev1.ProvisionedProvisionedReason,
+						Reason:  hivev1.ProvisionedReasonProvisioned,
 						Message: "Cluster is provisioned",
 					},
 				})
@@ -2546,7 +2546,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 						assert.Equal(t, corev1.ConditionFalse, cond.Status, "expected ProvisionStopped to be False")
 					}
 					if cond := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ProvisionedCondition); assert.NotNil(t, cond, "no Provisioned condition") {
-						assert.Equal(t, hivev1.ProvisioningProvisionedReason, cond.Reason, "expected Provisioned to be Provisioning")
+						assert.Equal(t, hivev1.ProvisionedReasonProvisioning, cond.Reason, "expected Provisioned to be Provisioning")
 					}
 				}
 				assert.Len(t, getProvisions(c), 2, "expected 2 ClusterProvisions to exist")
@@ -2574,7 +2574,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 						assert.Equal(t, "InstallAttemptsLimitReached", cond.Reason, "expected ProvisionStopped Reason to be InstallAttemptsLimitReached")
 					}
 					if cond := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ProvisionedCondition); assert.NotNil(t, cond, "no Provisioned condition") {
-						assert.Equal(t, hivev1.ProvisionStoppedProvisionedReason, cond.Reason, "expected Provisioned to be ProvisionStopped")
+						assert.Equal(t, hivev1.ProvisionedReasonProvisionStopped, cond.Reason, "expected Provisioned to be ProvisionStopped")
 					}
 				}
 				assert.Len(t, getProvisions(c), 1, "expected 1 ClusterProvision to exist")
@@ -2599,7 +2599,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 						assert.Equal(t, corev1.ConditionFalse, cond.Status, "expected ProvisionStopped to be False")
 					}
 					if cond := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ProvisionedCondition); assert.NotNil(t, cond, "no Provisioned condition") {
-						assert.Equal(t, hivev1.ProvisioningProvisionedReason, cond.Reason, "expected Provisioned to be Provisioning")
+						assert.Equal(t, hivev1.ProvisionedReasonProvisioning, cond.Reason, "expected Provisioned to be Provisioning")
 					}
 				}
 				assert.Len(t, getProvisions(c), 4, "expected 4 ClusterProvisions to exist")
@@ -2624,7 +2624,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 						assert.Equal(t, "FailureReasonNotRetryable", cond.Reason, "expected ProvisionStopped Reason to be FailureReasonNotRetryable")
 					}
 					if cond := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ProvisionedCondition); assert.NotNil(t, cond, "no Provisioned condition") {
-						assert.Equal(t, hivev1.ProvisionStoppedProvisionedReason, cond.Reason, "expected Provisioned to be ProvisionStopped")
+						assert.Equal(t, hivev1.ProvisionedReasonProvisionStopped, cond.Reason, "expected Provisioned to be ProvisionStopped")
 					}
 				}
 				assert.Len(t, getProvisions(c), 3, "expected 3 ClusterProvisions to exist")
@@ -2647,7 +2647,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 						assert.Equal(t, "FailureReasonNotRetryable", cond.Reason, "expected ProvisionStopped Reason to be FailureReasonNotRetryable")
 					}
 					if cond := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ProvisionedCondition); assert.NotNil(t, cond, "no Provisioned condition") {
-						assert.Equal(t, hivev1.ProvisionStoppedProvisionedReason, cond.Reason, "expected Provisioned to be ProvisionStopped")
+						assert.Equal(t, hivev1.ProvisionedReasonProvisionStopped, cond.Reason, "expected Provisioned to be ProvisionStopped")
 					}
 				}
 				assert.Len(t, getProvisions(c), 1, "expected 1 ClusterProvision to exist")
@@ -2669,7 +2669,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 						assert.Equal(t, corev1.ConditionFalse, cond.Status, "expected ProvisionStopped to be False")
 					}
 					if cond := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ProvisionedCondition); assert.NotNil(t, cond, "no Provisioned condition") {
-						assert.Equal(t, hivev1.ProvisioningProvisionedReason, cond.Reason, "expected Provisioned to be Provisioning")
+						assert.Equal(t, hivev1.ProvisionedReasonProvisioning, cond.Reason, "expected Provisioned to be Provisioning")
 					}
 				}
 				assert.Len(t, getProvisions(c), 1, "expected 1 ClusterProvisions to exist")
@@ -2693,7 +2693,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 						assert.Equal(t, "FailureReasonNotRetryable", cond.Reason, "expected ProvisionStopped Reason to be FailureReasonNotRetryable")
 					}
 					if cond := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ProvisionedCondition); assert.NotNil(t, cond, "no Provisioned condition") {
-						assert.Equal(t, hivev1.ProvisionStoppedProvisionedReason, cond.Reason, "expected Provisioned to be ProvisionStopped")
+						assert.Equal(t, hivev1.ProvisionedReasonProvisionStopped, cond.Reason, "expected Provisioned to be ProvisionStopped")
 					}
 				}
 				assert.Len(t, getProvisions(c), 1, "expected 1 ClusterProvision to exist")

--- a/pkg/controller/clusterdeployment/clusterinstalls.go
+++ b/pkg/controller/clusterdeployment/clusterinstalls.go
@@ -156,7 +156,7 @@ func (r *ReconcileClusterDeployment) reconcileExistingInstallingClusterInstall(c
 		conditions = controllerutils.SetClusterDeploymentCondition(conditions,
 			hivev1.ProvisionedCondition,
 			corev1.ConditionFalse,
-			hivev1.ProvisionStoppedProvisionedReason,
+			hivev1.ProvisionedReasonProvisionStopped,
 			"Provisioning failed terminally (see the ProvisionStopped condition for details)",
 			controllerutils.UpdateConditionIfReasonOrMessageChange,
 		)
@@ -170,7 +170,7 @@ func (r *ReconcileClusterDeployment) reconcileExistingInstallingClusterInstall(c
 			cd.Status.Conditions,
 			hivev1.ProvisionedCondition,
 			corev1.ConditionTrue,
-			hivev1.ProvisionedProvisionedReason,
+			hivev1.ProvisionedReasonProvisioned,
 			"Cluster is provisioned",
 			controllerutils.UpdateConditionAlways,
 		)

--- a/pkg/controller/clusterdeployment/clusterprovisions.go
+++ b/pkg/controller/clusterdeployment/clusterprovisions.go
@@ -76,7 +76,7 @@ func (r *ReconcileClusterDeployment) startNewProvision(
 			conditions,
 			hivev1.ProvisionedCondition,
 			corev1.ConditionFalse,
-			hivev1.ProvisionStoppedProvisionedReason,
+			hivev1.ProvisionedReasonProvisionStopped,
 			"Provisioning failed terminally (see the ProvisionStopped condition for details)",
 			controllerutils.UpdateConditionIfReasonOrMessageChange)
 
@@ -224,7 +224,7 @@ func (r *ReconcileClusterDeployment) startNewProvision(
 		cd,
 		hivev1.ProvisionedCondition,
 		corev1.ConditionFalse,
-		hivev1.ProvisioningProvisionedReason,
+		hivev1.ProvisionedReasonProvisioning,
 		"Cluster provision created",
 		logger,
 	); err != nil {
@@ -366,7 +366,7 @@ func (r *ReconcileClusterDeployment) reconcileInitializingProvision(cd *hivev1.C
 		cd,
 		hivev1.ProvisionedCondition,
 		corev1.ConditionFalse,
-		hivev1.ProvisioningProvisionedReason,
+		hivev1.ProvisionedReasonProvisioning,
 		"Cluster provision initializing",
 		cdLog,
 	); err != nil {
@@ -386,7 +386,7 @@ func (r *ReconcileClusterDeployment) reconcileProvisioningProvision(cd *hivev1.C
 		cd,
 		hivev1.ProvisionedCondition,
 		corev1.ConditionFalse,
-		hivev1.ProvisioningProvisionedReason,
+		hivev1.ProvisionedReasonProvisioning,
 		"Cluster is provisioning",
 		cdLog,
 	); err != nil {
@@ -459,7 +459,7 @@ func (r *ReconcileClusterDeployment) reconcileCompletedProvision(cd *hivev1.Clus
 		cd.Status.Conditions,
 		hivev1.ProvisionedCondition,
 		corev1.ConditionTrue,
-		hivev1.ProvisionedProvisionedReason,
+		hivev1.ProvisionedReasonProvisioned,
 		"Cluster is provisioned",
 		controllerutils.UpdateConditionIfReasonOrMessageChange,
 	)

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -49,9 +49,6 @@ const (
 )
 
 var (
-	// controllerKind contains the schema.GroupVersionKind for this controller type.
-	controllerKind = hivev1.SchemeGroupVersion.WithKind("ClusterPool")
-
 	// clusterPoolConditions are the cluster pool conditions controlled or initialized by cluster pool controller
 	clusterPoolConditions = []hivev1.ClusterPoolConditionType{
 		hivev1.ClusterPoolMissingDependenciesCondition,

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -456,9 +456,9 @@ func (r *ReconcileClusterPool) reconcileRunningClusters(
 		cd := cdList[i]
 		var desiredPowerState hivev1.ClusterPowerState
 		if i < runningCount {
-			desiredPowerState = hivev1.RunningClusterPowerState
+			desiredPowerState = hivev1.ClusterPowerStateRunning
 		} else {
-			desiredPowerState = hivev1.HibernatingClusterPowerState
+			desiredPowerState = hivev1.ClusterPowerStateHibernating
 		}
 		if cd.Spec.PowerState == desiredPowerState {
 			continue

--- a/pkg/controller/clusterpool/clusterpool_controller_test.go
+++ b/pkg/controller/clusterpool/clusterpool_controller_test.go
@@ -186,7 +186,6 @@ func TestReconcileClusterPool(t *testing.T) {
 			// Note: these observed counts are calculated before we start adding/deleting
 			// clusters, so they include the stale one we deleted.
 			expectedObservedSize:    2,
-			expectedObservedReady:   2,
 			expectedCDCurrentStatus: corev1.ConditionFalse,
 			expectedDeletedClusters: []string{"c2"},
 		},
@@ -208,7 +207,6 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters:   1,
 			expectedObservedSize:    2,
-			expectedObservedReady:   2,
 			expectedCDCurrentStatus: corev1.ConditionFalse,
 			expectedDeletedClusters: []string{"c1"},
 		},
@@ -225,7 +223,6 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters:   2,
 			expectedObservedSize:    2,
-			expectedObservedReady:   1,
 			expectedCDCurrentStatus: corev1.ConditionFalse,
 		},
 		{
@@ -243,7 +240,6 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters:   3,
 			expectedObservedSize:    2,
-			expectedObservedReady:   2,
 			expectedCDCurrentStatus: corev1.ConditionFalse,
 		},
 		{
@@ -255,18 +251,17 @@ func TestReconcileClusterPool(t *testing.T) {
 				),
 				unclaimedCDBuilder("c2").Build(
 					testcd.WithPoolVersion("stale"),
-					testcd.Installed(),
-					testcd.Generic(testgeneric.WithCreationTimestamp(nowish.Add(-time.Hour))),
+					testcd.Running(),
 				),
 			},
 			// This deletion happens because we're over capacity, not because we have staleness.
 			// This is proven below.
 			expectedTotalClusters:   1,
 			expectedObservedSize:    2,
-			expectedObservedReady:   2,
+			expectedObservedReady:   1,
 			expectedCDCurrentStatus: corev1.ConditionFalse,
 			// So this is kind of interesting. We delete c1 even though c2 is a) older, b) stale.
-			// This is because we prioritize keeping installed clusters, as they can satisfy claims
+			// This is because we prioritize keeping running clusters, as they can satisfy claims
 			// more quickly. Possible subject of a future optimization.
 			expectedDeletedClusters: []string{"c1"},
 		},
@@ -290,7 +285,6 @@ func TestReconcileClusterPool(t *testing.T) {
 			expectedTotalClusters: 4,
 			expectedObservedSize:  4,
 			// The broken one doesn't get counted as Ready
-			expectedObservedReady:   1,
 			expectedDeletedClusters: []string{"c1", "c2"},
 			expectedAssignedCDs:     2,
 		},
@@ -360,24 +354,24 @@ func TestReconcileClusterPool(t *testing.T) {
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(5)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 			},
 			expectedTotalClusters: 5,
 			expectedObservedSize:  3,
-			expectedObservedReady: 2,
+			expectedObservedReady: 1,
 		},
 		{
 			name: "scale up with no more capacity",
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(5), testcp.WithMaxSize(3)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 			},
 			expectedTotalClusters:  3,
 			expectedObservedSize:   3,
-			expectedObservedReady:  2,
+			expectedObservedReady:  1,
 			expectedCapacityStatus: corev1.ConditionFalse,
 		},
 		{
@@ -385,12 +379,12 @@ func TestReconcileClusterPool(t *testing.T) {
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(5), testcp.WithMaxSize(4)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 			},
 			expectedTotalClusters:  4,
 			expectedObservedSize:   3,
-			expectedObservedReady:  2,
+			expectedObservedReady:  1,
 			expectedCapacityStatus: corev1.ConditionTrue,
 		},
 		{
@@ -407,7 +401,6 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters:  3,
 			expectedObservedSize:   2,
-			expectedObservedReady:  1,
 			expectedAssignedClaims: 1,
 			expectedAssignedCDs:    1,
 			expectedCapacityStatus: corev1.ConditionFalse,
@@ -426,7 +419,6 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters:  4,
 			expectedObservedSize:   2,
-			expectedObservedReady:  1,
 			expectedAssignedClaims: 1,
 			expectedAssignedCDs:    1,
 			expectedCapacityStatus: corev1.ConditionTrue,
@@ -436,36 +428,36 @@ func TestReconcileClusterPool(t *testing.T) {
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(5), testcp.WithMaxConcurrent(1)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 			},
 			expectedTotalClusters: 3,
 			expectedObservedSize:  3,
-			expectedObservedReady: 2,
+			expectedObservedReady: 1,
 		},
 		{
 			name: "scale up with one more max concurrent",
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(5), testcp.WithMaxConcurrent(2)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 			},
 			expectedTotalClusters: 4,
 			expectedObservedSize:  3,
-			expectedObservedReady: 2,
+			expectedObservedReady: 1,
 		},
 		{
 			name: "scale up with max concurrent and max size",
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(6), testcp.WithMaxSize(5), testcp.WithMaxConcurrent(1)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 			},
 			expectedTotalClusters:  3,
 			expectedObservedSize:   3,
-			expectedObservedReady:  2,
+			expectedObservedReady:  1,
 			expectedCapacityStatus: corev1.ConditionTrue,
 		},
 		{
@@ -473,21 +465,8 @@ func TestReconcileClusterPool(t *testing.T) {
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(6), testcp.WithMaxSize(5), testcp.WithMaxConcurrent(1)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
-				unclaimedCDBuilder("c3").Build(testcd.Installed()),
-			},
-			expectedTotalClusters:  4,
-			expectedObservedSize:   3,
-			expectedObservedReady:  3,
-			expectedCapacityStatus: corev1.ConditionTrue,
-		},
-		{
-			name: "scale up with max concurrent and max size 3",
-			existing: []runtime.Object{
-				initializedPoolBuilder.Build(testcp.WithSize(6), testcp.WithMaxSize(4), testcp.WithMaxConcurrent(2)),
-				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
-				unclaimedCDBuilder("c3").Build(),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
+				unclaimedCDBuilder("c3").Build(testcd.Running()),
 			},
 			expectedTotalClusters:  4,
 			expectedObservedSize:   3,
@@ -495,16 +474,31 @@ func TestReconcileClusterPool(t *testing.T) {
 			expectedCapacityStatus: corev1.ConditionTrue,
 		},
 		{
+			name: "scale up with max concurrent and max size 3",
+			existing: []runtime.Object{
+				initializedPoolBuilder.Build(testcp.WithSize(6), testcp.WithMaxSize(4), testcp.WithMaxConcurrent(2)),
+				unclaimedCDBuilder("c1").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
+				unclaimedCDBuilder("c3").Build(),
+			},
+			expectedTotalClusters:  4,
+			expectedObservedSize:   3,
+			expectedObservedReady:  1,
+			expectedCapacityStatus: corev1.ConditionTrue,
+		},
+		{
 			name: "no scale up with max concurrent and some deleting",
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(5), testcp.WithMaxConcurrent(2)),
-				unclaimedCDBuilder("c1").GenericOptions(testgeneric.Deleted()).Build(testcd.Installed()),
+				unclaimedCDBuilder("c1").GenericOptions(testgeneric.Deleted()).Build(testcd.Running()),
 				unclaimedCDBuilder("c2").Build(testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(),
 			},
 			expectedTotalClusters: 3,
 			expectedObservedSize:  2,
-			expectedObservedReady: 1,
+			// runningCount==0 and we don't have pending claims, but we don't muck with the
+			// Running-ness of the deleting cluster.
+			expectedRunning: 1,
 		},
 		{
 			name: "no scale up with max concurrent and some deleting claimed clusters",
@@ -519,7 +513,6 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters:  3,
 			expectedObservedSize:   2,
-			expectedObservedReady:  1,
 			expectedAssignedClaims: 1,
 			expectedAssignedCDs:    1,
 		},
@@ -528,7 +521,7 @@ func TestReconcileClusterPool(t *testing.T) {
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(5), testcp.WithMaxConcurrent(3)),
 				unclaimedCDBuilder("c1").GenericOptions(testgeneric.Deleted()).Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 			},
 			expectedTotalClusters: 4,
@@ -542,13 +535,13 @@ func TestReconcileClusterPool(t *testing.T) {
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
 				unclaimedCDBuilder("c2").Build(testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(testcd.Installed()),
-				unclaimedCDBuilder("c4").Build(testcd.Installed()),
-				unclaimedCDBuilder("c5").Build(testcd.Installed()),
-				unclaimedCDBuilder("c6").Build(testcd.Installed()),
+				unclaimedCDBuilder("c4").Build(testcd.Running()),
+				unclaimedCDBuilder("c5").Build(testcd.Running()),
+				unclaimedCDBuilder("c6").Build(testcd.Running()),
 			},
 			expectedTotalClusters: 3,
 			expectedObservedSize:  6,
-			expectedObservedReady: 6,
+			expectedObservedReady: 3,
 		},
 		{
 			name: "scale down with max concurrent enough",
@@ -557,13 +550,13 @@ func TestReconcileClusterPool(t *testing.T) {
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
 				unclaimedCDBuilder("c2").Build(testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(testcd.Installed()),
-				unclaimedCDBuilder("c4").Build(testcd.Installed()),
-				unclaimedCDBuilder("c5").Build(testcd.Installed()),
-				unclaimedCDBuilder("c6").Build(testcd.Installed()),
+				unclaimedCDBuilder("c4").Build(testcd.Running()),
+				unclaimedCDBuilder("c5").Build(testcd.Running()),
+				unclaimedCDBuilder("c6").Build(testcd.Running()),
 			},
 			expectedTotalClusters: 3,
 			expectedObservedSize:  6,
-			expectedObservedReady: 6,
+			expectedObservedReady: 3,
 		},
 		{
 			name: "scale down with max concurrent not enough",
@@ -572,25 +565,26 @@ func TestReconcileClusterPool(t *testing.T) {
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
 				unclaimedCDBuilder("c2").Build(testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(testcd.Installed()),
-				unclaimedCDBuilder("c4").Build(testcd.Installed()),
-				unclaimedCDBuilder("c5").Build(testcd.Installed()),
-				unclaimedCDBuilder("c6").Build(testcd.Installed()),
+				unclaimedCDBuilder("c4").Build(testcd.Running()),
+				unclaimedCDBuilder("c5").Build(testcd.Running()),
+				unclaimedCDBuilder("c6").Build(testcd.Running()),
 			},
 			expectedTotalClusters: 4,
 			expectedObservedSize:  6,
-			expectedObservedReady: 6,
+			expectedObservedReady: 3,
 		},
 		{
 			name: "delete installing clusters first",
 			existing: []runtime.Object{
-				initializedPoolBuilder.Build(testcp.WithSize(1)),
+				initializedPoolBuilder.Build(testcp.WithSize(2)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
+				unclaimedCDBuilder("c3").Build(),
 			},
-			expectedTotalClusters:   1,
-			expectedObservedSize:    2,
+			expectedTotalClusters:   2,
+			expectedObservedSize:    3,
 			expectedObservedReady:   1,
-			expectedDeletedClusters: []string{"c2"},
+			expectedDeletedClusters: []string{"c3"},
 		},
 		{
 			name: "delete most recent installing clusters first",
@@ -609,28 +603,29 @@ func TestReconcileClusterPool(t *testing.T) {
 			expectedDeletedClusters: []string{"c2"},
 		},
 		{
+			// Also shows we delete installed clusters before running ones
 			name: "delete installed clusters when there are not enough installing to delete",
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(3)),
-				unclaimedCDBuilder("c1").Build(testcd.Installed()),
+				unclaimedCDBuilder("c1").Build(testcd.Running()),
 				unclaimedCDBuilder("c2").Build(testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(),
-				unclaimedCDBuilder("c4").Build(testcd.Installed()),
-				unclaimedCDBuilder("c5").Build(testcd.Installed()),
+				unclaimedCDBuilder("c4").Build(testcd.Running()),
+				unclaimedCDBuilder("c5").Build(testcd.Running()),
 				unclaimedCDBuilder("c6").Build(),
 			},
 			expectedTotalClusters:   3,
 			expectedObservedSize:    6,
-			expectedObservedReady:   4,
-			expectedDeletedClusters: []string{"c3", "c6"},
+			expectedObservedReady:   3,
+			expectedDeletedClusters: []string{"c2", "c3", "c6"},
 		},
 		{
 			name: "clusters deleted when clusterpool deleted",
 			existing: []runtime.Object{
 				initializedPoolBuilder.GenericOptions(testgeneric.Deleted()).Build(testcp.WithSize(3)),
 				unclaimedCDBuilder("c1").Build(),
-				unclaimedCDBuilder("c2").Build(),
-				unclaimedCDBuilder("c3").Build(),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
+				unclaimedCDBuilder("c3").Build(testcd.Installed()),
 			},
 			expectedTotalClusters:   0,
 			expectFinalizerRemoved:  true,
@@ -641,32 +636,32 @@ func TestReconcileClusterPool(t *testing.T) {
 			existing: []runtime.Object{
 				initializedPoolBuilder.GenericOptions(testgeneric.WithoutFinalizer(finalizer)).Build(testcp.WithSize(3)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 			},
 			expectedTotalClusters: 3,
 			expectedObservedSize:  3,
-			expectedObservedReady: 2,
+			expectedObservedReady: 1,
 		},
 		{
 			name: "clusters not part of pool are not counted against pool size",
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(3)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").Build(),
 			},
 			expectedTotalClusters: 4,
 			expectedObservedSize:  3,
-			expectedObservedReady: 2,
+			expectedObservedReady: 1,
 		},
 		{
 			name: "claimed clusters are not counted against pool size",
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(3)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").Build(
 					testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "test-claim"),
@@ -674,7 +669,7 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters: 4,
 			expectedObservedSize:  3,
-			expectedObservedReady: 2,
+			expectedObservedReady: 1,
 			expectedAssignedCDs:   1,
 		},
 		{
@@ -682,7 +677,7 @@ func TestReconcileClusterPool(t *testing.T) {
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(3)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").Build(
 					testcd.WithClusterPoolReference(testNamespace, "other-pool", "test-claim"),
@@ -690,21 +685,23 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters: 4,
 			expectedObservedSize:  3,
-			expectedObservedReady: 2,
+			expectedObservedReady: 1,
 		},
 		{
 			name: "deleting clusters are not counted against pool size",
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(3)),
-				unclaimedCDBuilder("c1").Build(testcd.Installed()),
+				unclaimedCDBuilder("c1").Build(testcd.Running()),
 				unclaimedCDBuilder("c2").Build(testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").GenericOptions(testgeneric.Deleted()).Build(testcd.Installed()),
-				cdBuilder("c5").GenericOptions(testgeneric.Deleted()).Build(),
+				cdBuilder("c5").GenericOptions(testgeneric.Deleted()).Build(testcd.Running()),
+				cdBuilder("c6").GenericOptions(testgeneric.Deleted()).Build(),
 			},
-			expectedTotalClusters: 5,
+			expectedTotalClusters: 6,
 			expectedObservedSize:  3,
-			expectedObservedReady: 2,
+			expectedObservedReady: 1,
+			expectedRunning:       1,
 		},
 		{
 			name: "missing ClusterImageSet",
@@ -770,12 +767,13 @@ func TestReconcileClusterPool(t *testing.T) {
 					}),
 				),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
-				unclaimedCDBuilder("c3").GenericOptions(testgeneric.Deleted()).Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
+				unclaimedCDBuilder("c3").GenericOptions(testgeneric.Deleted()).Build(testcd.Running()),
 			},
 			expectedTotalClusters:  3,
 			expectedObservedSize:   2,
-			expectedObservedReady:  2,
+			expectedObservedReady:  1,
+			expectedRunning:        1,
 			expectedCapacityStatus: corev1.ConditionFalse,
 		},
 		{
@@ -789,12 +787,12 @@ func TestReconcileClusterPool(t *testing.T) {
 						Status: corev1.ConditionFalse,
 					}),
 				),
-				unclaimedCDBuilder("c1").Build(testcd.Installed()),
+				unclaimedCDBuilder("c1").Build(testcd.Running()),
 				unclaimedCDBuilder("c2").Build(testcd.Installed()),
 			},
 			expectedTotalClusters:  2,
 			expectedObservedSize:   2,
-			expectedObservedReady:  2,
+			expectedObservedReady:  1,
 			expectedCapacityStatus: corev1.ConditionTrue,
 		},
 		{
@@ -843,13 +841,13 @@ func TestReconcileClusterPool(t *testing.T) {
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(3)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 				testclaim.FullBuilder(testNamespace, "test-claim", scheme).Build(testclaim.WithPool(testLeasePoolName)),
 			},
 			expectedTotalClusters:       4,
 			expectedObservedSize:        3,
-			expectedObservedReady:       2,
+			expectedObservedReady:       1,
 			expectedAssignedClaims:      1,
 			expectedAssignedCDs:         1,
 			expectedRunning:             1,
@@ -859,7 +857,7 @@ func TestReconcileClusterPool(t *testing.T) {
 			name: "no ready clusters to assign to claim",
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(3)),
-				unclaimedCDBuilder("c1").Build(),
+				unclaimedCDBuilder("c1").Build(testcd.Installed()),
 				unclaimedCDBuilder("c2").Build(),
 				unclaimedCDBuilder("c3").Build(),
 				testclaim.FullBuilder(testNamespace, "test-claim", scheme).Build(testclaim.WithPool(testLeasePoolName)),
@@ -869,15 +867,17 @@ func TestReconcileClusterPool(t *testing.T) {
 			expectedObservedReady:       0,
 			expectedAssignedClaims:      0,
 			expectedUnassignedClaims:    1,
+			expectedRunning:             1,
 			expectedClaimPendingReasons: map[string]string{"test-claim": "NoClusters"},
 		},
 		{
 			name: "assign to multiple claims",
 			existing: []runtime.Object{
-				initializedPoolBuilder.Build(testcp.WithSize(3)),
-				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
-				unclaimedCDBuilder("c3").Build(),
+				initializedPoolBuilder.Build(testcp.WithSize(4)),
+				unclaimedCDBuilder("c1").Build(testcd.Running()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
+				unclaimedCDBuilder("c3").Build(testcd.Installed()),
+				unclaimedCDBuilder("c4").Build(),
 				// Claims are assigned in FIFO order by creationTimestamp
 				testclaim.FullBuilder(testNamespace, "test-claim-1", scheme).Build(
 					testclaim.WithPool(testLeasePoolName),
@@ -892,12 +892,12 @@ func TestReconcileClusterPool(t *testing.T) {
 					testclaim.Generic(testgeneric.WithCreationTimestamp(nowish)),
 				),
 			},
-			expectedTotalClusters:    6,
-			expectedObservedSize:     3,
+			expectedTotalClusters:    7,
+			expectedObservedSize:     4,
 			expectedObservedReady:    2,
 			expectedAssignedClaims:   2,
 			expectedAssignedCDs:      2,
-			expectedRunning:          2,
+			expectedRunning:          3,
 			expectedUnassignedClaims: 1,
 			expectedClaimPendingReasons: map[string]string{
 				"test-claim-1": "ClusterAssigned",
@@ -910,7 +910,7 @@ func TestReconcileClusterPool(t *testing.T) {
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(3)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 				testclaim.FullBuilder(testNamespace, "test-claim", scheme).Build(
 					testclaim.WithPool("other-pool"),
@@ -924,7 +924,7 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters:       3,
 			expectedObservedSize:        3,
-			expectedObservedReady:       2,
+			expectedObservedReady:       1,
 			expectedAssignedClaims:      0,
 			expectedUnassignedClaims:    1,
 			expectedClaimPendingReasons: map[string]string{"test-claim": "ThisShouldNotChange"},
@@ -934,7 +934,7 @@ func TestReconcileClusterPool(t *testing.T) {
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(3)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 				testclaim.FullBuilder("other-namespace", "test-claim", scheme).Build(
 					testclaim.WithPool(testLeasePoolName),
@@ -948,7 +948,7 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters:       3,
 			expectedObservedSize:        3,
-			expectedObservedReady:       2,
+			expectedObservedReady:       1,
 			expectedAssignedClaims:      0,
 			expectedUnassignedClaims:    1,
 			expectedClaimPendingReasons: map[string]string{"test-claim": "ThisShouldNotChange"},
@@ -957,8 +957,8 @@ func TestReconcileClusterPool(t *testing.T) {
 			name: "do not delete previously claimed clusters",
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(3)),
-				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c1").Build(testcd.Running()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").Build(
 					testcd.WithClusterPoolReference(testNamespace, testLeasePoolName, "test-claim"),
@@ -973,8 +973,8 @@ func TestReconcileClusterPool(t *testing.T) {
 			name: "do not delete previously claimed clusters 2",
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(3)),
-				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c1").Build(testcd.Running()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").
 					GenericOptions(testgeneric.Deleted(), testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
@@ -992,7 +992,7 @@ func TestReconcileClusterPool(t *testing.T) {
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(3)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").
 					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
@@ -1002,7 +1002,7 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters:   3,
 			expectedObservedSize:    3,
-			expectedObservedReady:   2,
+			expectedObservedReady:   1,
 			expectedDeletedClusters: []string{"c4"},
 		},
 		{
@@ -1020,7 +1020,6 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters: 4,
 			expectedObservedSize:  3,
-			expectedObservedReady: 1,
 			expectedAssignedCDs:   1,
 		},
 		{
@@ -1038,7 +1037,6 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters: 4,
 			expectedObservedSize:  2,
-			expectedObservedReady: 1,
 			expectedAssignedCDs:   1,
 		},
 		{
@@ -1056,7 +1054,6 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters:   3,
 			expectedObservedSize:    2,
-			expectedObservedReady:   1,
 			expectedDeletedClusters: []string{"c4"},
 		},
 		{
@@ -1073,7 +1070,6 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters:   2,
 			expectedObservedSize:    2,
-			expectedObservedReady:   1,
 			expectedDeletedClusters: []string{"c4"},
 		},
 		{
@@ -1081,7 +1077,7 @@ func TestReconcileClusterPool(t *testing.T) {
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(4), testcp.WithMaxConcurrent(2)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c3").Build(testcd.Installed()),
+				unclaimedCDBuilder("c3").Build(testcd.Running()),
 				cdBuilder("c4").
 					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(
@@ -1095,7 +1091,7 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters:   2,
 			expectedObservedSize:    2,
-			expectedObservedReady:   2,
+			expectedObservedReady:   1,
 			expectedDeletedClusters: []string{"c4", "c5"},
 		},
 		{
@@ -1117,7 +1113,6 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters:   3,
 			expectedObservedSize:    2,
-			expectedObservedReady:   1,
 			expectedAssignedCDs:     1,
 			expectedDeletedClusters: []string{"c4"},
 		},
@@ -1126,7 +1121,7 @@ func TestReconcileClusterPool(t *testing.T) {
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(1), testcp.WithMaxConcurrent(2)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").
 					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
@@ -1136,7 +1131,7 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters:   3,
 			expectedObservedSize:    3,
-			expectedObservedReady:   2,
+			expectedObservedReady:   1,
 			expectedDeletedClusters: []string{"c4"},
 		},
 		{
@@ -1144,8 +1139,8 @@ func TestReconcileClusterPool(t *testing.T) {
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(1), testcp.WithMaxConcurrent(2)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
-				unclaimedCDBuilder("c3").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
+				unclaimedCDBuilder("c3").Build(testcd.Running()),
 				cdBuilder("c4").
 					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
 					Build(
@@ -1159,7 +1154,7 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters:   3,
 			expectedObservedSize:    3,
-			expectedObservedReady:   3,
+			expectedObservedReady:   2,
 			expectedDeletedClusters: []string{"c4", "c5"},
 		},
 		{
@@ -1167,7 +1162,7 @@ func TestReconcileClusterPool(t *testing.T) {
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(testcp.WithSize(1), testcp.WithMaxConcurrent(2)),
 				unclaimedCDBuilder("c1").Build(testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(),
 				cdBuilder("c4").
 					GenericOptions(testgeneric.WithAnnotation(constants.ClusterClaimRemoveClusterAnnotation, "true")).
@@ -1182,7 +1177,7 @@ func TestReconcileClusterPool(t *testing.T) {
 			},
 			expectedTotalClusters:   4,
 			expectedObservedSize:    3,
-			expectedObservedReady:   2,
+			expectedObservedReady:   1,
 			expectedAssignedCDs:     1,
 			expectedDeletedClusters: []string{"c4"},
 		},
@@ -1339,14 +1334,14 @@ func TestReconcileClusterPool(t *testing.T) {
 					testcp.WithSize(4),
 					testcp.WithRunningCount(2),
 				),
-				unclaimedCDBuilder("c1").Build(testcd.WithPowerState(hivev1.ClusterPowerStateRunning), testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.WithPowerState(hivev1.ClusterPowerStateRunning), testcd.Installed()),
+				unclaimedCDBuilder("c1").Build(testcd.Running()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(testcd.Installed()),
 				unclaimedCDBuilder("c4").Build(testcd.Installed()),
 				testclaim.FullBuilder(testNamespace, "test-claim", scheme).Build(testclaim.WithPool(testLeasePoolName)),
 			},
 			expectedObservedSize:   4,
-			expectedObservedReady:  4,
+			expectedObservedReady:  2,
 			expectedTotalClusters:  5,
 			expectedRunning:        3,
 			expectedAssignedCDs:    1,
@@ -1357,20 +1352,20 @@ func TestReconcileClusterPool(t *testing.T) {
 			existing: []runtime.Object{
 				initializedPoolBuilder.Build(
 					testcp.WithSize(4),
-					testcp.WithRunningCount(2),
+					testcp.WithRunningCount(3),
 				),
-				unclaimedCDBuilder("c1").Build(testcd.WithPowerState(hivev1.ClusterPowerStateRunning), testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.WithPowerState(hivev1.ClusterPowerStateRunning), testcd.Installed()),
-				unclaimedCDBuilder("c3").Build(testcd.Installed()),
+				unclaimedCDBuilder("c1").Build(testcd.Running()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
+				unclaimedCDBuilder("c3").Build(testcd.Running()),
 				unclaimedCDBuilder("c4").Build(testcd.Installed()),
 				testclaim.FullBuilder(testNamespace, "test-claim1", scheme).Build(testclaim.WithPool(testLeasePoolName)),
 				testclaim.FullBuilder(testNamespace, "test-claim2", scheme).Build(testclaim.WithPool(testLeasePoolName)),
 				testclaim.FullBuilder(testNamespace, "test-claim3", scheme).Build(testclaim.WithPool(testLeasePoolName)),
 			},
 			expectedObservedSize:   4,
-			expectedObservedReady:  4,
+			expectedObservedReady:  3,
 			expectedTotalClusters:  7,
-			expectedRunning:        5,
+			expectedRunning:        6,
 			expectedAssignedCDs:    3,
 			expectedAssignedClaims: 3,
 		},
@@ -1381,8 +1376,8 @@ func TestReconcileClusterPool(t *testing.T) {
 					testcp.WithSize(4),
 					testcp.WithRunningCount(2),
 				),
-				unclaimedCDBuilder("c1").Build(testcd.WithPowerState(hivev1.ClusterPowerStateRunning), testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.WithPowerState(hivev1.ClusterPowerStateRunning), testcd.Installed()),
+				unclaimedCDBuilder("c1").Build(testcd.Running()),
+				unclaimedCDBuilder("c2").Build(testcd.Running()),
 				unclaimedCDBuilder("c3").Build(testcd.Installed()),
 				unclaimedCDBuilder("c4").Build(testcd.Installed()),
 				testclaim.FullBuilder(testNamespace, "test-claim1", scheme).Build(testclaim.WithPool(testLeasePoolName)),
@@ -1392,15 +1387,16 @@ func TestReconcileClusterPool(t *testing.T) {
 				testclaim.FullBuilder(testNamespace, "test-claim5", scheme).Build(testclaim.WithPool(testLeasePoolName)),
 			},
 			expectedObservedSize:  4,
-			expectedObservedReady: 4,
+			expectedObservedReady: 2,
 			expectedTotalClusters: 9,
-			// The four original pool CDs got claimed. Two were already running; we started the other two.
-			// We create five new CDs to satisfy the pool size plus the additional claim.
-			// Of those, we start two for runningCount, and one more for the excess claim.
+			// The two original running pool CDs got claimed.
+			// We create five new CDs to satisfy the pool size plus the additional three claims.
+			// Of those, we start two for runningCount, and three more for the excess claims.
+			// Including the two originally running that we assigned to claims, that's seven.
 			expectedRunning:          7,
-			expectedAssignedCDs:      4,
-			expectedAssignedClaims:   4,
-			expectedUnassignedClaims: 1,
+			expectedAssignedCDs:      2,
+			expectedAssignedClaims:   2,
+			expectedUnassignedClaims: 3,
 		},
 	}
 

--- a/pkg/controller/clusterpool/clusterpool_controller_test.go
+++ b/pkg/controller/clusterpool/clusterpool_controller_test.go
@@ -76,7 +76,7 @@ func TestReconcileClusterPool(t *testing.T) {
 	)
 	cdBuilder := func(name string) testcd.Builder {
 		return testcd.FullBuilder(name, name, scheme).Options(
-			testcd.WithPowerState(hivev1.HibernatingClusterPowerState),
+			testcd.WithPowerState(hivev1.ClusterPowerStateHibernating),
 			testcd.WithPoolVersion(initialPoolVersion),
 		)
 	}
@@ -1324,8 +1324,8 @@ func TestReconcileClusterPool(t *testing.T) {
 					testcp.WithSize(4),
 					testcp.WithRunningCount(2),
 				),
-				unclaimedCDBuilder("c1").Build(testcd.Generic(testgeneric.Deleted()), testcd.WithPowerState(hivev1.RunningClusterPowerState)),
-				unclaimedCDBuilder("c2").Build(testcd.WithPowerState(hivev1.RunningClusterPowerState)),
+				unclaimedCDBuilder("c1").Build(testcd.Generic(testgeneric.Deleted()), testcd.WithPowerState(hivev1.ClusterPowerStateRunning)),
+				unclaimedCDBuilder("c2").Build(testcd.WithPowerState(hivev1.ClusterPowerStateRunning)),
 				unclaimedCDBuilder("c3").Build(),
 				unclaimedCDBuilder("c4").Build(),
 			},
@@ -1340,8 +1340,8 @@ func TestReconcileClusterPool(t *testing.T) {
 					testcp.WithSize(4),
 					testcp.WithRunningCount(2),
 				),
-				unclaimedCDBuilder("c1").Build(testcd.WithPowerState(hivev1.RunningClusterPowerState), testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.WithPowerState(hivev1.RunningClusterPowerState), testcd.Installed()),
+				unclaimedCDBuilder("c1").Build(testcd.WithPowerState(hivev1.ClusterPowerStateRunning), testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.WithPowerState(hivev1.ClusterPowerStateRunning), testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(testcd.Installed()),
 				unclaimedCDBuilder("c4").Build(testcd.Installed()),
 				testclaim.FullBuilder(testNamespace, "test-claim", scheme).Build(testclaim.WithPool(testLeasePoolName)),
@@ -1360,8 +1360,8 @@ func TestReconcileClusterPool(t *testing.T) {
 					testcp.WithSize(4),
 					testcp.WithRunningCount(2),
 				),
-				unclaimedCDBuilder("c1").Build(testcd.WithPowerState(hivev1.RunningClusterPowerState), testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.WithPowerState(hivev1.RunningClusterPowerState), testcd.Installed()),
+				unclaimedCDBuilder("c1").Build(testcd.WithPowerState(hivev1.ClusterPowerStateRunning), testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.WithPowerState(hivev1.ClusterPowerStateRunning), testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(testcd.Installed()),
 				unclaimedCDBuilder("c4").Build(testcd.Installed()),
 				testclaim.FullBuilder(testNamespace, "test-claim1", scheme).Build(testclaim.WithPool(testLeasePoolName)),
@@ -1382,8 +1382,8 @@ func TestReconcileClusterPool(t *testing.T) {
 					testcp.WithSize(4),
 					testcp.WithRunningCount(2),
 				),
-				unclaimedCDBuilder("c1").Build(testcd.WithPowerState(hivev1.RunningClusterPowerState), testcd.Installed()),
-				unclaimedCDBuilder("c2").Build(testcd.WithPowerState(hivev1.RunningClusterPowerState), testcd.Installed()),
+				unclaimedCDBuilder("c1").Build(testcd.WithPowerState(hivev1.ClusterPowerStateRunning), testcd.Installed()),
+				unclaimedCDBuilder("c2").Build(testcd.WithPowerState(hivev1.ClusterPowerStateRunning), testcd.Installed()),
 				unclaimedCDBuilder("c3").Build(testcd.Installed()),
 				unclaimedCDBuilder("c4").Build(testcd.Installed()),
 				testclaim.FullBuilder(testNamespace, "test-claim1", scheme).Build(testclaim.WithPool(testLeasePoolName)),
@@ -1523,9 +1523,9 @@ func TestReconcileClusterPool(t *testing.T) {
 					}
 				}
 				switch powerState := cd.Spec.PowerState; powerState {
-				case hivev1.RunningClusterPowerState:
+				case hivev1.ClusterPowerStateRunning:
 					actualRunning++
-				case hivev1.HibernatingClusterPowerState:
+				case hivev1.ClusterPowerStateHibernating:
 					actualHibernating++
 				}
 

--- a/pkg/controller/clusterpool/collections.go
+++ b/pkg/controller/clusterpool/collections.go
@@ -234,7 +234,7 @@ func isRunning(cd *hivev1.ClusterDeployment) bool {
 		// only check this for Installed clusters.)
 		return false
 	}
-	return cond.Reason == hivev1.RunningReadyReason
+	return cond.Reason == hivev1.ReadyReasonRunning
 }
 
 func (cds *cdCollection) sortInstalling() {
@@ -449,7 +449,7 @@ func (cds *cdCollection) Assign(c client.Client, cd *hivev1.ClusterDeployment, c
 			now := metav1.Now()
 			cdi.Spec.ClusterPoolRef.ClaimedTimestamp = &now
 			// This may be redundant if we already did it to satisfy runningCount; but no harm.
-			cdi.Spec.PowerState = hivev1.RunningClusterPowerState
+			cdi.Spec.PowerState = hivev1.ClusterPowerStateRunning
 			if err := c.Update(context.Background(), cdi); err != nil {
 				return err
 			}

--- a/pkg/controller/clusterpool/collections.go
+++ b/pkg/controller/clusterpool/collections.go
@@ -224,17 +224,6 @@ func isBroken(cd *hivev1.ClusterDeployment) bool {
 	return false
 }
 
-func isRunning(cd *hivev1.ClusterDeployment) bool {
-	cond := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ClusterReadyCondition)
-	if cond == nil {
-		// Since we should be initializing conditions, this probably means the CD is super fresh
-		// and quite unlikely to be running. (That said, this really should never happen, since we
-		// only check this for Installed clusters.)
-		return false
-	}
-	return cond.Reason == hivev1.ReadyReasonRunning
-}
-
 func (cds *cdCollection) sortInstalling() {
 	// Sort installing CDs so we prioritize deleting those that are furthest away from completing
 	// their installation (prioritizing preserving those that will be assignable the soonest).
@@ -290,7 +279,7 @@ func getAllClusterDeploymentsForPool(c client.Client, pool *hivev1.ClusterPool, 
 				cdCol.broken = append(cdCol.broken, ref)
 			} else if cd.Spec.Installed {
 				cdCol.assignable = append(cdCol.assignable, ref)
-				if isRunning(&cd) {
+				if cd.Status.PowerState == string(hivev1.RunningClusterPowerState) {
 					running++
 				}
 			} else {

--- a/pkg/controller/clusterpool/metrics.go
+++ b/pkg/controller/clusterpool/metrics.go
@@ -9,7 +9,7 @@ import (
 var (
 	metricClusterDeploymentsAssignable = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "hive_clusterpool_clusterdeployments_assignable",
-		Help: "The number of ClusterDeployments ready to be claimed. Contributes to Size and MaxSize.",
+		Help: "The number of ClusterDeployments ready to be claimed (installed and running). Contributes to Size and MaxSize.",
 	}, []string{"clusterpool_namespace", "clusterpool_name"})
 	metricClusterDeploymentsClaimed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "hive_clusterpool_clusterdeployments_claimed",
@@ -25,11 +25,11 @@ var (
 	}, []string{"clusterpool_namespace", "clusterpool_name"})
 	metricClusterDeploymentsUnclaimed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "hive_clusterpool_clusterdeployments_unclaimed",
-		Help: "The number of unclaimed ClusterDeployments, including both installing and assignable. Should tend toward the pool Size, unless constrained by MaxConcurrent or exceeded due to excess claims.",
+		Help: "The number of unclaimed ClusterDeployments, including installing, standby, and assignable. Should tend toward the pool Size, unless constrained by MaxConcurrent or exceeded due to excess claims.",
 	}, []string{"clusterpool_namespace", "clusterpool_name"})
-	metricClusterDeploymentsRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "hive_clusterpool_clusterdeployments_running",
-		Help: "The subset of assignable ClusterDeployments that are in Running state. Should tend toward RunningCount plus the number of pending ClusterClaims.",
+	metricClusterDeploymentsStandby = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hive_clusterpool_clusterdeployments_standby",
+		Help: "The number of ClusterDeployments that are installed but not running. Should tend toward pool Size minus RunningCount minus the number of pending ClusterClaims.",
 	}, []string{"clusterpool_namespace", "clusterpool_name"})
 	metricClusterDeploymentsStale = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "hive_clusterpool_clusterdeployments_stale",
@@ -71,7 +71,7 @@ func init() {
 	metrics.Registry.MustRegister(metricClusterDeploymentsDeleting)
 	metrics.Registry.MustRegister(metricClusterDeploymentsInstalling)
 	metrics.Registry.MustRegister(metricClusterDeploymentsUnclaimed)
-	metrics.Registry.MustRegister(metricClusterDeploymentsRunning)
+	metrics.Registry.MustRegister(metricClusterDeploymentsStandby)
 	metrics.Registry.MustRegister(metricClusterDeploymentsStale)
 	metrics.Registry.MustRegister(metricClusterDeploymentsBroken)
 	metrics.Registry.MustRegister(metricStaleClusterDeploymentsDeleted)

--- a/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller_test.go
+++ b/pkg/controller/clusterpoolnamespace/clusterpoolnamespace_controller_test.go
@@ -239,7 +239,7 @@ func Test_cleanupPreviouslyClaimedClusterDeployments(t *testing.T) {
 		)
 	cdBuilder := func(name string) testcd.Builder {
 		return testcd.FullBuilder(name, name, scheme).Options(
-			testcd.WithPowerState(hivev1.HibernatingClusterPowerState),
+			testcd.WithPowerState(hivev1.ClusterPowerStateHibernating),
 		)
 	}
 	cdBuilderWithPool := func(name, pool string) testcd.Builder {

--- a/pkg/controller/hibernation/aws_actuator_test.go
+++ b/pkg/controller/hibernation/aws_actuator_test.go
@@ -266,7 +266,7 @@ func TestReplacePreemptibleMachines(t *testing.T) {
 		testcd.WithClusterVersion("4.4.9"),
 		testcd.WithCondition(hivev1.ClusterDeploymentCondition{
 			Type:               hivev1.ClusterHibernatingCondition,
-			Reason:             hivev1.HibernatingHibernationReason,
+			Reason:             hivev1.HibernatingReasonHibernating,
 			Status:             corev1.ConditionFalse,
 			LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
 		}),

--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -153,6 +153,18 @@ func Installed() Option {
 	}
 }
 
+func Running() Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Spec.Installed = true
+		clusterDeployment.Spec.PowerState = hivev1.ClusterPowerStateRunning
+		clusterDeployment.Status.PowerState = hivev1.ClusterPowerStateRunning
+		// A little hack to make sure tests don't unexpectedly start swapping which clusters are
+		// running: since we start the oldest clusters first, fake the creation time of this
+		// cluster to be "old".
+		clusterDeployment.CreationTimestamp = metav1.NewTime(time.Now().Add(-6 * time.Hour))
+	}
+}
+
 func InstalledTimestamp(instTime time.Time) Option {
 	return func(clusterDeployment *hivev1.ClusterDeployment) {
 		clusterDeployment.Spec.Installed = true

--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -176,7 +176,7 @@ func WithPowerState(powerState hivev1.ClusterPowerState) Option {
 	}
 }
 
-func WithStatusPowerState(powerState string) Option {
+func WithStatusPowerState(powerState hivev1.ClusterPowerState) Option {
 	return func(clusterDeployment *hivev1.ClusterDeployment) {
 		clusterDeployment.Status.PowerState = powerState
 	}

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
@@ -110,7 +110,11 @@ type ClusterPoolStatus struct {
 	// Size is the number of unclaimed clusters that have been created for the pool.
 	Size int32 `json:"size"`
 
-	// Ready is the number of unclaimed clusters that have been installed and are ready to be claimed.
+	// Standby is the number of unclaimed clusters that are installed, but not running.
+	// +optional
+	Standby int32 `json:"standby"`
+
+	// Ready is the number of unclaimed clusters that are installed and are running and ready to be claimed.
 	Ready int32 `json:"ready"`
 
 	// Conditions includes more detailed status for the cluster pool
@@ -161,8 +165,9 @@ const (
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.size,statuspath=.status.size
-// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready"
 // +kubebuilder:printcolumn:name="Size",type="string",JSONPath=".spec.size"
+// +kubebuilder:printcolumn:name="Standby",type="string",JSONPath=".status.standby"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready"
 // +kubebuilder:printcolumn:name="BaseDomain",type="string",JSONPath=".spec.baseDomain"
 // +kubebuilder:printcolumn:name="ImageSet",type="string",JSONPath=".spec.imageSetRef.name"
 // +kubebuilder:resource:path=clusterpools,shortName=cp


### PR DESCRIPTION
With this PR, the cdCollection bucket called `assignable` now only contains installed, non-deleted/deleting, *running* clusters. Since we fulfill claims out of that bucket, the result is that, when your claim is assigned a cluster, that cluster is guaranteed to be running. Before this change, it might have been hibernating and we would initiate resume when assigning; so you would need to wait before using it.

To make this work, we also add a new bucket to cdCollection called `standby`. This contains the installed, non-deleted/deleting clusters that are *not* running.

The related metrics are changed accordingly:
- `hive_clusterpool_clusterdeployments_assignable` now only counts running clusters.
- `hive_clusterpool_clusterdeployments_running` is removed, as it would have been redundant with the above.
- `hive_clusterpool_clusterdeployments_standby` is added.

[HIVE-1679](https://issues.redhat.com/browse/HIVE-1679)