### PR TITLE
Rename & comment dnsendpoint/nameserverscraper vars/funcs

### DIFF
--- a/pkg/controller/dnsendpoint/nameserver/aws.go
+++ b/pkg/controller/dnsendpoint/nameserver/aws.go
@@ -47,8 +47,8 @@ func (q *awsQuery) Get(domain string) (map[string]sets.String, error) {
 	return currentNameServers, errors.Wrap(err, "error querying name servers")
 }
 
-// Create implements Query.Create.
-func (q *awsQuery) Create(rootDomain string, domain string, values sets.String) error {
+// CreateOrUpdate implements Query.CreateOrUpdate.
+func (q *awsQuery) CreateOrUpdate(rootDomain string, domain string, values sets.String) error {
 	awsClient, err := q.getAWSClient()
 	if err != nil {
 		return errors.Wrap(err, "failed to get AWS client")

--- a/pkg/controller/dnsendpoint/nameserver/aws_live_test.go
+++ b/pkg/controller/dnsendpoint/nameserver/aws_live_test.go
@@ -82,7 +82,7 @@ func (s *LiveAWSTestSuite) TestCreateAndDelete() {
 			cut := s.getCUT()
 			domain := fmt.Sprintf("live-aws-test-%08d.%s", rand.Intn(100000000), s.rootDomain)
 			s.T().Logf("domain = %q", domain)
-			err := cut.Create(s.rootDomain, domain, sets.NewString(tc.createValues...))
+			err := cut.CreateOrUpdate(s.rootDomain, domain, sets.NewString(tc.createValues...))
 			if s.NoError(err, "unexpected error creating NS") {
 				defer func() {
 					err := cut.Delete(s.rootDomain, domain, sets.NewString(tc.deleteValues...))

--- a/pkg/controller/dnsendpoint/nameserver/azure.go
+++ b/pkg/controller/dnsendpoint/nameserver/azure.go
@@ -61,8 +61,8 @@ func (q *azureQuery) Get(domain string) (map[string]sets.String, error) {
 	return currentNameServers, errors.Wrap(err, "error querying name servers")
 }
 
-// Create implements Query.Create.
-func (q *azureQuery) Create(rootDomain string, domain string, values sets.String) error {
+// CreateOrUpdate implements Query.Create.
+func (q *azureQuery) CreateOrUpdate(rootDomain string, domain string, values sets.String) error {
 	azureClient, err := q.getAzureClient()
 	if err != nil {
 		return errors.Wrap(err, "failed to get Azure client")

--- a/pkg/controller/dnsendpoint/nameserver/azure_live_test.go
+++ b/pkg/controller/dnsendpoint/nameserver/azure_live_test.go
@@ -128,7 +128,7 @@ func (s *LiveAzureTestSuite) testCreateAndDelete(tc *testCreateAndDeleteCase) {
 	cut := s.getCUT()
 	domain := fmt.Sprintf("live-azure-test-%08d.%s", rand.Intn(100000000), s.rootDomain)
 	s.T().Logf("domain = %q", domain)
-	err := cut.Create(s.rootDomain, domain, sets.NewString(tc.createValues...))
+	err := cut.CreateOrUpdate(s.rootDomain, domain, sets.NewString(tc.createValues...))
 	if s.NoError(err, "unexpected error creating NS") {
 		defer func() {
 			err := cut.Delete(s.rootDomain, domain, sets.NewString(tc.deleteValues...))
@@ -147,7 +147,7 @@ func (s *LiveAzureTestSuite) testCreateThenUpdate(tc *testCreateThenUpdateCase) 
 	cut := s.getCUT()
 	domain := fmt.Sprintf("live-azure-test-%08d.%s", rand.Intn(100000000), s.rootDomain)
 	s.T().Logf("domain = %q", domain)
-	err := cut.Create(s.rootDomain, domain, sets.NewString(tc.createValues...))
+	err := cut.CreateOrUpdate(s.rootDomain, domain, sets.NewString(tc.createValues...))
 	if s.NoError(err, "unexpected error creating NS") {
 		defer func() {
 			err := cut.Delete(s.rootDomain, domain, sets.NewString())
@@ -156,7 +156,7 @@ func (s *LiveAzureTestSuite) testCreateThenUpdate(tc *testCreateThenUpdateCase) 
 	}
 
 	// now test updating by re-issuing a Create()
-	err = cut.Create(s.rootDomain, domain, sets.NewString(tc.updateValues...))
+	err = cut.CreateOrUpdate(s.rootDomain, domain, sets.NewString(tc.updateValues...))
 	s.NoError(err, "unexpected error updating NS")
 
 	nameServers, err := cut.Get(s.rootDomain)

--- a/pkg/controller/dnsendpoint/nameserver/gcp.go
+++ b/pkg/controller/dnsendpoint/nameserver/gcp.go
@@ -58,8 +58,8 @@ func (q *gcpQuery) Get(domain string) (map[string]sets.String, error) {
 	return currentNameServers, errors.Wrap(err, "error querying name servers")
 }
 
-// Create implements Query.Create.
-func (q *gcpQuery) Create(rootDomain string, domain string, values sets.String) error {
+// CreateOrUpdate implements Query.CreateOrUpdate.
+func (q *gcpQuery) CreateOrUpdate(rootDomain string, domain string, values sets.String) error {
 	gcpClient, err := q.getGCPClient()
 	if err != nil {
 		return errors.Wrap(err, "failed to get GCP client")

--- a/pkg/controller/dnsendpoint/nameserver/gcp_live_test.go
+++ b/pkg/controller/dnsendpoint/nameserver/gcp_live_test.go
@@ -101,7 +101,7 @@ func (s *LiveGCPTestSuite) testCreateAndDelete(tc *testCreateAndDeleteCase) {
 	cut := s.getCUT()
 	domain := fmt.Sprintf("live-gcp-test-%08d.%s", rand.Intn(100000000), s.rootDomain)
 	s.T().Logf("domain = %q", domain)
-	err := cut.Create(s.rootDomain, domain, sets.NewString(tc.createValues...))
+	err := cut.CreateOrUpdate(s.rootDomain, domain, sets.NewString(tc.createValues...))
 	if s.NoError(err, "unexpected error creating NS") {
 		defer func() {
 			err := cut.Delete(s.rootDomain, domain, sets.NewString(tc.deleteValues...))
@@ -153,7 +153,7 @@ func (s *LiveGCPTestSuite) testCreateThenUpdate(tc *testCreateThenUpdateCase) {
 	cut := s.getCUT()
 	domain := fmt.Sprintf("live-gcp-test-%08d.%s", rand.Intn(100000000), s.rootDomain)
 	s.T().Logf("domain = %q", domain)
-	err := cut.Create(s.rootDomain, domain, sets.NewString(tc.createValues...))
+	err := cut.CreateOrUpdate(s.rootDomain, domain, sets.NewString(tc.createValues...))
 	if s.NoError(err, "unexpected error creating NS") {
 		defer func() {
 			err := cut.Delete(s.rootDomain, domain, sets.NewString())
@@ -162,7 +162,7 @@ func (s *LiveGCPTestSuite) testCreateThenUpdate(tc *testCreateThenUpdateCase) {
 	}
 
 	// now test updating by re-issuing a Create()
-	err = cut.Create(s.rootDomain, domain, sets.NewString(tc.updateValues...))
+	err = cut.CreateOrUpdate(s.rootDomain, domain, sets.NewString(tc.updateValues...))
 	s.NoError(err, "unexpected error updating NS")
 
 	nameServers, err := cut.Get(s.rootDomain)

--- a/pkg/controller/dnsendpoint/nameserver/mock/query_generated.go
+++ b/pkg/controller/dnsendpoint/nameserver/mock/query_generated.go
@@ -34,18 +34,18 @@ func (m *MockQuery) EXPECT() *MockQueryMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method.
-func (m *MockQuery) Create(rootDomain, domain string, values sets.String) error {
+// CreateOrUpdate mocks base method.
+func (m *MockQuery) CreateOrUpdate(rootDomain, domain string, values sets.String) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", rootDomain, domain, values)
+	ret := m.ctrl.Call(m, "CreateOrUpdate", rootDomain, domain, values)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Create indicates an expected call of Create.
-func (mr *MockQueryMockRecorder) Create(rootDomain, domain, values interface{}) *gomock.Call {
+// CreateOrUpdate indicates an expected call of CreateOrUpdate.
+func (mr *MockQueryMockRecorder) CreateOrUpdate(rootDomain, domain, values interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockQuery)(nil).Create), rootDomain, domain, values)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdate", reflect.TypeOf((*MockQuery)(nil).CreateOrUpdate), rootDomain, domain, values)
 }
 
 // Delete mocks base method.

--- a/pkg/controller/dnsendpoint/nameserver/query.go
+++ b/pkg/controller/dnsendpoint/nameserver/query.go
@@ -8,13 +8,18 @@ import (
 
 // Query is used to perform queries for name servers.
 type Query interface {
-	// Get the name servers under the specified root domain.
+	// Get returns a map, keyed by domain name, of sets of name servers configured in the root
+	// domain's hosted zone for each domain. Entries are included for the root domain as well as
+	// subdomains. For managed DNS, the root domain's hosted zone is created by the user; but the
+	// dnsendpoint controller populates it with the NS entries from the status of each DNSZone for
+	// the subdomain denoted by that DNSZone's spec.zone.
 	Get(rootDomain string) (map[string]sets.String, error)
 
-	// Create name servers for the specified domain under the specified root domain.
-	Create(rootDomain string, domain string, values sets.String) error
+	// CreateOrUpdate creates or replaces name servers for the specified subdomain under the
+	// specified root domain.
+	CreateOrUpdate(rootDomain string, domain string, values sets.String) error
 
-	// Delete the name servers for the specified domain under the specified root domain.
+	// Delete the name servers for the specified subdomain under the specified root domain.
 	// If specified values of the name servers only serve as guidance for what to delete.
 	// If there are other name servers for the specified domain server, those will be
 	// deleted as well.

--- a/pkg/controller/dnsendpoint/nameserverscraper.go
+++ b/pkg/controller/dnsendpoint/nameserverscraper.go
@@ -26,74 +26,105 @@ type endpointState struct {
 	nsValues sets.String
 }
 
-type nameServersMap map[string]endpointState
+// A map, keyed by subdomain name, of endpointState objects
+type endpointsBySubdomain map[string]endpointState
 
-type rootDomainsMap map[string]nameServersMap
+// A map, keyed by root domain name, of maps of subdomain names to their endpointStates, e.g.
+// {
+// 		"p1.openshiftapps.com": {
+// 			"abcd.p1.openshiftapps.com": {
+// 				dnsZone: $dnsZone,
+// 				nsValues: {
+//  				"ns-124.awsdns-15.com.",
+//  				...
+// 				}
+// 			}
+//  		"wxyz.p1.openshiftapps.com": { ... }
+// 		}
+//  	"p2.openshiftapps.com": { ... }
+// }
+// This is used as a cache with the intent of reducing the number of queries to the cloud provider.
+type rootDomainsMap map[string]endpointsBySubdomain
 
+// Every `defaultScrapePeriod` the scraper queries the cloud provider for the definitive list of
+// name servers configured in the root domain's hosted zone for each subdomain. It updates the
+// `rootDomainsMap` cache for each subdomain it knows about. If the list of name servers has
+// changed for a given subdomain (this should generally never happen unless the user did it
+// manually, which they should not do), the scraper enqueues the DNSZone to be reconciled again
+// by the dnsendpoint controller, which will effectively revert the changes.
+// Root domains come from HiveConfig.spec.managedDomains.domains[] and are seeded into the cache
+// when the scraper is created.
+// Subdomains come from DNSZone.spec.zone and are seeded into the cache by the dnsendpoint
+// controller. Thus, the cache is limited only to the subdomains managed by this controller (hive
+// instance), as other hives may be managing DNSZones in the same root domain.
+// The source of truth for subdomain NS entries is DNSZone.status.nameServers[]. The dnsendpoint
+// controller is responsible for curating the subdomain NS entries in the root hosted zone based on
+// that list. When it does so, it updates the cache to avoid an extra reconcile.
 type nameServerScraper struct {
 	logger          log.FieldLogger
 	mux             sync.Mutex
 	scrapePeriod    time.Duration
 	queue           workqueue.RateLimitingInterface
-	nameServers     rootDomainsMap
+	rootDomainsMap  rootDomainsMap
 	nameServerQuery nameserver.Query
 	notifyChange    func(client.Object)
 }
 
-func newNameServerScraper(logger log.FieldLogger, nameServerQuery nameserver.Query, domains []string, notifyChange func(client.Object)) *nameServerScraper {
-	if len(domains) == 0 {
+func newNameServerScraper(logger log.FieldLogger, nameServerQuery nameserver.Query, rootDomains []string, notifyChange func(client.Object)) *nameServerScraper {
+	if len(rootDomains) == 0 {
 		return nil
 	}
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(10*time.Second, 1*time.Hour), "nameServerScraper")
-	nameServers := make(rootDomainsMap, len(domains))
-	for _, domain := range domains {
-		queue.Add(domain)
-		nameServers[domain] = nil
+	rootDomainsMap := make(rootDomainsMap, len(rootDomains))
+	for _, rootDomain := range rootDomains {
+		queue.Add(rootDomain)
+		rootDomainsMap[rootDomain] = nil
 	}
 	return &nameServerScraper{
-		logger:          logger.WithField("scraper", "nameServer"),
-		scrapePeriod:    defaultScrapePeriod,
+		logger:       logger.WithField("scraper", "nameServer"),
+		scrapePeriod: defaultScrapePeriod,
+		// queue expects *root* domain names
 		queue:           queue,
-		nameServers:     nameServers,
+		rootDomainsMap:  rootDomainsMap,
 		nameServerQuery: nameServerQuery,
 		notifyChange:    notifyChange,
 	}
 }
 
-// GetEndpoint gets the name servers for the specified domain.
-func (s *nameServerScraper) GetEndpoint(domain string) (rootDomain string, nameServers sets.String) {
+// GetEndpoint gets the root domain name and the name servers for the specified subdomain.
+func (s *nameServerScraper) GetEndpoint(subdomain string) (rootDomain string, nameServers sets.String) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
-	rootDomain, nsMap := s.rootDomainNameServers(domain)
-	return rootDomain, nsMap[domain].nsValues
+	rootDomain, nsMap := s.rootDomainNameServers(subdomain)
+	return rootDomain, nsMap[subdomain].nsValues
 }
 
-// AddEndpoint adds an endpoint with the specified domain.
-func (s *nameServerScraper) AddEndpoint(object *hivev1.DNSZone, domain string, nameServers sets.String) {
+// SyncEndpoint adds or updates the subdomain's endpointState in the scraper's cache
+func (s *nameServerScraper) SyncEndpoint(dnsZone *hivev1.DNSZone, subdomain string, nameServers sets.String) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
-	_, nsMap := s.rootDomainNameServers(domain)
+	_, nsMap := s.rootDomainNameServers(subdomain)
 	if nsMap == nil {
 		return
 	}
-	nsMap[domain] = endpointState{
-		dnsZone:  object,
+	nsMap[subdomain] = endpointState{
+		dnsZone:  dnsZone,
 		nsValues: nameServers,
 	}
 }
 
 // RemoveEndpoint removes the endpoint with the specified domain.
-func (s *nameServerScraper) RemoveEndpoint(domain string) {
+func (s *nameServerScraper) RemoveEndpoint(subdomain string) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
-	_, nsMap := s.rootDomainNameServers(domain)
-	delete(nsMap, domain)
+	_, nsMap := s.rootDomainNameServers(subdomain)
+	delete(nsMap, subdomain)
 }
 
-func (s *nameServerScraper) HasBeenScraped(domain string) bool {
+func (s *nameServerScraper) HasBeenScraped(subdomain string) bool {
 	s.mux.Lock()
 	defer s.mux.Unlock()
-	_, nsMap := s.rootDomainNameServers(domain)
+	_, nsMap := s.rootDomainNameServers(subdomain)
 	return nsMap != nil
 }
 
@@ -108,18 +139,18 @@ func (s *nameServerScraper) Start(ctx context.Context) error {
 			}
 			func() {
 				defer s.queue.Done(obj)
-				domain, ok := obj.(string)
+				rootDomain, ok := obj.(string)
 				if !ok {
 					s.logger.WithField("obj", obj).Error("queued object is not a string")
 					s.queue.Forget(obj)
 					return
 				}
-				if err := s.scrape(domain); err == nil {
-					s.logger.WithField("domain", domain).Info("scrape name servers for domain")
+				if err := s.scrape(rootDomain); err == nil {
+					s.logger.WithField("domain", rootDomain).Info("scrape name servers for root domain")
 					s.queue.Forget(obj)
-					s.queue.AddAfter(domain, s.scrapePeriod)
+					s.queue.AddAfter(rootDomain, s.scrapePeriod)
 				} else {
-					s.logger.WithField("domain", domain).WithError(err).Error("failed to scrape name servers for domain")
+					s.logger.WithField("domain", rootDomain).WithError(err).Error("failed to scrape name servers for root domain")
 					s.queue.AddRateLimited(obj)
 				}
 			}()
@@ -130,40 +161,43 @@ func (s *nameServerScraper) Start(ctx context.Context) error {
 }
 
 func (s *nameServerScraper) scrape(rootDomain string) error {
-	currentNameServers, err := s.nameServerQuery.Get(rootDomain)
+	currentNameServerMap, err := s.nameServerQuery.Get(rootDomain)
 	if err != nil {
 		return errors.Wrap(err, "error querying name servers")
 	}
-	changedEndpoints := []client.Object{}
+	changedDNSZones := []client.Object{}
 	func() {
 		s.mux.Lock()
 		defer s.mux.Unlock()
-		oldNameServers, ok := s.nameServers[rootDomain]
+		oldNSMap, ok := s.rootDomainsMap[rootDomain]
 		if !ok {
 			s.logger.WithField("domain", rootDomain).Error("domain is not a root domain")
 			return
 		}
-		if oldNameServers == nil {
-			oldNameServers = nameServersMap{}
-			s.nameServers[rootDomain] = oldNameServers
+		if oldNSMap == nil {
+			oldNSMap = endpointsBySubdomain{}
+			s.rootDomainsMap[rootDomain] = oldNSMap
 		}
-		for domain, oldNameServer := range oldNameServers {
-			currentNameServer, ok := currentNameServers[domain]
-			if !ok || !currentNameServer.Equal(oldNameServer.nsValues) {
-				changedEndpoints = append(changedEndpoints, oldNameServer.dnsZone)
-				oldNameServer.nsValues = currentNameServer
-				oldNameServers[domain] = oldNameServer
+		// Sync our cache with NS entries for each subdomain that has already been seeded. If
+		// anything has changed, update the cache based on what came from the cloud provider
+		// and (set up to) requeue any affected DNSZone objects to the dnsendpoint controller.
+		for subdomain, oldEndpoints := range oldNSMap {
+			currentNameServers, ok := currentNameServerMap[subdomain]
+			if !ok || !currentNameServers.Equal(oldEndpoints.nsValues) {
+				changedDNSZones = append(changedDNSZones, oldEndpoints.dnsZone)
+				oldEndpoints.nsValues = currentNameServers
+				oldNSMap[subdomain] = oldEndpoints
 			}
 		}
 	}()
-	for _, e := range changedEndpoints {
-		s.notifyChange(e)
+	for _, changedDNSZone := range changedDNSZones {
+		s.notifyChange(changedDNSZone)
 	}
 	return nil
 }
 
-func (s *nameServerScraper) rootDomainNameServers(domain string) (string, nameServersMap) {
-	for root, nsMap := range s.nameServers {
+func (s *nameServerScraper) rootDomainNameServers(domain string) (string, endpointsBySubdomain) {
+	for root, nsMap := range s.rootDomainsMap {
 		if strings.HasSuffix(domain, root) {
 			return root, nsMap
 		}

--- a/pkg/controller/dnszone/dnszone_controller.go
+++ b/pkg/controller/dnszone/dnszone_controller.go
@@ -155,6 +155,7 @@ func (r *ReconcileDNSZone) Reconcile(ctx context.Context, request reconcile.Requ
 		return reconcile.Result{}, err
 	}
 
+	// NOTE: Can race with call to same in dnsendpoint controller
 	if result, err := controllerutils.ReconcileDNSZoneForRelocation(r.Client, dnsLog, desiredState, hivev1.FinalizerDNSZone); err != nil {
 		var changed bool
 		desiredState.Status.Conditions, changed = controllerutils.SetDNSZoneConditionWithChangeCheck(


### PR DESCRIPTION
It took two people three days to decipher this code after the original
authors had left. This commit renames variables and functions and leaves
helpful comments so future-we might be less confused.

[HIVE-1855](https://issues.redhat.com//browse/HIVE-1855)