### PR TITLE
bundle-gen: Add --image-only and --image-repo (for MCE)

### DIFF
--- a/hack/bundle-gen.py
+++ b/hack/bundle-gen.py
@@ -52,25 +52,6 @@ def get_params():
         action="store_true",
     )
     parser.add_argument(
-        "--branch",
-        default=HIVE_BRANCH_DEFAULT,
-        help="""The branch (or commit-ish) from which to build and push the image.
-                                If unspecified, we assume `{}`. If we're using `{}`, we
-                                generate the bundle version number based on the hive version prefix `{}` and
-                                update the `{}` channel. If BRANCH *also* corresponds to an `ocm-X.Y`,
-                                we'll also update that channel with the same bundle. If BRANCH corresponds
-                                to an `ocm-X.Y` but *not* `{}`, we'll generate the bundle version
-                                number based on `X.Y` and update only that channel. A BRANCH named
-                                `ocm-X.Y-mce-M.N` will result in a bundle with semver prefix `X.Y` in a
-                                channel named `mce-M.N`.""".format(
-            HIVE_BRANCH_DEFAULT,
-            HIVE_BRANCH_DEFAULT,
-            version.HIVE_VERSION_PREFIX,
-            CHANNEL_DEFAULT,
-            HIVE_BRANCH_DEFAULT,
-        ),
-    )
-    parser.add_argument(
         "--registry-auth-file",
         default=REGISTRY_AUTH_FILE_DEFAULT,
         help="Path to registry auth file",
@@ -93,6 +74,32 @@ def get_params():
         help="The hive git repository to clone. E.g. save time by using a local directory (but make sure it's up to date!)",
     )
     parser.add_argument(
+        "--image-repo",
+        default=OPERATORHUB_HIVE_IMAGE_DEFAULT,
+        help="""The image repository to which the operator image should be pushed, e.g. `quay.io/myproject/hive`.
+                                (Do not include a tag; it will be generated based on the branch/commit.)""",
+    )
+    mutex_group = parser.add_mutually_exclusive_group()
+    mutex_group.add_argument(
+        "--branch",
+        default=HIVE_BRANCH_DEFAULT,
+        help="""The branch (or commit-ish) from which to build and push the image.
+                                If unspecified, we assume `{}`. If we're using `{}`, we
+                                generate the bundle version number based on the hive version prefix `{}` and
+                                update the `{}` channel. If BRANCH *also* corresponds to an `ocm-X.Y`,
+                                we'll also update that channel with the same bundle. If BRANCH corresponds
+                                to an `ocm-X.Y` but *not* `{}`, we'll generate the bundle version
+                                number based on `X.Y` and update only that channel. A BRANCH named
+                                `ocm-X.Y-mce-M.N` will result in a bundle with semver prefix `X.Y` in a
+                                channel named `mce-M.N`.""".format(
+            HIVE_BRANCH_DEFAULT,
+            HIVE_BRANCH_DEFAULT,
+            version.HIVE_VERSION_PREFIX,
+            CHANNEL_DEFAULT,
+            HIVE_BRANCH_DEFAULT,
+        ),
+    )
+    mutex_group.add_argument(
         "--dummy-bundle",
         metavar="COMMIT-ISH",
         help="""Only generate bundle files. They will be placed in a subdirectory of your PWD named
@@ -101,6 +108,14 @@ def get_params():
                                 $sha is the first seven digits of the commit SHA corresponding to COMMIT-ISH.
                                 No image will be built. No package file will be generated. The CSV will not
                                 have any graph directives (`replaces`, `skipRange`, etc.)""",
+    )
+    mutex_group.add_argument(
+        "--image-only",
+        metavar="COMMIT-ISH",
+        help="""Only build and push the operator image. It will be tagged as '0.0.$count-$sha', where
+                                $count is the number of commits leading up to the requested COMMIT-ISH; and
+                                $sha is the first seven digits of the commit SHA corresponding to COMMIT-ISH.
+                                No bundle or OperatorHub PRs will be generated.""",
     )
     args = parser.parse_args()
 
@@ -129,8 +144,8 @@ def get_params():
 # build_and_push_image uses buildah or docker to build the HIVE image from the current
 # working directory (tagged with "v{hive_version}" eg. "v1.2.3187-18827f6") and then
 # pushes the image to quay.
-def build_and_push_image(registry_auth_file, hive_version, dry_run, build_engine):
-    container_name = "{}:v{}".format(OPERATORHUB_HIVE_IMAGE_DEFAULT, hive_version)
+def build_and_push_image(registry_auth_file, image_repo, hive_version, dry_run, build_engine):
+    container_name = "{}:v{}".format(image_repo, hive_version)
 
     if dry_run:
         print("Skipping build of container {}".format(container_name))
@@ -200,7 +215,7 @@ def get_previous_version(channel_name):
 # generate_csv_base generates a hive bundle from the current working directory
 # and deposits all artifacts in the specified bundle_dir.
 # If prev_version is not None/empty, the CSV will include it as `replaces`.
-def generate_csv_base(bundle_dir, version, prev_version):
+def generate_csv_base(bundle_dir, image_repo, version, prev_version):
     print("Writing bundle files to directory: %s" % bundle_dir)
     print("Generating CSV for version: %s" % version)
 
@@ -270,7 +285,7 @@ def generate_csv_base(bundle_dir, version, prev_version):
         csv["spec"]["replaces"] = "hive-operator.v%s" % prev_version
 
     # Update the deployment to use the defined image:
-    image_ref = "%s:v%s" % (OPERATORHUB_HIVE_IMAGE_DEFAULT, version)
+    image_ref = "%s:v%s" % (image_repo, version)
     csv["spec"]["install"]["spec"]["deployments"][0]["spec"]["template"]["spec"][
         "containers"
     ][0]["image"] = image_ref
@@ -490,9 +505,9 @@ if __name__ == "__main__":
 
     hive_repo = git.Repo(hive_repo_dir.name)
 
-    if args.dummy_bundle:
+    if args.dummy_bundle or args.image_only:
         # This will raise an exception if there's no such commit-ish
-        hive_commit = hive_repo.rev_parse(args.dummy_bundle).hexsha
+        hive_commit = hive_repo.rev_parse(args.dummy_bundle or args.image_only).hexsha
         hive_version_prefix = "0.0"
     else:
         hive_commit, hive_version_prefix, update_channels = version.process_branch(
@@ -519,7 +534,7 @@ if __name__ == "__main__":
         raise
 
     hive_version = version.gen_hive_version(hive_repo, hive_commit, hive_version_prefix)
-    if args.dummy_bundle:
+    if args.dummy_bundle or args.image_only:
         # Omit version graph stuff
         prev_version = None
     else:
@@ -527,8 +542,11 @@ if __name__ == "__main__":
         if hive_version == prev_version:
             raise ValueError("Version {} already exists upstream".format(hive_version))
 
-    build_and_push_image(args.registry_auth_file, hive_version, args.dry_run or args.dummy_bundle, args.build_engine)
-    version_dir = generate_csv_base(bundle_dir.name, hive_version, prev_version)
+    build_and_push_image(args.registry_auth_file, args.image_repo, hive_version, args.dry_run or args.dummy_bundle, args.build_engine)
+    if args.image_only:
+        sys.exit(0)
+
+    version_dir = generate_csv_base(bundle_dir.name, args.image_repo, hive_version, prev_version)
 
     if args.dummy_bundle:
         copy_bundle(orig_wd, version_dir, hive_version)


### PR DESCRIPTION
Add support to hack/bundle-gen.py for skipping all the OperatorHub
pieces and only building/pushing the operator image.

At the same time, add the ability to override the image repository to
which that image gets pushed.

The `--image-only`, `--dummy-bundle`, and `--branch` arguments are
mutually exclusive.

Example usage below. Note that the argument to `--image-only` can be any
commit-ish recognized by git, including a raw SHA.

```
[efried@efried hive]$ ./hack/bundle-gen.py --image-only master --image-repo quay.io/2uasimojo/hive
Cloning git@github.com:openshift/hive.git to /tmp/hive-repo-49b2mwqo
Working in /tmp/hive-repo-49b2mwqo
Checking out 52ff9fde3e9272015ff66c809503f14c38bb9889
Building container quay.io/2uasimojo/hive:v0.0.3739-52ff9fd
Sending build context to Docker daemon  269.1MB
Step 1/19 : FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
<snip>
Step 19/19 : ENTRYPOINT ["/opt/services/manager"]
 ---> Running in 492c2cad5b22
Removing intermediate container 492c2cad5b22
 ---> 6606a8b9d676
Successfully built 6606a8b9d676
Successfully tagged quay.io/2uasimojo/hive:v0.0.3739-52ff9fd
Pushing container
The push refers to repository [quay.io/2uasimojo/hive]
4ce8414ebfc5: Pushed
303981fa49b3: Pushed
5c579d91f1f0: Pushed
cdc174b9727e: Pushed
eb88336f5364: Pushed
d136ebfc6fba: Pushed
d33feb9e8957: Pushed
49a343c84da3: Mounted from openshift-hive/hive
d392da935ab9: Mounted from openshift-hive/hive
2e5b35302773: Mounted from openshift-hive/hive
a18e420160ca: Mounted from openshift-hive/hive
39f0f49cf7b6: Mounted from openshift-hive/hive
773711fd02f0: Mounted from openshift-hive/hive
5bf135c4a0de: Mounted from openshift-hive/hive
v0.0.3739-52ff9fd: digest: sha256:c084fbed2f7cba14d23c46807abc4a307acb10067a5df27edcc3515eaa6fb623 size: 3266
```

HIVE-1954