### PR TITLE
Hack: explicitly time out e2e tests

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -87,6 +87,12 @@ function save_hive_logs() {
     if oc logs -n $n deployment/$d > $tmpf; then
       mv $tmpf "${ARTIFACT_DIR}/${d}.log"
     fi
+    # If deployments' pods didn't start, the above won't produce logs; but these statuses may hint why.
+    for n in ${HIVE_NS} ${HIVE_OPERATOR_NS}; do
+      if oc describe po -n $n > $tmpf; then
+        mv $tmpf "${ARTIFACT_DIR}/describe-po-in-ns-${n}.txt"
+      fi
+    done
   done
 }
 # The consumer of this lib can set up its own exit trap, but this basic one will at least help

--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -1,3 +1,16 @@
+###
+# TEMPORARY workaround for https://issues.redhat.com/browse/DPTP-2871
+# The job timeout after 2h isn't signaling the test script like it should, so
+# our exit trap isn't being activated, so we're not cleaning up spoke clusters,
+# so we're leaking cloud resources. Inject a "manual" timeout that actually
+# does signal us.
+###
+# This is necessary so our child process can signal us.
+set -o monitor
+# Background an almost-2h sleep followed by sending SIGINT to our PID.
+/usr/bin/bash -c "sleep $((118*60)); echo 'Timed out!'; kill -n 2 $$" &
+###
+
 max_tries=120
 sleep_between_tries=10
 # Set timeout for the cluster deployment to install

--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -74,6 +74,7 @@ fi
 REAL_POOL_NAME=$CLUSTER_NAME
 
 function cleanup() {
+  echo "!EXIT TRAP!"
   capture_manifests
   # Let's save the logs now in case any of the following never finish
   echo "Saving hive logs before cleanup"

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -7,6 +7,7 @@ source ${0%/*}/e2e-common.sh
 
 
 function teardown() {
+  echo "!EXIT TRAP!"
   capture_manifests
   # Let's save the logs now in case any of the following never finish
   echo "Saving hive logs before cleanup"


### PR DESCRIPTION
This is a temporary workaround until the linked bug is resolved. The CI
environment is not signaling our test process at the 2h timeout, so add
an explicit internal timeout to do so.

DPTP-2871