### PR TITLE
Leader election migration 1: ConfigMap & Lease

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -60,8 +60,8 @@ import (
 )
 
 const (
-	defaultLogLevel         = "info"
-	leaderElectionConfigMap = "hive-controllers-leader"
+	defaultLogLevel        = "info"
+	leaderElectionLockName = "hive-controllers-leader"
 )
 
 type controllerSetupFunc func(manager.Manager) error
@@ -225,7 +225,7 @@ func newRootCommand() *cobra.Command {
 			if os.Getenv("HIVE_SKIP_LEADER_ELECTION") != "" {
 				run(ctx)
 			} else {
-				cmdutil.RunWithLeaderElection(ctx, cfg, hiveNSName, leaderElectionConfigMap, run)
+				cmdutil.RunWithLeaderElection(ctx, cfg, hiveNSName, leaderElectionLockName, run)
 			}
 		},
 	}

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -34,8 +34,8 @@ import (
 )
 
 const (
-	defaultLogLevel         = "info"
-	leaderElectionConfigMap = "hive-operator-leader"
+	defaultLogLevel        = "info"
+	leaderElectionLockName = "hive-operator-leader"
 )
 
 type controllerManagerOptions struct {
@@ -133,7 +133,7 @@ func newRootCommand() *cobra.Command {
 				cancel()
 			}
 
-			cmdutil.RunWithLeaderElection(ctx, cfg, operatorNS, leaderElectionConfigMap, run)
+			cmdutil.RunWithLeaderElection(ctx, cfg, operatorNS, leaderElectionLockName, run)
 		},
 	}
 

--- a/cmd/util/leaderelection.go
+++ b/cmd/util/leaderelection.go
@@ -1,0 +1,70 @@
+package util
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+const (
+	leaseDuration = 120 * time.Second
+	renewDeadline = 90 * time.Second
+	retryPeriod   = 30 * time.Second
+)
+
+func RunWithLeaderElection(ctx context.Context, cfg *rest.Config, lockNS, lockName string, run func(ctx context.Context)) {
+	// Leader election code based on:
+	// https://github.com/kubernetes/kubernetes/blob/f7e3bcdec2e090b7361a61e21c20b3dbbb41b7f0/staging/src/k8s.io/client-go/examples/leader-election/main.go#L92-L154
+	// This gives us ReleaseOnCancel which is not presently exposed in controller-runtime.
+
+	id := uuid.New().String()
+	leLog := log.WithField("id", id)
+	leLog.Info("generated leader election ID")
+
+	lock := &resourcelock.ConfigMapLock{
+		ConfigMapMeta: metav1.ObjectMeta{
+			Namespace: lockNS,
+			Name:      lockName,
+		},
+		Client: kubernetes.NewForConfigOrDie(cfg).CoreV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: id,
+		},
+	}
+
+	// start the leader election code loop
+	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		ReleaseOnCancel: true,
+		LeaseDuration:   leaseDuration,
+		RenewDeadline:   renewDeadline,
+		RetryPeriod:     retryPeriod,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				run(ctx)
+			},
+			OnStoppedLeading: func() {
+				// we can do cleanup here if necessary
+				leLog.Infof("leader lost")
+				os.Exit(0)
+			},
+			OnNewLeader: func(identity string) {
+				if identity == id {
+					// We just became the leader
+					leLog.Info("became leader")
+					return
+				}
+				log.Infof("current leader: %s", identity)
+			},
+		},
+	})
+
+}

--- a/config/controllers/hive_controllers_role.yaml
+++ b/config/controllers/hive_controllers_role.yaml
@@ -87,3 +87,15 @@ rules:
   - backups
   verbs:
   - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/config/operator/operator_role.yaml
+++ b/config/operator/operator_role.yaml
@@ -205,3 +205,15 @@ rules:
     - update
     - patch
     - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -6542,6 +6542,18 @@ objects:
     - update
     - patch
     - delete
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -954,6 +954,18 @@ rules:
   - backups
   verbs:
   - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 `)
 
 func configControllersHive_controllers_roleYamlBytes() ([]byte, error) {

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -44,12 +44,6 @@ const (
 	inputHashAnnotation = "hive.openshift.io/hive-admission-input-sources-hash"
 )
 
-const (
-	supportedContractsConfigMapName      = "hive-supported-contracts"
-	supportedContractsConfigMapNameKey   = "supported-contracts"
-	supportedContractsConfigMapMountPath = "/data/supported-contracts-config"
-)
-
 var webhookAssets = []string{
 	"config/hiveadmission/clusterdeployment-webhook.yaml",
 	"config/hiveadmission/clusterimageset-webhook.yaml",


### PR DESCRIPTION
We were using ConfigMap-based leader election. We need to migrate to using Lease instead.

Part 1: Use ConfigMap *and* Lease so we can upgrade smoothly from a build using just ConfigMap.
Part 2: Remove ConfigMap.

This is part 1.

[HIVE-1736](https://issues.redhat.com/browse/HIVE-1736)
