### PR TITLE
clustersync: fix missing memcpy

### DIFF
--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -547,7 +547,8 @@ func (r *ReconcileClusterSync) applySyncSets(
 		return syncSets[i].AsMetaObject().GetName() < syncSets[j].AsMetaObject().GetName()
 	})
 
-	deletionList := syncStatuses
+	deletionList := make([]hiveintv1alpha1.SyncStatus, len(syncStatuses))
+	copy(deletionList, syncStatuses)
 
 	for _, syncSet := range syncSets {
 		_, indexOfOldStatus := getOldSyncStatus(syncSet, deletionList)

--- a/pkg/controller/clustersync/clustersync_controller_test.go
+++ b/pkg/controller/clustersync/clustersync_controller_test.go
@@ -978,13 +978,24 @@ func TestReconcileClusterSync_ResourceRemovedFromSyncSet(t *testing.T) {
 			defer mockCtrl.Finish()
 			scheme := newScheme()
 			resourceToApply := testConfigMap("dest-namespace", "retained-resource")
+			resourceToApply2 := testConfigMap("another-namespace", "another-resource")
 			syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
 				testsyncset.ForClusterDeployments(testCDName),
 				testsyncset.WithGeneration(2),
 				testsyncset.WithResources(resourceToApply),
 				testsyncset.WithApplyMode(tc.resourceApplyMode),
 			)
+			syncSet2 := testsyncset.FullBuilder(testNamespace, "test-syncset2", scheme).Build(
+				testsyncset.ForClusterDeployments(testCDName),
+				testsyncset.WithGeneration(2),
+				testsyncset.WithResources(resourceToApply2),
+				testsyncset.WithApplyMode(tc.resourceApplyMode),
+			)
 			existingSyncStatusBuilder := newSyncStatusBuilder("test-syncset").Options(
+				withTransitionInThePast(),
+				withFirstSuccessTimeInThePast(),
+			)
+			existingSyncStatusBuilder2 := newSyncStatusBuilder("test-syncset2").Options(
 				withTransitionInThePast(),
 				withFirstSuccessTimeInThePast(),
 			)
@@ -993,8 +1004,14 @@ func TestReconcileClusterSync_ResourceRemovedFromSyncSet(t *testing.T) {
 					testConfigMapRef("dest-namespace", "deleted-resource"),
 					testConfigMapRef("dest-namespace", "retained-resource"),
 				))
+				existingSyncStatusBuilder2 = existingSyncStatusBuilder2.Options(withResourcesToDelete(
+					testConfigMapRef("another-namespace", "another-resource"),
+				))
 			}
-			clusterSync := clusterSyncBuilder(scheme).Build(testcs.WithSyncSetStatus(existingSyncStatusBuilder.Build()))
+			clusterSync := clusterSyncBuilder(scheme).Build(
+				testcs.WithSyncSetStatus(existingSyncStatusBuilder.Build()),
+				testcs.WithSyncSetStatus(existingSyncStatusBuilder2.Build()),
+			)
 			lease := buildSyncLease(time.Now().Add(-1 * time.Hour))
 			rt := newReconcileTest(t, mockCtrl, scheme,
 				cdBuilder(scheme).Build(),
@@ -1003,9 +1020,11 @@ func TestReconcileClusterSync_ResourceRemovedFromSyncSet(t *testing.T) {
 					teststatefulset.WithReplicas(3),
 				),
 				syncSet,
+				syncSet2,
 				clusterSync,
 				lease)
 			rt.mockResourceHelper.EXPECT().Apply(newApplyMatcher(resourceToApply)).Return(resource.CreatedApplyResult, nil)
+			rt.mockResourceHelper.EXPECT().Apply(newApplyMatcher(resourceToApply2)).Return(resource.CreatedApplyResult, nil)
 			if tc.expectDelete {
 				rt.mockResourceHelper.EXPECT().
 					Delete("v1", "ConfigMap", "dest-namespace", "deleted-resource").
@@ -1015,12 +1034,22 @@ func TestReconcileClusterSync_ResourceRemovedFromSyncSet(t *testing.T) {
 				withObservedGeneration(2),
 				withFirstSuccessTimeInThePast(),
 			)
+			expectedSyncStatusBuilder2 := newSyncStatusBuilder("test-syncset2").Options(
+				withObservedGeneration(2),
+				withFirstSuccessTimeInThePast(),
+			)
 			if tc.includeResourcesToDelete {
 				expectedSyncStatusBuilder = expectedSyncStatusBuilder.Options(withResourcesToDelete(
 					testConfigMapRef("dest-namespace", "retained-resource"),
 				))
+				expectedSyncStatusBuilder2 = expectedSyncStatusBuilder2.Options(withResourcesToDelete(
+					testConfigMapRef("another-namespace", "another-resource"),
+				))
 			}
-			rt.expectedSyncSetStatuses = []hiveintv1alpha1.SyncStatus{expectedSyncStatusBuilder.Build()}
+			rt.expectedSyncSetStatuses = []hiveintv1alpha1.SyncStatus{
+				expectedSyncStatusBuilder.Build(),
+				expectedSyncStatusBuilder2.Build(),
+			}
 			rt.expectUnchangedLeaseRenewTime = true
 			rt.run(t)
 		})


### PR DESCRIPTION
71c1839b / #1572 fixed an ordering problem in the clustersync controller
to address "moving" a resource from one syncset to another. In so doing,
it introduced a temporary list to look for the deletions. However, the
list was being aliased rather than copied, and the result was that
scenarios with multiple syncsets could end up ignoring changes to a
subset of them. Fix.

[HIVE-1891](https://issues.redhat.com//browse/HIVE-1891)