### PR TITLE
Add error message if install pods get killed or evicted

### DIFF
--- a/apis/hive/v1/clusterprovision_types.go
+++ b/apis/hive/v1/clusterprovision_types.go
@@ -44,6 +44,9 @@ type ClusterProvisionSpec struct {
 
 	// PrevInfraID is the infra ID of the previous failed provision attempt.
 	PrevInfraID *string `json:"prevInfraID,omitempty"`
+
+	// PrevProvisionName is the name of the previous failed provision attempt.
+	PrevProvisionName *string `json:"prevProvisionName,omitempty"`
 }
 
 // ClusterProvisionStatus defines the observed state of ClusterProvision.

--- a/apis/hive/v1/zz_generated.deepcopy.go
+++ b/apis/hive/v1/zz_generated.deepcopy.go
@@ -1536,6 +1536,11 @@ func (in *ClusterProvisionSpec) DeepCopyInto(out *ClusterProvisionSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.PrevProvisionName != nil {
+		in, out := &in.PrevProvisionName, &out.PrevProvisionName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/config/crds/hive.openshift.io_clusterprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterprovisions.yaml
@@ -102,6 +102,10 @@ spec:
                 description: PrevInfraID is the infra ID of the previous failed provision
                   attempt.
                 type: string
+              prevProvisionName:
+                description: PrevProvisionName is the name of the previous failed
+                  provision attempt.
+                type: string
               stage:
                 description: Stage is the stage of provisioning that the cluster deployment
                   has reached.

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -2379,6 +2379,10 @@ objects:
                   description: PrevInfraID is the infra ID of the previous failed
                     provision attempt.
                   type: string
+                prevProvisionName:
+                  description: PrevProvisionName is the name of the previous failed
+                    provision attempt.
+                  type: string
                 stage:
                   description: Stage is the stage of provisioning that the cluster
                     deployment has reached.

--- a/pkg/controller/clusterdeployment/clusterprovisions.go
+++ b/pkg/controller/clusterdeployment/clusterprovisions.go
@@ -175,10 +175,11 @@ func (r *ReconcileClusterDeployment) startNewProvision(
 		},
 	}
 
-	// Copy over the cluster ID and infra ID from previous provision so that a failed install can be removed.
-	if cd.Spec.ClusterMetadata != nil {
-		provision.Spec.PrevClusterID = &cd.Spec.ClusterMetadata.ClusterID
-		provision.Spec.PrevInfraID = &cd.Spec.ClusterMetadata.InfraID
+	// Copy over the name, cluster ID and infra ID from previous provision so that a failed install can be removed.
+	if lastFailedProvision != nil {
+		provision.Spec.PrevProvisionName = &lastFailedProvision.Name
+		provision.Spec.PrevClusterID = lastFailedProvision.Spec.ClusterID
+		provision.Spec.PrevInfraID = lastFailedProvision.Spec.InfraID
 	}
 
 	logger.WithField("derivedObject", provision.Name).Debug("Setting label on derived object")

--- a/pkg/installmanager/helper_test.go
+++ b/pkg/installmanager/helper_test.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakekubeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -43,6 +44,21 @@ func testClusterProvision() *hivev1.ClusterProvision {
 				Name: testDeploymentName,
 			},
 			Stage: hivev1.ClusterProvisionStageProvisioning,
+		},
+	}
+}
+func testClusterProvisionWithInfraIDSet() *hivev1.ClusterProvision {
+	return &hivev1.ClusterProvision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testProvisionName,
+			Namespace: testNamespace,
+		},
+		Spec: hivev1.ClusterProvisionSpec{
+			ClusterDeploymentRef: corev1.LocalObjectReference{
+				Name: testDeploymentName,
+			},
+			Stage:   hivev1.ClusterProvisionStageProvisioning,
+			InfraID: pointer.StringPtr("dummy-infra-id"),
 		},
 	}
 }

--- a/pkg/installmanager/installmanager_test.go
+++ b/pkg/installmanager/installmanager_test.go
@@ -145,6 +145,11 @@ func TestInstallManager(t *testing.T) {
 			expectPasswordSecret:          true,
 			expectProvisionMetadataUpdate: true,
 		},
+		{
+			name:        "infraID already set on cluster provision", // fatal error
+			existing:    []runtime.Object{testClusterDeployment(), testClusterProvisionWithInfraIDSet()},
+			expectError: true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterprovision_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterprovision_types.go
@@ -44,6 +44,9 @@ type ClusterProvisionSpec struct {
 
 	// PrevInfraID is the infra ID of the previous failed provision attempt.
 	PrevInfraID *string `json:"prevInfraID,omitempty"`
+
+	// PrevProvisionName is the name of the previous failed provision attempt.
+	PrevProvisionName *string `json:"prevProvisionName,omitempty"`
 }
 
 // ClusterProvisionStatus defines the observed state of ClusterProvision.

--- a/vendor/github.com/openshift/hive/apis/hive/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/zz_generated.deepcopy.go
@@ -1536,6 +1536,11 @@ func (in *ClusterProvisionSpec) DeepCopyInto(out *ClusterProvisionSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.PrevProvisionName != nil {
+		in, out := &in.PrevProvisionName, &out.PrevProvisionName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
This PR adds error message in the install log if we detect a
infraID set on cluster provision by previous install pod which
got killed or evicted midway through the installation process.
We also fail the cluster provision in this case. Earlier we use
to start a new install attempt which failed to update cluster
provision infraID - an immutable field giving a not so user
friendly admission webhook failure message.

    
This PR also fixes the bug where secrets associated with the
failed cluster provisions were getting leaked. We now store
the name of the previous provision and use it to delete
leaked secrets in the next provision attempt.

x-ref: https://issues.redhat.com/browse/HIVE-1725