### PR TITLE
Trigger CI to update to go1.17

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.16
+FROM registry.ci.openshift.org/openshift/release:golang-1.17
 
 # setting Git username and email for workaround of
 # https://github.com/jenkinsci/docker/issues/519


### PR DESCRIPTION
According to
[testplatform](https://coreos.slack.com/archives/CBN38N3MW/p1643925799875989)
the fact that we're using a bespoke build_root means we need to merge a
change to that dockerfile to use go1.17 to trigger the release repo's
bots to update our ci-operator config to build against 1.17. Only then
can we start dropping code changes that _need_ 1.17.

[HIVE-1753](https://issues.redhat.com/browse/HIVE-1753)