### PR TITLE
Set IBM Cloud VPC service API URLs for region

### DIFF
--- a/pkg/controller/hibernation/ibmcloud_actuator.go
+++ b/pkg/controller/hibernation/ibmcloud_actuator.go
@@ -58,7 +58,7 @@ func (a *ibmCloudActuator) StopMachines(cd *hivev1.ClusterDeployment, hiveClient
 		logger.Info("No instances were found to stop")
 		return nil
 	}
-	err = ibmCloudClient.StopInstances(instances)
+	err = ibmCloudClient.StopInstances(context.TODO(), instances, cd.Spec.Platform.IBMCloud.Region)
 	if err != nil {
 		logger.WithError(err).Error("failed to stop IBM Cloud instances")
 		return err
@@ -83,7 +83,7 @@ func (a *ibmCloudActuator) StartMachines(cd *hivev1.ClusterDeployment, hiveClien
 		logger.Info("No instances were found to start")
 		return nil
 	}
-	err = ibmCloudClient.StartInstances(instances)
+	err = ibmCloudClient.StartInstances(context.TODO(), instances, cd.Spec.Platform.IBMCloud.Region)
 	if err != nil {
 		logger.WithError(err).Error("failed to start IBM Cloud instances")
 		return err
@@ -149,7 +149,7 @@ func getIBMCloudClusterInstances(cd *hivev1.ClusterDeployment, c ibmclient.API, 
 	logger = logger.WithField("infraID", infraID)
 	logger.Debug("listing cluster instances")
 
-	instances, err := c.GetVPCInstances(context.TODO(), infraID)
+	instances, err := c.GetVPCInstances(context.TODO(), infraID, cd.Spec.Platform.IBMCloud.Region)
 	if err != nil {
 		logger.WithError(err).Error("failed to list instances")
 		return nil, err

--- a/pkg/ibmclient/client.go
+++ b/pkg/ibmclient/client.go
@@ -38,9 +38,9 @@ type API interface {
 	GetVSIProfiles(ctx context.Context) ([]vpcv1.InstanceProfile, error)
 	GetVPC(ctx context.Context, vpcID string) (*vpcv1.VPC, error)
 	GetVPCZonesForRegion(ctx context.Context, region string) ([]string, error)
-	GetVPCInstances(ctx context.Context, resourceGroupID string) ([]vpcv1.Instance, error)
-	StartInstances(instances []vpcv1.Instance) error
-	StopInstances(instances []vpcv1.Instance) error
+	GetVPCInstances(ctx context.Context, infraID, region string) ([]vpcv1.Instance, error)
+	StartInstances(ctx context.Context, instances []vpcv1.Instance, region string) error
+	StopInstances(ctx context.Context, instances []vpcv1.Instance, region string) error
 }
 
 // Client makes calls to the IBM Cloud API.
@@ -482,8 +482,12 @@ func GetAccountID(client API, ctx context.Context) (string, error) {
 	return *apiKeyDetails.AccountID, nil
 }
 
-func (c *Client) GetVPCInstances(ctx context.Context, infraID string) ([]vpcv1.Instance, error) {
-	options := &vpcv1.ListInstancesOptions{}
+func (c *Client) GetVPCInstances(ctx context.Context, infraID, region string) ([]vpcv1.Instance, error) {
+	err := c.setVPCServiceURLForRegion(ctx, region)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to set vpc service url for region %s", region)
+	}
+	options := c.vpcAPI.NewListInstancesOptions()
 	options.SetVPCName(fmt.Sprintf("%s-vpc", infraID))
 	result, _, err := c.vpcAPI.ListInstances(options)
 	if err != nil {
@@ -498,11 +502,13 @@ func (c *Client) GetVPCInstances(ctx context.Context, infraID string) ([]vpcv1.I
 	return instances, nil
 }
 
-func (c *Client) StopInstances(instances []vpcv1.Instance) error {
+func (c *Client) StopInstances(ctx context.Context, instances []vpcv1.Instance, region string) error {
+	err := c.setVPCServiceURLForRegion(ctx, region)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set vpc service url for region %s", region)
+	}
 	for _, instance := range instances {
-		options := &vpcv1.CreateInstanceActionOptions{}
-		options.SetInstanceID(*instance.ID)
-		options.SetType(vpcv1.CreateInstanceActionOptionsTypeStopConst)
+		options := c.vpcAPI.NewCreateInstanceActionOptions(*instance.ID, vpcv1.CreateInstanceActionOptionsTypeStopConst)
 		_, _, err := c.vpcAPI.CreateInstanceAction(options)
 		if err != nil {
 			return errors.Wrap(err, "failed to create stop instance action")
@@ -511,11 +517,13 @@ func (c *Client) StopInstances(instances []vpcv1.Instance) error {
 	return nil
 }
 
-func (c *Client) StartInstances(instances []vpcv1.Instance) error {
+func (c *Client) StartInstances(ctx context.Context, instances []vpcv1.Instance, region string) error {
+	err := c.setVPCServiceURLForRegion(ctx, region)
+	if err != nil {
+		return errors.Wrapf(err, "failed to set vpc service url for region %s", region)
+	}
 	for _, instance := range instances {
-		options := &vpcv1.CreateInstanceActionOptions{}
-		options.SetInstanceID(*instance.ID)
-		options.SetType(vpcv1.CreateInstanceActionOptionsTypeStartConst)
+		options := c.vpcAPI.NewCreateInstanceActionOptions(*instance.ID, vpcv1.CreateInstanceActionOptionsTypeStartConst)
 		_, _, err := c.vpcAPI.CreateInstanceAction(options)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create start instance action for instance %q", *instance.Name)

--- a/pkg/ibmclient/mock/client_generated.go
+++ b/pkg/ibmclient/mock/client_generated.go
@@ -221,18 +221,18 @@ func (mr *MockAPIMockRecorder) GetVPC(ctx, vpcID interface{}) *gomock.Call {
 }
 
 // GetVPCInstances mocks base method.
-func (m *MockAPI) GetVPCInstances(ctx context.Context, resourceGroupID string) ([]vpcv1.Instance, error) {
+func (m *MockAPI) GetVPCInstances(ctx context.Context, infraID, region string) ([]vpcv1.Instance, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVPCInstances", ctx, resourceGroupID)
+	ret := m.ctrl.Call(m, "GetVPCInstances", ctx, infraID, region)
 	ret0, _ := ret[0].([]vpcv1.Instance)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetVPCInstances indicates an expected call of GetVPCInstances.
-func (mr *MockAPIMockRecorder) GetVPCInstances(ctx, resourceGroupID interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) GetVPCInstances(ctx, infraID, region interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCInstances", reflect.TypeOf((*MockAPI)(nil).GetVPCInstances), ctx, resourceGroupID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPCInstances", reflect.TypeOf((*MockAPI)(nil).GetVPCInstances), ctx, infraID, region)
 }
 
 // GetVPCZonesForRegion mocks base method.
@@ -266,29 +266,29 @@ func (mr *MockAPIMockRecorder) GetVSIProfiles(ctx interface{}) *gomock.Call {
 }
 
 // StartInstances mocks base method.
-func (m *MockAPI) StartInstances(instances []vpcv1.Instance) error {
+func (m *MockAPI) StartInstances(ctx context.Context, instances []vpcv1.Instance, region string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartInstances", instances)
+	ret := m.ctrl.Call(m, "StartInstances", ctx, instances, region)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StartInstances indicates an expected call of StartInstances.
-func (mr *MockAPIMockRecorder) StartInstances(instances interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) StartInstances(ctx, instances, region interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartInstances", reflect.TypeOf((*MockAPI)(nil).StartInstances), instances)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartInstances", reflect.TypeOf((*MockAPI)(nil).StartInstances), ctx, instances, region)
 }
 
 // StopInstances mocks base method.
-func (m *MockAPI) StopInstances(instances []vpcv1.Instance) error {
+func (m *MockAPI) StopInstances(ctx context.Context, instances []vpcv1.Instance, region string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StopInstances", instances)
+	ret := m.ctrl.Call(m, "StopInstances", ctx, instances, region)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StopInstances indicates an expected call of StopInstances.
-func (mr *MockAPIMockRecorder) StopInstances(instances interface{}) *gomock.Call {
+func (mr *MockAPIMockRecorder) StopInstances(ctx, instances, region interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstances", reflect.TypeOf((*MockAPI)(nil).StopInstances), instances)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstances", reflect.TypeOf((*MockAPI)(nil).StopInstances), ctx, instances, region)
 }

--- a/pkg/test/clusterdeployment/clusterdeployment.go
+++ b/pkg/test/clusterdeployment/clusterdeployment.go
@@ -11,6 +11,7 @@ import (
 	hivev1aws "github.com/openshift/hive/apis/hive/v1/aws"
 	hivev1azure "github.com/openshift/hive/apis/hive/v1/azure"
 	hivev1gcp "github.com/openshift/hive/apis/hive/v1/gcp"
+	hivev1ibmcloud "github.com/openshift/hive/apis/hive/v1/ibmcloud"
 	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/test/generic"
 )
@@ -218,5 +219,19 @@ func WithGCPPlatform(platform *hivev1gcp.Platform) Option {
 func WithAzurePlatform(platform *hivev1azure.Platform) Option {
 	return func(clusterDeployment *hivev1.ClusterDeployment) {
 		clusterDeployment.Spec.Platform.Azure = platform
+	}
+}
+
+// WithIBMCloudPlatform sets the specified IBM Cloud platform on the cd.
+func WithIBMCloudPlatform(platform *hivev1ibmcloud.Platform) Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Spec.Platform.IBMCloud = platform
+	}
+}
+
+// WithClusterMetadata sets the specified cluster metadata on the cd.
+func WithClusterMetadata(clusterMetadata *hivev1.ClusterMetadata) Option {
+	return func(clusterDeployment *hivev1.ClusterDeployment) {
+		clusterDeployment.Spec.ClusterMetadata = clusterMetadata
 	}
 }


### PR DESCRIPTION
Region based endpoints must be set for calls to the VPC API, `ListInstances` and `CreateInstanceAction` (Start/Stop) in our client's case.
[HIVE-1801](https://issues.redhat.com/browse/HIVE-1801)