### PR TITLE
Groupify hiveconfig template

### DIFF
--- a/config/templates/hiveconfig.yaml
+++ b/config/templates/hiveconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: hive-config


### PR DESCRIPTION
...to get rid of this warning when deploying:

```
W0207 15:46:02.156006  359141 shim_kubectl.go:55] Using non-groupfied API resources is deprecated and will be removed in a future release, update apiVersion to "template.openshift.io/v1" for your resource
```