### PR TITLE
Ensure cluster metadata has an AdminPasswordSecretRef before copying.

### DIFF
--- a/pkg/controller/clusterdeployment/clusterinstalls.go
+++ b/pkg/controller/clusterdeployment/clusterinstalls.go
@@ -56,6 +56,7 @@ func (r *ReconcileClusterDeployment) reconcileExistingInstallingClusterInstall(c
 		met.InfraID != "" &&
 		met.ClusterID != "" &&
 		met.AdminKubeconfigSecretRef.Name != "" &&
+		met.AdminPasswordSecretRef != nil &&
 		met.AdminPasswordSecretRef.Name != "" {
 		if !reflect.DeepEqual(cd.Spec.ClusterMetadata, ci.Spec.ClusterMetadata) {
 			cd.Spec.ClusterMetadata = ci.Spec.ClusterMetadata


### PR DESCRIPTION
This change intends to fix a nil pointer dereference seen in assisted service CI.

```
time="2022-03-09T02:14:12.457Z" level=info msg="reconcile complete" clusterDeployment=assisted-spoke-cluster/assisted-test-cluster controller=clusterDeployment elapsedMillis=515 elapsedMillisGT=0 outcome=unspecified reconcileID=g57l4cz9
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x3a1df8e]

goroutine 1226 [running]:
github.com/openshift/hive/pkg/controller/clusterdeployment.(*ReconcileClusterDeployment).reconcileExistingInstallingClusterInstall(0xc005e47c00, 0xc0041b0c00, {0x55bea50, 0xc00673d5e0})
	github.com/openshift/hive/pkg/controller/clusterdeployment/clusterinstalls.go:59 +0x38e
github.com/openshift/hive/pkg/controller/clusterdeployment.(*ReconcileClusterDeployment).reconcileInstallingClusterInstall(0xc005ecaa20, 0xc0041b0c00, {0x55bea50, 0xc00673d5e0})
	github.com/openshift/hive/pkg/controller/clusterdeployment/clusterdeployment_controller.go:852 +0x33b
github.com/openshift/hive/pkg/controller/clusterdeployment.(*ReconcileClusterDeployment).reconcile(0xc005e47c00, {{{0xc00242ef18, 0x18}, {0xc00242ef00, 0xf}}}, 0xc0041b0c00, {0x55bea50, 0xc00673d5e0})
	github.com/openshift/hive/pkg/controller/clusterdeployment/clusterdeployment_controller.go:813 +0x2685
github.com/openshift/hive/pkg/controller/clusterdeployment.(*ReconcileClusterDeployment).Reconcile(0xc005e47c00, {0xc006750780, 0x478eea0}, {{{0xc00242ef18, 0x4d06d80}, {0xc00242ef00, 0x30}}})
	github.com/openshift/hive/pkg/controller/clusterdeployment/clusterdeployment_controller.go:351 +0xe2e
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0xc004936d10, {0x5522558, 0xc006750780}, {{{0xc00242ef18, 0x4d06d80}, {0xc00242ef00, 0x19869d4}}})
	sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:114 +0x26f
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc004936d10, {0x55224b0, 0xc000dc23c0}, {0x4966f20, 0xc002419a00})
	sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:311 +0x33e
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc004936d10, {0x55224b0, 0xc000dc23c0})
	sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:266 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:227 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
	sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/controller/controller.go:223 +0x357
```