### PR TITLE
Run version.py under python3 explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ endif
 # v{major}.{minor}.{commitcount}-{sha}
 # Note that building against a local commit may result in {major}.{minor} being rendered as
 # `UnknownBranch`. However, the {commitcount} and {sha} should still be accurate.
-SOURCE_GIT_TAG := v$(shell hack/version.py)
+SOURCE_GIT_TAG := v$(shell python3 -mpip install --user gitpython >&2; hack/version.py)
 
 BINDATA_INPUTS :=./config/clustersync/... ./config/hiveadmission/... ./config/controllers/... ./config/rbac/... ./config/configmaps/... ./config/monitoring/...
 $(call add-bindata,operator,$(BINDATA_INPUTS),,assets,pkg/operator/assets/bindata.go)

--- a/hack/version.py
+++ b/hack/version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import git
 import os


### PR DESCRIPTION
version.py has some python3-specific syntax. The `python` on the AppSRE
jenkins nodes on which we build is py2. Make the script run under py3
explicitly.

[HIVE-1717](https://issues.redhat.com//browse/HIVE-1717)