### PR TITLE
Add ClusterSyncFailingSeconds metric

### DIFF
--- a/apis/hive/v1/metricsconfig/durationMetrics.go
+++ b/apis/hive/v1/metricsconfig/durationMetrics.go
@@ -29,6 +29,8 @@ const (
 	CurrentResuming DurationMetricType = "currentResuming"
 	// CurrentWaitingForCO corresponds to hive_cluster_deployments_waiting_for_cluster_operators_seconds
 	CurrentWaitingForCO DurationMetricType = "currentWaitingForCO"
+	// CurrentClusterSyncFailing corresponds to hive_clustersync_failing_seconds
+	CurrentClusterSyncFailing DurationMetricType = "currentClusterSyncFailing"
 
 	// These metrics will not be cleared and can potentially blow up the cardinality
 

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -512,11 +512,7 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 			// removed the finalizer.
 			clearDeprovisionUnderwaySecondsMetric(cd, cdLog)
 			// Clear ClusterSyncFailing metric
-			clusterSync := &hiveintv1alpha1.ClusterSync{}
-			err := r.Get(context.Background(), types.NamespacedName{Namespace: cd.Namespace, Name: cd.Name}, clusterSync)
-			if err != nil {
-				clustersync.ClearClusterSyncFailingSecondsMetric(clusterSync, cdLog)
-			}
+			clustersync.ClearClusterSyncFailingSecondsMetric(cd.Namespace, cd.Name, cdLog)
 
 			return reconcile.Result{}, nil
 		}
@@ -1414,11 +1410,7 @@ func (r *ReconcileClusterDeployment) removeClusterDeploymentFinalizer(cd *hivev1
 
 	clearDeprovisionUnderwaySecondsMetric(cd, cdLog)
 	// Clear ClusterSyncFailing metric
-	clusterSync := &hiveintv1alpha1.ClusterSync{}
-	err := r.Get(context.Background(), types.NamespacedName{Namespace: cd.Namespace, Name: cd.Name}, clusterSync)
-	if err != nil {
-		clustersync.ClearClusterSyncFailingSecondsMetric(clusterSync, cdLog)
-	}
+	clustersync.ClearClusterSyncFailingSecondsMetric(cd.Namespace, cd.Name, cdLog)
 
 	// Increment the clusters deleted counter:
 	metricClustersDeleted.WithLabelValues(hivemetrics.GetClusterDeploymentType(cd)).Inc()
@@ -2085,7 +2077,7 @@ func (r *ReconcileClusterDeployment) setSyncSetFailedCondition(cd *hivev1.Cluste
 			message = "ClusterSync has not yet been created"
 		}
 		// In case the clusterSync has been deleted at this point, clear the clusterSyncFailing metric
-		clustersync.ClearClusterSyncFailingSecondsMetric(clusterSync, cdLog)
+		clustersync.ClearClusterSyncFailingSecondsMetric(cd.Namespace, cd.Name, cdLog)
 	case err != nil:
 		cdLog.WithError(err).Log(controllerutils.LogLevel(err), "could not get ClusterSync")
 		return err

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -43,6 +43,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	hiveintv1alpha1 "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
 	"github.com/openshift/hive/pkg/constants"
+	"github.com/openshift/hive/pkg/controller/clustersync"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/imageset"
@@ -510,6 +511,12 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 			// Make sure we have no deprovision underway metric even though this was probably cleared when we
 			// removed the finalizer.
 			clearDeprovisionUnderwaySecondsMetric(cd, cdLog)
+			// Clear ClusterSyncFailing metric
+			clusterSync := &hiveintv1alpha1.ClusterSync{}
+			err := r.Get(context.Background(), types.NamespacedName{Namespace: cd.Namespace, Name: cd.Name}, clusterSync)
+			if err != nil {
+				clustersync.ClearClusterSyncFailingSecondsMetric(clusterSync, cdLog)
+			}
 
 			return reconcile.Result{}, nil
 		}
@@ -1406,6 +1413,12 @@ func (r *ReconcileClusterDeployment) removeClusterDeploymentFinalizer(cd *hivev1
 	}
 
 	clearDeprovisionUnderwaySecondsMetric(cd, cdLog)
+	// Clear ClusterSyncFailing metric
+	clusterSync := &hiveintv1alpha1.ClusterSync{}
+	err := r.Get(context.Background(), types.NamespacedName{Namespace: cd.Namespace, Name: cd.Name}, clusterSync)
+	if err != nil {
+		clustersync.ClearClusterSyncFailingSecondsMetric(clusterSync, cdLog)
+	}
 
 	// Increment the clusters deleted counter:
 	metricClustersDeleted.WithLabelValues(hivemetrics.GetClusterDeploymentType(cd)).Inc()
@@ -2044,10 +2057,9 @@ func (r *ReconcileClusterDeployment) validatePlatformCreds(cd *hivev1.ClusterDep
 
 // checkForFailedSync returns true if it finds that the ClusterSync has the Failed condition set
 func checkForFailedSync(clusterSync *hiveintv1alpha1.ClusterSync) bool {
-	for _, cond := range clusterSync.Status.Conditions {
-		if cond.Type == hiveintv1alpha1.ClusterSyncFailed {
-			return cond.Status == corev1.ConditionTrue
-		}
+	cond := controllerutils.FindClusterSyncCondition(clusterSync.Status.Conditions, hiveintv1alpha1.ClusterSyncFailed)
+	if cond != nil {
+		return cond.Status == corev1.ConditionTrue
 	}
 	return false
 }
@@ -2072,6 +2084,8 @@ func (r *ReconcileClusterDeployment) setSyncSetFailedCondition(cd *hivev1.Cluste
 			reason = "MissingClusterSync"
 			message = "ClusterSync has not yet been created"
 		}
+		// In case the clusterSync has been deleted at this point, clear the clusterSyncFailing metric
+		clustersync.ClearClusterSyncFailingSecondsMetric(clusterSync, cdLog)
 	case err != nil:
 		cdLog.WithError(err).Log(controllerutils.LogLevel(err), "could not get ClusterSync")
 		return err

--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -502,7 +502,7 @@ func (r *ReconcileClusterSync) Reconcile(ctx context.Context, request reconcile.
 	}
 	// Clear the cluster sync failing metric
 	if !failing {
-		ClearClusterSyncFailingSecondsMetric(clusterSync, logger)
+		ClearClusterSyncFailingSecondsMetric(clusterSync.Namespace, clusterSync.Name, logger)
 	}
 
 	if needToDoFullReapply {
@@ -1147,11 +1147,11 @@ func (r *ReconcileClusterSync) timeUntilFullReapply(lease *hiveintv1alpha1.Clust
 	return timeUntilNext
 }
 
-func ClearClusterSyncFailingSecondsMetric(cs *hiveintv1alpha1.ClusterSync, csLog log.FieldLogger) {
+func ClearClusterSyncFailingSecondsMetric(namespace string, name string, log log.FieldLogger) {
 	cleared := hivemetrics.MetricClusterSyncFailingSeconds.Delete(map[string]string{
-		"namespaced_name": hivemetrics.GetNameSpacedName(cs.Namespace, cs.Name),
+		"namespaced_name": hivemetrics.GetNameSpacedName(namespace, name),
 	})
 	if cleared {
-		csLog.Debug("cleared metric: %v", hivemetrics.MetricClusterSyncFailingSeconds)
+		log.Debug("cleared metric: %v", hivemetrics.MetricClusterSyncFailingSeconds)
 	}
 }

--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -665,7 +665,7 @@ func deleteTransitionMetric(metric *prometheus.HistogramVec, cd *hivev1.ClusterD
 
 // logCumulativeMetric should be used to log cumulative metrics
 func logCumulativeMetric(metric *prometheus.HistogramVec, cd *hivev1.ClusterDeployment, time float64) {
-	if !hivemetrics.ShouldLogDurationMetric(metric, time) {
+	if !hivemetrics.ShouldLogHistogramDurationMetric(metric, time) {
 		return
 	}
 	poolNS, poolName := "<none>", "<none>"

--- a/pkg/controller/utils/conditions.go
+++ b/pkg/controller/utils/conditions.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	v1alpha1 "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
 )
 
 // UpdateConditionCheck tests whether a condition should be updated from the
@@ -795,6 +796,17 @@ func FindClusterDeprovisionCondition(conditions []hivev1.ClusterDeprovisionCondi
 // FindClusterInstallCondition finds in the condition that has the
 // specified condition type in the given list. If none exists, then returns nil.
 func FindClusterInstallCondition(conditions []hivev1.ClusterInstallCondition, conditionType string) *hivev1.ClusterInstallCondition {
+	for i, condition := range conditions {
+		if condition.Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+// FindClusterSyncCondition finds the condition that has the
+// specified condition type in the given list. If none exists, then returns nil.
+func FindClusterSyncCondition(conditions []v1alpha1.ClusterSyncCondition, conditionType v1alpha1.ClusterSyncConditionType) *v1alpha1.ClusterSyncCondition {
 	for i, condition := range conditions {
 		if condition.Type == conditionType {
 			return &conditions[i]

--- a/vendor/github.com/openshift/hive/apis/hive/v1/metricsconfig/durationMetrics.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/metricsconfig/durationMetrics.go
@@ -29,6 +29,8 @@ const (
 	CurrentResuming DurationMetricType = "currentResuming"
 	// CurrentWaitingForCO corresponds to hive_cluster_deployments_waiting_for_cluster_operators_seconds
 	CurrentWaitingForCO DurationMetricType = "currentWaitingForCO"
+	// CurrentClusterSyncFailing corresponds to hive_clustersync_failing_seconds
+	CurrentClusterSyncFailing DurationMetricType = "currentClusterSyncFailing"
 
 	// These metrics will not be cleared and can potentially blow up the cardinality
 


### PR DESCRIPTION
- Add gauge "hive_clustersync_failing_seconds" that logs time since the lastTransitionTime of the clusterSync's Failed condition with the label namespaced_name as $namespace/$name
- Make it optional and log it conditionally if the time since it has been failing is more than the threshold mentioned
- Skip reporting for Unreachable clusters
- Clear the metric when the clusterSync succeeds
- Clear the metric when the clusterSync is deleted
- Clear the metric when the clusterDeplyment is deleted

xref: https://issues.redhat.com/browse/HIVE-1857

/assign @2uasimojo 