### PR TITLE
Skip "claimed CD" creation webhook for DR

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -380,6 +380,11 @@ const (
 	// is "Running", the cluster may not be in the same ready state as when it first finished
 	// installing. Use with caution.
 	ResumeSkipsClusterOperatorsLabel = "hive.openshift.io/resume-skips-cluster-operators"
+
+	// DisableCreationWebHookForDisasterRecovery is a label that can be added to CRs for which we
+	// normally validate creation. Specific hooks can be disabled by setting this label to (string)
+	// "true".
+	DisableCreationWebHookForDisasterRecovery = "hive.openshift.io/disable-creation-webhook-for-dr"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook.go
+++ b/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook.go
@@ -215,6 +215,8 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateCreate(admissionSpec 
 		}
 	}
 
+	dr := creationHooksDisabled(cd)
+
 	// Add the new data to the contextLogger
 	contextLogger.Data["object.Name"] = cd.Name
 
@@ -313,9 +315,12 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateCreate(admissionSpec 
 		}
 	}
 
-	if poolRef := cd.Spec.ClusterPoolRef; poolRef != nil {
-		if claimName := poolRef.ClaimName; claimName != "" {
-			allErrs = append(allErrs, field.Invalid(specPath.Child("clusterPoolRef", "claimName"), claimName, "cannot create a ClusterDeployment that is already claimed"))
+	// Disable this check for DR
+	if !dr {
+		if poolRef := cd.Spec.ClusterPoolRef; poolRef != nil {
+			if claimName := poolRef.ClaimName; claimName != "" {
+				allErrs = append(allErrs, field.Invalid(specPath.Child("clusterPoolRef", "claimName"), claimName, "cannot create a ClusterDeployment that is already claimed"))
+			}
 		}
 	}
 

--- a/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook_test.go
@@ -291,6 +291,16 @@ func TestClusterDeploymentValidate(t *testing.T) {
 			expectedAllowed: false,
 		},
 		{
+			name: "Test DR create (restore) with Claimed ClusterPoolReference",
+			newObject: func() *hivev1.ClusterDeployment {
+				cd := validAWSClusterDeploymentFromPool("pool-ns", "mypool", "test-claim")
+				cd.Labels = map[string]string{constants.DisableCreationWebHookForDisasterRecovery: "true"}
+				return cd
+			}(),
+			operation:       admissionv1beta1.Create,
+			expectedAllowed: true,
+		},
+		{
 			name:            "Test update with removed ClusterPoolReference",
 			oldObject:       validAWSClusterDeploymentFromPool("pool-ns", "mypool", ""),
 			newObject:       validAWSClusterDeployment(),

--- a/pkg/validating-webhooks/hive/v1/utils.go
+++ b/pkg/validating-webhooks/hive/v1/utils.go
@@ -1,0 +1,20 @@
+package v1
+
+import (
+	"strconv"
+
+	"github.com/openshift/hive/pkg/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func creationHooksDisabled(o metav1.Object) bool {
+	v, ok := o.GetLabels()[constants.DisableCreationWebHookForDisasterRecovery]
+	if !ok {
+		return false
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false
+	}
+	return b
+}


### PR DESCRIPTION
We have a webhook to disallow creating a ClusterDeployment with the
ClusterClaim already set. This is a problem for disaster recovery. Add a
granny switch to disable that specific check via the following label:

`"hive.openshift.io/disable-creation-webhook-for-dr": "true"`

[HIVE-1791](https://issues.redhat.com/browse/HIVE-1791)

Conflicts:
      pkg/constants/constants.go

...for IBMCloud again.