### PR TITLE
Fix default credentials path for alibaba used by hiveutil

### DIFF
--- a/contrib/pkg/createcluster/create.go
+++ b/contrib/pkg/createcluster/create.go
@@ -620,7 +620,7 @@ func (o *Options) GenerateObjects() ([]runtime.Object, error) {
 
 	switch o.Cloud {
 	case cloudAlibaba:
-		defaultCredsFilePath := filepath.Join(o.homeDir, ".alibaba", "credentials")
+		defaultCredsFilePath := filepath.Join(o.homeDir, ".alibabacloud", "credentials")
 		accessKeyID, accessKeySecret, err := alibabacloudutils.GetAlibabaCloud(o.CredsFile, defaultCredsFilePath)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Currently, default is ~/.alibaba/credentials. This PR changes
the default path to ~/.alibabacloud/credentials and makes it
consistent with the installer and ccoctl