### PR TITLE
e2e: increase targetNamespace timeout 30s=>3m

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -124,10 +124,13 @@ trap 'kill %1; save_hive_logs' EXIT
 # Install Hive
 IMG="${HIVE_IMAGE}" make deploy
 
-# Wait for $HIVE_NS to appear, as subsequent test steps rely on it
+# Wait for $HIVE_NS to appear, as subsequent test steps rely on it.
+# Timeout needs to account for Deployment=>ReplicaSet=>Pod=>Container as well
+# as the operator starting up and reconciling HiveConfig to create the
+# targetNamespace.
 echo -n "Waiting for namespace $HIVE_NS to appear"
 i=0
-while [[ $i -lt 30 ]]; do
+while [[ $i -lt 180 ]]; do
   oc get namespace $HIVE_NS >/dev/null 2>&1 && break
   i=$((i+1))
   echo -n .


### PR DESCRIPTION
30s wasn't a reasonable amount of time to expect to get all the way from
Deployment to a completed reconcile loop, and we've been seeing a lot of
CI flakes as a result.