### PR TITLE
ClusterClaim: ClusterRunning cond => ClusterState status

### DIFF
--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -429,32 +429,32 @@ var PositivePolarityClusterDeploymentConditions = []ClusterDeploymentConditionTy
 
 // Cluster hibernating and ready reasons
 const (
-	// ResumingOrRunningHibernationReason is used as the reason for the Hibernating condition when the cluster
+	// ResumingOrRunningHibernatingReason is used as the reason for the Hibernating condition when the cluster
 	// is resuming or running. Precise details are available in the Ready condition.
-	ResumingOrRunningHibernationReason = "ResumingOrRunning"
-	// StoppingHibernationReason is used as the reason when the cluster is transitioning
+	ResumingOrRunningHibernatingReason = "ResumingOrRunning"
+	// StoppingHibernatingReason is used as the reason when the cluster is transitioning
 	// from a Running state to a Hibernating state.
-	StoppingHibernationReason = "Stopping"
+	StoppingHibernatingReason = "Stopping"
 	// WaitingForMachinesToStopHibernatingReason is used on the Hibernating condition when waiting for cloud VMs to stop
 	WaitingForMachinesToStopHibernatingReason = "WaitingForMachinesToStop"
-	// HibernatingHibernationReason is used as the reason when the cluster is in a
+	// HibernatingHibernatingReason is used as the reason when the cluster is in a
 	// Hibernating state.
-	HibernatingHibernationReason = "Hibernating"
-	// UnsupportedHibernationReason is used as the reason when the cluster spec
+	HibernatingHibernatingReason = string(HibernatingClusterPowerState)
+	// UnsupportedHibernatingReason is used as the reason when the cluster spec
 	// specifies that the cluster be moved to a Hibernating state, but either the cluster
 	// version is not compatible with hibernation (< 4.4.8) or the cloud provider of
 	// the cluster is not supported.
-	UnsupportedHibernationReason = "Unsupported"
-	// FailedToStopHibernationReason is used when there was an error stopping machines
+	UnsupportedHibernatingReason = "Unsupported"
+	// FailedToStopHibernatingReason is used when there was an error stopping machines
 	// to enter hibernation
-	FailedToStopHibernationReason = "FailedToStop"
-	// SyncSetsNotAppliedReason is used as the reason when SyncSets have not yet been applied
+	FailedToStopHibernatingReason = "FailedToStop"
+	// SyncSetsNotAppliedHibernatingReason is used as the reason when SyncSets have not yet been applied
 	// for the cluster based on ClusterSync.Status.FirstSucessTime
-	SyncSetsNotAppliedReason = "SyncSetsNotApplied"
-	// SyncSetsAppliedReason means SyncSets have been successfully applied at some point.
+	SyncSetsNotAppliedHibernatingReason = "SyncSetsNotApplied"
+	// SyncSetsAppliedHibernatingReason means SyncSets have been successfully applied at some point.
 	// (It does not necessarily mean they are currently copacetic -- check ClusterSync status
 	// for that.)
-	SyncSetsAppliedReason = "SyncSetsApplied"
+	SyncSetsAppliedHibernatingReason = "SyncSetsApplied"
 
 	// StoppingOrHibernatingReadyReason is used as the reason for the Ready condition when the cluster
 	// is stopping or hibernating. Precise details are available in the Hibernating condition.
@@ -474,7 +474,7 @@ const (
 	// get to a good state. (Available=True, Processing=False, Degraded=False)
 	WaitingForClusterOperatorsReadyReason = "WaitingForClusterOperators"
 	// RunningReadyReason is used on the Ready condition as the reason when the cluster is running and ready
-	RunningReadyReason = "Running"
+	RunningReadyReason = string(RunningClusterPowerState)
 )
 
 // Provisioned status condition reasons

--- a/apis/hive/v1/clusterpool_types.go
+++ b/apis/hive/v1/clusterpool_types.go
@@ -110,7 +110,11 @@ type ClusterPoolStatus struct {
 	// Size is the number of unclaimed clusters that have been created for the pool.
 	Size int32 `json:"size"`
 
-	// Ready is the number of unclaimed clusters that have been installed and are ready to be claimed.
+	// Standby is the number of unclaimed clusters that are installed, but not running.
+	// +optional
+	Standby int32 `json:"standby"`
+
+	// Ready is the number of unclaimed clusters that are installed and are running and ready to be claimed.
 	Ready int32 `json:"ready"`
 
 	// Conditions includes more detailed status for the cluster pool
@@ -161,8 +165,9 @@ const (
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.size,statuspath=.status.size
-// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready"
 // +kubebuilder:printcolumn:name="Size",type="string",JSONPath=".spec.size"
+// +kubebuilder:printcolumn:name="Standby",type="string",JSONPath=".status.standby"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready"
 // +kubebuilder:printcolumn:name="BaseDomain",type="string",JSONPath=".spec.baseDomain"
 // +kubebuilder:printcolumn:name="ImageSet",type="string",JSONPath=".spec.imageSetRef.name"
 // +kubebuilder:resource:path=clusterpools,shortName=cp

--- a/config/crds/hive.openshift.io_clusterclaims.yaml
+++ b/config/crds/hive.openshift.io_clusterclaims.yaml
@@ -21,11 +21,11 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Pending')].reason
       name: Pending
       type: string
+    - jsonPath: .status.clusterState
+      name: ClusterState
+      type: string
     - jsonPath: .spec.namespace
       name: ClusterNamespace
-      type: string
-    - jsonPath: .status.conditions[?(@.type=='ClusterRunning')].reason
-      name: ClusterRunning
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -64,9 +64,7 @@ spec:
               namespace:
                 description: Namespace is the namespace containing the ClusterDeployment
                   (name will match the namespace) of the claimed cluster. This field
-                  will be set as soon as a suitable cluster can be found, however
-                  that cluster may still be resuming and not yet ready for use. Wait
-                  for the ClusterRunning condition to be true to avoid this issue.
+                  will be set as soon as a suitable cluster can be found.
                 type: string
               subjects:
                 description: Subjects hold references to which to authorize access
@@ -107,6 +105,10 @@ spec:
           status:
             description: ClusterClaimStatus defines the observed state of ClusterClaim.
             properties:
+              clusterState:
+                description: ClusterState indicates the status of the cluster assigned
+                  to this ClusterClaim.
+                type: string
               conditions:
                 description: Conditions includes more detailed status for the cluster
                   pool.

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -17,11 +17,14 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.ready
-      name: Ready
-      type: string
     - jsonPath: .spec.size
       name: Size
+      type: string
+    - jsonPath: .status.standby
+      name: Standby
+      type: string
+    - jsonPath: .status.ready
+      name: Ready
       type: string
     - jsonPath: .spec.baseDomain
       name: BaseDomain
@@ -541,13 +544,18 @@ spec:
                   type: object
                 type: array
               ready:
-                description: Ready is the number of unclaimed clusters that have been
-                  installed and are ready to be claimed.
+                description: Ready is the number of unclaimed clusters that are installed
+                  and are running and ready to be claimed.
                 format: int32
                 type: integer
               size:
                 description: Size is the number of unclaimed clusters that have been
                   created for the pool.
+                format: int32
+                type: integer
+              standby:
+                description: Standby is the number of unclaimed clusters that are
+                  installed, but not running.
                 format: int32
                 type: integer
             required:

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -104,11 +104,11 @@ objects:
       - jsonPath: .status.conditions[?(@.type=='Pending')].reason
         name: Pending
         type: string
+      - jsonPath: .status.clusterState
+        name: ClusterState
+        type: string
       - jsonPath: .spec.namespace
         name: ClusterNamespace
-        type: string
-      - jsonPath: .status.conditions[?(@.type=='ClusterRunning')].reason
-        name: ClusterRunning
         type: string
       - jsonPath: .metadata.creationTimestamp
         name: Age
@@ -150,10 +150,7 @@ objects:
                 namespace:
                   description: Namespace is the namespace containing the ClusterDeployment
                     (name will match the namespace) of the claimed cluster. This field
-                    will be set as soon as a suitable cluster can be found, however
-                    that cluster may still be resuming and not yet ready for use.
-                    Wait for the ClusterRunning condition to be true to avoid this
-                    issue.
+                    will be set as soon as a suitable cluster can be found.
                   type: string
                 subjects:
                   description: Subjects hold references to which to authorize access
@@ -194,6 +191,10 @@ objects:
             status:
               description: ClusterClaimStatus defines the observed state of ClusterClaim.
               properties:
+                clusterState:
+                  description: ClusterState indicates the status of the cluster assigned
+                    to this ClusterClaim.
+                  type: string
                 conditions:
                   description: Conditions includes more detailed status for the cluster
                     pool.

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -1707,11 +1707,14 @@ objects:
     scope: Namespaced
     versions:
     - additionalPrinterColumns:
-      - jsonPath: .status.ready
-        name: Ready
-        type: string
       - jsonPath: .spec.size
         name: Size
+        type: string
+      - jsonPath: .status.standby
+        name: Standby
+        type: string
+      - jsonPath: .status.ready
+        name: Ready
         type: string
       - jsonPath: .spec.baseDomain
         name: BaseDomain
@@ -2243,13 +2246,18 @@ objects:
                     type: object
                   type: array
                 ready:
-                  description: Ready is the number of unclaimed clusters that have
-                    been installed and are ready to be claimed.
+                  description: Ready is the number of unclaimed clusters that are
+                    installed and are running and ready to be claimed.
                   format: int32
                   type: integer
                 size:
                   description: Size is the number of unclaimed clusters that have
                     been created for the pool.
+                  format: int32
+                  type: integer
+                standby:
+                  description: Standby is the number of unclaimed clusters that are
+                    installed, but not running.
                   format: int32
                   type: integer
               required:

--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -98,7 +98,7 @@ function wait_for_pool_to_be_ready() {
   local poolname=$1
   local i=0
   # NOTE: This will need to change if we add a test with a zero-size pool.
-  while [[ $(oc get clusterpool $poolname -o json | jq '.status.size != 0 and .status.ready == .status.size') != "true" ]] || ! expect_all_clusters_current $poolname True; do
+  while [[ $(oc get clusterpool $poolname -o json | jq '.status.size != 0 and .status.ready + .status.standby == .status.size') != "true" ]] || ! expect_all_clusters_current $poolname True; do
     i=$((i+1))
     if [[ $i -gt $max_cluster_deployment_status_checks ]]; then
       echo "Timed out waiting for clusterpool $poolname to be ready."

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -49,9 +49,6 @@ const (
 )
 
 var (
-	// controllerKind contains the schema.GroupVersionKind for this controller type.
-	controllerKind = hivev1.SchemeGroupVersion.WithKind("ClusterPool")
-
 	// clusterPoolConditions are the cluster pool conditions controlled or initialized by cluster pool controller
 	clusterPoolConditions = []hivev1.ClusterPoolConditionType{
 		hivev1.ClusterPoolMissingDependenciesCondition,

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -299,7 +299,8 @@ func (r *ReconcileClusterPool) Reconcile(ctx context.Context, request reconcile.
 	cds.SyncClaimAssignments(r.Client, claims, logger)
 
 	origStatus := clp.Status.DeepCopy()
-	clp.Status.Size = int32(len(cds.Installing()) + len(cds.Assignable()) + len(cds.Broken()))
+	clp.Status.Size = int32(len(cds.Unassigned(true)))
+	clp.Status.Standby = int32(len(cds.Standby()))
 	clp.Status.Ready = int32(len(cds.Assignable()))
 	if !reflect.DeepEqual(origStatus, &clp.Status) {
 		if err := r.Status().Update(context.Background(), clp); err != nil {
@@ -311,11 +312,10 @@ func (r *ReconcileClusterPool) Reconcile(ctx context.Context, request reconcile.
 	availableCapacity := math.MaxInt32
 	if clp.Spec.MaxSize != nil {
 		availableCapacity = int(*clp.Spec.MaxSize) - cds.Total()
-		numUnassigned := len(cds.Installing()) + len(cds.Assignable()) + len(cds.Broken())
 		numAssigned := cds.NumAssigned()
 		if availableCapacity <= 0 {
 			logger.WithFields(log.Fields{
-				"UnclaimedSize": numUnassigned,
+				"UnclaimedSize": len(cds.Unassigned(true)),
 				"ClaimedSize":   numAssigned,
 				"Capacity":      *clp.Spec.MaxSize,
 			}).Info("Cannot add more clusters because no capacity available.")
@@ -324,23 +324,6 @@ func (r *ReconcileClusterPool) Reconcile(ctx context.Context, request reconcile.
 	if err := r.setAvailableCapacityCondition(clp, availableCapacity > 0, logger); err != nil {
 		logger.WithError(err).Error("error setting CapacityAvailable condition")
 		return reconcile.Result{}, err
-	}
-
-	// reserveSize is the number of clusters that the pool currently has in reserve
-	reserveSize := len(cds.Installing()) + len(cds.Assignable()) + len(cds.Broken()) - len(claims.Unassigned())
-
-	// excessSize is the number of clusters in excess of the pool's capacity (Size) that we are
-	// creating to satisfy unassigned claims. For example:
-	// - In steady state, if Size=3 and we have 5 unassigned claims, excessSize is 2.
-	// - If Size=3, and we only have 2 clusters in the pool, and we have 6 unassigned claims,
-	//   excessSize is 4: the two existing clusters satisfy two of the claims, leaving four;
-	//   we need three to refill the pool and another four to fulfil the remaining unassigned
-	//   claims.
-	// - Any time the number of unassigned claims is less than the number of clusters in the
-	//   pool, we will be able to satisfy them from the pool, so excessSize is 0.
-	excessSize := 0
-	if reserveSize < 0 {
-		excessSize = -reserveSize
 	}
 
 	if err := assignClustersToClaims(r.Client, claims, cds, logger); err != nil {
@@ -369,7 +352,10 @@ func (r *ReconcileClusterPool) Reconcile(ctx context.Context, request reconcile.
 	}
 	availableCurrent -= toDel
 
-	switch drift := reserveSize - int(clp.Spec.Size); {
+	// drift will indicate how many clusters we need to add or delete to get back to steady state
+	// of the pool's Size. This needs to take into account the clusters we're creating to satisfy
+	// the immediate demand of pending claims.
+	switch drift := len(cds.Unassigned(true)) - int(clp.Spec.Size) - len(claims.Unassigned()); {
 	// activity quota exceeded, so no action
 	case availableCurrent <= 0:
 		logger.WithFields(log.Fields{
@@ -408,7 +394,7 @@ func (r *ReconcileClusterPool) Reconcile(ctx context.Context, request reconcile.
 		metricStaleClusterDeploymentsDeleted.WithLabelValues(clp.Namespace, clp.Name).Inc()
 	}
 
-	if err := r.reconcileRunningClusters(clp, cds, excessSize, logger); err != nil {
+	if err := r.reconcileRunningClusters(clp, cds, len(claims.Unassigned()), logger); err != nil {
 		log.WithError(err).Error("error updating hibernating/running state")
 		return reconcile.Result{}, err
 	}
@@ -429,19 +415,22 @@ func (r *ReconcileClusterPool) Reconcile(ctx context.Context, request reconcile.
 	return reconcile.Result{}, nil
 }
 
-// reconcileRunningClusters ensures the oldest pool.spec.runningCount unassigned clusters are
-// set to running, and the remainder are set to hibernating.
+// reconcileRunningClusters ensures the oldest unassigned clusters are set to running, and the
+// remainder are set to hibernating. The number of clusters we set to running is determined by
+// adding the cluster's configured runningCount to the number of unsatisfied claims for which we're
+// spinning up new clusters.
 func (r *ReconcileClusterPool) reconcileRunningClusters(
 	clp *hivev1.ClusterPool,
 	cds *cdCollection,
-	excessCount int,
+	extraRunning int,
 	logger log.FieldLogger,
 ) error {
 	// If we're creating excess clusters to satisfy unassigned claims, add that many
 	// to the runningCount. They'll get snatched up immediately, bringing the number
 	// of running clusters back down to runningCount once the pool reaches steady state.
-	runningCount := int(clp.Spec.RunningCount) + excessCount
-	cdList := append(cds.Assignable(), cds.Installing()...)
+	runningCount := int(clp.Spec.RunningCount) + extraRunning
+	// Exclude broken clusters
+	cdList := cds.Unassigned(false)
 	// Sort by age, oldest first
 	sort.Slice(
 		cdList,
@@ -741,6 +730,38 @@ func (r *ReconcileClusterPool) createRandomNamespace(clp *hivev1.ClusterPool) (*
 	return ns, err
 }
 
+func getClustersToDelete(cds *cdCollection, deletionsNeeded int, logger log.FieldLogger) []*hivev1.ClusterDeployment {
+	installingClusters := cds.Installing()
+	if deletionsNeeded <= len(installingClusters) {
+		return installingClusters[:deletionsNeeded]
+	}
+
+	clustersToDelete := installingClusters
+	origDeletionsNeeded := deletionsNeeded
+	deletionsNeeded -= len(installingClusters)
+
+	standbyClusters := cds.Standby()
+	if deletionsNeeded <= len(standbyClusters) {
+		return append(clustersToDelete, standbyClusters[:deletionsNeeded]...)
+	}
+
+	clustersToDelete = append(clustersToDelete, standbyClusters...)
+	deletionsNeeded -= len(standbyClusters)
+
+	readyClusters := cds.Assignable()
+	if deletionsNeeded <= len(readyClusters) {
+		return append(clustersToDelete, readyClusters[:deletionsNeeded]...)
+	}
+
+	logger.WithField("deletionsNeeded", origDeletionsNeeded).
+		WithField("installingClusters", len(installingClusters)).
+		WithField("standbyClusters", len(standbyClusters)).
+		WithField("readyClusters", len(readyClusters)).
+		Error("trying to delete more clusters than there are available")
+
+	return append(clustersToDelete, readyClusters...)
+}
+
 func (r *ReconcileClusterPool) deleteExcessClusters(
 	cds *cdCollection,
 	deletionsNeeded int,
@@ -748,24 +769,7 @@ func (r *ReconcileClusterPool) deleteExcessClusters(
 ) error {
 
 	logger.WithField("deletionsNeeded", deletionsNeeded).Info("deleting excess clusters")
-	clustersToDelete := make([]*hivev1.ClusterDeployment, 0, deletionsNeeded)
-	installingClusters := cds.Installing()
-	readyClusters := cds.Assignable()
-	if deletionsNeeded < len(installingClusters) {
-		clustersToDelete = installingClusters[:deletionsNeeded]
-	} else {
-		clustersToDelete = append(clustersToDelete, installingClusters...)
-		deletionsOfInstalledClustersNeeded := deletionsNeeded - len(installingClusters)
-		if deletionsOfInstalledClustersNeeded <= len(readyClusters) {
-			clustersToDelete = append(clustersToDelete, readyClusters[:deletionsOfInstalledClustersNeeded]...)
-		} else {
-			logger.WithField("deletionsNeeded", deletionsNeeded).
-				WithField("installingClusters", len(installingClusters)).
-				WithField("installedClusters", len(readyClusters)).
-				Error("trying to delete more clusters than there are available")
-			clustersToDelete = append(clustersToDelete, readyClusters...)
-		}
-	}
+	clustersToDelete := getClustersToDelete(cds, deletionsNeeded, logger)
 	for _, cd := range clustersToDelete {
 		logger := logger.WithField("cluster", cd.Name)
 		logger.Info("deleting cluster deployment")
@@ -802,7 +806,7 @@ func (r *ReconcileClusterPool) reconcileDeletedPool(pool *hivev1.ClusterPool, lo
 	if err != nil {
 		return err
 	}
-	for _, cd := range append(cds.Assignable(), cds.Installing()...) {
+	for _, cd := range cds.Unassigned(true) {
 		if cd.DeletionTimestamp != nil {
 			continue
 		}
@@ -811,6 +815,7 @@ func (r *ReconcileClusterPool) reconcileDeletedPool(pool *hivev1.ClusterPool, lo
 			return errors.Wrap(err, "could not delete ClusterDeployment")
 		}
 	}
+	// TODO: Wait to remove finalizer until all (unclaimed??) clusters are gone.
 	controllerutils.DeleteFinalizer(pool, finalizer)
 	if err := r.Update(context.Background(), pool); err != nil {
 		logger.WithError(err).Log(controllerutils.LogLevel(err), "could not remove finalizer from ClusterPool")

--- a/pkg/controller/clusterpool/collections.go
+++ b/pkg/controller/clusterpool/collections.go
@@ -190,8 +190,10 @@ func (c *claimCollection) Untrack(claimNames ...string) {
 }
 
 type cdCollection struct {
-	// Unclaimed installed clusters which belong to this pool and are not (marked for) deleting
+	// Unclaimed, installed, running clusters which belong to this pool and are not (marked for) deleting
 	assignable []*hivev1.ClusterDeployment
+	// Unclaimed, installed, non-deleted clusters which are not running and therefore not (yet) assignable
+	standby []*hivev1.ClusterDeployment
 	// Unclaimed installing clusters which belong to this pool and are not (marked for) deleting
 	installing []*hivev1.ClusterDeployment
 	// Clusters with a DeletionTimestamp. Mutually exclusive with markedForDeletion.
@@ -246,6 +248,7 @@ func getAllClusterDeploymentsForPool(c client.Client, pool *hivev1.ClusterPool, 
 	}
 	cdCol := cdCollection{
 		assignable:            make([]*hivev1.ClusterDeployment, 0),
+		standby:               make([]*hivev1.ClusterDeployment, 0),
 		installing:            make([]*hivev1.ClusterDeployment, 0),
 		deleting:              make([]*hivev1.ClusterDeployment, 0),
 		broken:                make([]*hivev1.ClusterDeployment, 0),
@@ -254,7 +257,6 @@ func getAllClusterDeploymentsForPool(c client.Client, pool *hivev1.ClusterPool, 
 		byCDName:              make(map[string]*hivev1.ClusterDeployment),
 		byClaimName:           make(map[string]*hivev1.ClusterDeployment),
 	}
-	running := 0
 	for i, cd := range cdList.Items {
 		poolRef := cd.Spec.ClusterPoolRef
 		if poolRef == nil || poolRef.Namespace != pool.Namespace || poolRef.PoolName != pool.Name {
@@ -278,9 +280,10 @@ func getAllClusterDeploymentsForPool(c client.Client, pool *hivev1.ClusterPool, 
 			if isBroken(&cd) {
 				cdCol.broken = append(cdCol.broken, ref)
 			} else if cd.Spec.Installed {
-				cdCol.assignable = append(cdCol.assignable, ref)
 				if cd.Status.PowerState == string(hivev1.RunningClusterPowerState) {
-					running++
+					cdCol.assignable = append(cdCol.assignable, ref)
+				} else {
+					cdCol.standby = append(cdCol.standby, ref)
 				}
 			} else {
 				cdCol.installing = append(cdCol.installing, ref)
@@ -312,6 +315,13 @@ func getAllClusterDeploymentsForPool(c client.Client, pool *hivev1.ClusterPool, 
 			return cdCol.assignable[i].CreationTimestamp.Before(&cdCol.assignable[j].CreationTimestamp)
 		},
 	)
+	// Sort standby CDs so we delete them in FIFO order
+	sort.Slice(
+		cdCol.standby,
+		func(i, j int) bool {
+			return cdCol.standby[i].CreationTimestamp.Before(&cdCol.standby[j].CreationTimestamp)
+		},
+	)
 	cdCol.sortInstalling()
 	// Sort stale CDs by age so we delete the oldest first
 	sort.Slice(
@@ -329,11 +339,11 @@ func getAllClusterDeploymentsForPool(c client.Client, pool *hivev1.ClusterPool, 
 
 	logger.WithFields(log.Fields{
 		"assignable": len(cdCol.assignable),
+		"standby":    len(cdCol.standby),
 		"claimed":    len(cdCol.byClaimName),
 		"deleting":   len(cdCol.deleting),
 		"installing": len(cdCol.installing),
 		"unclaimed":  len(cdCol.installing) + len(cdCol.assignable),
-		"running":    running,
 		"stale":      len(cdCol.unknownPoolVersion) + len(cdCol.mismatchedPoolVersion),
 		"broken":     len(cdCol.broken),
 	}).Debug("found clusters for ClusterPool")
@@ -342,8 +352,8 @@ func getAllClusterDeploymentsForPool(c client.Client, pool *hivev1.ClusterPool, 
 	metricClusterDeploymentsClaimed.WithLabelValues(pool.Namespace, pool.Name).Set(float64(len(cdCol.byClaimName)))
 	metricClusterDeploymentsDeleting.WithLabelValues(pool.Namespace, pool.Name).Set(float64(len(cdCol.deleting)))
 	metricClusterDeploymentsInstalling.WithLabelValues(pool.Namespace, pool.Name).Set(float64(len(cdCol.installing)))
-	metricClusterDeploymentsUnclaimed.WithLabelValues(pool.Namespace, pool.Name).Set(float64(len(cdCol.installing) + len(cdCol.assignable)))
-	metricClusterDeploymentsRunning.WithLabelValues(pool.Namespace, pool.Name).Set(float64(running))
+	metricClusterDeploymentsUnclaimed.WithLabelValues(pool.Namespace, pool.Name).Set(float64(len(cdCol.installing) + len(cdCol.standby) + len(cdCol.assignable)))
+	metricClusterDeploymentsStandby.WithLabelValues(pool.Namespace, pool.Name).Set(float64(len(cdCol.standby)))
 	metricClusterDeploymentsStale.WithLabelValues(pool.Namespace, pool.Name).Set(float64(len(cdCol.unknownPoolVersion) + len(cdCol.mismatchedPoolVersion)))
 	metricClusterDeploymentsBroken.WithLabelValues(pool.Namespace, pool.Name).Set(float64(len(cdCol.broken)))
 
@@ -370,6 +380,11 @@ func (cds *cdCollection) Assignable() []*hivev1.ClusterDeployment {
 	return cds.assignable
 }
 
+// Standby returns a list of refs to ClusterDeployments that are not running, but otherwise ready
+func (cds *cdCollection) Standby() []*hivev1.ClusterDeployment {
+	return cds.standby
+}
+
 // Deleting returns the list of ClusterDeployments whose DeletionTimestamp is set. Not to be
 // confused with MarkedForDeletion.
 func (cds *cdCollection) Deleting() []*hivev1.ClusterDeployment {
@@ -392,6 +407,18 @@ func (cds *cdCollection) Installing() []*hivev1.ClusterDeployment {
 // Broken returns the list of ClusterDeployments we've deemed unrecoverably broken.
 func (cds *cdCollection) Broken() []*hivev1.ClusterDeployment {
 	return cds.broken
+}
+
+// Unassigned returns a *copy* of the list of unclaimed, non-deleted/deleting ClusterDeployments
+func (cds *cdCollection) Unassigned(includeBroken bool) []*hivev1.ClusterDeployment {
+	ret := make([]*hivev1.ClusterDeployment, len(cds.installing))
+	copy(ret, cds.installing)
+	ret = append(ret, cds.standby...)
+	ret = append(ret, cds.assignable...)
+	if includeBroken {
+		ret = append(ret, cds.broken...)
+	}
+	return ret
 }
 
 // UnknownPoolVersion returns the list of ClusterDeployments whose pool version annotation is

--- a/pkg/controller/clusterpool/metrics.go
+++ b/pkg/controller/clusterpool/metrics.go
@@ -9,7 +9,7 @@ import (
 var (
 	metricClusterDeploymentsAssignable = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "hive_clusterpool_clusterdeployments_assignable",
-		Help: "The number of ClusterDeployments ready to be claimed. Contributes to Size and MaxSize.",
+		Help: "The number of ClusterDeployments ready to be claimed (installed and running). Contributes to Size and MaxSize.",
 	}, []string{"clusterpool_namespace", "clusterpool_name"})
 	metricClusterDeploymentsClaimed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "hive_clusterpool_clusterdeployments_claimed",
@@ -25,11 +25,11 @@ var (
 	}, []string{"clusterpool_namespace", "clusterpool_name"})
 	metricClusterDeploymentsUnclaimed = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "hive_clusterpool_clusterdeployments_unclaimed",
-		Help: "The number of unclaimed ClusterDeployments, including both installing and assignable. Should tend toward the pool Size, unless constrained by MaxConcurrent or exceeded due to excess claims.",
+		Help: "The number of unclaimed ClusterDeployments, including installing, standby, and assignable. Should tend toward the pool Size, unless constrained by MaxConcurrent or exceeded due to excess claims.",
 	}, []string{"clusterpool_namespace", "clusterpool_name"})
-	metricClusterDeploymentsRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "hive_clusterpool_clusterdeployments_running",
-		Help: "The subset of assignable ClusterDeployments that are in Running state. Should tend toward RunningCount plus the number of pending ClusterClaims.",
+	metricClusterDeploymentsStandby = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "hive_clusterpool_clusterdeployments_standby",
+		Help: "The number of ClusterDeployments that are installed but not running. Should tend toward pool Size minus RunningCount minus the number of pending ClusterClaims.",
 	}, []string{"clusterpool_namespace", "clusterpool_name"})
 	metricClusterDeploymentsStale = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "hive_clusterpool_clusterdeployments_stale",
@@ -71,7 +71,7 @@ func init() {
 	metrics.Registry.MustRegister(metricClusterDeploymentsDeleting)
 	metrics.Registry.MustRegister(metricClusterDeploymentsInstalling)
 	metrics.Registry.MustRegister(metricClusterDeploymentsUnclaimed)
-	metrics.Registry.MustRegister(metricClusterDeploymentsRunning)
+	metrics.Registry.MustRegister(metricClusterDeploymentsStandby)
 	metrics.Registry.MustRegister(metricClusterDeploymentsStale)
 	metrics.Registry.MustRegister(metricClusterDeploymentsBroken)
 	metrics.Registry.MustRegister(metricStaleClusterDeploymentsDeleted)

--- a/pkg/controller/hibernation/aws_actuator_test.go
+++ b/pkg/controller/hibernation/aws_actuator_test.go
@@ -266,7 +266,7 @@ func TestReplacePreemptibleMachines(t *testing.T) {
 		testcd.WithClusterVersion("4.4.9"),
 		testcd.WithCondition(hivev1.ClusterDeploymentCondition{
 			Type:               hivev1.ClusterHibernatingCondition,
-			Reason:             hivev1.HibernatingHibernationReason,
+			Reason:             hivev1.HibernatingHibernatingReason,
 			Status:             corev1.ConditionFalse,
 			LastTransitionTime: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
 		}),

--- a/pkg/controller/hibernation/hibernation_controller_test.go
+++ b/pkg/controller/hibernation/hibernation_controller_test.go
@@ -105,7 +105,7 @@ func TestReconcile(t *testing.T) {
 				cond, _ := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.UnsupportedHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.UnsupportedHibernatingReason, cond.Reason)
 			},
 		},
 		{
@@ -114,7 +114,7 @@ func TestReconcile(t *testing.T) {
 				testcd.WithCondition(hivev1.ClusterDeploymentCondition{
 					Type:    hivev1.ClusterHibernatingCondition,
 					Status:  corev1.ConditionFalse,
-					Reason:  hivev1.UnsupportedHibernationReason,
+					Reason:  hivev1.UnsupportedHibernatingReason,
 					Message: "Unsupported version, need version 4.4.8 or greater"})).Build(),
 			cs: csBuilder.Build(),
 			setupActuator: func(actuator *mock.MockHibernationActuator) {
@@ -130,7 +130,7 @@ func TestReconcile(t *testing.T) {
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
-				assert.Equal(t, hivev1.UnsupportedHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.UnsupportedHibernatingReason, cond.Reason)
 				require.NotNil(t, runCond)
 				assert.Equal(t, hivev1.RunningReadyReason, runCond.Reason)
 				assert.Equal(t, hivev1.RunningReadyReason, cd.Status.PowerState)
@@ -144,7 +144,7 @@ func TestReconcile(t *testing.T) {
 				cond, _ := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.UnsupportedHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.UnsupportedHibernatingReason, cond.Reason)
 			},
 		},
 		{
@@ -164,8 +164,8 @@ func TestReconcile(t *testing.T) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.StoppingHibernationReason, cond.Reason)
-				assert.Equal(t, hivev1.StoppingHibernationReason, cd.Status.PowerState)
+				assert.Equal(t, hivev1.StoppingHibernatingReason, cond.Reason)
+				assert.Equal(t, hivev1.StoppingHibernatingReason, cd.Status.PowerState)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
 				assert.Equal(t, hivev1.StoppingOrHibernatingReadyReason, runCond.Reason)
@@ -179,8 +179,8 @@ func TestReconcile(t *testing.T) {
 				cond, _ := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.SyncSetsNotAppliedReason, cond.Reason)
-				assert.Equal(t, hivev1.SyncSetsNotAppliedReason, cd.Status.PowerState)
+				assert.Equal(t, hivev1.SyncSetsNotAppliedHibernatingReason, cond.Reason)
+				assert.Equal(t, hivev1.SyncSetsNotAppliedHibernatingReason, cd.Status.PowerState)
 			},
 			expectError:        false,
 			expectRequeueAfter: time.Duration(time.Minute * 10),
@@ -192,7 +192,7 @@ func TestReconcile(t *testing.T) {
 				testcd.WithCondition(hivev1.ClusterDeploymentCondition{
 					Type:    hivev1.ClusterHibernatingCondition,
 					Status:  corev1.ConditionFalse,
-					Reason:  hivev1.SyncSetsNotAppliedReason,
+					Reason:  hivev1.SyncSetsNotAppliedHibernatingReason,
 					Message: "Cluster SyncSets have not been applied",
 				}),
 			).Build(),
@@ -200,7 +200,7 @@ func TestReconcile(t *testing.T) {
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
 				cond, _ := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
-				assert.Equal(t, hivev1.SyncSetsAppliedReason, cond.Reason)
+				assert.Equal(t, hivev1.SyncSetsAppliedHibernatingReason, cond.Reason)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
 			},
 		},
@@ -210,7 +210,7 @@ func TestReconcile(t *testing.T) {
 				testcd.WithCondition(hivev1.ClusterDeploymentCondition{
 					Type:    hivev1.ClusterHibernatingCondition,
 					Status:  corev1.ConditionFalse,
-					Reason:  hivev1.SyncSetsAppliedReason,
+					Reason:  hivev1.SyncSetsAppliedHibernatingReason,
 					Message: "SyncSets have been applied"}),
 				testcd.WithCondition(hivev1.ClusterDeploymentCondition{
 					Type:   hivev1.ClusterReadyCondition,
@@ -243,8 +243,8 @@ func TestReconcile(t *testing.T) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.StoppingHibernationReason, cond.Reason)
-				assert.Equal(t, hivev1.StoppingHibernationReason, cd.Status.PowerState)
+				assert.Equal(t, hivev1.StoppingHibernatingReason, cond.Reason)
+				assert.Equal(t, hivev1.StoppingHibernatingReason, cd.Status.PowerState)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
 				assert.Equal(t, hivev1.StoppingOrHibernatingReadyReason, runCond.Reason)
@@ -261,8 +261,8 @@ func TestReconcile(t *testing.T) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.StoppingHibernationReason, cond.Reason)
-				assert.Equal(t, hivev1.StoppingHibernationReason, cd.Status.PowerState)
+				assert.Equal(t, hivev1.StoppingHibernatingReason, cond.Reason)
+				assert.Equal(t, hivev1.StoppingHibernatingReason, cd.Status.PowerState)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
 				assert.Equal(t, hivev1.StoppingOrHibernatingReadyReason, runCond.Reason)
@@ -280,8 +280,8 @@ func TestReconcile(t *testing.T) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.FailedToStopHibernationReason, cond.Reason)
-				assert.Equal(t, hivev1.FailedToStopHibernationReason, cd.Status.PowerState)
+				assert.Equal(t, hivev1.FailedToStopHibernatingReason, cond.Reason)
+				assert.Equal(t, hivev1.FailedToStopHibernatingReason, cd.Status.PowerState)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
 				assert.Equal(t, hivev1.StoppingOrHibernatingReadyReason, runCond.Reason)
@@ -303,8 +303,8 @@ func TestReconcile(t *testing.T) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionTrue, cond.Status)
-				assert.Equal(t, hivev1.HibernatingHibernationReason, cond.Reason)
-				assert.Equal(t, hivev1.HibernatingHibernationReason, cd.Status.PowerState)
+				assert.Equal(t, hivev1.HibernatingHibernatingReason, cond.Reason)
+				assert.Equal(t, hivev1.HibernatingHibernatingReason, cd.Status.PowerState)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
 				assert.Equal(t, hivev1.StoppingOrHibernatingReadyReason, runCond.Reason)
@@ -347,8 +347,8 @@ func TestReconcile(t *testing.T) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.StoppingHibernationReason, cond.Reason)
-				assert.Equal(t, hivev1.StoppingHibernationReason, cd.Status.PowerState)
+				assert.Equal(t, hivev1.StoppingHibernatingReason, cond.Reason)
+				assert.Equal(t, hivev1.StoppingHibernatingReason, cd.Status.PowerState)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
 				assert.Equal(t, hivev1.StoppingOrHibernatingReadyReason, runCond.Reason)
@@ -365,7 +365,7 @@ func TestReconcile(t *testing.T) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.ResumingOrRunningHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.ResumingOrRunningHibernatingReason, cond.Reason)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
 				assert.Equal(t, hivev1.StartingMachinesReadyReason, runCond.Reason)
@@ -384,7 +384,7 @@ func TestReconcile(t *testing.T) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.ResumingOrRunningHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.ResumingOrRunningHibernatingReason, cond.Reason)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
 				assert.Equal(t, hivev1.FailedToStartMachinesReadyReason, runCond.Reason)
@@ -408,8 +408,8 @@ func TestReconcile(t *testing.T) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.StoppingHibernationReason, cond.Reason)
-				assert.Equal(t, hivev1.StoppingHibernationReason, cd.Status.PowerState)
+				assert.Equal(t, hivev1.StoppingHibernatingReason, cond.Reason)
+				assert.Equal(t, hivev1.StoppingHibernatingReason, cd.Status.PowerState)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
 				assert.Equal(t, hivev1.StoppingOrHibernatingReadyReason, runCond.Reason)
@@ -418,7 +418,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "resuming, machines have not started",
 			cd: cdBuilder.Options(o.shouldRun).Build(
-				testcd.WithCondition(hibernatingCondition(corev1.ConditionFalse, hivev1.ResumingOrRunningHibernationReason, 6*time.Hour)),
+				testcd.WithCondition(hibernatingCondition(corev1.ConditionFalse, hivev1.ResumingOrRunningHibernatingReason, 6*time.Hour)),
 				testcd.WithCondition(readyCondition(corev1.ConditionFalse, hivev1.StartingMachinesReadyReason, 1*time.Hour))),
 			cs: csBuilder.Build(),
 			setupActuator: func(actuator *mock.MockHibernationActuator) {
@@ -430,7 +430,7 @@ func TestReconcile(t *testing.T) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.ResumingOrRunningHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.ResumingOrRunningHibernatingReason, cond.Reason)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
 				assert.Equal(t, hivev1.WaitingForMachinesReadyReason, runCond.Reason)
@@ -442,7 +442,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "resuming unready node",
 			cd: cdBuilder.Options().Build(
-				testcd.WithCondition(hibernatingCondition(corev1.ConditionFalse, hivev1.ResumingOrRunningHibernationReason, 6*time.Hour)),
+				testcd.WithCondition(hibernatingCondition(corev1.ConditionFalse, hivev1.ResumingOrRunningHibernatingReason, 6*time.Hour)),
 				testcd.WithCondition(readyCondition(corev1.ConditionFalse, "unused", 6*time.Hour))),
 			cs: csBuilder.Build(),
 			setupActuator: func(actuator *mock.MockHibernationActuator) {
@@ -458,7 +458,7 @@ func TestReconcile(t *testing.T) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.ResumingOrRunningHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.ResumingOrRunningHibernatingReason, cond.Reason)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
 				assert.Equal(t, hivev1.WaitingForNodesReadyReason, runCond.Reason)
@@ -469,7 +469,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "resuming pending csrs",
 			cd: cdBuilder.Options().Build(
-				testcd.WithCondition(hibernatingCondition(corev1.ConditionFalse, hivev1.ResumingOrRunningHibernationReason, 6*time.Hour)),
+				testcd.WithCondition(hibernatingCondition(corev1.ConditionFalse, hivev1.ResumingOrRunningHibernatingReason, 6*time.Hour)),
 				testcd.WithCondition(readyCondition(corev1.ConditionFalse, "unused", 6*time.Hour))),
 			cs: csBuilder.Build(),
 			setupActuator: func(actuator *mock.MockHibernationActuator) {
@@ -492,7 +492,7 @@ func TestReconcile(t *testing.T) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.ResumingOrRunningHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.ResumingOrRunningHibernatingReason, cond.Reason)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
 				assert.Equal(t, hivev1.WaitingForNodesReadyReason, runCond.Reason)
@@ -505,7 +505,7 @@ func TestReconcile(t *testing.T) {
 				testcd.WithCondition(hivev1.ClusterDeploymentCondition{
 					Type:               hivev1.ClusterHibernatingCondition,
 					Status:             corev1.ConditionFalse,
-					Reason:             hivev1.ResumingOrRunningHibernationReason,
+					Reason:             hivev1.ResumingOrRunningHibernatingReason,
 					LastProbeTime:      metav1.Time{Time: time.Now().Add(-2 * time.Hour)},
 					LastTransitionTime: metav1.Time{Time: time.Now().Add(-2 * time.Hour)},
 				}),
@@ -532,7 +532,7 @@ func TestReconcile(t *testing.T) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.ResumingOrRunningHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.ResumingOrRunningHibernatingReason, cond.Reason)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
 				assert.Equal(t, hivev1.PausingForClusterOperatorsToSettleReadyReason, runCond.Reason)
@@ -546,7 +546,7 @@ func TestReconcile(t *testing.T) {
 				testcd.WithCondition(hivev1.ClusterDeploymentCondition{
 					Type:               hivev1.ClusterHibernatingCondition,
 					Status:             corev1.ConditionFalse,
-					Reason:             hivev1.ResumingOrRunningHibernationReason,
+					Reason:             hivev1.ResumingOrRunningHibernatingReason,
 					LastProbeTime:      metav1.Time{Time: time.Now().Add(-2 * time.Hour)},
 					LastTransitionTime: metav1.Time{Time: time.Now().Add(-2 * time.Hour)},
 				}),
@@ -573,7 +573,7 @@ func TestReconcile(t *testing.T) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.ResumingOrRunningHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.ResumingOrRunningHibernatingReason, cond.Reason)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
 				assert.Equal(t, hivev1.WaitingForClusterOperatorsReadyReason, runCond.Reason)
@@ -586,7 +586,7 @@ func TestReconcile(t *testing.T) {
 				testcd.WithCondition(hivev1.ClusterDeploymentCondition{
 					Type:               hivev1.ClusterHibernatingCondition,
 					Status:             corev1.ConditionFalse,
-					Reason:             hivev1.ResumingOrRunningHibernationReason,
+					Reason:             hivev1.ResumingOrRunningHibernatingReason,
 					LastProbeTime:      metav1.Time{Time: time.Now().Add(-2 * time.Hour)},
 					LastTransitionTime: metav1.Time{Time: time.Now().Add(-2 * time.Hour)},
 				}),
@@ -613,7 +613,7 @@ func TestReconcile(t *testing.T) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.ResumingOrRunningHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.ResumingOrRunningHibernatingReason, cond.Reason)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
 				assert.Equal(t, hivev1.WaitingForClusterOperatorsReadyReason, runCond.Reason)
@@ -625,7 +625,7 @@ func TestReconcile(t *testing.T) {
 			cd: cdBuilder.Options().Build(testcd.WithCondition(hivev1.ClusterDeploymentCondition{
 				Type:               hivev1.ClusterHibernatingCondition,
 				Status:             corev1.ConditionFalse,
-				Reason:             hivev1.ResumingOrRunningHibernationReason,
+				Reason:             hivev1.ResumingOrRunningHibernatingReason,
 				LastProbeTime:      metav1.Time{Time: time.Now().Add(-2 * time.Hour)},
 				LastTransitionTime: metav1.Time{Time: time.Now().Add(-2 * time.Hour)},
 			}),
@@ -652,7 +652,7 @@ func TestReconcile(t *testing.T) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
-				assert.Equal(t, hivev1.ResumingOrRunningHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.ResumingOrRunningHibernatingReason, cond.Reason)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionTrue, runCond.Status)
 				assert.Equal(t, hivev1.RunningReadyReason, runCond.Reason)
@@ -667,7 +667,7 @@ func TestReconcile(t *testing.T) {
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
 				cond, _ := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
-				assert.Equal(t, hivev1.ResumingOrRunningHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.ResumingOrRunningHibernatingReason, cond.Reason)
 				assert.Equal(t, "Hibernation capable", cond.Message)
 			},
 		},
@@ -681,13 +681,13 @@ func TestReconcile(t *testing.T) {
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
-				assert.Equal(t, hivev1.HibernatingHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.HibernatingHibernatingReason, cond.Reason)
 				assert.Equal(t, corev1.ConditionTrue, cond.Status)
 				assert.Equal(t, "Fake cluster is stopped", cond.Message)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionFalse, runCond.Status)
 				assert.Equal(t, hivev1.StoppingOrHibernatingReadyReason, runCond.Reason)
-				assert.Equal(t, hivev1.HibernatingHibernationReason, cd.Status.PowerState)
+				assert.Equal(t, hivev1.HibernatingHibernatingReason, cd.Status.PowerState)
 			},
 		},
 		{
@@ -699,7 +699,7 @@ func TestReconcile(t *testing.T) {
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
 				cond, runCond := getHibernatingAndRunningConditions(cd)
 				require.NotNil(t, cond)
-				assert.Equal(t, hivev1.ResumingOrRunningHibernationReason, cond.Reason)
+				assert.Equal(t, hivev1.ResumingOrRunningHibernatingReason, cond.Reason)
 				assert.Equal(t, corev1.ConditionFalse, cond.Status)
 				require.NotNil(t, runCond)
 				assert.Equal(t, corev1.ConditionTrue, runCond.Status)
@@ -814,7 +814,7 @@ func TestHibernateAfter(t *testing.T) {
 				testcd.InstalledTimestamp(time.Now().Add(-10*time.Hour))),
 			cs:                      csBuilder.Build(),
 			expectedPowerState:      "",
-			expectedConditionReason: hivev1.UnsupportedHibernationReason,
+			expectedConditionReason: hivev1.UnsupportedHibernatingReason,
 		},
 		{
 			name: "cluster not yet due for hibernate older version", // cluster that has never been hibernated and thus has no running condition
@@ -826,7 +826,7 @@ func TestHibernateAfter(t *testing.T) {
 				testcs.WithFirstSuccessTime(time.Now().Add(-3 * time.Hour)),
 			).Build(),
 			expectedPowerState:      "",
-			expectedConditionReason: hivev1.UnsupportedHibernationReason,
+			expectedConditionReason: hivev1.UnsupportedHibernatingReason,
 		},
 		{
 			name: "cluster not yet due for hibernate no running condition", // cluster that has never been hibernated
@@ -850,7 +850,7 @@ func TestHibernateAfter(t *testing.T) {
 		{
 			name: "cluster with running condition not due for hibernate",
 			cd: cdBuilder.Build(
-				testcd.WithCondition(hibernatingCondition(corev1.ConditionFalse, hivev1.ResumingOrRunningHibernationReason, 6*time.Hour)),
+				testcd.WithCondition(hibernatingCondition(corev1.ConditionFalse, hivev1.ResumingOrRunningHibernatingReason, 6*time.Hour)),
 				testcd.WithCondition(readyCondition(corev1.ConditionTrue, hivev1.RunningReadyReason, 6*time.Hour)),
 				testcd.WithHibernateAfter(20*time.Hour),
 				testcd.InstalledTimestamp(time.Now().Add(-10*time.Hour))),
@@ -868,7 +868,7 @@ func TestHibernateAfter(t *testing.T) {
 			cd: cdBuilder.Build(
 				testcd.WithHibernateAfter(8*time.Hour),
 				testcd.InstalledTimestamp(time.Now().Add(-10*time.Hour)),
-				testcd.WithCondition(hibernatingCondition(corev1.ConditionFalse, hivev1.ResumingOrRunningHibernationReason, 8*time.Hour)),
+				testcd.WithCondition(hibernatingCondition(corev1.ConditionFalse, hivev1.ResumingOrRunningHibernatingReason, 8*time.Hour)),
 				testcd.WithCondition(readyCondition(corev1.ConditionFalse, hivev1.WaitingForNodesReadyReason, 8*time.Hour)),
 				o.shouldRun),
 			cs:                 csBuilder.Build(),
@@ -1045,14 +1045,14 @@ func (*clusterDeploymentOptions) shouldRun(cd *hivev1.ClusterDeployment) {
 func (*clusterDeploymentOptions) stopping(cd *hivev1.ClusterDeployment) {
 	cd.Status.Conditions = append(cd.Status.Conditions, hivev1.ClusterDeploymentCondition{
 		Type:   hivev1.ClusterHibernatingCondition,
-		Reason: hivev1.StoppingHibernationReason,
+		Reason: hivev1.StoppingHibernatingReason,
 		Status: corev1.ConditionFalse,
 	})
 }
 func (*clusterDeploymentOptions) hibernating(cd *hivev1.ClusterDeployment) {
 	cd.Status.Conditions = append(cd.Status.Conditions, hivev1.ClusterDeploymentCondition{
 		Type:   hivev1.ClusterHibernatingCondition,
-		Reason: hivev1.HibernatingHibernationReason,
+		Reason: hivev1.HibernatingHibernatingReason,
 		Status: corev1.ConditionTrue,
 	})
 }
@@ -1060,7 +1060,7 @@ func (*clusterDeploymentOptions) unsupported(cd *hivev1.ClusterDeployment) {
 	cd.Status.Conditions = append(cd.Status.Conditions, hivev1.ClusterDeploymentCondition{
 		Type:   hivev1.ClusterHibernatingCondition,
 		Status: corev1.ConditionFalse,
-		Reason: hivev1.UnsupportedHibernationReason,
+		Reason: hivev1.UnsupportedHibernatingReason,
 	})
 }
 

--- a/pkg/test/clusterclaim/clusterclaim.go
+++ b/pkg/test/clusterclaim/clusterclaim.go
@@ -93,6 +93,12 @@ func WithSubjects(subjects []rbacv1.Subject) Option {
 	}
 }
 
+func WithClusterState(state hivev1.ClusterClaimClusterState) Option {
+	return func(clusterClaim *hivev1.ClusterClaim) {
+		clusterClaim.Status.ClusterState = state
+	}
+}
+
 // WithCondition adds the specified condition to the ClusterClaim
 func WithCondition(cond hivev1.ClusterClaimCondition) Option {
 	return func(clusterClaim *hivev1.ClusterClaim) {

--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -153,6 +153,18 @@ func Installed() Option {
 	}
 }
 
+func Running() Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Spec.Installed = true
+		clusterDeployment.Spec.PowerState = hivev1.RunningClusterPowerState
+		clusterDeployment.Status.PowerState = hivev1.RunningReadyReason
+		// A little hack to make sure tests don't unexpectedly start swapping which clusters are
+		// running: since we start the oldest clusters first, fake the creation time of this
+		// cluster to be "old".
+		clusterDeployment.CreationTimestamp = metav1.NewTime(time.Now().Add(-6 * time.Hour))
+	}
+}
+
 func InstalledTimestamp(instTime time.Time) Option {
 	return func(clusterDeployment *hivev1.ClusterDeployment) {
 		clusterDeployment.Spec.Installed = true

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -429,32 +429,32 @@ var PositivePolarityClusterDeploymentConditions = []ClusterDeploymentConditionTy
 
 // Cluster hibernating and ready reasons
 const (
-	// ResumingOrRunningHibernationReason is used as the reason for the Hibernating condition when the cluster
+	// ResumingOrRunningHibernatingReason is used as the reason for the Hibernating condition when the cluster
 	// is resuming or running. Precise details are available in the Ready condition.
-	ResumingOrRunningHibernationReason = "ResumingOrRunning"
-	// StoppingHibernationReason is used as the reason when the cluster is transitioning
+	ResumingOrRunningHibernatingReason = "ResumingOrRunning"
+	// StoppingHibernatingReason is used as the reason when the cluster is transitioning
 	// from a Running state to a Hibernating state.
-	StoppingHibernationReason = "Stopping"
+	StoppingHibernatingReason = "Stopping"
 	// WaitingForMachinesToStopHibernatingReason is used on the Hibernating condition when waiting for cloud VMs to stop
 	WaitingForMachinesToStopHibernatingReason = "WaitingForMachinesToStop"
-	// HibernatingHibernationReason is used as the reason when the cluster is in a
+	// HibernatingHibernatingReason is used as the reason when the cluster is in a
 	// Hibernating state.
-	HibernatingHibernationReason = "Hibernating"
-	// UnsupportedHibernationReason is used as the reason when the cluster spec
+	HibernatingHibernatingReason = string(HibernatingClusterPowerState)
+	// UnsupportedHibernatingReason is used as the reason when the cluster spec
 	// specifies that the cluster be moved to a Hibernating state, but either the cluster
 	// version is not compatible with hibernation (< 4.4.8) or the cloud provider of
 	// the cluster is not supported.
-	UnsupportedHibernationReason = "Unsupported"
-	// FailedToStopHibernationReason is used when there was an error stopping machines
+	UnsupportedHibernatingReason = "Unsupported"
+	// FailedToStopHibernatingReason is used when there was an error stopping machines
 	// to enter hibernation
-	FailedToStopHibernationReason = "FailedToStop"
-	// SyncSetsNotAppliedReason is used as the reason when SyncSets have not yet been applied
+	FailedToStopHibernatingReason = "FailedToStop"
+	// SyncSetsNotAppliedHibernatingReason is used as the reason when SyncSets have not yet been applied
 	// for the cluster based on ClusterSync.Status.FirstSucessTime
-	SyncSetsNotAppliedReason = "SyncSetsNotApplied"
-	// SyncSetsAppliedReason means SyncSets have been successfully applied at some point.
+	SyncSetsNotAppliedHibernatingReason = "SyncSetsNotApplied"
+	// SyncSetsAppliedHibernatingReason means SyncSets have been successfully applied at some point.
 	// (It does not necessarily mean they are currently copacetic -- check ClusterSync status
 	// for that.)
-	SyncSetsAppliedReason = "SyncSetsApplied"
+	SyncSetsAppliedHibernatingReason = "SyncSetsApplied"
 
 	// StoppingOrHibernatingReadyReason is used as the reason for the Ready condition when the cluster
 	// is stopping or hibernating. Precise details are available in the Hibernating condition.
@@ -474,7 +474,7 @@ const (
 	// get to a good state. (Available=True, Processing=False, Degraded=False)
 	WaitingForClusterOperatorsReadyReason = "WaitingForClusterOperators"
 	// RunningReadyReason is used on the Ready condition as the reason when the cluster is running and ready
-	RunningReadyReason = "Running"
+	RunningReadyReason = string(RunningClusterPowerState)
 )
 
 // Provisioned status condition reasons

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
@@ -110,7 +110,11 @@ type ClusterPoolStatus struct {
 	// Size is the number of unclaimed clusters that have been created for the pool.
 	Size int32 `json:"size"`
 
-	// Ready is the number of unclaimed clusters that have been installed and are ready to be claimed.
+	// Standby is the number of unclaimed clusters that are installed, but not running.
+	// +optional
+	Standby int32 `json:"standby"`
+
+	// Ready is the number of unclaimed clusters that are installed and are running and ready to be claimed.
 	Ready int32 `json:"ready"`
 
 	// Conditions includes more detailed status for the cluster pool
@@ -161,8 +165,9 @@ const (
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.size,statuspath=.status.size
-// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready"
 // +kubebuilder:printcolumn:name="Size",type="string",JSONPath=".spec.size"
+// +kubebuilder:printcolumn:name="Standby",type="string",JSONPath=".status.standby"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready"
 // +kubebuilder:printcolumn:name="BaseDomain",type="string",JSONPath=".spec.baseDomain"
 // +kubebuilder:printcolumn:name="ImageSet",type="string",JSONPath=".spec.imageSetRef.name"
 // +kubebuilder:resource:path=clusterpools,shortName=cp


### PR DESCRIPTION
Since #1652, we only ever assign claims to clusters that are already running, so we don't need the ClusterRunning condition anymore.
    
However, some of the other information for which that condition was being used -- namely, indicating when the cluster is deleting or nonexistent -- is still useful, though doesn't make sense to be associated with a thing called "ClusterRunning". So we add a Status.ClusterState which can have one of three values:
- `NoCluster`: Either we haven't fulfilled the claim yet, or the associated cluster has been deleted.
- `Provisioned`: The claimed cluster exists and is not being deleted (though it is not necessarily running).
- `Deleting`: The claimed cluster is in the process of being deleted (usually meaning it is deprovisioning.)

[HIVE-1743](https://issues.redhat.com/browse/HIVE-1743)
