### PR TITLE
Add output to de-confuse first appsre build

### DIFF
--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -91,6 +91,8 @@ image_exists_in_repo() {
 if image_exists_in_repo "${IMG}"; then
     echo "Skipping image build/push for ${IMG}"
     exit 0
+else
+    echo "Building and pushing ${IMG}..."
 fi
 
 # build the image


### PR DESCRIPTION
Due to ICSP quirks, our app-sre build script skips building and pushing
an image if that has already been done. In checking whether the image
already exists, the following output (example) is normal:

```
11:23:27 + stderr='time="2022-02-07T12:23:27-05:00" level=fatal msg="Error parsing image name \"docker://quay.io/app-sre/hive:cddf7e5\": Error reading manifest cddf7e5 in quay.io/app-sre/hive: manifest unknown: manifest unknown"'
...
11:23:27 Image quay.io/app-sre/hive:cddf7e5 does not exist in the repository.
```

This is confusing because it looks like an error.

This commit adds a line of output immediately after the above like:

```
Building and pushing quay.io/app-sre/hive:cddf7e5...
```

...which will hopefully alleviate some of this confusion.