### PR TITLE
Leader election migration 2: Lease only

### DIFF
--- a/cmd/util/leaderelection.go
+++ b/cmd/util/leaderelection.go
@@ -25,7 +25,7 @@ func RunWithLeaderElection(ctx context.Context, cfg *rest.Config, lockNS, lockNa
 	// This gives us ReleaseOnCancel which is not presently exposed in controller-runtime.
 
 	// [Later] Migrated to using resourcelock.New() with ConfigMapsLeasesResourceLock.
-	// TODO: Migrate to LeasesResourceLock after the next version boundary.
+	// [Later] Migrated to using LeasesResourceLock.
 
 	id := uuid.New().String()
 	leLog := log.WithField("id", id)
@@ -33,7 +33,7 @@ func RunWithLeaderElection(ctx context.Context, cfg *rest.Config, lockNS, lockNa
 
 	kubeClient := kubernetes.NewForConfigOrDie(cfg)
 	lock, err := resourcelock.New(
-		resourcelock.ConfigMapsLeasesResourceLock,
+		resourcelock.LeasesResourceLock,
 		lockNS,
 		lockName,
 		kubeClient.CoreV1(),


### PR DESCRIPTION
Follows up on #1660 / 7ec5c25fab0d734f9702666b1244cdd737eacee9

This is phase 2 where we move from ConfigMap+Lease to Lease only.

[HIVE-1754](https://issues.redhat.com/browse/HIVE-1754)