### PR TITLE
Add clustersyncfailing metric to crd

### DIFF
--- a/apis/hive/v1/metricsconfig/durationMetrics.go
+++ b/apis/hive/v1/metricsconfig/durationMetrics.go
@@ -6,7 +6,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // The purpose of these metrics should be to track outliers - ensure their duration is not set too low.
 type MetricsWithDuration struct {
 	// Name of the metric. It will correspond to an optional relevant metric in hive
-	// +kubebuilder:validation:Enum=currentStopping;currentResuming;currentWaitingForCO;cumulativeHibernated;cumulativeResumed
+	// +kubebuilder:validation:Enum=currentStopping;currentResuming;currentWaitingForCO;currentClusterSyncFailing;cumulativeHibernated;cumulativeResumed
 	Name DurationMetricType `json:"name"`
 	// Duration is the minimum time taken - the relevant metric will be logged only if the value reported by that metric
 	// is more than the time mentioned here. For example, if a user opts-in for current clusters stopping and mentions

--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -579,6 +579,7 @@ spec:
                           - currentStopping
                           - currentResuming
                           - currentWaitingForCO
+                          - currentClusterSyncFailing
                           - cumulativeHibernated
                           - cumulativeResumed
                           type: string

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -4197,6 +4197,7 @@ objects:
                             - currentStopping
                             - currentResuming
                             - currentWaitingForCO
+                            - currentClusterSyncFailing
                             - cumulativeHibernated
                             - cumulativeResumed
                             type: string

--- a/vendor/github.com/openshift/hive/apis/hive/v1/metricsconfig/durationMetrics.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/metricsconfig/durationMetrics.go
@@ -6,7 +6,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // The purpose of these metrics should be to track outliers - ensure their duration is not set too low.
 type MetricsWithDuration struct {
 	// Name of the metric. It will correspond to an optional relevant metric in hive
-	// +kubebuilder:validation:Enum=currentStopping;currentResuming;currentWaitingForCO;cumulativeHibernated;cumulativeResumed
+	// +kubebuilder:validation:Enum=currentStopping;currentResuming;currentWaitingForCO;currentClusterSyncFailing;cumulativeHibernated;cumulativeResumed
 	Name DurationMetricType `json:"name"`
 	// Duration is the minimum time taken - the relevant metric will be logged only if the value reported by that metric
 	// is more than the time mentioned here. For example, if a user opts-in for current clusters stopping and mentions


### PR DESCRIPTION
While adding ClusterSyncFailingSeconds metric, adding it to the enum in
durationMetrics was missed, which didn't catch the appropriate make
targets for adding it to the crd. This commit fixes that.

xref: https://issues.redhat.com/browse/HIVE-1857

/assign @2uasimojo 