### PR TITLE
Fix condition initialization

### DIFF
--- a/pkg/controller/awsprivatelink/awsprivatelink_controller.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller.go
@@ -173,8 +173,8 @@ func (r *ReconcileAWSPrivateLink) Reconcile(ctx context.Context, request reconci
 	}
 
 	// Initialize cluster deployment conditions if not present
-	newConditions := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentAWSPrivateLinkConditions)
-	if len(newConditions) > len(cd.Status.Conditions) {
+	newConditions, changed := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentAWSPrivateLinkConditions)
+	if changed {
 		cd.Status.Conditions = newConditions
 		logger.Info("initializing AWS private link controller conditions")
 		if err := r.Status().Update(context.TODO(), cd); err != nil {

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -307,8 +307,8 @@ func (r *ReconcileClusterDeployment) Reconcile(ctx context.Context, request reco
 	}
 
 	// Initialize cluster deployment conditions if not set
-	newConditions := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentConditions)
-	if len(newConditions) > len(cd.Status.Conditions) {
+	newConditions, changed := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentConditions)
+	if changed {
 		cd.Status.Conditions = newConditions
 		cdLog.Info("initializing cluster deployment controller conditions")
 		if err := r.Status().Update(context.TODO(), cd); err != nil {

--- a/pkg/controller/clusterrelocate/clusterrelocate_controller.go
+++ b/pkg/controller/clusterrelocate/clusterrelocate_controller.go
@@ -174,9 +174,9 @@ func (r *ReconcileClusterRelocate) Reconcile(ctx context.Context, request reconc
 	}
 
 	// Initialize cluster deployment conditions if not present
-	newConditions := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions,
+	newConditions, changed := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions,
 		clusterDeploymentClusterRelocateConditions)
-	if len(newConditions) > len(cd.Status.Conditions) {
+	if changed {
 		cd.Status.Conditions = newConditions
 		logger.Info("initializing cluster relocate controller conditions")
 		if err := r.Status().Update(context.TODO(), cd); err != nil {

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller.go
@@ -144,8 +144,8 @@ func (r *ReconcileControlPlaneCerts) Reconcile(ctx context.Context, request reco
 	}
 
 	// Initialize cluster deployment conditions if not present
-	newConditions := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentControlPlaneCertsConditions)
-	if len(newConditions) > len(cd.Status.Conditions) {
+	newConditions, changed := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentControlPlaneCertsConditions)
+	if changed {
 		cd.Status.Conditions = newConditions
 		cdLog.Info("initializing control plane certs controller conditions")
 		if err := r.Status().Update(context.TODO(), cd); err != nil {

--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -186,8 +186,8 @@ func (r *hibernationReconciler) Reconcile(ctx context.Context, request reconcile
 	}
 
 	// Initialize cluster deployment conditions if not present
-	newConditions := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentHibernationConditions)
-	if len(newConditions) > len(cd.Status.Conditions) {
+	newConditions, changed := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentHibernationConditions)
+	if changed {
 		cd.Status.Conditions = newConditions
 		cdLog.Info("initializing hibernating controller conditions")
 		if err := r.updateClusterDeploymentStatus(cd, cdLog); err != nil {

--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -159,8 +159,8 @@ func (r *ReconcileRemoteClusterIngress) Reconcile(ctx context.Context, request r
 	rContext.clusterDeployment = cd
 
 	// Initialize cluster deployment conditions if not present
-	newConditions := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentRemoteIngressConditions)
-	if len(newConditions) > len(cd.Status.Conditions) {
+	newConditions, changed := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentRemoteIngressConditions)
+	if changed {
 		cd.Status.Conditions = newConditions
 		cdLog.Info("initializing remote ingress controller conditions")
 		if err := r.Status().Update(context.TODO(), cd); err != nil {

--- a/pkg/controller/unreachable/unreachable_controller.go
+++ b/pkg/controller/unreachable/unreachable_controller.go
@@ -138,8 +138,8 @@ func (r *ReconcileRemoteMachineSet) Reconcile(ctx context.Context, request recon
 	}
 
 	// Initialize cluster deployment conditions if not present
-	newConditions := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentUnreachableConditions)
-	if len(newConditions) > len(cd.Status.Conditions) {
+	newConditions, changed := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentUnreachableConditions)
+	if changed {
 		cd.Status.Conditions = newConditions
 		cdLog.Info("initializing unreachable controller conditions")
 		if err := r.Status().Update(context.TODO(), cd); err != nil {


### PR DESCRIPTION
We were using flawed logic to determine whether to push a status update
when initializing ClusterDeployment conditions. Fix.

[HIVE-1873](https://issues.redhat.com//browse/HIVE-1873)