### PR TITLE
Explicit permissions in operator ClusterRole

### DIFF
--- a/config/operator/operator_role.yaml
+++ b/config/operator/operator_role.yaml
@@ -43,7 +43,13 @@ rules:
   - namespaces
   - persistentvolumeclaims
   verbs:
-  - "*"
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - apiregistration.k8s.io
   resources:

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -6748,7 +6748,13 @@ objects:
     - namespaces
     - persistentvolumeclaims
     verbs:
-    - '*'
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
   - apiGroups:
     - apiregistration.k8s.io
     resources:


### PR DESCRIPTION
[SEC-OPS-DEP-04](https://source.redhat.com/groups/public/product-security/content/product_security_wiki/operators_secure_deployment_guide)
recommends explicitly enumerating permissions in an RBAC (Cluster)Role
rather than using wildcards (`"*"`). We believe wildcarding permissions
for groups we own is appropriate; but fix it elsewhere (which turns out
to be only one place).

[HIVE-1919](https://issues.redhat.com//browse/HIVE-1919)