### PR TITLE
Backport ocm-2.4: move to centos:stream base container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,8 @@ WORKDIR /go/src/github.com/openshift/hive
 COPY . .
 RUN make build
 
-FROM quay.io/centos/centos:8
+FROM quay.io/centos/centos:stream
 
-# CentOS images do not get updates as they are meant to mirror ISO content, and thus this update
-# is strongly recommended for security updates.
 RUN dnf -y update && dnf clean all
 
 # ssh-agent required for gathering logs in some situations:


### PR DESCRIPTION
As CentOS 8 goes out of support on 12/2021, move the base container away
from centos:8.

Choices were:
centos:stream
centos:stream8
centos:stream9

stream9 appears to be still in development, so going with building
against 'stream'. This will probably start pointing to 'stream9' when
that becomes an officially released build.
[BZ2089490](https://bugzilla.redhat.com/show_bug.cgi?id=2089490)