### PR TITLE
prefer generic InconsistentTerraformResult install log regexp

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -144,29 +144,23 @@ data:
       - "Error waiting for instance .* to become ready .* User initiated shutdown"
       installFailingReason: UserInitiatedShutdown
       installFailingMessage: User initiated shutdown of instances as the install was running
+    # openshift-installer intermittent failure on AWS with Error: Provider produced inconsistent result after apply
+    - name: InconsistentTerraformResult
+      searchRegexStrings:
+      - "Error: Provider produced inconsistent result after apply"
+      installFailingReason: InconsistentTerraformResult
+      installFailingMessage: Inconsistent result after Terraform apply
     - name: AWSVPCDoesNotExist
       searchRegexStrings:
       - "The vpc ID .* does not exist"
       installFailingReason: AWSVPCDoesNotExist
       installFailingMessage: The AWS VPC does not exist
-    - name: VPCDhcpOptionAssociationPresentNowAbsent
-    # https://bugzilla.redhat.com/show_bug.cgi?id=2032521
-      searchRegexStrings:
-      - "error .* applying changes to module.vpc.aws_vpc_dhcp_options_association.*\n.*\n.*was present, but now absent"
-      installFailingReason: VPCDhcpOptionAssociationPresentNowAbsent
-      installFailingMessage: The VPC Dhcp Option Association absent after creation
     - name: TargetGroupNotFound
     # https://bugzilla.redhat.com/show_bug.cgi?id=1898265
       searchRegexStrings:
       - "TargetGroupNotFound"
       installFailingReason: TargetGroupNotFound
       installFailingMessage: Target Group cannot be found
-    - name: RouteTablePrivateRoutesPresentNowAbsent
-    # https://bugzilla.redhat.com/show_bug.cgi?id=2033256
-      searchRegexStrings:
-      - "ERROR When applying changes to module.vpc.aws_route_table.private_routes.*\n.*\n.*was present, but now absent"
-      installFailingReason: RouteTablePrivateRoutesPresentNowAbsent
-      installFailingMessage: VPC Route Table private routes absent after creation
     - name: ErrorCreatingNetworkLoadBalancer
       searchRegexStrings:
       - "Error creating network Load Balancer: InternalFailure: "
@@ -247,13 +241,6 @@ data:
       - "Bootstrap failed to complete"
       installFailingReason: BootstrapFailed
       installFailingMessage: Bootstrap failed to complete
-    # https://bugzilla.redhat.com/show_bug.cgi?id=2032521
-    # openshift-installer intermittent failure on AWS with Error: Provider produced inconsistent result after apply
-    - name: InconsistentTerraformResult
-      searchRegexStrings:
-      - "Error: Provider produced inconsistent result after apply"
-      installFailingReason: InconsistentTerraformResult
-      installFailingMessage: Inconsistent result after Terraform apply
     - name: KubeAPIWaitTimeout
       searchRegexStrings:
       - "waiting for Kubernetes API: context deadline exceeded"

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -56,11 +56,9 @@ const (
 	// NOTE: This embedded newline matters: our regex must be able to match the two chunks of the message on separate lines.
 	noWorkerNodesFmt = `time="2021-12-09T10:51:06Z" level=debug msg="Symlinking plugin terraform-provider-%s src: \"/usr/bin/openshift-install\" dst: \"/tmp/openshift-install-cluster-723469510/plugins/terraform-provider-%s\""
 time="2021-12-09T10:53:06Z" level=error msg="blahblah. Got 0 worker nodes, 3 master nodes blah"`
-	dhcpOptionAssociationAbsent = "level=error msg=Error: Provider produced inconsistent result after apply\nlevel=error\nlevel=error msg=When applying changes to module.vpc.aws_vpc_dhcp_options_association.main[0],\n	level=error msg=provider \"registry.terraform.io/-/aws\" produced an unexpected new value for\nlevel=error msg=was present, but now absent."
-	targetGroupNotFound         = "level=error msg=Error: error updating LB Target Group (arn:aws:elasticloadbalancing:us-east-1:xxxx:targetgroup/aaaabbbbcccc/dddd) tags: error tagging resource (arn:aws:elasticloadbalancing:us-east-1:0123445698:targetgroup/aaaabbbbcccc/dddd): TargetGroupNotFound: Target groups 'arn:aws:elasticloadbalancing:us-east-1:xxxx:targetgroup/aaaabbbbcccc/dddd' not found"
-	routeTablePrivateRoute      = "ERROR When applying changes to module.vpc.aws_route_table.private_routes[1],\nERROR provider \"registry.terraform.io/-/aws\" produced an unexpected new value for \nERROR was present, but now absent."
-	errorCreatingNLB            = "time=\"2022-01-27T03:33:08Z\" level=error msg=\"Error: Error creating network Load Balancer: InternalFailure: \""
-	noMatchLog                  = "an example of something that doesn't match the log regexes"
+	targetGroupNotFound = "level=error msg=Error: error updating LB Target Group (arn:aws:elasticloadbalancing:us-east-1:xxxx:targetgroup/aaaabbbbcccc/dddd) tags: error tagging resource (arn:aws:elasticloadbalancing:us-east-1:0123445698:targetgroup/aaaabbbbcccc/dddd): TargetGroupNotFound: Target groups 'arn:aws:elasticloadbalancing:us-east-1:xxxx:targetgroup/aaaabbbbcccc/dddd' not found"
+	errorCreatingNLB    = "time=\"2022-01-27T03:33:08Z\" level=error msg=\"Error: Error creating network Load Balancer: InternalFailure: \""
+	noMatchLog          = "an example of something that doesn't match the log regexes"
 )
 
 func TestParseInstallLog(t *testing.T) {
@@ -369,19 +367,9 @@ func TestParseInstallLog(t *testing.T) {
 			expectedReason: "AWSVPCDoesNotExist",
 		},
 		{
-			name:           "VPCDhcpOptionAssociationPresentNowAbsent",
-			log:            pointer.StringPtr(dhcpOptionAssociationAbsent),
-			expectedReason: "VPCDhcpOptionAssociationPresentNowAbsent",
-		},
-		{
 			name:           "TargetGroupNotFound",
 			log:            pointer.StringPtr(targetGroupNotFound),
 			expectedReason: "TargetGroupNotFound",
-		},
-		{
-			name:           "RouteTablePrivateRoutesPresentNowAbsent",
-			log:            pointer.StringPtr(routeTablePrivateRoute),
-			expectedReason: "RouteTablePrivateRoutesPresentNowAbsent",
 		},
 		{
 			name:           "ErrorCreatingNetworkLoadBalancer",

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1732,29 +1732,23 @@ data:
       - "Error waiting for instance .* to become ready .* User initiated shutdown"
       installFailingReason: UserInitiatedShutdown
       installFailingMessage: User initiated shutdown of instances as the install was running
+    # openshift-installer intermittent failure on AWS with Error: Provider produced inconsistent result after apply
+    - name: InconsistentTerraformResult
+      searchRegexStrings:
+      - "Error: Provider produced inconsistent result after apply"
+      installFailingReason: InconsistentTerraformResult
+      installFailingMessage: Inconsistent result after Terraform apply
     - name: AWSVPCDoesNotExist
       searchRegexStrings:
       - "The vpc ID .* does not exist"
       installFailingReason: AWSVPCDoesNotExist
       installFailingMessage: The AWS VPC does not exist
-    - name: VPCDhcpOptionAssociationPresentNowAbsent
-    # https://bugzilla.redhat.com/show_bug.cgi?id=2032521
-      searchRegexStrings:
-      - "error .* applying changes to module.vpc.aws_vpc_dhcp_options_association.*\n.*\n.*was present, but now absent"
-      installFailingReason: VPCDhcpOptionAssociationPresentNowAbsent
-      installFailingMessage: The VPC Dhcp Option Association absent after creation
     - name: TargetGroupNotFound
     # https://bugzilla.redhat.com/show_bug.cgi?id=1898265
       searchRegexStrings:
       - "TargetGroupNotFound"
       installFailingReason: TargetGroupNotFound
       installFailingMessage: Target Group cannot be found
-    - name: RouteTablePrivateRoutesPresentNowAbsent
-    # https://bugzilla.redhat.com/show_bug.cgi?id=2033256
-      searchRegexStrings:
-      - "ERROR When applying changes to module.vpc.aws_route_table.private_routes.*\n.*\n.*was present, but now absent"
-      installFailingReason: RouteTablePrivateRoutesPresentNowAbsent
-      installFailingMessage: VPC Route Table private routes absent after creation
     - name: ErrorCreatingNetworkLoadBalancer
       searchRegexStrings:
       - "Error creating network Load Balancer: InternalFailure: "
@@ -1835,13 +1829,6 @@ data:
       - "Bootstrap failed to complete"
       installFailingReason: BootstrapFailed
       installFailingMessage: Bootstrap failed to complete
-    # https://bugzilla.redhat.com/show_bug.cgi?id=2032521
-    # openshift-installer intermittent failure on AWS with Error: Provider produced inconsistent result after apply
-    - name: InconsistentTerraformResult
-      searchRegexStrings:
-      - "Error: Provider produced inconsistent result after apply"
-      installFailingReason: InconsistentTerraformResult
-      installFailingMessage: Inconsistent result after Terraform apply
     - name: KubeAPIWaitTimeout
       searchRegexStrings:
       - "waiting for Kubernetes API: context deadline exceeded"


### PR DESCRIPTION
there were two specific terraform race related regexps in the list,
but new ones are popping up every day. replace with a generic
catch-all InconsistentTerraformResult code.

/assign @2uasimojo 