### PR TITLE
Add replica ordinal to clustersync status

### DIFF
--- a/apis/hiveinternal/v1alpha1/clustersync_types.go
+++ b/apis/hiveinternal/v1alpha1/clustersync_types.go
@@ -42,6 +42,12 @@ type ClusterSyncStatus struct {
 	// FirstSuccessTime is the time we first successfully applied all (selector)syncsets to a cluster.
 	// +optional
 	FirstSuccessTime *metav1.Time `json:"firstSuccessTime,omitempty"`
+
+	// ControlledByReplica indicates which replica of the hive-clustersync StatefulSet is responsible
+	// for (the CD related to) this clustersync. Note that this value indicates the replica that most
+	// recently handled the ClusterSync. If the hive-clustersync statefulset is scaled up or down, the
+	// controlling replica can change, potentially causing logs to be spread across multiple pods.
+	ControlledByReplica *int64 `json:"controlledByReplica,omitempty"`
 }
 
 // SyncStatus is the status of applying a specific SyncSet or SelectorSyncSet to the cluster.

--- a/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
+++ b/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
@@ -83,6 +83,15 @@ spec:
                   - type
                   type: object
                 type: array
+              controlledByReplica:
+                description: ControlledByReplica indicates which replica of the hive-clustersync
+                  StatefulSet is responsible for (the CD related to) this clustersync.
+                  Note that this value indicates the replica that most recently handled
+                  the ClusterSync. If the hive-clustersync statefulset is scaled up
+                  or down, the controlling replica can change, potentially causing
+                  logs to be spread across multiple pods.
+                format: int64
+                type: integer
               firstSuccessTime:
                 description: FirstSuccessTime is the time we first successfully applied
                   all (selector)syncsets to a cluster.

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -3028,6 +3028,16 @@ objects:
                     - type
                     type: object
                   type: array
+                controlledByReplica:
+                  description: ControlledByReplica indicates which replica of the
+                    hive-clustersync StatefulSet is responsible for (the CD related
+                    to) this clustersync. Note that this value indicates the replica
+                    that most recently handled the ClusterSync. If the hive-clustersync
+                    statefulset is scaled up or down, the controlling replica can
+                    change, potentially causing logs to be spread across multiple
+                    pods.
+                  format: int64
+                  type: integer
                 firstSuccessTime:
                   description: FirstSuccessTime is the time we first successfully
                     applied all (selector)syncsets to a cluster.

--- a/vendor/github.com/openshift/hive/apis/hiveinternal/v1alpha1/clustersync_types.go
+++ b/vendor/github.com/openshift/hive/apis/hiveinternal/v1alpha1/clustersync_types.go
@@ -42,6 +42,12 @@ type ClusterSyncStatus struct {
 	// FirstSuccessTime is the time we first successfully applied all (selector)syncsets to a cluster.
 	// +optional
 	FirstSuccessTime *metav1.Time `json:"firstSuccessTime,omitempty"`
+
+	// ControlledByReplica indicates which replica of the hive-clustersync StatefulSet is responsible
+	// for (the CD related to) this clustersync. Note that this value indicates the replica that most
+	// recently handled the ClusterSync. If the hive-clustersync statefulset is scaled up or down, the
+	// controlling replica can change, potentially causing logs to be spread across multiple pods.
+	ControlledByReplica *int64 `json:"controlledByReplica,omitempty"`
 }
 
 // SyncStatus is the status of applying a specific SyncSet or SelectorSyncSet to the cluster.


### PR DESCRIPTION
In an environment with multiple hive-clustersync replicas and a lot of
clustersync activity, a barrier to debugging was figuring out which
hive-clustersync replica was responsible for a given clusterdeployment's
syncsets. The usual way would be to grep the logs for the CD name, which
can take a nontrivial amount of time across multiple logs.

This commit adds a field to ClusterSync.Status called
ControlledByReplica. It is a pointer (so it doesn't default to zero) to
an integer indicating the ordinal of the replica reconciling it.