### PR TITLE
Revert "Remove NoMatchingRoute53Zone regex"

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -68,6 +68,11 @@ data:
       - "PendingVerification: Your request for accessing resources in this region is being validated"
       installFailingReason: PendingVerification
       installFailingMessage: Account pending verification for region
+    - name: NoMatchingRoute53Zone
+      searchRegexStrings:
+      - "data.aws_route53_zone.public: no matching Route53Zone found"
+      installFailingReason: NoMatchingRoute53Zone
+      installFailingMessage: No matching Route53Zone found
     - name: TooManyRoute53Zones
       searchRegexStrings:
       - "error creating Route53 Hosted Zone: TooManyHostedZones: Limits Exceeded"

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1655,6 +1655,11 @@ data:
       - "PendingVerification: Your request for accessing resources in this region is being validated"
       installFailingReason: PendingVerification
       installFailingMessage: Account pending verification for region
+    - name: NoMatchingRoute53Zone
+      searchRegexStrings:
+      - "data.aws_route53_zone.public: no matching Route53Zone found"
+      installFailingReason: NoMatchingRoute53Zone
+      installFailingMessage: No matching Route53Zone found
     - name: TooManyRoute53Zones
       searchRegexStrings:
       - "error creating Route53 Hosted Zone: TooManyHostedZones: Limits Exceeded"


### PR DESCRIPTION
Reverts openshift/hive#1796

@cblecker pointed out that we might still be able to hit this in non-managed DNS code paths. It's harmless to keep it, so...

[HIVE-1933](https://issues.redhat.com//browse/HIVE-1933)