### PR TITLE
Updates to ibmclient authenticator.

### DIFF
--- a/pkg/ibmclient/client.go
+++ b/pkg/ibmclient/client.go
@@ -45,10 +45,11 @@ type API interface {
 
 // Client makes calls to the IBM Cloud API.
 type Client struct {
+	APIKey string
+
 	managementAPI *resourcemanagerv2.ResourceManagerV2
 	controllerAPI *resourcecontrollerv2.ResourceControllerV2
 	vpcAPI        *vpcv1.VpcV1
-	Authenticator *core.IamAuthenticator
 }
 
 // cisServiceID is the Cloud Internet Services' catalog service ID.
@@ -87,12 +88,8 @@ type EncryptionKeyResponse struct{}
 
 // NewClient initializes a client with a session.
 func NewClient(apiKey string) (*Client, error) {
-	authenticator := &core.IamAuthenticator{
-		ApiKey: apiKey,
-	}
-
 	client := &Client{
-		Authenticator: authenticator,
+		APIKey: apiKey,
 	}
 
 	if err := client.loadSDKServices(); err != nil {
@@ -130,15 +127,19 @@ func (c *Client) loadSDKServices() error {
 // GetAuthenticatorAPIKeyDetails gets detailed information on the API key used
 // for authentication to the IBM Cloud APIs
 func (c *Client) GetAuthenticatorAPIKeyDetails(ctx context.Context) (*iamidentityv1.APIKey, error) {
+	authenticator, err := NewIamAuthenticator(c.APIKey)
+	if err != nil {
+		return nil, err
+	}
 	iamIdentityService, err := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
-		Authenticator: c.Authenticator,
+		Authenticator: authenticator,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	options := iamIdentityService.NewGetAPIKeysDetailsOptions()
-	options.SetIamAPIKey(c.Authenticator.ApiKey)
+	options.SetIamAPIKey(c.APIKey)
 	details, _, err := iamIdentityService.GetAPIKeysDetailsWithContext(ctx, options)
 	if err != nil {
 		return nil, err
@@ -201,9 +202,13 @@ func (c *Client) GetDedicatedHostProfiles(ctx context.Context, region string) ([
 // GetDNSRecordsByName gets DNS records in specific Cloud Internet Services instance
 // by its CRN, zone ID, and DNS record name.
 func (c *Client) GetDNSRecordsByName(ctx context.Context, crnstr string, zoneID string, recordName string) ([]dnsrecordsv1.DnsrecordDetails, error) {
+	authenticator, err := NewIamAuthenticator(c.APIKey)
+	if err != nil {
+		return nil, err
+	}
 	// Set CIS DNS record service
 	dnsService, err := dnsrecordsv1.NewDnsRecordsV1(&dnsrecordsv1.DnsRecordsV1Options{
-		Authenticator:  c.Authenticator,
+		Authenticator:  authenticator,
 		Crn:            core.StringPtr(crnstr),
 		ZoneIdentifier: core.StringPtr(zoneID),
 	})
@@ -254,9 +259,13 @@ func (c *Client) GetDNSZones(ctx context.Context) ([]DNSZoneResponse, error) {
 
 	var allZones []DNSZoneResponse
 	for _, instance := range listResourceInstancesResponse.Resources {
+		authenticator, err := NewIamAuthenticator(c.APIKey)
+		if err != nil {
+			return nil, err
+		}
 		crnstr := instance.CRN
 		zonesService, err := zonesv1.NewZonesV1(&zonesv1.ZonesV1Options{
-			Authenticator: c.Authenticator,
+			Authenticator: authenticator,
 			Crn:           crnstr,
 		})
 		if err != nil {
@@ -409,8 +418,12 @@ func (c *Client) getVPCRegions(ctx context.Context) ([]vpcv1.Region, error) {
 }
 
 func (c *Client) loadResourceManagementAPI() error {
+	authenticator, err := NewIamAuthenticator(c.APIKey)
+	if err != nil {
+		return err
+	}
 	options := &resourcemanagerv2.ResourceManagerV2Options{
-		Authenticator: c.Authenticator,
+		Authenticator: authenticator,
 	}
 	resourceManagerV2Service, err := resourcemanagerv2.NewResourceManagerV2(options)
 	if err != nil {
@@ -421,8 +434,12 @@ func (c *Client) loadResourceManagementAPI() error {
 }
 
 func (c *Client) loadResourceControllerAPI() error {
+	authenticator, err := NewIamAuthenticator(c.APIKey)
+	if err != nil {
+		return err
+	}
 	options := &resourcecontrollerv2.ResourceControllerV2Options{
-		Authenticator: c.Authenticator,
+		Authenticator: authenticator,
 	}
 	resourceControllerV2Service, err := resourcecontrollerv2.NewResourceControllerV2(options)
 	if err != nil {
@@ -433,8 +450,12 @@ func (c *Client) loadResourceControllerAPI() error {
 }
 
 func (c *Client) loadVPCV1API() error {
+	authenticator, err := NewIamAuthenticator(c.APIKey)
+	if err != nil {
+		return err
+	}
 	vpcService, err := vpcv1.NewVpcV1(&vpcv1.VpcV1Options{
-		Authenticator: c.Authenticator,
+		Authenticator: authenticator,
 	})
 	if err != nil {
 		return err
@@ -530,4 +551,9 @@ func (c *Client) StartInstances(ctx context.Context, instances []vpcv1.Instance,
 		}
 	}
 	return nil
+}
+
+// NewIamAuthenticator returns a new IamAuthenticator for using IBM Cloud services.
+func NewIamAuthenticator(apiKey string) (*core.IamAuthenticator, error) {
+	return core.NewIamAuthenticatorBuilder().SetApiKey(apiKey).Build()
 }


### PR DESCRIPTION
IBM Cloud deprovision was broken by https://github.com/openshift/hive/pull/1764 and this PR brings the client back in line with changes in the installer's client. I attempted to consume the installer client directly but we'll need a way to instantiate the client with a secret or just the `apiKey` string in addition to needing functions related to stopping/starting/listing instances.

[HIVE-1951](https://issues.redhat.com//browse/HIVE-1951)
/assign @2uasimojo
