### PR TITLE
Fix dnsendpoint/nameserverscraper cache

### DIFF
--- a/pkg/controller/dnsendpoint/dnsendpoint_controller.go
+++ b/pkg/controller/dnsendpoint/dnsendpoint_controller.go
@@ -3,7 +3,6 @@ package dnsendpoint
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -221,10 +220,10 @@ func (r *ReconcileDNSEndpoint) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, err
 	}
 
-	if !nsTool.scraper.HasBeenScraped(rootDomain) {
-		// HIVE-1855: Delay this requeue to give the scraping a chance to complete, reducing
-		// thrashing and error rate in the controller.
-		return reconcile.Result{RequeueAfter: 15 * time.Second}, errors.New("name servers have not yet been scraped")
+	if !nsTool.scraper.CheckSeedScrapeStatus(instance, rootDomain) {
+		dnsLog.Info("name servers have not yet been scraped")
+		// The scraper will notify this controller when it has scraped for the subdomain, so don't requeue
+		return reconcile.Result{}, nil
 	}
 
 	if !hasFinalizer {

--- a/pkg/controller/dnszone/dnszone_controller.go
+++ b/pkg/controller/dnszone/dnszone_controller.go
@@ -445,7 +445,6 @@ func (r *ReconcileDNSZone) getActuator(dnsZone *hivev1.DNSZone, dnsLog log.Field
 
 func (r *ReconcileDNSZone) updateStatus(nameServers []string, isSOAAvailable bool, dnsZone *hivev1.DNSZone, logger log.FieldLogger) error {
 	orig := dnsZone.DeepCopy()
-	logger.Debug("Updating DNSZone status")
 
 	dnsZone.Status.NameServers = nameServers
 
@@ -474,6 +473,7 @@ func (r *ReconcileDNSZone) updateStatus(nameServers []string, isSOAAvailable boo
 		controllerutils.UpdateConditionNever)
 
 	if !reflect.DeepEqual(orig.Status, dnsZone.Status) {
+		logger.Debug("Updating DNSZone status")
 		err := r.Client.Status().Update(context.TODO(), dnsZone)
 		if err != nil {
 			logger.WithError(err).Log(controllerutils.LogLevel(err), "Cannot update DNSZone status")


### PR DESCRIPTION
For existing DNSZones with copacetic name server entries in the root
hosted zone, restarting the controller was resulting in thrashing
because:

- the nameserverscraper would ignore subdomains not already in the
cache.
- the dnsendpoint controller would error if the scraper hadn't scraped
the subdomain yet.

This chicken/egg situation would eventually resolve itself because the
scraper would "seed" the cache entry for the subdomain on the first
pass. However, it would not resolve until the second pass of the scraper
two hours later.

This commit makes the dnsendpoint controller seed the cache when it
notices it's necessary. The scraper will then scrape for the subdomain
on its next pass *and* notify the dnsendpoint controller to reconcile
that DNSZone again.

We also needed to change the scraper to cache *all* subdomains for a
root domain, rather than trying to select only those for which this
controller is responsible (one root domain may be "shared" across
multiple hive shards). This is necessary because the scraper doesn't
know which subdomains those are beforehand. (It would theoretically be
nice to set up the controller to trigger the scraper when a
previously-unknown subdomain is encountered; but on controller restart
with a large number of existing DNSZones this would result in a massive
glut of requests to the cloud provider, which is exactly what the
nameserverscraper was designed to avoid.) This does increase the
memory footprint of the controller; but we calculated it to be on the
order of single-digit MiB with O(thousands) of "extraneous" subdomains,
which would be a fraction of a percent of the existing memory footprint;
and thus acceptable.

[HIVE-1855](https://issues.redhat.com//browse/HIVE-1855)