### PR TITLE
Update default AWS volumeType chosen by hiveutil from gp2 to gp3.

### DIFF
--- a/pkg/clusterresource/aws.go
+++ b/pkg/clusterresource/aws.go
@@ -19,7 +19,7 @@ const (
 	awsInstanceType = "m4.xlarge"
 	volumeIOPS      = 100
 	volumeSize      = 22
-	volumeType      = "gp2"
+	volumeType      = "gp3"
 )
 
 var _ CloudBuilder = (*AWSCloudBuilder)(nil)


### PR DESCRIPTION
https://github.com/openshift/installer/pull/5925 introduces checks which disallow our previous default of a gp2 volumeType with 100 IOPS as it was an incorrect configuration. From the linked change, IOPS may now only be set for io1, io2, & gp3 volume types.