### PR TITLE
Pass ClusterName to uninstall for IBM Cloud DNS cleanup.

### DIFF
--- a/apis/hive/v1/clusterdeprovision_types.go
+++ b/apis/hive/v1/clusterdeprovision_types.go
@@ -15,6 +15,11 @@ type ClusterDeprovisionSpec struct {
 	// ClusterID is a globally unique identifier for the cluster to deprovision. It will be used if specified.
 	ClusterID string `json:"clusterID,omitempty"`
 
+	// ClusterName is the friendly name of the cluster. It is used for subdomains,
+	// some resource tagging, and other instances where a friendly name for the
+	// cluster is useful.
+	ClusterName string `json:"clusterName,omitempty"`
+
 	// Platform contains platform-specific configuration for a ClusterDeprovision
 	Platform ClusterDeprovisionPlatform `json:"platform,omitempty"`
 }

--- a/config/crds/hive.openshift.io_clusterdeprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterdeprovisions.yaml
@@ -54,6 +54,11 @@ spec:
                 description: ClusterID is a globally unique identifier for the cluster
                   to deprovision. It will be used if specified.
                 type: string
+              clusterName:
+                description: ClusterName is the friendly name of the cluster. It is
+                  used for subdomains, some resource tagging, and other instances
+                  where a friendly name for the cluster is useful.
+                type: string
               infraID:
                 description: InfraID is the identifier generated during installation
                   for a cluster. It is used for tagging/naming resources in cloud

--- a/contrib/pkg/deprovision/ibmcloud.go
+++ b/contrib/pkg/deprovision/ibmcloud.go
@@ -15,15 +15,16 @@ import (
 
 // ibmCloudDeprovisionOptions is the set of options to deprovision an IBM Cloud cluster
 type ibmCloudDeprovisionOptions struct {
-	logLevel          string
-	infraID           string
-	region            string
 	accountID         string
 	baseDomain        string
 	cisInstanceCRN    string
+	clusterName       string
+	infraID           string
+	logLevel          string
+	region            string
 	resourceGroupName string
-	vpc               string
 	subnets           []string
+	vpc               string
 }
 
 // NewDeprovisionIBMCloudCommand is the entrypoint to create the IBM Cloud deprovision subcommand
@@ -52,6 +53,7 @@ func NewDeprovisionIBMCloudCommand() *cobra.Command {
 	// Required flags
 	flags.StringVar(&opt.accountID, "account-id", "", "IBM Cloud account ID")
 	flags.StringVar(&opt.baseDomain, "base-domain", "", "cluster's base domain")
+	flags.StringVar(&opt.clusterName, "cluster-name", "", "cluster's name")
 	flags.StringVar(&opt.cisInstanceCRN, "cis-instance-crn", "", "IBM cloud internet services CRN")
 	flags.StringVar(&opt.region, "region", "", "region in which to deprovision cluster")
 	flags.StringVar(&opt.resourceGroupName, "resource-group-name", "", "IBM resource group name from user provided VPC")
@@ -91,6 +93,10 @@ func (o *ibmCloudDeprovisionOptions) Validate(cmd *cobra.Command) error {
 		cmd.Usage()
 		return fmt.Errorf("No --resource-group-name provided, cannot proceed")
 	}
+	if o.clusterName == "" {
+		cmd.Usage()
+		return fmt.Errorf("No --cluster-name provided, cannot proceed")
+	}
 	return nil
 }
 
@@ -113,7 +119,8 @@ func (o *ibmCloudDeprovisionOptions) Run() error {
 	})
 
 	metadata := &types.ClusterMetadata{
-		InfraID: o.infraID,
+		ClusterName: o.clusterName,
+		InfraID:     o.infraID,
 		ClusterPlatformMetadata: types.ClusterPlatformMetadata{
 			IBMCloud: &typesibmcloud.Metadata{
 				AccountID:         o.accountID,

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -1422,6 +1422,11 @@ objects:
                   description: ClusterID is a globally unique identifier for the cluster
                     to deprovision. It will be used if specified.
                   type: string
+                clusterName:
+                  description: ClusterName is the friendly name of the cluster. It
+                    is used for subdomains, some resource tagging, and other instances
+                    where a friendly name for the cluster is useful.
+                  type: string
                 infraID:
                   description: InfraID is the identifier generated during installation
                     for a cluster. It is used for tagging/naming resources in cloud

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -1691,8 +1691,9 @@ func generateDeprovision(cd *hivev1.ClusterDeployment) (*hivev1.ClusterDeprovisi
 			Namespace: cd.Namespace,
 		},
 		Spec: hivev1.ClusterDeprovisionSpec{
-			InfraID:   cd.Spec.ClusterMetadata.InfraID,
-			ClusterID: cd.Spec.ClusterMetadata.ClusterID,
+			InfraID:     cd.Spec.ClusterMetadata.InfraID,
+			ClusterID:   cd.Spec.ClusterMetadata.ClusterID,
+			ClusterName: cd.Spec.ClusterName,
 		},
 	}
 

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -1104,6 +1104,8 @@ func completeIBMCloudDeprovisionJob(req *hivev1.ClusterDeprovision, job *batchv1
 				req.Spec.Platform.IBMCloud.BaseDomain,
 				"--cis-instance-crn",
 				req.Spec.Platform.IBMCloud.CISInstanceCRN,
+				"--cluster-name",
+				req.Spec.ClusterName,
 				"--account-id",
 				req.Spec.Platform.IBMCloud.AccountID,
 				"--loglevel",

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeprovision_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeprovision_types.go
@@ -15,6 +15,11 @@ type ClusterDeprovisionSpec struct {
 	// ClusterID is a globally unique identifier for the cluster to deprovision. It will be used if specified.
 	ClusterID string `json:"clusterID,omitempty"`
 
+	// ClusterName is the friendly name of the cluster. It is used for subdomains,
+	// some resource tagging, and other instances where a friendly name for the
+	// cluster is useful.
+	ClusterName string `json:"clusterName,omitempty"`
+
 	// Platform contains platform-specific configuration for a ClusterDeprovision
 	Platform ClusterDeprovisionPlatform `json:"platform,omitempty"`
 }


### PR DESCRIPTION
IBM Cloud uninstall requires being passed the `ClusterName` to clean up the correct DNS entries. `ClusterName` is currently not being provided resulting in **ALL** DNS entries in a CIS instance being deleted that match the uninstall `BaseDomain`. Without the `ClusterName`, the following regex matches all DNS entries for the provided `BaseDomain`: https://github.com/openshift/installer/blob/master/pkg/destroy/ibmcloud/dns.go#L31.

This PR passes `ClusterName` obtained from `cd.Spec.ClusterName` (which is a required field for `ClusterDeployment`) to uninstall.