### PR TITLE
e2e-pool: hack timeout at ~2h

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -13,7 +13,9 @@ set -o monitor
 # Compute the timeout as 2m less than what's configured for the job in prow --
 # keep these up to date with the job config!
 if [[ $0 == */e2e-pool-test.sh ]]; then
-  timeout_minutes=148
+  # TODO: set this back to 148 when we figure out how to make the *test script*
+  # timeout something other than 2h.
+  timeout_minutes=118
 else
   timeout_minutes=118
 fi


### PR DESCRIPTION
We're still trying to figure out how to make e2e-pool time out after
2h30m instead of 2h. In the meantime, until the linked bug is resolved,
we need our hacked timeout to happen at ~2h -- otherwise we don't get
manifests/logs.

[DPTP-2871](https://issues.redhat.com//browse/DPTP-2871)