### PR TITLE
Label to disable ClusterOperators check during resume

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -372,6 +372,13 @@ const (
 	// CreatedByHiveLabel is the label used for artifacts for external systems we integrate with
 	// that were created by Hive. The value for this label should be "true".
 	CreatedByHiveLabel = "hive.openshift.io/created-by"
+
+	// ResumeSkipsClusterOperatorsLabel is used to label a ClusterDeployment or a ClusterPool. If
+	// set to "true", affected ClusterDeployments will skip checking ClusterOperators health when
+	// resuming from hibernation. NOTE: This means when the ClusterDeployment's status.powerState
+	// is "Running", the cluster may not be in the same ready state as when it first finished
+	// installing. Use with caution.
+	ResumeSkipsClusterOperatorsLabel = "hive.openshift.io/resume-skips-cluster-operators"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment


### PR DESCRIPTION
Prior to #1604 we were lying about cluster status when resuming from
hibernation. That PR introduced checking the health of ClusterOperators
before we declared a ClusterDeployment to be Running.

However, this bug fix immediately began causing problems for some
consumers because:
1. It nontrivially increased the time to resume. Consumers need to
accommodate this by increasing the respective timeouts in their tooling.
2. Resume doesn't work great right now, so sometimes cluster operators
were _never_ coming up. This could result in ClusterClaims never being
fulfilled (because the pool could never present a Running cluster).

For 1, we would like to give consumers some time to stage the changes to
accommodate the fix.
For 2, we would like to provide the ability to revert to the pre-bugfix
behavior, since some consumers are able to use clusters that aren't
fully operational in this way.

This commit introduces a label,
`hive.openshift.io/resume-skips-cluster-operators`, which can be set on
a ClusterDeployment or a ClusterPool (in the latter case it is applied
to all ClusterDeployments created by the pool). When `"true"`, the
hibernation controller skips checking ClusterOperators and reports the
ClusterDeployment as Running as soon as nodes are ready.

[HIVE-1746](https://issues.redhat.com/browse/HIVE-1746)