### PR TITLE
Robustify e2e a bit

### DIFF
--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -24,7 +24,9 @@ EOF
 }
 
 function count_cds() {
-  oc get cd -A -o json | jq -r '.items | length'
+  J=$(oc get cd -A -o json)
+  [[ -z "$J" ]] && return
+  jq -r '.items | length' <<<"$J"
 }
 
 function wait_for_hibernation_state() {


### PR DESCRIPTION
This commit hits some cases that were making e2e failures hard to debug:
- There was a default exit trap that restored the original default
namespace. This wasn't useful. Remove.
- If things go badly very early -- during `make deploy` or managed DNS
setup performed by e2e-common.sh -- there was no way to troubleshoot.
Set up a basic exit trap to save logs. This is overridden by consuming
tests (whose traps also include saving the logs) once they have gotten
past this early setup.
- After `make deploy`, it takes a little while for hive-operator to
reconcile the hiveconfig with a non-default `targetNamespace`. We were
seeing failures in subsequent steps due to that namespace being absent.
So we add a loop to wait for the namespace to appear before proceeding.
- We had a trivial loop to try enabling managed DNS thrice, but we
weren't killing the test if the last attempt failed. Fix.
- This may be n/a now due to the above, but: If managed DNS enablement
failed, a subsequent step that looked for its credentials would fail
with an inscrutable error (`unable to get type info from the object
"*unstructured.Unstructured": Object 'Kind' is missing in 'object has no
kind field '`). This came from a multi-step operation to feed the secret
through jq and `oc apply` it. Split up that operation, add some error
checking, fail the test if things don't look right.
- In e2e-pool, the `count_cds` function would spuriously return `"0"` if
the `oc get cd` command failed. This could cause leaks during cleanup,
among other anomalies. Fix.