### PR TITLE
Pass ClusterName when cleaning up failed provision.

### DIFF
--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -688,7 +688,8 @@ func cleanupFailedProvision(dynClient client.Client, cd *hivev1.ClusterDeploymen
 		}
 	case cd.Spec.Platform.IBMCloud != nil:
 		metadata := &installertypes.ClusterMetadata{
-			InfraID: infraID,
+			InfraID:     infraID,
+			ClusterName: cd.Spec.ClusterName,
 			ClusterPlatformMetadata: installertypes.ClusterPlatformMetadata{
 				IBMCloud: &installertypesibmcloud.Metadata{
 					AccountID:         cd.Spec.Platform.IBMCloud.AccountID,


### PR DESCRIPTION
`ClusterName` must also be set when we clean up a failed provision during install.

https://github.com/openshift/hive/pull/1700