### PR TITLE
IBMCloud: Hiveutil fixes

### DIFF
--- a/contrib/pkg/deprovision/ibmcloud.go
+++ b/contrib/pkg/deprovision/ibmcloud.go
@@ -18,23 +18,22 @@ import (
 
 // ibmCloudDeprovisionOptions is the set of options to deprovision an IBM Cloud cluster
 type ibmCloudDeprovisionOptions struct {
-	accountID         string
-	baseDomain        string
-	cisInstanceCRN    string
-	clusterName       string
-	infraID           string
-	logLevel          string
-	region            string
-	resourceGroupName string
-	subnets           []string
-	vpc               string
+	accountID      string
+	baseDomain     string
+	cisInstanceCRN string
+	clusterName    string
+	infraID        string
+	logLevel       string
+	region         string
+	subnets        []string
+	vpc            string
 }
 
 // NewDeprovisionIBMCloudCommand is the entrypoint to create the IBM Cloud deprovision subcommand
 func NewDeprovisionIBMCloudCommand() *cobra.Command {
 	opt := &ibmCloudDeprovisionOptions{}
 	cmd := &cobra.Command{
-		Use:   "ibmcloud INFRAID --region=us-east --base-domain=BASE_DOMAIN",
+		Use:   "ibmcloud INFRAID --region=us-east --base-domain=BASE_DOMAIN --cluster-name=CLUSTERNAME",
 		Short: "Deprovision IBM Cloud assets (as created by openshift-installer)",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -57,7 +56,6 @@ func NewDeprovisionIBMCloudCommand() *cobra.Command {
 	flags.StringVar(&opt.baseDomain, "base-domain", "", "cluster's base domain")
 	flags.StringVar(&opt.clusterName, "cluster-name", "", "cluster's name")
 	flags.StringVar(&opt.region, "region", "", "region in which to deprovision cluster")
-	flags.StringVar(&opt.resourceGroupName, "resource-group-name", "", "IBM resource group name from user provided VPC")
 
 	return cmd
 }
@@ -103,10 +101,6 @@ func (o *ibmCloudDeprovisionOptions) Validate(cmd *cobra.Command) error {
 		cmd.Usage()
 		return fmt.Errorf("No --base-domain provided, cannot proceed")
 	}
-	if o.resourceGroupName == "" {
-		cmd.Usage()
-		return fmt.Errorf("No --resource-group-name provided, cannot proceed")
-	}
 	if o.clusterName == "" {
 		cmd.Usage()
 		return fmt.Errorf("No --cluster-name provided, cannot proceed")
@@ -141,7 +135,7 @@ func (o *ibmCloudDeprovisionOptions) Run() error {
 				BaseDomain:        o.baseDomain,
 				CISInstanceCRN:    o.cisInstanceCRN,
 				Region:            o.region,
-				ResourceGroupName: o.resourceGroupName,
+				ResourceGroupName: o.infraID,
 			},
 		},
 	}

--- a/contrib/pkg/deprovision/ibmcloud.go
+++ b/contrib/pkg/deprovision/ibmcloud.go
@@ -34,7 +34,7 @@ type ibmCloudDeprovisionOptions struct {
 func NewDeprovisionIBMCloudCommand() *cobra.Command {
 	opt := &ibmCloudDeprovisionOptions{}
 	cmd := &cobra.Command{
-		Use:   "ibmcloud INFRAID --region=us-east --account-id=ACCOUNT_ID --base-domain=BASE_DOMAIN --cis-instance-crn=CIS_INSTANCE_CRN",
+		Use:   "ibmcloud INFRAID --region=us-east --base-domain=BASE_DOMAIN",
 		Short: "Deprovision IBM Cloud assets (as created by openshift-installer)",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/clusterresource/ibmcloud.go
+++ b/pkg/clusterresource/ibmcloud.go
@@ -76,6 +76,15 @@ func (p *IBMCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installertype
 		},
 	}
 
+	// Used for both control plane and workers.
+	if p.InstanceType != "" {
+		mpp := &installeribmcloud.MachinePool{
+			InstanceType: p.InstanceType,
+		}
+		ic.ControlPlane.Platform.IBMCloud = mpp
+		ic.Compute[0].Platform.IBMCloud = mpp
+	}
+
 	// IBM Cloud only supports manual credentials mode. Manifests including required secrets
 	// must be passed to hive via cd.spec.provisioning.manifestsConfigmapRef
 	ic.CredentialsMode = installertypes.ManualCredentialsMode

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -1096,8 +1096,6 @@ func completeIBMCloudDeprovisionJob(req *hivev1.ClusterDeprovision, job *batchv1
 				"deprovision",
 				"ibmcloud",
 				req.Spec.InfraID,
-				"--resource-group-name",
-				req.Spec.InfraID,
 				"--region",
 				req.Spec.Platform.IBMCloud.Region,
 				"--base-domain",


### PR DESCRIPTION
[HIVE-1620](https://issues.redhat.com/browse/HIVE-1620)

* Remove `--resource-group-name` from `hiveutil deprovision ibmcloud`. Use provided `InfraID` as `ResourceGroupName`.
* Remove `--cis-instance-crn` and `--account-id` from `hiveutil deprovision ibmcloud` usage. These were removed in #1706 and I missed removing them here.
* Add `--cluster-name` to `hiveutil deprovision ibmcloud` usage. `--cluster-name` is a required parameter (needed for cleaning up DNS entries) should be in the usage example. 
* Fix an inconsistency with `hiveutil create-cluster` I noticed writing usage docs. `--ibm-instance-type` should also be reflected in the generated install config as should the default.

/hold