### PR TITLE
e2e: Save hive pod descriptions

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -87,6 +87,12 @@ function save_hive_logs() {
     if oc logs -n $n deployment/$d > $tmpf; then
       mv $tmpf "${ARTIFACT_DIR}/${d}.log"
     fi
+    # If deployments' pods didn't start, the above won't produce logs; but these statuses may hint why.
+    for n in ${HIVE_NS} ${HIVE_OPERATOR_NS}; do
+      if oc describe po -n $n > $tmpf; then
+        mv $tmpf "${ARTIFACT_DIR}/describe-po-in-ns-${n}.txt"
+      fi
+    done
   done
 }
 # The consumer of this lib can set up its own exit trap, but this basic one will at least help


### PR DESCRIPTION
Some e2e failures happen because the pods for one or more deployments
don't start at all. In those cases, we don't get any logs, so we can't
figure out what went wrong.

This commit captures `oc describe po` for both the operator and target
namespaces, as those descriptions often contain hints (e.g. events) as
to what went wrong.