### PR TITLE
Ensure go.mod matches apis/go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,6 +320,11 @@ lint: install-tools
 # Remove the golangci-lint from the verify until a fix is in place for permisions for writing to the /.cache directory.
 #verify: lint
 
+.PHONY: modcheck
+modcheck:
+	go run ./hack/modcheck.go
+verify: modcheck
+
 .PHONY: install-tools
 install-tools:
 	go install $(GO_MOD_FLAGS) github.com/golang/mock/mockgen

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -9,9 +9,9 @@ require (
 )
 
 require (
-	github.com/go-logr/logr v1.2.0 // indirect
+	github.com/go-logr/logr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -29,8 +29,9 @@ github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSy
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
-github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.2 h1:ahHml/yUpnlb96Rp8HCvtYVPY8ZYpxq3g7UYchIYwbs=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
@@ -60,8 +61,9 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
+github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20181127221834-b4f47329b966/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/apis/vendor/github.com/go-logr/logr/logr.go
+++ b/apis/vendor/github.com/go-logr/logr/logr.go
@@ -43,7 +43,9 @@ limitations under the License.
 //
 // Info() and Error() are very similar, but they are separate methods so that
 // LogSink implementations can choose to do things like attach additional
-// information (such as stack traces) on calls to Error().
+// information (such as stack traces) on calls to Error(). Error() messages are
+// always logged, regardless of the current verbosity.  If there is no error
+// instance available, passing nil is valid.
 //
 // Verbosity
 //
@@ -53,6 +55,7 @@ limitations under the License.
 // Log-lines with V-levels that are not enabled (as per the LogSink) will not
 // be written.  Level V(0) is the default, and logger.V(0).Info() has the same
 // meaning as logger.Info().  Negative V-levels have the same meaning as V(0).
+// Error messages do not have a verbosity level and are always logged.
 //
 // Where we might have written:
 //   if flVerbose >= 2 {
@@ -253,11 +256,13 @@ func (l Logger) Info(msg string, keysAndValues ...interface{}) {
 // Error logs an error, with the given message and key/value pairs as context.
 // It functions similarly to Info, but may have unique behavior, and should be
 // preferred for logging errors (see the package documentations for more
-// information).
+// information). The log message will always be emitted, regardless of
+// verbosity level.
 //
 // The msg argument should be used to add context to any underlying error,
 // while the err argument should be used to attach the actual error that
-// triggered this log line, if present.
+// triggered this log line, if present. The err parameter is optional
+// and nil may be passed instead of an error instance.
 func (l Logger) Error(err error, msg string, keysAndValues ...interface{}) {
 	if withHelper, ok := l.sink.(CallStackHelperLogSink); ok {
 		withHelper.GetCallStackHelper()()

--- a/apis/vendor/github.com/google/gofuzz/.travis.yml
+++ b/apis/vendor/github.com/google/gofuzz/.travis.yml
@@ -1,13 +1,10 @@
 language: go
 
 go:
-  - 1.4
-  - 1.3
-  - 1.2
-  - tip
-
-install:
-  - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+  - 1.11.x
+  - 1.12.x
+  - 1.13.x
+  - master
 
 script:
   - go test -cover

--- a/apis/vendor/github.com/google/gofuzz/CONTRIBUTING.md
+++ b/apis/vendor/github.com/google/gofuzz/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # How to contribute #
 
 We'd love to accept your patches and contributions to this project.  There are
-a just a few small guidelines you need to follow.
+just a few small guidelines you need to follow.
 
 
 ## Contributor License Agreement ##

--- a/apis/vendor/github.com/google/gofuzz/README.md
+++ b/apis/vendor/github.com/google/gofuzz/README.md
@@ -68,4 +68,22 @@ f.Fuzz(&myObject) // Type will correspond to whether A or B info is set.
 
 See more examples in ```example_test.go```.
 
+You can use this library for easier [go-fuzz](https://github.com/dvyukov/go-fuzz)ing.
+go-fuzz provides the user a byte-slice, which should be converted to different inputs
+for the tested function. This library can help convert the byte slice. Consider for
+example a fuzz test for a the function `mypackage.MyFunc` that takes an int arguments:
+```go
+// +build gofuzz
+package mypackage
+
+import fuzz "github.com/google/gofuzz"
+
+func Fuzz(data []byte) int {
+        var i int
+        fuzz.NewFromGoFuzz(data).Fuzz(&i)
+        MyFunc(i)
+        return 0
+}
+```
+
 Happy testing!

--- a/apis/vendor/github.com/google/gofuzz/bytesource/bytesource.go
+++ b/apis/vendor/github.com/google/gofuzz/bytesource/bytesource.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2014 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package bytesource provides a rand.Source64 that is determined by a slice of bytes.
+package bytesource
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"math/rand"
+)
+
+// ByteSource implements rand.Source64 determined by a slice of bytes. The random numbers are
+// generated from each 8 bytes in the slice, until the last bytes are consumed, from which a
+// fallback pseudo random source is created in case more random numbers are required.
+// It also exposes a `bytes.Reader` API, which lets callers consume the bytes directly.
+type ByteSource struct {
+	*bytes.Reader
+	fallback rand.Source
+}
+
+// New returns a new ByteSource from a given slice of bytes.
+func New(input []byte) *ByteSource {
+	s := &ByteSource{
+		Reader:   bytes.NewReader(input),
+		fallback: rand.NewSource(0),
+	}
+	if len(input) > 0 {
+		s.fallback = rand.NewSource(int64(s.consumeUint64()))
+	}
+	return s
+}
+
+func (s *ByteSource) Uint64() uint64 {
+	// Return from input if it was not exhausted.
+	if s.Len() > 0 {
+		return s.consumeUint64()
+	}
+
+	// Input was exhausted, return random number from fallback (in this case fallback should not be
+	// nil). Try first having a Uint64 output (Should work in current rand implementation),
+	// otherwise return a conversion of Int63.
+	if s64, ok := s.fallback.(rand.Source64); ok {
+		return s64.Uint64()
+	}
+	return uint64(s.fallback.Int63())
+}
+
+func (s *ByteSource) Int63() int64 {
+	return int64(s.Uint64() >> 1)
+}
+
+func (s *ByteSource) Seed(seed int64) {
+	s.fallback = rand.NewSource(seed)
+	s.Reader = bytes.NewReader(nil)
+}
+
+// consumeUint64 reads 8 bytes from the input and convert them to a uint64. It assumes that the the
+// bytes reader is not empty.
+func (s *ByteSource) consumeUint64() uint64 {
+	var bytes [8]byte
+	_, err := s.Read(bytes[:])
+	if err != nil && err != io.EOF {
+		panic("failed reading source") // Should not happen.
+	}
+	return binary.BigEndian.Uint64(bytes[:])
+}

--- a/apis/vendor/github.com/google/gofuzz/fuzz.go
+++ b/apis/vendor/github.com/google/gofuzz/fuzz.go
@@ -22,6 +22,9 @@ import (
 	"reflect"
 	"regexp"
 	"time"
+
+	"github.com/google/gofuzz/bytesource"
+	"strings"
 )
 
 // fuzzFuncMap is a map from a type to a fuzzFunc that handles that type.
@@ -59,6 +62,34 @@ func NewWithSeed(seed int64) *Fuzzer {
 		maxDepth:    100,
 	}
 	return f
+}
+
+// NewFromGoFuzz is a helper function that enables using gofuzz (this
+// project) with go-fuzz (https://github.com/dvyukov/go-fuzz) for continuous
+// fuzzing. Essentially, it enables translating the fuzzing bytes from
+// go-fuzz to any Go object using this library.
+//
+// This implementation promises a constant translation from a given slice of
+// bytes to the fuzzed objects. This promise will remain over future
+// versions of Go and of this library.
+//
+// Note: the returned Fuzzer should not be shared between multiple goroutines,
+// as its deterministic output will no longer be available.
+//
+// Example: use go-fuzz to test the function `MyFunc(int)` in the package
+// `mypackage`. Add the file: "mypacakge_fuzz.go" with the content:
+//
+// // +build gofuzz
+// package mypacakge
+// import fuzz "github.com/google/gofuzz"
+// func Fuzz(data []byte) int {
+// 	var i int
+// 	fuzz.NewFromGoFuzz(data).Fuzz(&i)
+// 	MyFunc(i)
+// 	return 0
+// }
+func NewFromGoFuzz(data []byte) *Fuzzer {
+	return New().RandSource(bytesource.New(data))
 }
 
 // Funcs adds each entry in fuzzFuncs as a custom fuzzing function.
@@ -141,7 +172,7 @@ func (f *Fuzzer) genElementCount() int {
 }
 
 func (f *Fuzzer) genShouldFill() bool {
-	return f.r.Float64() > f.nilChance
+	return f.r.Float64() >= f.nilChance
 }
 
 // MaxDepth sets the maximum number of recursive fuzz calls that will be made
@@ -240,6 +271,7 @@ func (fc *fuzzerContext) doFuzz(v reflect.Value, flags uint64) {
 		fn(v, fc.fuzzer.r)
 		return
 	}
+
 	switch v.Kind() {
 	case reflect.Map:
 		if fc.fuzzer.genShouldFill() {
@@ -450,10 +482,10 @@ var fillFuncMap = map[reflect.Kind]func(reflect.Value, *rand.Rand){
 		v.SetFloat(r.Float64())
 	},
 	reflect.Complex64: func(v reflect.Value, r *rand.Rand) {
-		panic("unimplemented")
+		v.SetComplex(complex128(complex(r.Float32(), r.Float32())))
 	},
 	reflect.Complex128: func(v reflect.Value, r *rand.Rand) {
-		panic("unimplemented")
+		v.SetComplex(complex(r.Float64(), r.Float64()))
 	},
 	reflect.String: func(v reflect.Value, r *rand.Rand) {
 		v.SetString(randString(r))
@@ -465,38 +497,105 @@ var fillFuncMap = map[reflect.Kind]func(reflect.Value, *rand.Rand){
 
 // randBool returns true or false randomly.
 func randBool(r *rand.Rand) bool {
-	if r.Int()&1 == 1 {
-		return true
-	}
-	return false
+	return r.Int31()&(1<<30) == 0
 }
 
-type charRange struct {
-	first, last rune
+type int63nPicker interface {
+	Int63n(int64) int64
 }
+
+// UnicodeRange describes a sequential range of unicode characters.
+// Last must be numerically greater than First.
+type UnicodeRange struct {
+	First, Last rune
+}
+
+// UnicodeRanges describes an arbitrary number of sequential ranges of unicode characters.
+// To be useful, each range must have at least one character (First <= Last) and
+// there must be at least one range.
+type UnicodeRanges []UnicodeRange
 
 // choose returns a random unicode character from the given range, using the
 // given randomness source.
-func (r *charRange) choose(rand *rand.Rand) rune {
-	count := int64(r.last - r.first)
-	return r.first + rune(rand.Int63n(count))
+func (ur UnicodeRange) choose(r int63nPicker) rune {
+	count := int64(ur.Last - ur.First + 1)
+	return ur.First + rune(r.Int63n(count))
 }
 
-var unicodeRanges = []charRange{
+// CustomStringFuzzFunc constructs a FuzzFunc which produces random strings.
+// Each character is selected from the range ur. If there are no characters
+// in the range (cr.Last < cr.First), this will panic.
+func (ur UnicodeRange) CustomStringFuzzFunc() func(s *string, c Continue) {
+	ur.check()
+	return func(s *string, c Continue) {
+		*s = ur.randString(c.Rand)
+	}
+}
+
+// check is a function that used to check whether the first of ur(UnicodeRange)
+// is greater than the last one.
+func (ur UnicodeRange) check() {
+	if ur.Last < ur.First {
+		panic("The last encoding must be greater than the first one.")
+	}
+}
+
+// randString of UnicodeRange makes a random string up to 20 characters long.
+// Each character is selected form ur(UnicodeRange).
+func (ur UnicodeRange) randString(r *rand.Rand) string {
+	n := r.Intn(20)
+	sb := strings.Builder{}
+	sb.Grow(n)
+	for i := 0; i < n; i++ {
+		sb.WriteRune(ur.choose(r))
+	}
+	return sb.String()
+}
+
+// defaultUnicodeRanges sets a default unicode range when user do not set
+// CustomStringFuzzFunc() but wants fuzz string.
+var defaultUnicodeRanges = UnicodeRanges{
 	{' ', '~'},           // ASCII characters
 	{'\u00a0', '\u02af'}, // Multi-byte encoded characters
 	{'\u4e00', '\u9fff'}, // Common CJK (even longer encodings)
 }
 
+// CustomStringFuzzFunc constructs a FuzzFunc which produces random strings.
+// Each character is selected from one of the ranges of ur(UnicodeRanges).
+// Each range has an equal probability of being chosen. If there are no ranges,
+// or a selected range has no characters (.Last < .First), this will panic.
+// Do not modify any of the ranges in ur after calling this function.
+func (ur UnicodeRanges) CustomStringFuzzFunc() func(s *string, c Continue) {
+	// Check unicode ranges slice is empty.
+	if len(ur) == 0 {
+		panic("UnicodeRanges is empty.")
+	}
+	// if not empty, each range should be checked.
+	for i := range ur {
+		ur[i].check()
+	}
+	return func(s *string, c Continue) {
+		*s = ur.randString(c.Rand)
+	}
+}
+
+// randString of UnicodeRanges makes a random string up to 20 characters long.
+// Each character is selected form one of the ranges of ur(UnicodeRanges),
+// and each range has an equal probability of being chosen.
+func (ur UnicodeRanges) randString(r *rand.Rand) string {
+	n := r.Intn(20)
+	sb := strings.Builder{}
+	sb.Grow(n)
+	for i := 0; i < n; i++ {
+		sb.WriteRune(ur[r.Intn(len(ur))].choose(r))
+	}
+	return sb.String()
+}
+
 // randString makes a random string up to 20 characters long. The returned string
 // may include a variety of (valid) UTF-8 encodings.
 func randString(r *rand.Rand) string {
-	n := r.Intn(20)
-	runes := make([]rune, n)
-	for i := range runes {
-		runes[i] = unicodeRanges[r.Intn(len(unicodeRanges))].choose(r)
-	}
-	return string(runes)
+	return defaultUnicodeRanges.randString(r)
 }
 
 // randUint64 makes random 64 bit numbers.

--- a/apis/vendor/modules.txt
+++ b/apis/vendor/modules.txt
@@ -1,13 +1,14 @@
-# github.com/go-logr/logr v1.2.0
+# github.com/go-logr/logr v1.2.2
 ## explicit; go 1.16
 github.com/go-logr/logr
 # github.com/gogo/protobuf v1.3.2
 ## explicit; go 1.15
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/sortkeys
-# github.com/google/gofuzz v1.1.0
+# github.com/google/gofuzz v1.2.0
 ## explicit; go 1.12
 github.com/google/gofuzz
+github.com/google/gofuzz/bytesource
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -2,36 +2,35 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [Developing Hive](#developing-hive)
-  - [Prerequisites](#prerequisites)
-    - [External tools](#external-tools)
-  - [Build and run tests](#build-and-run-tests)
-  - [Setting up the development environment](#setting-up-the-development-environment)
-    - [Cloning the repository](#cloning-the-repository)
-  - [Obtaining a Cluster](#obtaining-a-cluster)
-    - [Creating a Kubernetes In Docker (kind) Cluster](#creating-a-kubernetes-in-docker-kind-cluster)
-  - [Deploying from Source](#deploying-from-source)
-    - [Full Container Build](#full-container-build)
-    - [Fedora Development Container Build](#fedora-development-container-build)
-    - [Running Code Locally](#running-code-locally)
-      - [hive-operator](#hive-operator)
-    - [hive-controllers](#hive-controllers)
-  - [Developing Hiveutil Install Manager](#developing-hiveutil-install-manager)
-  - [Enable Debug Logging In Hive Controllers](#enable-debug-logging-in-hive-controllers)
-  - [Using Serving Certificates](#using-serving-certificates)
-    - [Generating a Certificate](#generating-a-certificate)
-    - [Using Generated Certificate](#using-generated-certificate)
-  - [Code editors and multi-module repositories](#code-editors-and-multi-module-repositories)
-  - [Updating Hive APIs](#updating-hive-apis)
-  - [Importing Hive APIs](#importing-hive-apis)
-  - [Dependency management](#dependency-management)
-    - [Updating Dependencies](#updating-dependencies)
-    - [Re-creating vendor Directory](#re-creating-vendor-directory)
-    - [Updating the Kubernetes dependencies](#updating-the-kubernetes-dependencies)
-    - [Vendoring the OpenShift Installer](#vendoring-the-openshift-installer)
-  - [Running the e2e test locally](#running-the-e2e-test-locally)
-  - [Viewing Metrics with Prometheus](#viewing-metrics-with-prometheus)
-  - [Hive Controllers CPU Profiling](#hive-controllers-cpu-profiling)
+- [Prerequisites](#prerequisites)
+  - [External tools](#external-tools)
+- [Build and run tests](#build-and-run-tests)
+- [Setting up the development environment](#setting-up-the-development-environment)
+  - [Cloning the repository](#cloning-the-repository)
+- [Obtaining a Cluster](#obtaining-a-cluster)
+  - [Creating a Kubernetes In Docker (kind) Cluster](#creating-a-kubernetes-in-docker-kind-cluster)
+- [Deploying from Source](#deploying-from-source)
+  - [Full Container Build](#full-container-build)
+  - [Fedora Development Container Build](#fedora-development-container-build)
+  - [Running Code Locally](#running-code-locally)
+    - [hive-operator](#hive-operator)
+  - [hive-controllers](#hive-controllers)
+- [Developing Hiveutil Install Manager](#developing-hiveutil-install-manager)
+- [Enable Debug Logging In Hive Controllers](#enable-debug-logging-in-hive-controllers)
+- [Using Serving Certificates](#using-serving-certificates)
+  - [Generating a Certificate](#generating-a-certificate)
+  - [Using Generated Certificate](#using-generated-certificate)
+- [Code editors and multi-module repositories](#code-editors-and-multi-module-repositories)
+- [Updating Hive APIs](#updating-hive-apis)
+- [Importing Hive APIs](#importing-hive-apis)
+- [Dependency management](#dependency-management)
+  - [Updating Dependencies](#updating-dependencies)
+  - [Re-creating vendor Directory](#re-creating-vendor-directory)
+  - [Updating the Kubernetes dependencies](#updating-the-kubernetes-dependencies)
+  - [Vendoring the OpenShift Installer](#vendoring-the-openshift-installer)
+- [Running the e2e test locally](#running-the-e2e-test-locally)
+- [Viewing Metrics with Prometheus](#viewing-metrics-with-prometheus)
+- [Hive Controllers CPU Profiling](#hive-controllers-cpu-profiling)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -275,21 +274,21 @@ the `github.com/openshift/hive/apis` go submodule.
 A separate `github.com/openshift/hive/apis` submodule allows other repositories to easily import the Hive APIs without
 having to deal with the complex vendoring introduced by dependencies of Hive controllers like the OpenShift Installer.
 
-Since Hive module `github.com/openshift/hive` or `root` module uses vendor directory for all it's dependencies, **ANY**
-change in `github.com/openshift/hive/apis` module requires updating the dependency in the `root` module for change to
+Since Hive's `github.com/openshift/hive` and `root` modules both use vendor directories for all their dependencies, **ANY**
+change in the `github.com/openshift/hive/apis` module requires updating the corresponding dependency in the `root` module for the change to
 take effect.
 
-Therefore, these steps must be followed when updating the Hive APIs,
+Therefore, these steps must be followed when updating the Hive APIs:
 
 1. Make necessary modifications to `github.com/openshift/hive/apis`.
 
-2. Follow the steps defined in [Updating Dependencies](#Updating-Dependencies) to update the dependecies of `root` module
+2. Follow the steps defined in [Updating Dependencies](#Updating-Dependencies) to update the dependecies of the `root` module
 
 3. Now you can use various `make` targets or `go test` for testing your changes.
 
 **IMPORTANT**: go versions => 1.15 default to `-mod=vendor` for all the subcommands and therefore will
-only use the copy of modules in the `vendor/` directory. Anytime you make changes to apis submodule and
-not update the dependencies of the root module, all the builds, tests will continue to use old version of the
+only use the copy of the modules in the `vendor/` directory. Any time you make changes to the `apis` submodule and do
+not update the dependencies of the root module, all the builds and tests will continue to use the old version of the
 submodule.
 
 ## Importing Hive APIs
@@ -311,25 +310,23 @@ go get -u github.com/openshift/hive/apis@master
 
 ### Updating Dependencies
 
-If your work requires a change to the dependencies, you need to update the modules.
+If your work requires a change to dependencies, you need to update the vendored modules.
 
 * If you are upgrading an existing dependency, run `go get [module]`. If you are adding a dependency, then you should
-not need to do anything explicit for this step. The go tooling should pick up the dependency from the include directives
+not need to do anything explicit for this step. The go tooling should pick up the dependency from the `import` directives
 that you added in code.
 
 * Run `make vendor` to fetch changed dependencies.
 
 * Test that everything still compiles with changed files in place by running `make`.
 
-**Refer Go modules documents for more information.**
+**Refer to Go modules documents for more information.**
 
 * [go modules wiki](https://github.com/golang/go/wiki/Modules)
 
 ### Re-creating vendor Directory
 
-If you delete *_vendor_* directory which contain the needed {project} dependencies.
-
-To recreate *_vendor_* directory, you can run the following command:
+If you delete the `vendor` directory which contains the necessary project dependencies, you can recreate it via the following command:
 
 ```
 make vendor
@@ -337,21 +334,38 @@ make vendor
 
 ### Updating the Kubernetes dependencies
 
-Hive is a [multi-module repository](https://github.com/golang/go/wiki/Modules#faqs--multi-module-repositories) with
-the various submodules like,
+Hive is a [multi-module repository](https://github.com/golang/go/wiki/Modules#faqs--multi-module-repositories) with a `github.com/openshift/hive/apis` submodule.
 
-- `github.com/openshift/hive/apis`
-
-These submodules define their own dependencies, most commonly from the Kubernetes ecosystem. All build artifacts are
+This submodule defines its own dependencies, most commonly from the Kubernetes ecosystem. All build artifacts are
 generated from the `root` module and therefore the version of all dependencies used is defined by the `go.mod` in the
-root module, but making sure the dependecies of the all the submodules match the root modules help reduce divergence
-and dependencies pain.
+root module, but making sure the dependecies of the submodule match those of the root module helps reduce divergence
+and dependency pain for consumers.
 
 So whenever the root module updates the Kubernetes ecosystem dependencies,
 
 1. Update the submodules to use the desired version of the Kubernetes ecosystem.
 
-2. Update the root mosdule dependencies to the desired version of the Kubernetes ecosystem.
+2. Update the root module dependencies to the desired version of the Kubernetes ecosystem.
+
+You can validate that the root and submodule dependencies match by running
+
+```
+make modcheck
+```
+
+This will exit nonzero if any discrepancies are found, and the output will denote which dependencies
+are mismatched. For example:
+```
+$ make modcheck
+go run ./hack/modcheck.go
+XX require github.com/go-logr/logr: root(v1.2.2) apis(v1.2.0)
+XX require github.com/google/gofuzz: root(v1.2.0) apis(v1.1.0)
+exit status 1
+make: *** [Makefile:325: modcheck] Error 1
+```
+In this example, address the first error by updating the version of the `require github.com/go-logr/logr` dependency in `apis/go.mod` from `v1.2.0` to `v1.2.2`.
+Repeat for the other errors until the output is clean.
+Don't forget to `make vendor` when you're done to sync the vendor directories with your go.mod changes.
 
 ### Vendoring the OpenShift Installer
 

--- a/hack/modcheck.go
+++ b/hack/modcheck.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/mod/modfile"
+)
+
+func main() {
+	rootgmf := readGoMod("go.mod")
+	apisgmf := readGoMod("apis/go.mod")
+	insync := true
+	insync = cmp1("require", mapRequire(rootgmf.Require), mapRequire(apisgmf.Require)) && insync
+	insync = cmp1("exclude", mapExclude(rootgmf.Exclude), mapExclude(apisgmf.Exclude)) && insync
+	insync = cmp2("replace", mapReplace(rootgmf.Replace), mapReplace(apisgmf.Replace)) && insync
+	if insync {
+		os.Exit(0)
+	} else {
+		os.Exit(1)
+	}
+}
+
+func readGoMod(path string) *modfile.File {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+	f, err := modfile.Parse(path, b, nil)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}
+
+// TODO: Figure out how to collapse these with generics
+// LATER: Virtually impossible. My attempts ultimately didn't and couldn't work, and were more
+// LOC anyway. Sad face.
+func mapRequire(theList []*modfile.Require) map[string]string {
+	ret := make(map[string]string, len(theList))
+	for _, item := range theList {
+		path, ver := (*item).Mod.Path, item.Mod.Version
+		if existingver, ok := ret[path]; ok {
+			fmt.Printf("WARNING: require path %s listed at multiple versions: %s | %s\n", path, existingver, ver)
+		}
+		ret[path] = ver
+	}
+	return ret
+}
+func mapExclude(theList []*modfile.Exclude) map[string]string {
+	ret := make(map[string]string, len(theList))
+	for _, item := range theList {
+		path, ver := item.Mod.Path, item.Mod.Version
+		if existingver, ok := ret[path]; ok {
+			fmt.Printf("WARNING: exclude path %s listed at multiple versions: %s | %s\n", path, existingver, ver)
+		}
+		ret[path] = ver
+	}
+	return ret
+}
+
+type replacement struct {
+	oldver  string
+	newpath string
+	newver  string
+}
+
+func mapReplace(theList []*modfile.Replace) map[string]replacement {
+	ret := make(map[string]replacement, len(theList))
+	for _, item := range theList {
+		path := item.Old.Path
+		repl := replacement{
+			oldver:  item.Old.Version,
+			newpath: item.New.Path,
+			newver:  item.New.Version,
+		}
+		if existingrepl, ok := ret[path]; ok {
+			fmt.Printf("WARNING: replace path %s listed more than once:\n\t%#v\n\t%#v\n", path, existingrepl, repl)
+		}
+		ret[path] = repl
+	}
+	return ret
+}
+
+func cmp1(category string, root, apis map[string]string) bool {
+	insync := true
+	for path, rootver := range root {
+		apisver, ok := apis[path]
+		if !ok {
+			// For a future "verbose mode":
+			// fmt.Printf("\t(path in root but not apis: %s)\n", path)
+			continue
+		}
+		if rootver == apisver {
+			// For a future "verbose mode":
+			// fmt.Printf("\tOK %s %s\n", path, rootver)
+		} else {
+			fmt.Printf("XX %s %s: root(%s) apis(%s)\n", category, path, rootver, apisver)
+			insync = false
+		}
+	}
+	return insync
+}
+
+func cmp2(category string, root, apis map[string]replacement) bool {
+	insync := true
+	for path, rootrepl := range root {
+		apisrepl, ok := apis[path]
+		if !ok {
+			// For a future "verbose mode":
+			// fmt.Printf("\t(path in root but not apis: %s)\n", path)
+			continue
+		}
+		if rootrepl == apisrepl {
+			// For a future "verbose mode":
+			// fmt.Printf("\tOK %s %s\n", path, rootrepl)
+		} else {
+			fmt.Printf("XX %s %s: root(%s) apis(%s)\n", category, path, rootrepl, apisrepl)
+			insync = false
+		}
+	}
+	return insync
+}

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -53,6 +53,10 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 func NewForConfig(c *rest.Config) (*Clientset, error) {
 	configShallowCopy := *c
 
+	if configShallowCopy.UserAgent == "" {
+		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
 	// share the transport between all clients
 	httpClient, err := rest.HTTPClientFor(&configShallowCopy)
 	if err != nil {


### PR DESCRIPTION
Add a utility that compares statements in go.mod and apis/go.mod. If
matching module paths are found, the utility determines whether the
versions match, printing a human-readable report and exiting nonzero iff
*any* versions *do not* match.

Add a make rule, `make modcheck`, to run it.

Plumb `modcheck` into `verify`.

[HIVE-1941](https://issues.redhat.com//browse/HIVE-1941)