### PR TITLE
e2e: kill the timeout subprocess on exit

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -8,6 +8,8 @@
 # This is necessary so our child process can signal us.
 set -o monitor
 # Background an almost-2h sleep followed by sending SIGINT to our PID.
+# Exit traps need to kill this, or it'll hold the test env until the timeout is
+# reached :(
 /usr/bin/bash -c "sleep $((118*60)); echo 'Timed out!'; kill -n 2 $$" &
 ###
 
@@ -110,7 +112,7 @@ function save_hive_logs() {
 }
 # The consumer of this lib can set up its own exit trap, but this basic one will at least help
 # debug e.g. problems from `make deploy` and managed DNS setup.
-trap save_hive_logs EXIT
+trap 'kill %1; save_hive_logs' EXIT
 
 # Install Hive
 IMG="${HIVE_IMAGE}" make deploy

--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -95,7 +95,7 @@ function cleanup() {
   echo "Saving hive logs after cleanup"
   save_hive_logs
 }
-trap cleanup EXIT
+trap 'kill %1; cleanup' EXIT
 
 function wait_for_pool_to_be_ready() {
   local poolname=$1

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -42,7 +42,7 @@ function teardown() {
   echo "Saving hive logs after cleanup"
   save_hive_logs
 }
-trap 'teardown' EXIT
+trap 'kill %1; teardown' EXIT
 
 echo "Running post-deploy tests in original namespace $HIVE_NS"
 make test-e2e-postdeploy


### PR DESCRIPTION
0bfa044cb / #1782 added an explicit timeout to work around the linked
issue. However, when the test process exits *normally*, the timeout
subprocess was sticking around, essentially forcing the test to take
~2h even when it could have finished earlier. Fix.

This needs to be reverted along with 0bfa044cb / #1782 when the linked
card is resolved.

[DPTP-2871](https://issues.redhat.com//browse/DPTP-2871)