### PR TITLE
Pass field logger around dnszone controller

### DIFF
--- a/pkg/controller/dnszone/dnszone_controller_test.go
+++ b/pkg/controller/dnszone/dnszone_controller_test.go
@@ -206,7 +206,7 @@ func TestReconcileDNSProviderForAWS(t *testing.T) {
 			}
 
 			// Act
-			_, err := r.reconcileDNSProvider(zr, tc.dnsZone)
+			_, err := r.reconcileDNSProvider(zr, tc.dnsZone, zr.logger)
 
 			// Assert
 			if tc.errorExpected {
@@ -358,7 +358,7 @@ func TestReconcileDNSProviderForGCP(t *testing.T) {
 			}
 
 			// Act
-			_, err = r.reconcileDNSProvider(zr, tc.dnsZone)
+			_, err = r.reconcileDNSProvider(zr, tc.dnsZone, zr.logger)
 
 			// Assert
 			if tc.errorExpected {
@@ -492,7 +492,7 @@ func TestReconcileDNSProviderForAzure(t *testing.T) {
 			}
 
 			// Act
-			_, err := r.reconcileDNSProvider(zr, tc.dnsZone)
+			_, err := r.reconcileDNSProvider(zr, tc.dnsZone, zr.logger)
 
 			// Assert
 			if tc.errorExpected {
@@ -608,7 +608,7 @@ func TestReconcileDNSProviderForAWSWithConditions(t *testing.T) {
 			}
 
 			// Act
-			_, err := r.reconcileDNSProvider(zr, tc.dnsZone)
+			_, err := r.reconcileDNSProvider(zr, tc.dnsZone, zr.logger)
 			zr.SetConditionsForError(err)
 
 			// Assert


### PR DESCRIPTION
The dnszone controller's main Reconcile func carefully constructs a
logger that helpfully includes the name of the DNSZone being reconciled;
but helper funcs -- including the one that contains the meat of the
reconcile logic -- were using the reconciler's default logger instead.

This commit propagates the detailed logger throughout the controller to
make it easier to trace activity for a specific DNSZone.