### PR TITLE
ClusterPool.Spec.HibernationConfig.ResumeTimeout

### DIFF
--- a/apis/hive/v1/clusterpool_types.go
+++ b/apis/hive/v1/clusterpool_types.go
@@ -84,6 +84,19 @@ type ClusterPoolSpec struct {
 	// ClaimLifetime defines the lifetimes for claims for the cluster pool.
 	// +optional
 	ClaimLifetime *ClusterPoolClaimLifetime `json:"claimLifetime,omitempty"`
+
+	// HibernationConfig configures the hibernation/resume behavior of ClusterDeployments owned by the ClusterPool.
+	// +optional
+	HibernationConfig *HibernationConfig `json:"hibernationConfig"`
+}
+
+type HibernationConfig struct {
+	// ResumeTimeout is the maximum amount of time we will wait for an unclaimed ClusterDeployment to resume from
+	// hibernation (e.g. at the behest of runningCount, or in preparation for being claimed). If this time is
+	// exceeded, the ClusterDeployment will be considered Broken and we will replace it. The default (unspecified
+	// or zero) means no timeout -- we will allow the ClusterDeployment to continue trying to resume "forever".
+	// +optional
+	ResumeTimeout metav1.Duration `json:"resumeTimeout"`
 }
 
 // ClusterPoolClaimLifetime defines the lifetimes for claims for the cluster pool.

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -95,6 +95,20 @@ spec:
                   see https://pkg.go.dev/time#ParseDuration for accepted formats.
                 format: duration
                 type: string
+              hibernationConfig:
+                description: HibernationConfig configures the hibernation/resume behavior
+                  of ClusterDeployments owned by the ClusterPool.
+                properties:
+                  resumeTimeout:
+                    description: ResumeTimeout is the maximum amount of time we will
+                      wait for an unclaimed ClusterDeployment to resume from hibernation
+                      (e.g. at the behest of runningCount, or in preparation for being
+                      claimed). If this time is exceeded, the ClusterDeployment will
+                      be considered Broken and we will replace it. The default (unspecified
+                      or zero) means no timeout -- we will allow the ClusterDeployment
+                      to continue trying to resume "forever".
+                    type: string
+                type: object
               imageSetRef:
                 description: ImageSetRef is a reference to a ClusterImageSet. The
                   release image specified in the ClusterImageSet will be used by clusters

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -1789,6 +1789,20 @@ objects:
                     formats.
                   format: duration
                   type: string
+                hibernationConfig:
+                  description: HibernationConfig configures the hibernation/resume
+                    behavior of ClusterDeployments owned by the ClusterPool.
+                  properties:
+                    resumeTimeout:
+                      description: ResumeTimeout is the maximum amount of time we
+                        will wait for an unclaimed ClusterDeployment to resume from
+                        hibernation (e.g. at the behest of runningCount, or in preparation
+                        for being claimed). If this time is exceeded, the ClusterDeployment
+                        will be considered Broken and we will replace it. The default
+                        (unspecified or zero) means no timeout -- we will allow the
+                        ClusterDeployment to continue trying to resume "forever".
+                      type: string
+                  type: object
                 imageSetRef:
                   description: ImageSetRef is a reference to a ClusterImageSet. The
                     release image specified in the ClusterImageSet will be used by

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
@@ -84,6 +84,19 @@ type ClusterPoolSpec struct {
 	// ClaimLifetime defines the lifetimes for claims for the cluster pool.
 	// +optional
 	ClaimLifetime *ClusterPoolClaimLifetime `json:"claimLifetime,omitempty"`
+
+	// HibernationConfig configures the hibernation/resume behavior of ClusterDeployments owned by the ClusterPool.
+	// +optional
+	HibernationConfig *HibernationConfig `json:"hibernationConfig"`
+}
+
+type HibernationConfig struct {
+	// ResumeTimeout is the maximum amount of time we will wait for an unclaimed ClusterDeployment to resume from
+	// hibernation (e.g. at the behest of runningCount, or in preparation for being claimed). If this time is
+	// exceeded, the ClusterDeployment will be considered Broken and we will replace it. The default (unspecified
+	// or zero) means no timeout -- we will allow the ClusterDeployment to continue trying to resume "forever".
+	// +optional
+	ResumeTimeout metav1.Duration `json:"resumeTimeout"`
 }
 
 // ClusterPoolClaimLifetime defines the lifetimes for claims for the cluster pool.


### PR DESCRIPTION
Add a knob causing the clusterpool controller to consider a
ClusterDeployment broken if it spends too long resuming.

[HIVE-1746](https://issues.redhat.com/browse/HIVE-1746)