### PR TITLE
AWS PrivateLink: "Spread" VPC endpoints across VPCs

### DIFF
--- a/pkg/controller/awsprivatelink/awsprivatelink_controller.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller.go
@@ -296,7 +296,7 @@ func (r *ReconcileAWSPrivateLink) Reconcile(ctx context.Context, request reconci
 	if cp.Spec.InfraID == nil ||
 		(cp.Spec.InfraID != nil && *cp.Spec.InfraID == "") ||
 		(cp.Spec.AdminKubeconfigSecretRef == nil) ||
-		(cp.Spec.AdminKubeconfigSecretRef != nil && *&cp.Spec.AdminKubeconfigSecretRef.Name == "") {
+		(cp.Spec.AdminKubeconfigSecretRef != nil && cp.Spec.AdminKubeconfigSecretRef.Name == "") {
 		logger.Debug("waiting for cluster deployment provision to provide ClusterMetadata, will retry soon.")
 		return reconcile.Result{}, nil
 	}
@@ -325,7 +325,7 @@ func shouldSync(desired *hivev1.ClusterDeployment) (bool, time.Duration) {
 	if readyCondition == nil || readyCondition.Status != corev1.ConditionTrue {
 		return true, 0 // we have not reached Ready level
 	}
-	delta := time.Now().Sub(readyCondition.LastProbeTime.Time)
+	delta := time.Since(readyCondition.LastProbeTime.Time)
 
 	if !desired.Spec.Installed {
 		// as cluster is installing, but the private link has been setup once, we wait

--- a/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
@@ -115,7 +115,7 @@ func Test_setErrCondition(t *testing.T) {
 			cd := testcd.FullBuilder(testNS, "test", scheme).Build()
 			cd.Status.Conditions = test.conditions
 
-			fakeClient := fake.NewFakeClientWithScheme(scheme, cd)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(cd).Build()
 			reconciler := &ReconcileAWSPrivateLink{
 				Client: fakeClient,
 			}
@@ -295,7 +295,7 @@ func Test_setProgressCondition(t *testing.T) {
 			cd := testcd.FullBuilder(testNS, "test", scheme).Build()
 			cd.Status.Conditions = test.conditions
 
-			fakeClient := fake.NewFakeClientWithScheme(scheme, cd)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(cd).Build()
 			reconciler := &ReconcileAWSPrivateLink{
 				Client: fakeClient,
 			}
@@ -415,7 +415,7 @@ users:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := testSecret("test", tt.existing)
-			fakeClient := fake.NewFakeClientWithScheme(scheme, s)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(s).Build()
 
 			got, err := initialURL(fakeClient, client.ObjectKey{Namespace: testNS, Name: "test"})
 			require.NoError(t, err)
@@ -1742,7 +1742,7 @@ users:
 				test.configureAWSClient(mockedAWSClient)
 			}
 
-			fakeClient := fake.NewFakeClientWithScheme(scheme, test.existing...)
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(test.existing...).Build()
 			log.SetLevel(log.DebugLevel)
 			reconciler := &ReconcileAWSPrivateLink{
 				Client: fakeClient,

--- a/pkg/controller/awsprivatelink/vpcinventory.go
+++ b/pkg/controller/awsprivatelink/vpcinventory.go
@@ -1,6 +1,7 @@
 package awsprivatelink
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -73,6 +74,12 @@ func (r *ReconcileAWSPrivateLink) chooseVPCForVPCEndpoint(awsClient awsclient.Cl
 		logger.WithField("vpcs", vpcs).Error(errNoVPCWithQuotaInInventory.Error())
 		return nil, errNoVPCWithQuotaInInventory
 	}
+
+	// "Spread" strategy: sort the candidates by the number of endpoints already used, ascending,
+	// and return the first (emptiest) one.
+	sort.Slice(candidates, func(i, j int) bool {
+		return endpointsPerVPC[candidates[i].VPCID] < endpointsPerVPC[candidates[j].VPCID]
+	})
 
 	return &candidates[0], nil
 }

--- a/pkg/controller/awsprivatelink/vpcinventory.go
+++ b/pkg/controller/awsprivatelink/vpcinventory.go
@@ -107,9 +107,6 @@ func toSupportedSubnets(azs sets.String) filterVPCInventoryFn {
 			}
 		}
 		inv.Subnets = inv.Subnets[:n]
-		if len(inv.Subnets) > 0 {
-			return true
-		}
-		return false
+		return len(inv.Subnets) > 0
 	}
 }

--- a/pkg/controller/awsprivatelink/vpcinventory.go
+++ b/pkg/controller/awsprivatelink/vpcinventory.go
@@ -17,7 +17,6 @@ import (
 
 var (
 	errNoSupportedAZsInInventory = errors.New("no supported VPC in inventory which support the AZs of the service")
-	errNoVPCWithQuotaInInventory = errors.New("no supported VPC in inventory with available quota")
 )
 
 func (r *ReconcileAWSPrivateLink) chooseVPCForVPCEndpoint(awsClient awsclient.Client,
@@ -69,12 +68,6 @@ func (r *ReconcileAWSPrivateLink) chooseVPCForVPCEndpoint(awsClient awsclient.Cl
 		endpointsPerVPC[vpcID] = endpointsPerVPC[vpcID] + 1
 	}
 
-	candidates = filterVPCInventory(candidates, toAvailableQuota(endpointsPerVPC))
-	if len(candidates) == 0 {
-		logger.WithField("vpcs", vpcs).Error(errNoVPCWithQuotaInInventory.Error())
-		return nil, errNoVPCWithQuotaInInventory
-	}
-
 	// "Spread" strategy: sort the candidates by the number of endpoints already used, ascending,
 	// and return the first (emptiest) one.
 	sort.Slice(candidates, func(i, j int) bool {
@@ -115,24 +108,6 @@ func toSupportedSubnets(azs sets.String) filterVPCInventoryFn {
 		}
 		inv.Subnets = inv.Subnets[:n]
 		if len(inv.Subnets) > 0 {
-			return true
-		}
-		return false
-	}
-}
-
-const (
-	// VPCEndpointPerVPCLimit is a limit on the maximum number of VPC endpoints that can
-	// be created in a VPC. This limit is used to filter out any VPCs in the inventory
-	// that are already at the this upper limit.
-	// The actual limit is 255, but we limit to lower limit.
-	VPCEndpointPerVPCLimit = 250
-)
-
-func toAvailableQuota(existingPerVPC map[string]int) filterVPCInventoryFn {
-	return func(inv *hivev1.AWSPrivateLinkInventory) bool {
-		avail := VPCEndpointPerVPCLimit - existingPerVPC[inv.VPCID]
-		if avail > 0 {
 			return true
 		}
 		return false


### PR DESCRIPTION
Since we don't know the actual quota of endpoints per VPC, remove the arbitrary limit check, and create new endpoints in the least-used VPC. The result should be that we hit quota only when all the VPCs are full.

[HIVE-1803](https://issues.redhat.com//browse/HIVE-1803)