### PR TITLE
Allow admin/view role aggregation for CRDs

### DIFF
--- a/config/rbac/hive_admin_role.yaml
+++ b/config/rbac/hive_admin_role.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: hive-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
 - apiGroups:
   - batch

--- a/config/rbac/hive_reader_role.yaml
+++ b/config/rbac/hive_reader_role.yaml
@@ -4,6 +4,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: hive-reader
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups:
   - batch

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1092,6 +1092,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: hive-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
 - apiGroups:
   - batch
@@ -1473,6 +1475,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: hive-reader
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups:
   - batch


### PR DESCRIPTION
...per https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles

When hive is deployed via OLM, OLM automatically creates ClusterRoles
for owned CRDs and labels them

```rbac.authorization.k8s.io/aggregate-to-$X: "true"```

for `X` in `[admin, edit, view]`.

OSD was taking advantage of these labels to perform role aggregation per
https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles

When OSD stopped deploying hive via OLM (see
https://issues.redhat.com/browse/SDE-1333), hive shards were only
getting the ClusterRoles explicitly laid down by hive-operator, and
these were unlabeled, so role aggregation was no longer happening.
However, as the existing OLM-generated ClusterRoles weren't removed at
that time, we didn't notice until new shards were deployed.

With this commit, we add those labels for our `admin` and `reader`
(`view`) ClusterRoles to re-enable role aggregation for OSD.

APPSRE-5886