### PR TITLE
awsactuator: remove Info level log from decodeAWSMachineProviderSpec.

### DIFF
--- a/pkg/controller/machinepool/awsactuator.go
+++ b/pkg/controller/machinepool/awsactuator.go
@@ -292,7 +292,6 @@ func decodeAWSMachineProviderSpec(rawExtension *runtime.RawExtension, logger log
 		return nil, fmt.Errorf("error unmarshalling providerSpec: %v", err)
 	}
 
-	logger.Infof("Got provider spec from raw extension: %+v", spec)
 	return spec, nil
 }
 


### PR DESCRIPTION
Too noisy. :no_bell: 
/assign @2uasimojo 