### PR TITLE
Remove NoMatchingRoute53Zone regex

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -68,11 +68,6 @@ data:
       - "PendingVerification: Your request for accessing resources in this region is being validated"
       installFailingReason: PendingVerification
       installFailingMessage: Account pending verification for region
-    - name: NoMatchingRoute53Zone
-      searchRegexStrings:
-      - "data.aws_route53_zone.public: no matching Route53Zone found"
-      installFailingReason: NoMatchingRoute53Zone
-      installFailingMessage: No matching Route53Zone found
     - name: TooManyRoute53Zones
       searchRegexStrings:
       - "error creating Route53 Hosted Zone: TooManyHostedZones: Limits Exceeded"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1655,11 +1655,6 @@ data:
       - "PendingVerification: Your request for accessing resources in this region is being validated"
       installFailingReason: PendingVerification
       installFailingMessage: Account pending verification for region
-    - name: NoMatchingRoute53Zone
-      searchRegexStrings:
-      - "data.aws_route53_zone.public: no matching Route53Zone found"
-      installFailingReason: NoMatchingRoute53Zone
-      installFailingMessage: No matching Route53Zone found
     - name: TooManyRoute53Zones
       searchRegexStrings:
       - "error creating Route53 Hosted Zone: TooManyHostedZones: Limits Exceeded"


### PR DESCRIPTION
This regex hasn't been seen in recent memory, and should be "impossible"
based on the current state of the code. Remove it for now. If the error
manifests again, it'll show up as "Unknown" and be routed through the
usual triage procedures, the result of which may be one or more of:
- Fixing the root cause in code
- Reinstating the regex
- Adding it to RetryReasons
- Nothing

[HIVE-1933](https://issues.redhat.com//browse/HIVE-1933)