### PR TITLE
dnsendpoint: not-yet-scraped: no error, no requeue

### DIFF
--- a/pkg/controller/dnsendpoint/dnsendpoint_controller_test.go
+++ b/pkg/controller/dnsendpoint/dnsendpoint_controller_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
@@ -69,7 +68,6 @@ func TestDNSEndpointReconcile(t *testing.T) {
 		nameServers              rootDomainsMap
 		configureQuery           func(*mock.MockQuery)
 		expectErr                bool
-		requeueAfter             time.Duration
 		expectedNameServers      rootDomainsMap
 		expectedCreatedCondition bool
 		expectDNSZoneDeleted     bool
@@ -232,8 +230,7 @@ func TestDNSEndpointReconcile(t *testing.T) {
 			nameServers: rootDomainsMap{
 				rootDomain: nil,
 			},
-			expectErr:    true,
-			requeueAfter: 15 * time.Second,
+			expectErr: false,
 			expectedNameServers: rootDomainsMap{
 				rootDomain: nil,
 			},
@@ -355,7 +352,7 @@ func TestDNSEndpointReconcile(t *testing.T) {
 			} else {
 				assert.NoError(t, err, "expected no error from reconcile")
 			}
-			assert.Equal(t, reconcile.Result{RequeueAfter: tc.requeueAfter}, result, "unexpected reconcile result")
+			assert.Equal(t, reconcile.Result{}, result, "unexpected reconcile result")
 			assertRootDomainsMapEqual(t, tc.expectedNameServers, scraper.nameServers)
 			dnsZone := &hivev1.DNSZone{}
 			err = fakeClient.Get(context.Background(), objectKey, dnsZone)


### PR DESCRIPTION
Second attempt to reduce thrashing on controller startup with lots of
clusters.

Since the scraper posts an event causing the DNSZone to be enqueued,
there's no need for this path to requeue (immediately, or ever). And
since we're just waiting for the scrape, it's not really an error
condition.

[HIVE-1855](https://issues.redhat.com//browse/HIVE-1855)