### PR TITLE
e2e-pool: turn off trace

### DIFF
--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 TEST_NAME=e2e-pool
 source ${0%/*}/e2e-common.sh


### PR DESCRIPTION
`set -x` was producing waaay too much output, making the logs of a CI
run unusable. Turn it off. (We should augment the normal stdout/stderr
if it turns out to be inadequate as is.)