### PR TITLE
OSD-9688: Add regex for VPC missing install failure

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -144,6 +144,11 @@ data:
       - "Error waiting for instance .* to become ready .* User initiated shutdown"
       installFailingReason: UserInitiatedShutdown
       installFailingMessage: User initiated shutdown of instances as the install was running
+    - name: AWSVPCDoesNotExist
+      searchRegexStrings:
+      - "The vpc ID .* does not exist"
+      installFailingReason: AWSVPCDoesNotExist
+      installFailingMessage: The AWS VPC does not exist
 
 
     # GCP Specific

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -50,6 +50,7 @@ const (
 	proxyInvalidCABundleLog     = "time=\"2021-08-27T05:56:50Z\" level=info msg=\"[pull.q1w2.quay.rhcloud.com/openshift-release-dev/ocp-release@sha256:7047acb946649cc1f54d98a1c28dd7b487fe91479aa52c13c971ea014a66c8a8: error pinging docker registry pull.q1w2.quay.rhcloud.com: Get \\\"https://pull.q1w2.quay.rhcloud.com/v2/\\\": proxyconnect tcp: x509: certificate signed by unknown authority]): quay.io/openshift-release-dev/ocp-release@sha256:7047acb946649cc1f54d98a1c28dd7b487fe91479aa52c13c971ea014a66c8a8: error pinging docker registry quay.io: Get \\\"https://quay.io/v2/\\\": proxyconnect tcp: x509: certificate signed by unknown authority"
 	awsEC2QuotaExceeded         = "time=\"2021-12-12T12:54:36Z\" level=fatal msg=\"failed to fetch Cluster: failed to fetch dependency of \"Cluster\": failed to generate asset \"Platform Quota Check\": error(MissingQuota): ec2/L-1234A56B is not available in us-east-1 because the required number of resources (36) is more than the limit of 32\""
 	bootstrapFailed             = "time=\"2021-12-13T21:15:55Z\" level=error msg=\"Bootstrap failed to complete: timed out waiting for the condition\""
+	awsInvalidVpcId             = "time=\"2022-01-11T18:25:33Z\" level=error msg=\"Error: InvalidVpcID.NotFound: The vpc ID 'vpc-whatever' does not exist\""
 	route53Timeout              = "level=error\nlevel=error msg=Error: error waiting for Route53 Hosted Zone (Z1234567890ACBD) creation: timeout while waiting for state to become 'INSYNC' (last state: 'PENDING', timeout: 15m0s)\nlevel=error\nlevel=error msg= on ../tmp/openshift-install-cluster-260510522/route53/base.tf line 22, in resource \"aws_route53_zone\" \"new_int\":\nlevel=error msg= 22: resource \"aws_route53_zone\" \"new_int\""
 	inconsistentTerraformResult = "time=\"2021-12-01T16:08:46Z\" level=error msg=\"Error: Provider produced inconsistent result after apply\""
 	// NOTE: This embedded newline matters: our regex must be able to match the two chunks of the message on separate lines.
@@ -357,6 +358,11 @@ func TestParseInstallLog(t *testing.T) {
 			name:           "InconsistentTerraformResult",
 			log:            pointer.StringPtr(inconsistentTerraformResult),
 			expectedReason: "InconsistentTerraformResult",
+		},
+		{
+			name:           "AWSVPCDoesNotExist",
+			log:            pointer.StringPtr(awsInvalidVpcId),
+			expectedReason: "AWSVPCDoesNotExist",
 		},
 	}
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1706,6 +1706,11 @@ data:
       - "Error waiting for instance .* to become ready .* User initiated shutdown"
       installFailingReason: UserInitiatedShutdown
       installFailingMessage: User initiated shutdown of instances as the install was running
+    - name: AWSVPCDoesNotExist
+      searchRegexStrings:
+      - "The vpc ID .* does not exist"
+      installFailingReason: AWSVPCDoesNotExist
+      installFailingMessage: The AWS VPC does not exist
 
 
     # GCP Specific


### PR DESCRIPTION
This adds a regex and test for the AWS "VPC not found" install error. This is believed to be a transient error due to AWS API slowness. 

Additional details in: https://issues.redhat.com/browse/OSD-9688