### PR TITLE
powerstate-pause annotation: skip hibernation controller

### DIFF
--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -100,6 +100,9 @@ const (
 	// ClusterPowerStateWaitingForClusterOperators is used when waiting for ClusterOperators to
 	// get to a good state. (Available=True, Processing=False, Degraded=False)
 	ClusterPowerStateWaitingForClusterOperators ClusterPowerState = "WaitingForClusterOperators"
+
+	// ClusterPowerStateUnknown indicates that we can't/won't discover the state of the cluster's cloud machines.
+	ClusterPowerStateUnknown = "Unknown"
 )
 
 // ClusterDeploymentSpec defines the desired state of ClusterDeployment
@@ -496,6 +499,9 @@ const (
 	// (It does not necessarily mean they are currently copacetic -- check ClusterSync status
 	// for that.)
 	HibernatingReasonSyncSetsApplied = "SyncSetsApplied"
+	// HibernatingReasonPowerStatePaused indicates that we can't/won't discover the state of the
+	// cluster's cloud machines because the powerstate-paused annotation is set.
+	HibernatingReasonPowerStatePaused = "PowerStatePaused"
 
 	// ReadyReasonStoppingOrHibernating is used as the reason for the Ready condition when the cluster
 	// is stopping or hibernating. Precise details are available in the Hibernating condition.
@@ -516,6 +522,9 @@ const (
 	ReadyReasonWaitingForClusterOperators = string(ClusterPowerStateWaitingForClusterOperators)
 	// ReadyReasonRunning is used on the Ready condition as the reason when the cluster is running and ready
 	ReadyReasonRunning = string(ClusterPowerStateRunning)
+	// ReadyReasonPowerStatePaused indicates that we can't/won't discover the state of the
+	// cluster's cloud machines because the powerstate-paused annotation is set.
+	ReadyReasonPowerStatePaused = "PowerStatePaused"
 )
 
 // Provisioned status condition reasons

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -130,6 +130,10 @@ const (
 	// SyncsetPauseAnnotation is a annotation used by clusterDeployment, if it's true, then we will disable syncing to a specific cluster
 	SyncsetPauseAnnotation = "hive.openshift.io/syncset-pause"
 
+	// PowerStatePauseAnnotation is an annotation used by ClusterDeployment. If "true", the hibernation controller will ignore
+	// the cluster, causing its machines to remain in their current state (unless acted on externally) regardless of CD.Spec.PowerState.
+	PowerStatePauseAnnotation = "hive.openshift.io/powerstate-pause"
+
 	// HiveManagedLabel is a label added to any resources we sync to the remote cluster to help identify that they are
 	// managed by Hive, and any manual changes may be undone the next time the resource is reconciled.
 	HiveManagedLabel = "hive.openshift.io/managed"

--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -240,10 +240,11 @@ func (r *hibernationReconciler) Reconcile(ctx context.Context, request reconcile
 		// Fail and requeue to wait for it to exist.
 		return reconcile.Result{}, fmt.Errorf("could not get ClusterSync: %v", err)
 	}
+	syncSetsApplied := clusterSync.Status.FirstSuccessTime != nil
 
 	// Check on the SyncSetsNotApplied condition. Usually this is happening on a freshly installed cluster that's
 	// running; checkClusterRunning will discover that state and flip the condition appropriately.
-	if hibernatingCondition.Reason == hivev1.HibernatingReasonSyncSetsNotApplied && clusterSync.Status.FirstSuccessTime != nil {
+	if hibernatingCondition.Reason == hivev1.HibernatingReasonSyncSetsNotApplied && syncSetsApplied {
 		r.setCDCondition(cd, hivev1.ClusterHibernatingCondition, hivev1.HibernatingReasonSyncSetsApplied,
 			"SyncSets have been applied", corev1.ConditionFalse, cdLog)
 		return reconcile.Result{}, r.updateClusterDeploymentStatus(cd, cdLog)
@@ -328,10 +329,10 @@ func (r *hibernationReconciler) Reconcile(ctx context.Context, request reconcile
 
 	if shouldHibernate || readyToHibernate {
 		// Signal a problem if we should be hibernating and the SyncSets have not yet been applied.
-		if clusterSync.Status.FirstSuccessTime == nil {
+		if !syncSetsApplied {
 			// Allow hibernation (do not set condition) if hibernateAfterSyncSetsNotApplied duration has passed since cluster
 			// installed and syncsets still not applied
-			if cd.Status.InstalledTimestamp != nil && time.Now().Sub(cd.Status.InstalledTimestamp.Time) < hibernateAfterSyncSetsNotApplied {
+			if cd.Status.InstalledTimestamp != nil && time.Since(cd.Status.InstalledTimestamp.Time) < hibernateAfterSyncSetsNotApplied {
 				changed := r.setCDCondition(cd, hivev1.ClusterHibernatingCondition, hivev1.HibernatingReasonSyncSetsNotApplied,
 					"Cluster SyncSets have not been applied", corev1.ConditionFalse, cdLog)
 				if changed {
@@ -387,7 +388,7 @@ func (r *hibernationReconciler) Reconcile(ctx context.Context, request reconcile
 	if shouldStartMachines(cd, hibernatingCondition, readyCondition) {
 		return r.startMachines(cd, cdLog)
 	}
-	return r.checkClusterRunning(cd, cdLog, readyCondition, hibernatingCondition)
+	return r.checkClusterRunning(cd, syncSetsApplied, cdLog, readyCondition, hibernatingCondition)
 }
 
 func (r *hibernationReconciler) startMachines(cd *hivev1.ClusterDeployment, logger log.FieldLogger) (reconcile.Result, error) {
@@ -501,7 +502,7 @@ func (r *hibernationReconciler) checkClusterStopped(cd *hivev1.ClusterDeployment
 	return reconcile.Result{}, nil
 }
 
-func (r *hibernationReconciler) checkClusterRunning(cd *hivev1.ClusterDeployment, logger log.FieldLogger,
+func (r *hibernationReconciler) checkClusterRunning(cd *hivev1.ClusterDeployment, syncSetsApplied bool, logger log.FieldLogger,
 	readyCondition *hivev1.ClusterDeploymentCondition, hibernatingCondition *hivev1.ClusterDeploymentCondition) (reconcile.Result, error) {
 	actuator := r.getActuator(cd)
 	if actuator == nil {
@@ -537,6 +538,17 @@ func (r *hibernationReconciler) checkClusterRunning(cd *hivev1.ClusterDeployment
 	remoteClient, err := r.remoteClientBuilder(cd).Build()
 	if err != nil {
 		logger.WithError(err).Log(controllerutils.LogLevel(err), "Failed to connect to target cluster")
+		// Special case: it's possible to get here when we're in StartingMachines state. But MachinesRunning
+		// returned true, so really we're waiting for nodes. So make sure that state is set.
+		if cd.Status.PowerState == hivev1.ClusterPowerStateStartingMachines {
+			r.setCDCondition(cd, hivev1.ClusterReadyCondition, hivev1.ReadyReasonWaitingForNodes,
+				"Waiting for Nodes to be ready (step 2/4)", corev1.ConditionFalse, logger)
+			cd.Status.PowerState = hivev1.ClusterPowerStateWaitingForNodes
+			if lerr := r.updateClusterDeploymentStatus(cd, logger); lerr != nil {
+				return reconcile.Result{}, lerr
+			}
+		}
+		// Regardless, return the error from remoteClientBuilder
 		return reconcile.Result{}, err
 	}
 
@@ -554,7 +566,7 @@ func (r *hibernationReconciler) checkClusterRunning(cd *hivev1.ClusterDeployment
 		}
 	}
 
-	nodesReady, err := r.nodesReady(cd, remoteClient, logger)
+	nodesReady, err := r.nodesReady(cd, syncSetsApplied, remoteClient, logger)
 	if err != nil {
 		logger.WithError(err).Log(controllerutils.LogLevel(err), "Failed to check whether nodes are ready")
 		return reconcile.Result{}, err
@@ -747,14 +759,14 @@ func (r *hibernationReconciler) hibernationSupported(cd *hivev1.ClusterDeploymen
 	return true, "Hibernation capable"
 }
 
-func (r *hibernationReconciler) nodesReady(cd *hivev1.ClusterDeployment, remoteClient client.Client, logger log.FieldLogger) (bool, error) {
+func (r *hibernationReconciler) nodesReady(cd *hivev1.ClusterDeployment, syncSetsApplied bool, remoteClient client.Client, logger log.FieldLogger) (bool, error) {
 
 	hibernatingCondition := controllerutils.FindClusterDeploymentCondition(cd.Status.Conditions, hivev1.ClusterHibernatingCondition)
 	if hibernatingCondition == nil {
 		return false, errors.New("cannot find hibernating condition")
 	}
-	// Don't delay nodeCheckWaitTime if we just discovered SyncSets have been applied
-	if hibernatingCondition.Reason != hivev1.HibernatingReasonSyncSetsApplied && time.Since(hibernatingCondition.LastProbeTime.Time) < nodeCheckWaitTime {
+	// Don't delay nodeCheckWaitTime if SyncSets have been applied
+	if !syncSetsApplied && time.Since(hibernatingCondition.LastProbeTime.Time) < nodeCheckWaitTime {
 		return false, nil
 	}
 	nodeList := &corev1.NodeList{}

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -100,6 +100,9 @@ const (
 	// ClusterPowerStateWaitingForClusterOperators is used when waiting for ClusterOperators to
 	// get to a good state. (Available=True, Processing=False, Degraded=False)
 	ClusterPowerStateWaitingForClusterOperators ClusterPowerState = "WaitingForClusterOperators"
+
+	// ClusterPowerStateUnknown indicates that we can't/won't discover the state of the cluster's cloud machines.
+	ClusterPowerStateUnknown = "Unknown"
 )
 
 // ClusterDeploymentSpec defines the desired state of ClusterDeployment
@@ -496,6 +499,9 @@ const (
 	// (It does not necessarily mean they are currently copacetic -- check ClusterSync status
 	// for that.)
 	HibernatingReasonSyncSetsApplied = "SyncSetsApplied"
+	// HibernatingReasonPowerStatePaused indicates that we can't/won't discover the state of the
+	// cluster's cloud machines because the powerstate-paused annotation is set.
+	HibernatingReasonPowerStatePaused = "PowerStatePaused"
 
 	// ReadyReasonStoppingOrHibernating is used as the reason for the Ready condition when the cluster
 	// is stopping or hibernating. Precise details are available in the Hibernating condition.
@@ -516,6 +522,9 @@ const (
 	ReadyReasonWaitingForClusterOperators = string(ClusterPowerStateWaitingForClusterOperators)
 	// ReadyReasonRunning is used on the Ready condition as the reason when the cluster is running and ready
 	ReadyReasonRunning = string(ClusterPowerStateRunning)
+	// ReadyReasonPowerStatePaused indicates that we can't/won't discover the state of the
+	// cluster's cloud machines because the powerstate-paused annotation is set.
+	ReadyReasonPowerStatePaused = "PowerStatePaused"
 )
 
 // Provisioned status condition reasons


### PR DESCRIPTION
Add a (secret, "unsupported") `hive.openshift.io/powerstate-pause`
annotation. When `"true"`, it causes the hibernation controller to
ignore the state of the cluster's machines with respect to
`cd.spec.powerState`; and set `cd.status.powerState` and the Ready and
Hibernating status conditions to `"Unknown"`.

[HIVE-1755](https://issues.redhat.com//browse/HIVE-1755)