### PR TITLE
Fix clearing of ClusterSync Failing metric 

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -44,7 +44,6 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	hiveintv1alpha1 "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
 	"github.com/openshift/hive/pkg/constants"
-	"github.com/openshift/hive/pkg/controller/clustersync"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/imageset"
@@ -513,7 +512,7 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 			// removed the finalizer.
 			clearDeprovisionUnderwaySecondsMetric(cd, cdLog)
 			// Clear ClusterSyncFailing metric
-			clustersync.ClearClusterSyncFailingSecondsMetric(cd.Namespace, cd.Name, cdLog)
+			hivemetrics.ClearClusterSyncFailingSecondsMetric(cd.Namespace, cd.Name, cdLog)
 
 			return reconcile.Result{}, nil
 		}
@@ -1422,7 +1421,7 @@ func (r *ReconcileClusterDeployment) removeClusterDeploymentFinalizer(cd *hivev1
 
 	clearDeprovisionUnderwaySecondsMetric(cd, cdLog)
 	// Clear ClusterSyncFailing metric
-	clustersync.ClearClusterSyncFailingSecondsMetric(cd.Namespace, cd.Name, cdLog)
+	hivemetrics.ClearClusterSyncFailingSecondsMetric(cd.Namespace, cd.Name, cdLog)
 
 	// Increment the clusters deleted counter:
 	metricClustersDeleted.WithLabelValues(hivemetrics.GetClusterDeploymentType(cd)).Inc()
@@ -2113,7 +2112,7 @@ func (r *ReconcileClusterDeployment) setSyncSetFailedCondition(cd *hivev1.Cluste
 			message = "ClusterSync has not yet been created"
 		}
 		// In case the clusterSync has been deleted at this point, clear the clusterSyncFailing metric
-		clustersync.ClearClusterSyncFailingSecondsMetric(cd.Namespace, cd.Name, cdLog)
+		hivemetrics.ClearClusterSyncFailingSecondsMetric(cd.Namespace, cd.Name, cdLog)
 	case err != nil:
 		cdLog.WithError(err).Log(controllerutils.LogLevel(err), "could not get ClusterSync")
 		return err


### PR DESCRIPTION
ClusterSync Failing metric must be cleared when clustersync is no longer
failing, however the code path that evoked clearing of that metric in
clustersync controller when the failing condition was changed to success
was somehow never evoked.

- This commit moves the clearing logic under this criterion to the
  metrics controller. The controller assumes that if any clustersync is
not failing than the corresponding metric should be cleared.
- Since the code path in clustersync controller wasn't being evoked,
  this commit also reverts to the previous code, and moves the clearing
logic to the metrics controller, thereby ensuring we are only setting or
clearing the metric in either the metrics controller or the
clusterdeployment controller

xref: https://issues.redhat.com/browse/HIVE-1857

/assign @2uasimojo 