### PR TITLE
Further filter ODF security group filter by VPC ID

### DIFF
--- a/pkg/controller/machinepool/awsactuator.go
+++ b/pkg/controller/machinepool/awsactuator.go
@@ -597,7 +597,7 @@ func GetVPCIDForMachinePool(awsClient awsclient.Client, pool *hivev1.MachinePool
 	}
 	vpcID := *subnetsOutput.Subnets[0].VpcId
 	if vpcID == "" {
-		return "", errors.Errorf("DescribeSubnets unexpectedly returned a subnet without a VPC ID %s", subnetID)
+		return "", errors.Errorf("DescribeSubnets unexpectedly returned subnet %s without a VPC ID", subnetID)
 	}
 	return vpcID, nil
 }

--- a/pkg/controller/machinepool/awsactuator_test.go
+++ b/pkg/controller/machinepool/awsactuator_test.go
@@ -470,12 +470,14 @@ func TestAWSActuator(t *testing.T) {
 			}(),
 			masterMachine: testMachine("master0", "master"),
 			mockAWSClient: func(client *mockaws.MockClient) {
-				firstCall := mockDescribeSubnets(client, []string{"zone1", "zone2"},
-					[]string{"subnet-zone1", "subnet-zone2"}, []string{"pubSubnet-zone1", "pubSubnet-zone2"}, "vpc-1")
-				// When an ExtraWorkerSecurityGroup annotation is configured we query the subnets for the first subnet
-				// in the list configured for a MachinePool to discover the VPC ID of the subnet.
-				mockDescribeSubnets(client, []string{"zone1"},
-					[]string{"subnet-zone1"}, []string{}, "vpc-1").After(firstCall)
+				gomock.InOrder(
+					mockDescribeSubnets(client, []string{"zone1", "zone2"},
+						[]string{"subnet-zone1", "subnet-zone2"}, []string{"pubSubnet-zone1", "pubSubnet-zone2"}, "vpc-1"),
+					// When an ExtraWorkerSecurityGroup annotation is configured we query the subnets for the first subnet
+					// in the list configured for a MachinePool to discover the VPC ID of the subnet.
+					mockDescribeSubnets(client, []string{"zone1"},
+						[]string{"subnet-zone1"}, []string{}, "vpc-1"),
+				)
 				mockDescribeRouteTables(client,
 					map[string]bool{
 						"subnet-zone1":    false,

--- a/pkg/installmanager/installmanager_test.go
+++ b/pkg/installmanager/installmanager_test.go
@@ -39,6 +39,7 @@ const (
 	testDeploymentName   = "test-deployment"
 	testProvisionName    = "test-provision"
 	testNamespace        = "test-namespace"
+	testVPCID            = "testvpc123"
 	pullSecretSecretName = "pull-secret"
 
 	installerBinary     = "openshift-install"
@@ -830,7 +831,7 @@ spec:
 				},
 			}
 			logger := log.WithFields(log.Fields{"machinePool": pool.Name})
-			modifiedBytes, err := patchWorkerMachineSetManifest([]byte(tc.manifestYAML), pool, logger)
+			modifiedBytes, err := patchWorkerMachineSetManifest([]byte(tc.manifestYAML), pool, testVPCID, logger)
 			if tc.expectModified {
 				assert.NotNil(t, modifiedBytes, "expected manifest to be modified")
 			} else {
@@ -854,7 +855,9 @@ spec:
 				assert.NoError(t, err, "expected to be able to decode AWSMachineProviderConfig")
 				awsMachineTemplate, _ := awsMachineTemplateObj.(*awsproviderv1beta1.AWSMachineProviderConfig)
 
-				assert.Contains(t, awsMachineTemplate.SecurityGroups[0].Filters[0].Values, "test-security-group", "expected test-security-group to be configured within AWSMachineProviderConfig")
+				assert.Contains(t, awsMachineTemplate.SecurityGroups[0].Filters[0].Values, "test-security-group", "expected test-security-group to be configured within Security Group Filters in AWSMachineProviderConfig")
+				assert.Equal(t, awsMachineTemplate.SecurityGroups[0].Filters[1].Name, "vpc-id", "expected an vpc-id named filter to be configured within Security Group Filters in AWSMachineProviderConfig")
+				assert.Contains(t, awsMachineTemplate.SecurityGroups[0].Filters[1].Values, "testvpc123", "expected testvpc123 to be configured within Security Group Filters in AWSMachineProviderConfig")
 			}
 		})
 	}


### PR DESCRIPTION
Security group names may be the same within an AWS account (belonging to different VPCs) which means filtering on the name alone is insufficient. The VPC ID is now used to further filter the correct security group when configuring the ODF security group in worker machineset manifests. The VPC ID is discovered by using the AWS client to query subnets from the worker MachinePool. BYO VPC is required when using ODF so it is expected that the worker MachinePool platform will contain subnets we can use to discover the VPC ID.

[HIVE-1874](https://issues.redhat.com//browse/HIVE-1874)
