### PR TITLE
Minor changes for transitioning metrics

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,6 +1,8 @@
 package constants
 
 import (
+	"time"
+
 	apihelpers "github.com/openshift/hive/apis/helpers"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 )
@@ -415,6 +417,11 @@ const (
 
 	// AlibabaCloudAccessKeySecretSecretKey is the key we use in a Kubernetes Secret containing Alibaba Cloud credentials for the access key secret.
 	AlibabaCloudAccessKeySecretSecretKey = "alibaba_cloud_access_key_secret"
+
+	// ClusterOperatorSettlePause is the time interval we wait after Nodes are reporting ready, before
+	// actually checking if ClusterOperators are in a good state. This is to allow them time to start
+	// their pods and report accurate status so we avoid reading good state from before hibernation.
+	ClusterOperatorSettlePause = 2 * time.Minute
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment


### PR DESCRIPTION
- Rename some metrics for consistency
- Account for hard coded wait while pausing before we list cluster
  operators while logging the metric for WaitingForClusterOperator
- Also ensure the minimum time bucket for WaitingForClusterOperator
  metric is greater than the hardcoded wait (2 minutes)
  
  xref: https://issues.redhat.com/browse/HIVE-1630
/assign @2uasimojo 