### PR TITLE
Add log tagging for aggregation

### DIFF
--- a/contrib/pkg/deprovision/alibabacloud.go
+++ b/contrib/pkg/deprovision/alibabacloud.go
@@ -2,8 +2,8 @@ package deprovision
 
 import (
 	"fmt"
-	"os"
 
+	"github.com/openshift/hive/contrib/pkg/utils"
 	"github.com/openshift/installer/pkg/destroy/alibabacloud"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -77,21 +77,10 @@ func (o *alibabaCloudDeprovisionOptions) Validate(cmd *cobra.Command) error {
 
 // Run executes the command
 func (o *alibabaCloudDeprovisionOptions) Run() error {
-	// Set log level
-	level, err := log.ParseLevel(o.logLevel)
+	logger, err := utils.NewLogger(o.logLevel)
 	if err != nil {
-		log.WithError(err).Error("cannot parse log level")
 		return err
 	}
-
-	logger := log.NewEntry(&log.Logger{
-		Out: os.Stdout,
-		Formatter: &log.TextFormatter{
-			FullTimestamp: true,
-		},
-		Hooks: make(log.LevelHooks),
-		Level: level,
-	})
 
 	metadata := &types.ClusterMetadata{
 		InfraID: o.infraID,

--- a/contrib/pkg/deprovision/awstagdeprovision.go
+++ b/contrib/pkg/deprovision/awstagdeprovision.go
@@ -2,12 +2,12 @@ package deprovision
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/hive/contrib/pkg/utils"
 	"github.com/openshift/installer/pkg/destroy/aws"
 )
 
@@ -55,21 +55,10 @@ func completeAWSUninstaller(o *aws.ClusterUninstaller, logLevel string, args []s
 		o.Filters = append(o.Filters, filter)
 	}
 
-	// Set log level
-	level, err := log.ParseLevel(logLevel)
-	if err != nil {
-		log.WithError(err).Error("cannot parse log level")
+	var err error
+	if o.Logger, err = utils.NewLogger(logLevel); err != nil {
 		return err
 	}
-
-	o.Logger = log.NewEntry(&log.Logger{
-		Out: os.Stdout,
-		Formatter: &log.TextFormatter{
-			FullTimestamp: true,
-		},
-		Hooks: make(log.LevelHooks),
-		Level: level,
-	})
 
 	return nil
 }

--- a/contrib/pkg/deprovision/azure.go
+++ b/contrib/pkg/deprovision/azure.go
@@ -1,8 +1,6 @@
 package deprovision
 
 import (
-	"os"
-
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -12,6 +10,7 @@ import (
 	"github.com/openshift/installer/pkg/types"
 	installertypesazure "github.com/openshift/installer/pkg/types/azure"
 
+	"github.com/openshift/hive/contrib/pkg/utils"
 	azureutils "github.com/openshift/hive/contrib/pkg/utils/azure"
 )
 
@@ -61,21 +60,10 @@ func validate() error {
 
 func completeAzureUninstaller(logLevel, cloudName string, args []string) (providers.Destroyer, error) {
 
-	// Set log level
-	level, err := log.ParseLevel(logLevel)
+	logger, err := utils.NewLogger(logLevel)
 	if err != nil {
-		log.WithError(err).Error("cannot parse log level")
 		return nil, err
 	}
-
-	logger := log.NewEntry(&log.Logger{
-		Out: os.Stdout,
-		Formatter: &log.TextFormatter{
-			FullTimestamp: true,
-		},
-		Hooks: make(log.LevelHooks),
-		Level: level,
-	})
 
 	metadata := &types.ClusterMetadata{
 		InfraID: args[0],

--- a/contrib/pkg/deprovision/gcp.go
+++ b/contrib/pkg/deprovision/gcp.go
@@ -2,7 +2,6 @@ package deprovision
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -12,6 +11,7 @@ import (
 	"github.com/openshift/installer/pkg/types"
 	typesgcp "github.com/openshift/installer/pkg/types/gcp"
 
+	"github.com/openshift/hive/contrib/pkg/utils"
 	gcputils "github.com/openshift/hive/contrib/pkg/utils/gcp"
 	"github.com/openshift/hive/pkg/gcpclient"
 )
@@ -77,21 +77,10 @@ func (o *gcpOptions) Validate(cmd *cobra.Command) error {
 
 // Run executes the command
 func (o *gcpOptions) Run() error {
-	// Set log level
-	level, err := log.ParseLevel(o.logLevel)
+	logger, err := utils.NewLogger(o.logLevel)
 	if err != nil {
-		log.WithError(err).Error("cannot parse log level")
 		return err
 	}
-
-	logger := log.NewEntry(&log.Logger{
-		Out: os.Stdout,
-		Formatter: &log.TextFormatter{
-			FullTimestamp: true,
-		},
-		Hooks: make(log.LevelHooks),
-		Level: level,
-	})
 
 	metadata := &types.ClusterMetadata{
 		InfraID: o.infraID,

--- a/contrib/pkg/deprovision/ibmcloud.go
+++ b/contrib/pkg/deprovision/ibmcloud.go
@@ -9,6 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/hive/contrib/pkg/utils"
 	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/ibmclient"
 	"github.com/openshift/installer/pkg/destroy/ibmcloud"
@@ -110,21 +111,10 @@ func (o *ibmCloudDeprovisionOptions) Validate(cmd *cobra.Command) error {
 
 // Run executes the command
 func (o *ibmCloudDeprovisionOptions) Run() error {
-	// Set log level
-	level, err := log.ParseLevel(o.logLevel)
+	logger, err := utils.NewLogger(o.logLevel)
 	if err != nil {
-		log.WithError(err).Error("cannot parse log level")
 		return err
 	}
-
-	logger := log.NewEntry(&log.Logger{
-		Out: os.Stdout,
-		Formatter: &log.TextFormatter{
-			FullTimestamp: true,
-		},
-		Hooks: make(log.LevelHooks),
-		Level: level,
-	})
 
 	metadata := &types.ClusterMetadata{
 		ClusterName: o.clusterName,

--- a/contrib/pkg/deprovision/openstack.go
+++ b/contrib/pkg/deprovision/openstack.go
@@ -7,6 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/hive/contrib/pkg/utils"
 	"github.com/openshift/installer/pkg/destroy/openstack"
 	"github.com/openshift/installer/pkg/types"
 	typesopenstack "github.com/openshift/installer/pkg/types/openstack"
@@ -66,21 +67,10 @@ func (o *openStackOptions) Validate(cmd *cobra.Command) error {
 
 // Run executes the command
 func (o *openStackOptions) Run() error {
-	// Set log level
-	level, err := log.ParseLevel(o.logLevel)
+	logger, err := utils.NewLogger(o.logLevel)
 	if err != nil {
-		log.WithError(err).Error("cannot parse log level")
 		return err
 	}
-
-	logger := log.NewEntry(&log.Logger{
-		Out: os.Stdout,
-		Formatter: &log.TextFormatter{
-			FullTimestamp: true,
-		},
-		Hooks: make(log.LevelHooks),
-		Level: level,
-	})
 
 	metadata := &types.ClusterMetadata{
 		InfraID: o.infraID,

--- a/contrib/pkg/deprovision/ovirt.go
+++ b/contrib/pkg/deprovision/ovirt.go
@@ -2,11 +2,11 @@ package deprovision
 
 import (
 	"errors"
-	"os"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/hive/contrib/pkg/utils"
 	"github.com/openshift/installer/pkg/destroy/ovirt"
 	"github.com/openshift/installer/pkg/types"
 	typesovirt "github.com/openshift/installer/pkg/types/ovirt"
@@ -60,21 +60,10 @@ func (o *oVirtOptions) Validate(cmd *cobra.Command) error {
 
 // Run executes the command
 func (o *oVirtOptions) Run() error {
-	// Set log level
-	level, err := log.ParseLevel(o.logLevel)
+	logger, err := utils.NewLogger(o.logLevel)
 	if err != nil {
-		log.WithError(err).Error("cannot parse log level")
 		return err
 	}
-
-	logger := log.NewEntry(&log.Logger{
-		Out: os.Stdout,
-		Formatter: &log.TextFormatter{
-			FullTimestamp: true,
-		},
-		Hooks: make(log.LevelHooks),
-		Level: level,
-	})
 
 	metadata := &types.ClusterMetadata{
 		InfraID: o.infraID,

--- a/contrib/pkg/deprovision/vsphere.go
+++ b/contrib/pkg/deprovision/vsphere.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/installer/pkg/types"
 	typesvsphere "github.com/openshift/installer/pkg/types/vsphere"
 
+	"github.com/openshift/hive/contrib/pkg/utils"
 	"github.com/openshift/hive/pkg/constants"
 )
 
@@ -75,21 +76,10 @@ func (o *vSphereOptions) Validate(cmd *cobra.Command) error {
 
 // Run executes the command
 func (o *vSphereOptions) Run() error {
-	// Set log level
-	level, err := log.ParseLevel(o.logLevel)
+	logger, err := utils.NewLogger(o.logLevel)
 	if err != nil {
-		log.WithError(err).Error("cannot parse log level")
 		return err
 	}
-
-	logger := log.NewEntry(&log.Logger{
-		Out: os.Stdout,
-		Formatter: &log.TextFormatter{
-			FullTimestamp: true,
-		},
-		Hooks: make(log.LevelHooks),
-		Level: level,
-	})
 
 	metadata := &types.ClusterMetadata{
 		InfraID: o.infraID,

--- a/contrib/pkg/utils/generic.go
+++ b/contrib/pkg/utils/generic.go
@@ -71,3 +71,24 @@ func GetPullSecret(logger log.FieldLogger, pullSecret string, pullSecretFile str
 	}
 	return "", nil
 }
+
+func NewLogger(logLevel string) (*log.Entry, error) {
+
+	// Set log level
+	level, err := log.ParseLevel(logLevel)
+	if err != nil {
+		log.WithError(err).Error("cannot parse log level")
+		return nil, err
+	}
+
+	logger := log.NewEntry(&log.Logger{
+		Out: os.Stdout,
+		Formatter: &log.TextFormatter{
+			FullTimestamp: true,
+		},
+		Hooks: make(log.LevelHooks),
+		Level: level,
+	})
+
+	return logger, nil
+}

--- a/contrib/pkg/utils/generic.go
+++ b/contrib/pkg/utils/generic.go
@@ -11,6 +11,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	"github.com/openshift/hive/pkg/constants"
+	"github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/resource"
 )
 
@@ -89,6 +91,9 @@ func NewLogger(logLevel string) (*log.Entry, error) {
 		Hooks: make(log.LevelHooks),
 		Level: level,
 	})
+
+	// Decorate with additional log fields, if requested
+	logger = utils.AddLogFields(utils.StringLogTagger{S: os.Getenv(constants.AdditionalLogFieldsEnvVar)}, logger)
 
 	return logger, nil
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -431,6 +431,11 @@ const (
 	// nonempty, and parseable into such a map, the key/value pairs are blindly included in log lines for any controller
 	// dealing with the annotated object.
 	AdditionalLogFieldsAnnotation = "hive.openshift.io/additional-log-fields"
+
+	// AdditionalLogFieldsEnvVar, if present, contains a string comprising a JSON-encoded map of key/value pairs. If specified,
+	// nonempty, and parseable into such a map, the key/value pairs are blindly included in log lines from hive binaries
+	// (currently only hiveutil).
+	AdditionalLogFieldsEnvVar = "HIVE_ADDITIONAL_LOG_FIELDS"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -426,6 +426,11 @@ const (
 	// actually checking if ClusterOperators are in a good state. This is to allow them time to start
 	// their pods and report accurate status so we avoid reading good state from before hibernation.
 	ClusterOperatorSettlePause = 2 * time.Minute
+
+	// AdditionalLogFieldsAnnotation keys an annotation containing a JSON-encoded map of key/value pairs. If specified,
+	// nonempty, and parseable into such a map, the key/value pairs are blindly included in log lines for any controller
+	// dealing with the annotated object.
+	AdditionalLogFieldsAnnotation = "hive.openshift.io/additional-log-fields"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/pkg/controller/argocdregister/argocdregister_controller.go
+++ b/pkg/controller/argocdregister/argocdregister_controller.go
@@ -52,6 +52,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 )
 
@@ -152,6 +153,7 @@ func (r *ArgoCDRegisterController) Reconcile(ctx context.Context, request reconc
 		log.WithError(err).Error("error looking up cluster deployment")
 		return reconcile.Result{}, err
 	}
+	cdLog = utils.AddLogFields(cd, cdLog)
 
 	if !cd.Spec.Installed {
 		cdLog.Info("cluster installation is not complete")

--- a/pkg/controller/argocdregister/argocdregister_controller.go
+++ b/pkg/controller/argocdregister/argocdregister_controller.go
@@ -153,7 +153,7 @@ func (r *ArgoCDRegisterController) Reconcile(ctx context.Context, request reconc
 		log.WithError(err).Error("error looking up cluster deployment")
 		return reconcile.Result{}, err
 	}
-	cdLog = utils.AddLogFields(cd, cdLog)
+	cdLog = utils.AddLogFields(utils.MetaObjectLogTagger{Object: cd}, cdLog)
 
 	if !cd.Spec.Installed {
 		cdLog.Info("cluster installation is not complete")

--- a/pkg/controller/awsprivatelink/awsprivatelink_controller.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller.go
@@ -42,6 +42,7 @@ import (
 	"github.com/openshift/hive/pkg/awsclient"
 	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 )
 
@@ -171,6 +172,7 @@ func (r *ReconcileAWSPrivateLink) Reconcile(ctx context.Context, request reconci
 		logger.WithError(err).Error("error getting ClusterDeployment")
 		return reconcile.Result{}, err
 	}
+	logger = utils.AddLogFields(cd, logger)
 
 	// Initialize cluster deployment conditions if not present
 	newConditions, changed := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentAWSPrivateLinkConditions)

--- a/pkg/controller/awsprivatelink/awsprivatelink_controller.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller.go
@@ -172,7 +172,7 @@ func (r *ReconcileAWSPrivateLink) Reconcile(ctx context.Context, request reconci
 		logger.WithError(err).Error("error getting ClusterDeployment")
 		return reconcile.Result{}, err
 	}
-	logger = utils.AddLogFields(cd, logger)
+	logger = utils.AddLogFields(utils.MetaObjectLogTagger{Object: cd}, logger)
 
 	// Initialize cluster deployment conditions if not present
 	newConditions, changed := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentAWSPrivateLinkConditions)

--- a/pkg/controller/clusterclaim/clusterclaim_controller.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller.go
@@ -23,6 +23,7 @@ import (
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/resource"
 )
@@ -175,6 +176,7 @@ func (r *ReconcileClusterClaim) Reconcile(ctx context.Context, request reconcile
 		log.WithError(err).Error("error getting ClusterClaim")
 		return reconcile.Result{}, err
 	}
+	logger = utils.AddLogFields(claim, logger)
 
 	// Initialize cluster claim conditions if not set
 	newConditions, changed := controllerutils.InitializeClusterClaimConditions(claim.Status.Conditions, clusterClaimConditions)

--- a/pkg/controller/clusterclaim/clusterclaim_controller.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller.go
@@ -176,7 +176,7 @@ func (r *ReconcileClusterClaim) Reconcile(ctx context.Context, request reconcile
 		log.WithError(err).Error("error getting ClusterClaim")
 		return reconcile.Result{}, err
 	}
-	logger = utils.AddLogFields(claim, logger)
+	logger = utils.AddLogFields(utils.MetaObjectLogTagger{Object: claim}, logger)
 
 	// Initialize cluster claim conditions if not set
 	newConditions, changed := controllerutils.InitializeClusterClaimConditions(claim.Status.Conditions, clusterClaimConditions)

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -300,7 +300,7 @@ func (r *ReconcileClusterDeployment) Reconcile(ctx context.Context, request reco
 		cdLog.WithError(err).Error("Error getting cluster deployment")
 		return reconcile.Result{}, err
 	}
-	cdLog = utils.AddLogFields(cd, cdLog)
+	cdLog = utils.AddLogFields(utils.MetaObjectLogTagger{Object: cd}, cdLog)
 
 	// Ensure owner references are correctly set
 	err = controllerutils.ReconcileOwnerReferences(cd, generateOwnershipUniqueKeys(cd), r, r.scheme, r.logger)

--- a/pkg/controller/clusterdeployment/clusterprovisions.go
+++ b/pkg/controller/clusterdeployment/clusterprovisions.go
@@ -29,6 +29,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/install"
 	k8slabels "github.com/openshift/hive/pkg/util/labels"
@@ -180,6 +181,7 @@ func (r *ReconcileClusterDeployment) startNewProvision(
 			Stage:   hivev1.ClusterProvisionStageInitializing,
 		},
 	}
+	utils.CopyLogAnnotation(cd, provision)
 
 	// Copy over the name, cluster ID and infra ID from previous provision so that a failed install can be removed.
 	if lastFailedProvision != nil {

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
@@ -169,7 +169,7 @@ func (r *ReconcileClusterDeprovision) Reconcile(ctx context.Context, request rec
 		rLog.WithError(err).Error("cannot get clusterdeprovision")
 		return reconcile.Result{}, err
 	}
-	rLog = utils.AddLogFields(instance, rLog)
+	rLog = utils.AddLogFields(utils.MetaObjectLogTagger{Object: instance}, rLog)
 
 	// Ensure owner references are correctly set
 	err = controllerutils.ReconcileOwnerReferences(instance, generateOwnershipUniqueKeys(instance), r, r.scheme, rLog)

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
@@ -31,6 +31,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/install"
 	k8slabels "github.com/openshift/hive/pkg/util/labels"
@@ -168,6 +169,7 @@ func (r *ReconcileClusterDeprovision) Reconcile(ctx context.Context, request rec
 		rLog.WithError(err).Error("cannot get clusterdeprovision")
 		return reconcile.Result{}, err
 	}
+	rLog = utils.AddLogFields(instance, rLog)
 
 	// Ensure owner references are correctly set
 	err = controllerutils.ReconcileOwnerReferences(instance, generateOwnershipUniqueKeys(instance), r, r.scheme, rLog)

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/openshift/hive/pkg/clusterresource"
 	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 )
 
@@ -298,6 +299,7 @@ func (r *ReconcileClusterPool) Reconcile(ctx context.Context, request reconcile.
 		log.WithError(err).Error("error reading cluster pool")
 		return reconcile.Result{}, err
 	}
+	logger = utils.AddLogFields(clp, logger)
 
 	if p := clp.Spec.Platform; clp.Spec.RunningCount != clp.Spec.Size && (p.OpenStack != nil || p.Ovirt != nil || p.VSphere != nil) {
 		return reconcile.Result{}, errors.New("Hibernation is not supported on Openstack, VShpere and Ovirt, unless runningCount==size")

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -299,7 +299,7 @@ func (r *ReconcileClusterPool) Reconcile(ctx context.Context, request reconcile.
 		log.WithError(err).Error("error reading cluster pool")
 		return reconcile.Result{}, err
 	}
-	logger = utils.AddLogFields(clp, logger)
+	logger = utils.AddLogFields(utils.MetaObjectLogTagger{Object: clp}, logger)
 
 	if p := clp.Spec.Platform; clp.Spec.RunningCount != clp.Spec.Size && (p.OpenStack != nil || p.Ovirt != nil || p.VSphere != nil) {
 		return reconcile.Result{}, errors.New("Hibernation is not supported on Openstack, VShpere and Ovirt, unless runningCount==size")

--- a/pkg/controller/clusterprovision/clusterprovision_controller.go
+++ b/pkg/controller/clusterprovision/clusterprovision_controller.go
@@ -161,7 +161,7 @@ func (r *ReconcileClusterProvision) Reconcile(ctx context.Context, request recon
 		pLog.WithError(err).Error("cannot get ClusterProvision")
 		return reconcile.Result{}, err
 	}
-	pLog = utils.AddLogFields(instance, pLog)
+	pLog = utils.AddLogFields(utils.MetaObjectLogTagger{Object: instance}, pLog)
 
 	// Ensure owner references are correctly set
 	err = controllerutils.ReconcileOwnerReferences(instance, generateOwnershipUniqueKeys(instance), r, r.scheme, pLog)

--- a/pkg/controller/clusterprovision/clusterprovision_controller.go
+++ b/pkg/controller/clusterprovision/clusterprovision_controller.go
@@ -29,6 +29,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/install"
 	k8slabels "github.com/openshift/hive/pkg/util/labels"
@@ -160,6 +161,7 @@ func (r *ReconcileClusterProvision) Reconcile(ctx context.Context, request recon
 		pLog.WithError(err).Error("cannot get ClusterProvision")
 		return reconcile.Result{}, err
 	}
+	pLog = utils.AddLogFields(instance, pLog)
 
 	// Ensure owner references are correctly set
 	err = controllerutils.ReconcileOwnerReferences(instance, generateOwnershipUniqueKeys(instance), r, r.scheme, pLog)

--- a/pkg/controller/clusterrelocate/clusterrelocate_controller.go
+++ b/pkg/controller/clusterrelocate/clusterrelocate_controller.go
@@ -173,7 +173,7 @@ func (r *ReconcileClusterRelocate) Reconcile(ctx context.Context, request reconc
 		logger.WithError(err).Error("Error getting cluster deployment")
 		return reconcile.Result{}, err
 	}
-	logger = utils.AddLogFields(cd, logger)
+	logger = utils.AddLogFields(utils.MetaObjectLogTagger{Object: cd}, logger)
 
 	// Initialize cluster deployment conditions if not present
 	newConditions, changed := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions,

--- a/pkg/controller/clusterrelocate/clusterrelocate_controller.go
+++ b/pkg/controller/clusterrelocate/clusterrelocate_controller.go
@@ -28,6 +28,7 @@ import (
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/remoteclient"
 )
@@ -172,6 +173,7 @@ func (r *ReconcileClusterRelocate) Reconcile(ctx context.Context, request reconc
 		logger.WithError(err).Error("Error getting cluster deployment")
 		return reconcile.Result{}, err
 	}
+	logger = utils.AddLogFields(cd, logger)
 
 	// Initialize cluster deployment conditions if not present
 	newConditions, changed := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions,

--- a/pkg/controller/clusterstate/clusterstate_controller.go
+++ b/pkg/controller/clusterstate/clusterstate_controller.go
@@ -121,7 +121,7 @@ func (r *ReconcileClusterState) Reconcile(ctx context.Context, request reconcile
 		logger.WithError(err).Error("Error getting cluster deployment")
 		return reconcile.Result{}, err
 	}
-	logger = utils.AddLogFields(cd, logger)
+	logger = utils.AddLogFields(utils.MetaObjectLogTagger{Object: cd}, logger)
 
 	// Ensure owner references are correctly set
 	err = controllerutils.ReconcileOwnerReferences(cd, generateOwnershipUniqueKeys(cd), r, r.scheme, logger)

--- a/pkg/controller/clusterstate/clusterstate_controller.go
+++ b/pkg/controller/clusterstate/clusterstate_controller.go
@@ -29,6 +29,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/remoteclient"
 )
@@ -120,6 +121,7 @@ func (r *ReconcileClusterState) Reconcile(ctx context.Context, request reconcile
 		logger.WithError(err).Error("Error getting cluster deployment")
 		return reconcile.Result{}, err
 	}
+	logger = utils.AddLogFields(cd, logger)
 
 	// Ensure owner references are correctly set
 	err = controllerutils.ReconcileOwnerReferences(cd, generateOwnershipUniqueKeys(cd), r, r.scheme, logger)

--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -39,6 +39,7 @@ import (
 	hiveintv1alpha1 "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
 	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/remoteclient"
 	"github.com/openshift/hive/pkg/resource"
@@ -361,6 +362,7 @@ func (r *ReconcileClusterSync) Reconcile(ctx context.Context, request reconcile.
 		log.WithError(err).Error("failed to get ClusterDeployment")
 		return reconcile.Result{}, err
 	}
+	logger = utils.AddLogFields(cd, logger)
 
 	sts, err := r.getAndCheckClusterSyncStatefulSet(logger)
 	if err != nil {

--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -362,7 +362,7 @@ func (r *ReconcileClusterSync) Reconcile(ctx context.Context, request reconcile.
 		log.WithError(err).Error("failed to get ClusterDeployment")
 		return reconcile.Result{}, err
 	}
-	logger = utils.AddLogFields(cd, logger)
+	logger = utils.AddLogFields(utils.MetaObjectLogTagger{Object: cd}, logger)
 
 	sts, err := r.getAndCheckClusterSyncStatefulSet(logger)
 	if err != nil {

--- a/pkg/controller/clusterversion/clusterversion_controller.go
+++ b/pkg/controller/clusterversion/clusterversion_controller.go
@@ -111,7 +111,7 @@ func (r *ReconcileClusterVersion) Reconcile(ctx context.Context, request reconci
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
-	cdLog = utils.AddLogFields(cd, cdLog)
+	cdLog = utils.AddLogFields(utils.MetaObjectLogTagger{Object: cd}, cdLog)
 	// If the clusterdeployment is deleted, do not reconcile.
 	if cd.DeletionTimestamp != nil {
 		return reconcile.Result{}, nil

--- a/pkg/controller/clusterversion/clusterversion_controller.go
+++ b/pkg/controller/clusterversion/clusterversion_controller.go
@@ -24,6 +24,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/remoteclient"
 )
@@ -110,6 +111,7 @@ func (r *ReconcileClusterVersion) Reconcile(ctx context.Context, request reconci
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
+	cdLog = utils.AddLogFields(cd, cdLog)
 	// If the clusterdeployment is deleted, do not reconcile.
 	if cd.DeletionTimestamp != nil {
 		return reconcile.Result{}, nil

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller.go
@@ -143,7 +143,7 @@ func (r *ReconcileControlPlaneCerts) Reconcile(ctx context.Context, request reco
 		}
 		return reconcile.Result{}, err
 	}
-	cdLog = utils.AddLogFields(cd, cdLog)
+	cdLog = utils.AddLogFields(utils.MetaObjectLogTagger{Object: cd}, cdLog)
 
 	// Initialize cluster deployment conditions if not present
 	newConditions, changed := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentControlPlaneCertsConditions)

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller.go
@@ -34,6 +34,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/remoteclient"
 	"github.com/openshift/hive/pkg/resource"
@@ -142,6 +143,7 @@ func (r *ReconcileControlPlaneCerts) Reconcile(ctx context.Context, request reco
 		}
 		return reconcile.Result{}, err
 	}
+	cdLog = utils.AddLogFields(cd, cdLog)
 
 	// Initialize cluster deployment conditions if not present
 	newConditions, changed := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentControlPlaneCertsConditions)

--- a/pkg/controller/dnsendpoint/dnsendpoint_controller.go
+++ b/pkg/controller/dnsendpoint/dnsendpoint_controller.go
@@ -175,7 +175,7 @@ func (r *ReconcileDNSEndpoint) Reconcile(ctx context.Context, request reconcile.
 		dnsLog.WithError(err).Error("Error fetching dnszone object")
 		return reconcile.Result{}, err
 	}
-	dnsLog = utils.AddLogFields(instance, dnsLog)
+	dnsLog = utils.AddLogFields(utils.MetaObjectLogTagger{Object: instance}, dnsLog)
 
 	if !instance.Spec.LinkToParentDomain {
 		return reconcile.Result{}, nil

--- a/pkg/controller/dnsendpoint/dnsendpoint_controller.go
+++ b/pkg/controller/dnsendpoint/dnsendpoint_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/controller/dnsendpoint/nameserver"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/manageddns"
 )
@@ -174,6 +175,7 @@ func (r *ReconcileDNSEndpoint) Reconcile(ctx context.Context, request reconcile.
 		dnsLog.WithError(err).Error("Error fetching dnszone object")
 		return reconcile.Result{}, err
 	}
+	dnsLog = utils.AddLogFields(instance, dnsLog)
 
 	if !instance.Spec.LinkToParentDomain {
 		return reconcile.Result{}, nil

--- a/pkg/controller/dnszone/dnszone_controller.go
+++ b/pkg/controller/dnszone/dnszone_controller.go
@@ -155,7 +155,7 @@ func (r *ReconcileDNSZone) Reconcile(ctx context.Context, request reconcile.Requ
 		dnsLog.WithError(err).Error("Error fetching dnszone object")
 		return reconcile.Result{}, err
 	}
-	dnsLog = utils.AddLogFields(desiredState, dnsLog)
+	dnsLog = utils.AddLogFields(utils.MetaObjectLogTagger{Object: desiredState}, dnsLog)
 
 	// NOTE: Can race with call to same in dnsendpoint controller
 	if result, err := controllerutils.ReconcileDNSZoneForRelocation(r.Client, dnsLog, desiredState, hivev1.FinalizerDNSZone); err != nil {

--- a/pkg/controller/dnszone/dnszone_controller.go
+++ b/pkg/controller/dnszone/dnszone_controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/hive/pkg/azureclient"
 	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	gcpclient "github.com/openshift/hive/pkg/gcpclient"
 	corev1 "k8s.io/api/core/v1"
@@ -154,6 +155,7 @@ func (r *ReconcileDNSZone) Reconcile(ctx context.Context, request reconcile.Requ
 		dnsLog.WithError(err).Error("Error fetching dnszone object")
 		return reconcile.Result{}, err
 	}
+	dnsLog = utils.AddLogFields(desiredState, dnsLog)
 
 	// NOTE: Can race with call to same in dnsendpoint controller
 	if result, err := controllerutils.ReconcileDNSZoneForRelocation(r.Client, dnsLog, desiredState, hivev1.FinalizerDNSZone); err != nil {

--- a/pkg/controller/fakeclusterinstall/fakeclusterinstall_controller.go
+++ b/pkg/controller/fakeclusterinstall/fakeclusterinstall_controller.go
@@ -107,7 +107,7 @@ func (r *ReconcileClusterInstall) Reconcile(ctx context.Context, request reconci
 		logger.WithError(err).Error("Error getting FakeClusterInstall")
 		return reconcile.Result{}, err
 	}
-	logger = utils.AddLogFields(fci, logger)
+	logger = utils.AddLogFields(utils.MetaObjectLogTagger{Object: fci}, logger)
 
 	if !fci.DeletionTimestamp.IsZero() {
 		logger.Info("FakeClusterInstall resource has been deleted")

--- a/pkg/controller/fakeclusterinstall/fakeclusterinstall_controller.go
+++ b/pkg/controller/fakeclusterinstall/fakeclusterinstall_controller.go
@@ -26,6 +26,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	hiveint "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 )
 
@@ -106,6 +107,7 @@ func (r *ReconcileClusterInstall) Reconcile(ctx context.Context, request reconci
 		logger.WithError(err).Error("Error getting FakeClusterInstall")
 		return reconcile.Result{}, err
 	}
+	logger = utils.AddLogFields(fci, logger)
 
 	if !fci.DeletionTimestamp.IsZero() {
 		logger.Info("FakeClusterInstall resource has been deleted")

--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -175,7 +175,7 @@ func (r *hibernationReconciler) Reconcile(ctx context.Context, request reconcile
 		cdLog.WithError(err).Log(controllerutils.LogLevel(err), "Error getting cluster deployment")
 		return reconcile.Result{}, err
 	}
-	cdLog = utils.AddLogFields(cd, cdLog)
+	cdLog = utils.AddLogFields(utils.MetaObjectLogTagger{Object: cd}, cdLog)
 
 	// If cluster is already deleted, skip any processing
 	if !cd.DeletionTimestamp.IsZero() {

--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -34,6 +34,7 @@ import (
 	hiveintv1alpha1 "github.com/openshift/hive/apis/hiveinternal/v1alpha1"
 	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/remoteclient"
 )
@@ -174,6 +175,7 @@ func (r *hibernationReconciler) Reconcile(ctx context.Context, request reconcile
 		cdLog.WithError(err).Log(controllerutils.LogLevel(err), "Error getting cluster deployment")
 		return reconcile.Result{}, err
 	}
+	cdLog = utils.AddLogFields(cd, cdLog)
 
 	// If cluster is already deleted, skip any processing
 	if !cd.DeletionTimestamp.IsZero() {

--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -222,7 +222,7 @@ func (r *ReconcileMachinePool) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, err
 	}
 	// NOTE: This may be sparse if we haven't yet synced from the ClusterDeployment (below)
-	logger = utils.AddLogFields(pool, logger)
+	logger = utils.AddLogFields(utils.MetaObjectLogTagger{Object: pool}, logger)
 
 	// Initialize machine pool conditions if not present
 	newConditions, changed := controllerutils.InitializeMachinePoolConditions(pool.Status.Conditions, machinePoolConditions)

--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -157,7 +157,7 @@ func (r *ReconcileRemoteClusterIngress) Reconcile(ctx context.Context, request r
 		log.WithError(err).Error("error looking up cluster deployment")
 		return reconcile.Result{}, err
 	}
-	cdLog = utils.AddLogFields(cd, cdLog)
+	cdLog = utils.AddLogFields(utils.MetaObjectLogTagger{Object: cd}, cdLog)
 	rContext.clusterDeployment = cd
 
 	// Initialize cluster deployment conditions if not present

--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -34,6 +34,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/resource"
 )
@@ -156,6 +157,7 @@ func (r *ReconcileRemoteClusterIngress) Reconcile(ctx context.Context, request r
 		log.WithError(err).Error("error looking up cluster deployment")
 		return reconcile.Result{}, err
 	}
+	cdLog = utils.AddLogFields(cd, cdLog)
 	rContext.clusterDeployment = cd
 
 	// Initialize cluster deployment conditions if not present

--- a/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
+++ b/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
@@ -193,7 +193,7 @@ func (r *ReconcileSyncIdentityProviders) Reconcile(ctx context.Context, request 
 		log.WithError(err).Error("error looking up cluster deployment")
 		return reconcile.Result{}, err
 	}
-	contextLogger = utils.AddLogFields(cd, contextLogger)
+	contextLogger = utils.AddLogFields(utils.MetaObjectLogTagger{Object: cd}, contextLogger)
 
 	// Ensure owner references are correctly set
 	err = controllerutils.ReconcileOwnerReferences(cd, generateOwnershipUniqueKeys(cd), r, r.scheme, contextLogger)

--- a/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
+++ b/pkg/controller/syncidentityprovider/syncidentityprovider_controller.go
@@ -32,6 +32,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	k8slabels "github.com/openshift/hive/pkg/util/labels"
 )
@@ -192,6 +193,7 @@ func (r *ReconcileSyncIdentityProviders) Reconcile(ctx context.Context, request 
 		log.WithError(err).Error("error looking up cluster deployment")
 		return reconcile.Result{}, err
 	}
+	contextLogger = utils.AddLogFields(cd, contextLogger)
 
 	// Ensure owner references are correctly set
 	err = controllerutils.ReconcileOwnerReferences(cd, generateOwnershipUniqueKeys(cd), r, r.scheme, contextLogger)

--- a/pkg/controller/unreachable/unreachable_controller.go
+++ b/pkg/controller/unreachable/unreachable_controller.go
@@ -41,6 +41,7 @@ import (
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/remoteclient"
 )
@@ -136,6 +137,7 @@ func (r *ReconcileRemoteMachineSet) Reconcile(ctx context.Context, request recon
 		log.WithError(err).Error("error looking up cluster deployment")
 		return reconcile.Result{}, err
 	}
+	cdLog = utils.AddLogFields(cd, cdLog)
 
 	// Initialize cluster deployment conditions if not present
 	newConditions, changed := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentUnreachableConditions)

--- a/pkg/controller/unreachable/unreachable_controller.go
+++ b/pkg/controller/unreachable/unreachable_controller.go
@@ -137,7 +137,7 @@ func (r *ReconcileRemoteMachineSet) Reconcile(ctx context.Context, request recon
 		log.WithError(err).Error("error looking up cluster deployment")
 		return reconcile.Result{}, err
 	}
-	cdLog = utils.AddLogFields(cd, cdLog)
+	cdLog = utils.AddLogFields(utils.MetaObjectLogTagger{Object: cd}, cdLog)
 
 	// Initialize cluster deployment conditions if not present
 	newConditions, changed := controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentUnreachableConditions)

--- a/pkg/controller/utils/logtagger.go
+++ b/pkg/controller/utils/logtagger.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/hive/pkg/constants"
+	log "github.com/sirupsen/logrus"
+)
+
+func AddLogFields(obj metav1.Object, logger *log.Entry) *log.Entry {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return logger
+	}
+
+	if addl_log_fields, exists := annotations[constants.AdditionalLogFieldsAnnotation]; exists {
+		kvmap := log.Fields{}
+		if err := json.Unmarshal([]byte(addl_log_fields), &kvmap); err != nil {
+			logger.WithError(err).Warning("failed to unmarshal additional log fields -- ignoring")
+		} else {
+			kvmap["component"] = "hive"
+			logger = logger.WithFields(kvmap)
+		}
+	}
+
+	return logger
+}
+
+func CopyLogAnnotation(from, to metav1.Object) bool {
+	froma := from.GetAnnotations()
+	if froma == nil {
+		// Spoof empty so we can delete the annotation if it exists on `to`
+		froma = make(map[string]string)
+	}
+
+	toa := to.GetAnnotations()
+	if toa == nil {
+		toa = make(map[string]string)
+	}
+
+	changed := false
+	key := constants.AdditionalLogFieldsAnnotation
+	fromv, fromexists := froma[key]
+	tov, toexists := toa[key]
+	if fromexists && fromv != tov {
+		changed = true
+		toa[key] = fromv
+	} else if !fromexists && toexists {
+		changed = true
+		delete(toa, key)
+	}
+
+	if changed {
+		to.SetAnnotations(toa)
+	}
+
+	return changed
+}

--- a/pkg/controller/utils/logtagger_test.go
+++ b/pkg/controller/utils/logtagger_test.go
@@ -1,0 +1,70 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestAddLogFields(t *testing.T) {
+	type args struct {
+		obj    AdditionalLogFieldHavinThing
+		logger *log.Entry
+	}
+	tests := []struct {
+		name string
+		args args
+		want *log.Entry
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AddLogFields(tt.args.obj, tt.args.logger); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AddLogFields() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddLogFieldsEnvVar(t *testing.T) {
+	type args struct {
+		from metav1.Object
+		to   *batchv1.Job
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			AddLogFieldsEnvVar(tt.args.from, tt.args.to)
+		})
+	}
+}
+
+func TestCopyLogAnnotations(t *testing.T) {
+	type args struct {
+		from metav1.Object
+		to   metav1.Object
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CopyLogAnnotations(tt.args.from, tt.args.to); got != tt.want {
+				t.Errorf("CopyLogAnnotations() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/utils/logtagger_test.go
+++ b/pkg/controller/utils/logtagger_test.go
@@ -1,69 +1,353 @@
 package utils
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/openshift/hive/pkg/constants"
+	testcd "github.com/openshift/hive/pkg/test/clusterdeployment"
+	testjob "github.com/openshift/hive/pkg/test/job"
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	// save some typing
+	alfa = constants.AdditionalLogFieldsAnnotation
 )
 
 func TestAddLogFields(t *testing.T) {
-	type args struct {
-		obj    AdditionalLogFieldHavinThing
-		logger *log.Entry
-	}
 	tests := []struct {
-		name string
-		args args
-		want *log.Entry
+		name        string
+		annotations map[string]string
+		want        map[string]interface{}
 	}{
-		// TODO: Add test cases.
+		{
+			name: "no annotations",
+		},
+		{
+			name:        "annotations, but not the one we care about",
+			annotations: map[string]string{"foo": "bar"},
+		},
+		{
+			name:        "empty string (unparseable json)",
+			annotations: map[string]string{alfa: ""},
+		},
+		{
+			name:        "unparseable json",
+			annotations: map[string]string{alfa: "foo: bar"},
+		},
+		{
+			name:        "empty json",
+			annotations: map[string]string{alfa: `{}`},
+			want:        map[string]interface{}{"component": "hive"},
+		},
+		{
+			name:        "one field",
+			annotations: map[string]string{alfa: `{"foo": "bar"}`},
+			want: map[string]interface{}{
+				"foo":       "bar",
+				"component": "hive",
+			},
+		},
+		{
+			name:        "multiple fields",
+			annotations: map[string]string{alfa: `{"foo": "bar", "HELLO": "WORLD"}`},
+			want: map[string]interface{}{
+				"foo":       "bar",
+				"HELLO":     "WORLD",
+				"component": "hive",
+			},
+		},
+		{
+			name: "complex value",
+			// logrus.WithFields happily accepts this (and marshals to a string when emitting)
+			annotations: map[string]string{alfa: `{"foo": {"bar": "baz"}}`},
+			want: map[string]interface{}{
+				"foo":       map[string]interface{}{"bar": "baz"},
+				"component": "hive",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := AddLogFields(tt.args.obj, tt.args.logger); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("AddLogFields() = %v, want %v", got, tt.want)
+			origLogger := log.NewEntry(&log.Logger{})
+			cd := testcd.BasicBuilder().Build()
+			var s string
+			if tt.annotations != nil {
+				cd.SetAnnotations(tt.annotations)
+				// May be "" if not using alfa
+				s = tt.annotations[alfa]
+			}
+			for typstr, obj := range map[string]AdditionalLogFieldHavinThing{
+				"meta":   MetaObjectLogTagger{Object: cd},
+				"string": StringLogTagger{S: s},
+			} {
+				if got := AddLogFields(obj, origLogger); assert.NotNil(t, got, "%s: expected AddLogFields to return non-nil", typstr) {
+					// If no fields are expected, `component` should be absent
+					if tt.want == nil {
+						gotv, exists := got.Data["component"]
+						assert.False(t, exists, "%s: unexpected component %q", typstr, gotv)
+					}
+
+					for wantk, wantv := range tt.want {
+						if gotv, exists := got.Data[wantk]; assert.True(t, exists, "%s: key %q missing", typstr, wantk) {
+							assert.Equal(t, wantv, gotv, "%s: bad value for key %q", typstr, wantk)
+						}
+					}
+				}
+
 			}
 		})
 	}
 }
 
 func TestAddLogFieldsEnvVar(t *testing.T) {
-	type args struct {
-		from metav1.Object
-		to   *batchv1.Job
+	mkJob := func(containers []v1.Container) *batchv1.Job {
+		if containers == nil {
+			containers = make([]v1.Container, 0)
+		}
+		job := testjob.BasicBuilder().Build()
+		job.Spec.Template.Spec.Containers = containers
+		return job
 	}
 	tests := []struct {
-		name string
-		args args
+		name           string
+		annotations    map[string]string
+		origContainers []v1.Container
 	}{
-		// TODO: Add test cases.
+		{
+			name: "no op: source has no annotations",
+			origContainers: []v1.Container{
+				{},
+			},
+		},
+		{
+			name:        "no op: source has annotations, but not the one we care about",
+			annotations: map[string]string{"foo": "bar"},
+			origContainers: []v1.Container{
+				{},
+			},
+		},
+		{
+			name:        "no op: target has no containers",
+			annotations: map[string]string{alfa: `{"HELLO": "WORLD}`},
+		},
+		{
+			name:        "add, replace, no-op",
+			annotations: map[string]string{alfa: `{"HELLO": "WORLD}`},
+			origContainers: []v1.Container{
+				// Empty container gets the var added
+				{},
+				{
+					Env: []v1.EnvVar{
+						{
+							Name:  "UNRELATED",
+							Value: "unchanged",
+						},
+						{
+							Name:  constants.AdditionalLogFieldsEnvVar,
+							Value: "will be replaced",
+						},
+					},
+				},
+				{
+					Env: []v1.EnvVar{
+						{
+							Name:  constants.AdditionalLogFieldsEnvVar,
+							Value: `{"HELLO": "WORLD}`,
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			AddLogFieldsEnvVar(tt.args.from, tt.args.to)
+			from := testcd.BasicBuilder().Build()
+			if tt.annotations != nil {
+				from.SetAnnotations(tt.annotations)
+			}
+			job := mkJob(tt.origContainers)
+			origJob := job.DeepCopy()
+			AddLogFieldsEnvVar(from, job)
+			var alfaVal *string
+			if tt.annotations != nil {
+				if annotation, exists := tt.annotations[constants.AdditionalLogFieldsAnnotation]; exists {
+					alfaVal = &annotation
+				}
+			}
+			if alfaVal == nil {
+				assert.Equal(t, origJob, job, "expected job to be unchanged")
+			} else {
+				// Env var should be present on every container
+				for i, c := range job.Spec.Template.Spec.Containers {
+					found := false
+					for _, e := range c.Env {
+						if e.Name != constants.AdditionalLogFieldsEnvVar {
+							continue
+						}
+						found = true
+						assert.Equal(t, *alfaVal, e.Value, "incorrect env var value")
+					}
+					assert.True(t, found, "didn't find env var in container %d", i)
+				}
+			}
 		})
 	}
 }
 
-func TestCopyLogAnnotations(t *testing.T) {
-	type args struct {
-		from metav1.Object
-		to   metav1.Object
-	}
+func TestCopyLogAnnotation(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
 	tests := []struct {
-		name string
-		args args
-		want bool
+		name                   string
+		froma                  map[string]string
+		toa                    map[string]string
+		expectChanged          bool
+		expectTargetAnnotation *string
 	}{
-		// TODO: Add test cases.
+		{
+			name: "no op: none, none",
+		},
+		{
+			name: "no op: none, empty",
+			toa:  map[string]string{},
+		},
+		{
+			name: "no op: none, unrelated",
+			toa:  map[string]string{"foo": "bar"},
+		},
+		{
+			name: "delete: none, present",
+			toa: map[string]string{
+				"foo": "bar",
+				alfa:  `{"HELLO": "WORLD"}`,
+			},
+			expectChanged: true,
+		},
+		{
+			name:  "no op: empty, none",
+			froma: map[string]string{},
+		},
+		{
+			name:  "no op: empty, empty",
+			froma: map[string]string{},
+			toa:   map[string]string{},
+		},
+		{
+			name:  "no op: empty, unrelated",
+			froma: map[string]string{},
+			toa:   map[string]string{"foo": "bar"},
+		},
+		{
+			name:  "delete: empty, present",
+			froma: map[string]string{},
+			toa: map[string]string{
+				"foo": "bar",
+				alfa:  `{"HELLO": "WORLD"}`,
+			},
+			expectChanged: true,
+		},
+		{
+			name:  "no op: unrelated, none",
+			froma: map[string]string{"foo": "bar"},
+		},
+		{
+			name:  "no op: unrelated, empty",
+			froma: map[string]string{"foo": "bar"},
+			toa:   map[string]string{},
+		},
+		{
+			name:  "no op: unrelated, unrelated",
+			froma: map[string]string{"foo": "bar"},
+			toa:   map[string]string{"foo": "baz"},
+		},
+		{
+			name:  "delete: unrelated, present",
+			froma: map[string]string{"foo": "bar"},
+			toa: map[string]string{
+				"foo": "bar",
+				alfa:  `{"HELLO": "WORLD"}`,
+			},
+			expectChanged: true,
+		},
+		{
+			name: "create: present, none",
+			froma: map[string]string{
+				"foo": "bar",
+				alfa:  `{"HELLO": "WORLD"}`,
+			},
+			expectChanged:          true,
+			expectTargetAnnotation: strPtr(`{"HELLO": "WORLD}`),
+		},
+		{
+			name: "add: present, empty",
+			froma: map[string]string{
+				"foo": "bar",
+				alfa:  `{"HELLO": "WORLD"}`,
+			},
+			toa:                    map[string]string{},
+			expectChanged:          true,
+			expectTargetAnnotation: strPtr(`{"HELLO": "WORLD}`),
+		},
+		{
+			name: "add: present, unrelated",
+			froma: map[string]string{
+				"foo": "bar",
+				alfa:  `{"HELLO": "WORLD"}`,
+			},
+			toa:                    map[string]string{"foo": "baz"},
+			expectChanged:          true,
+			expectTargetAnnotation: strPtr(`{"HELLO": "WORLD}`),
+		},
+		{
+			name: "replace: present, different",
+			froma: map[string]string{
+				"foo": "bar",
+				alfa:  `{"HELLO": "WORLD"}`,
+			},
+			toa: map[string]string{
+				alfa: `{"GOODBYE": "CRUEL WORLD"}`,
+			},
+			expectChanged:          true,
+			expectTargetAnnotation: strPtr(`{"HELLO": "WORLD}`),
+		},
+		{
+			name: "no op: present, same",
+			froma: map[string]string{
+				"foo": "bar",
+				alfa:  `{"HELLO": "WORLD"}`,
+			},
+			toa: map[string]string{
+				alfa: `{"HELLO": "WORLD"}`,
+			},
+			expectTargetAnnotation: strPtr(`{"HELLO": "WORLD}`),
+		},
 	}
 	for _, tt := range tests {
+		if tt.name != "delete: none, present" {
+			continue
+		}
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CopyLogAnnotations(tt.args.from, tt.args.to); got != tt.want {
-				t.Errorf("CopyLogAnnotations() = %v, want %v", got, tt.want)
+			from := testcd.BasicBuilder().Build()
+			if tt.froma != nil {
+				from.Annotations = tt.froma
+			}
+			to := testcd.BasicBuilder().Build()
+			if tt.toa != nil {
+				to.Annotations = tt.toa
+			}
+			if got := CopyLogAnnotation(from, to); got != tt.expectChanged {
+				t.Errorf("CopyLogAnnotations() = %v, want %v", got, tt.expectChanged)
+			}
+			if tt.expectTargetAnnotation != nil {
+				if assert.NotNil(t, to.Annotations, "expected target's annotations not to be nil") {
+					value, exists := to.Annotations[alfa]
+					if assert.True(t, exists, "expected %s annotation to exist", alfa) {
+						assert.Equal(t, *tt.expectTargetAnnotation, value, "wrong value for %s annotation", alfa)
+					}
+				}
 			}
 		})
 	}

--- a/pkg/imageset/generate.go
+++ b/pkg/imageset/generate.go
@@ -3,6 +3,7 @@ package imageset
 import (
 	"time"
 
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	log "github.com/sirupsen/logrus"
 
@@ -121,6 +122,7 @@ func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAcco
 			},
 		},
 	}
+	utils.AddLogFieldsEnvVar(cd, job)
 
 	return job
 }

--- a/pkg/imageset/updateinstaller.go
+++ b/pkg/imageset/updateinstaller.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/openshift/hive/apis"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/openshift/hive/contrib/pkg/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 )
 
@@ -82,21 +83,11 @@ func NewUpdateInstallerImageCommand() *cobra.Command {
 
 // Complete sets remaining fields on the UpdateInstallerImageOptions based on command options and arguments.
 func (o *UpdateInstallerImageOptions) Complete() error {
-	// Set log level
-	level, err := log.ParseLevel(o.LogLevel)
+	var err error
+	o.log, err = utils.NewLogger(o.LogLevel)
 	if err != nil {
-		log.WithError(err).Error("cannot parse log level")
 		return err
 	}
-
-	o.log = log.NewEntry(&log.Logger{
-		Out: os.Stdout,
-		Formatter: &log.TextFormatter{
-			FullTimestamp: true,
-		},
-		Hooks: make(log.LevelHooks),
-		Level: level,
-	})
 
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &clientcmd.ConfigOverrides{})

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -634,6 +634,7 @@ func GenerateInstallerJob(provision *hivev1.ClusterProvision) (*batchv1.Job, err
 			},
 		},
 	}
+	utils.AddLogFieldsEnvVar(provision, job)
 
 	return job, nil
 }
@@ -711,6 +712,7 @@ func GenerateUninstallerJobForDeprovision(
 		job.Spec.Template.Spec.Containers[idx].Env = append(job.Spec.Template.Spec.Containers[idx].Env, extraEnvVars...)
 	}
 	controllerutils.SetProxyEnvVars(&job.Spec.Template.Spec, httpProxy, httpsProxy, noProxy)
+	utils.AddLogFieldsEnvVar(req, job)
 
 	return job, nil
 }

--- a/pkg/installmanager/dnscleanup.go
+++ b/pkg/installmanager/dnscleanup.go
@@ -30,6 +30,7 @@ func cleanupDNSZone(dynClient client.Client, cd *hivev1.ClusterDeployment, logge
 	dnsZoneNamespacedName := types.NamespacedName{Namespace: cd.Namespace, Name: controllerutils.DNSZoneName(cd.Name)}
 	if err := dynClient.Get(context.TODO(), dnsZoneNamespacedName, dnsZone); err != nil {
 		logger.WithError(err).Error("error looking up managed dnszone")
+		// TODO: Return the err?!?
 	}
 
 	switch {

--- a/pkg/installmanager/fake.go
+++ b/pkg/installmanager/fake.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/google/uuid"
 	installertypes "github.com/openshift/installer/pkg/types"
-
-	hivev1 "github.com/openshift/hive/apis/hive/v1"
 )
 
 const fakeMetadataFormatStr = `{"aws":{"identifier":[{"kubernetes.io/cluster/fake-infraid":"owned"},{"openshiftClusterID":"%s"}],"region":"us-east-1"},"clusterID":"%s","clusterName":"%s","infraID":"fake-infra-id"}`
@@ -17,10 +15,10 @@ func fakeLoadAdminPassword(m *InstallManager) (string, error) {
 	return "fake-password", nil
 }
 
-func fakeReadClusterMetadata(provision *hivev1.ClusterProvision, m *InstallManager) ([]byte, *installertypes.ClusterMetadata, error) {
+func fakeReadClusterMetadata(m *InstallManager) ([]byte, *installertypes.ClusterMetadata, error) {
 	m.log.Warn("returning fake cluster metadata")
 	clusterID := "fake-cluster-" + uuid.New().String()
-	metadataBytes := []byte(fmt.Sprintf(fakeMetadataFormatStr, clusterID, clusterID, provision.Spec.ClusterDeploymentRef.Name))
+	metadataBytes := []byte(fmt.Sprintf(fakeMetadataFormatStr, clusterID, clusterID, m.ClusterProvision.Spec.ClusterDeploymentRef.Name))
 
 	// Extract and save the cluster ID, this step is critical and a failure here
 	// should abort the install. Note that this is run *before* we begin provisioning cloud

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -208,21 +208,12 @@ func (m *InstallManager) Complete(args []string) error {
 	m.provisionCluster = provisionCluster
 	m.waitForProvisioningStage = waitForProvisioningStage
 
-	// Set log level
-	level, err := log.ParseLevel(m.LogLevel)
+	var err error
+	m.log, err = contributils.NewLogger(m.LogLevel)
 	if err != nil {
-		log.WithError(err).Error("cannot parse log level")
 		return err
 	}
 
-	m.log = log.NewEntry(&log.Logger{
-		Out: os.Stdout,
-		Formatter: &log.TextFormatter{
-			FullTimestamp: true,
-		},
-		Hooks: make(log.LevelHooks),
-		Level: level,
-	})
 	// Add an installID logger field with a randomly generated string to help with debugging across multiple
 	// install attempts in the namespace.
 	m.log = m.log.WithField("installID", utilrand.String(8))

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -1001,7 +1001,7 @@ func (m *InstallManager) tailFullInstallLog(scrubInstallLog bool) {
 
 	// Set up additional log fields
 	suffix := ""
-	if fields, err := utils.ExtractLogFields(m.ClusterProvision); err != nil {
+	if fields, err := utils.ExtractLogFields(utils.MetaObjectLogTagger{Object: m.ClusterProvision}); err != nil {
 		m.log.WithError(err).Warning("failed to extract additional log fields -- ignoring")
 	} else {
 		// We should get this with component=hive; override to indicate that the component
@@ -1082,7 +1082,7 @@ func (m *InstallManager) loadClusterProvision() error {
 		m.log.WithError(err).Error("error getting cluster provision")
 		return err
 	}
-	m.log = utils.AddLogFields(m.ClusterProvision, (m.log).(*log.Entry))
+	m.log = utils.AddLogFields(utils.MetaObjectLogTagger{Object: m.ClusterProvision}, (m.log).(*log.Entry))
 	return nil
 }
 

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -106,20 +106,21 @@ type InstallManager struct {
 	ClusterID                        string
 	ClusterName                      string
 	ClusterProvisionName             string
+	ClusterProvision                 *hivev1.ClusterProvision
 	Namespace                        string
 	InstallConfigMountPath           string
 	PullSecretMountPath              string
 	ManifestsMountPath               string
 	DynamicClient                    client.Client
 	cleanupFailedProvision           func(dynamicClient client.Client, cd *hivev1.ClusterDeployment, infraID string, logger log.FieldLogger) error
-	updateClusterProvision           func(*hivev1.ClusterProvision, *InstallManager, provisionMutation) error
-	readClusterMetadata              func(*hivev1.ClusterProvision, *InstallManager) ([]byte, *installertypes.ClusterMetadata, error)
-	uploadAdminKubeconfig            func(*hivev1.ClusterProvision, *InstallManager) (*corev1.Secret, error)
-	uploadAdminPassword              func(*hivev1.ClusterProvision, *InstallManager) (*corev1.Secret, error)
+	updateClusterProvision           func(*InstallManager, provisionMutation) error
+	readClusterMetadata              func(*InstallManager) ([]byte, *installertypes.ClusterMetadata, error)
+	uploadAdminKubeconfig            func(*InstallManager) (*corev1.Secret, error)
+	uploadAdminPassword              func(*InstallManager) (*corev1.Secret, error)
 	loadAdminPassword                func(*InstallManager) (string, error)
 	provisionCluster                 func(*InstallManager) error
-	readInstallerLog                 func(*hivev1.ClusterProvision, *InstallManager, bool) (string, error)
-	waitForProvisioningStage         func(*hivev1.ClusterProvision, *InstallManager) error
+	readInstallerLog                 func(*InstallManager, bool) (string, error)
+	waitForProvisioningStage         func(*InstallManager) error
 	waitForInstallCompleteExecutions int
 	binaryDir                        string
 	actuator                         LogUploaderActuator
@@ -193,6 +194,7 @@ SSH_PRIV_KEY_PATH: File system path of a file containing the SSH private key cor
 }
 
 // Complete sets remaining fields on the InstallManager based on command options and arguments.
+// ...except for the clusterProvision field. That's loaded up by Run(), since it involves a REST call.
 func (m *InstallManager) Complete(args []string) error {
 	// Connect up structure's function pointers
 	m.updateClusterProvision = updateClusterProvisionWithRetries
@@ -253,20 +255,20 @@ func (m *InstallManager) Validate() error {
 
 // Run is the entrypoint to start the install process
 func (m *InstallManager) Run() error {
-	provision := &hivev1.ClusterProvision{}
-	if err := m.loadClusterProvision(provision); err != nil {
+	m.ClusterProvision = &hivev1.ClusterProvision{}
+	if err := m.loadClusterProvision(); err != nil {
 		m.log.WithError(err).Fatal("error looking up cluster provision")
 	}
-	switch provision.Spec.Stage {
+	switch m.ClusterProvision.Spec.Stage {
 	case hivev1.ClusterProvisionStageInitializing, hivev1.ClusterProvisionStageProvisioning:
 	default:
 		// This should not be possible but just in-case we can somehow
 		// run the install job for a cluster provision that is already complete, exit early,
 		// and don't delete *anything*.
-		m.log.Warnf("provision is at stage %q, exiting", provision.Spec.Stage)
+		m.log.Warnf("provision is at stage %q, exiting", m.ClusterProvision.Spec.Stage)
 		os.Exit(0)
 	}
-	cd, err := m.loadClusterDeployment(provision)
+	cd, err := m.loadClusterDeployment()
 	if err != nil {
 		m.log.WithError(err).Fatal("error looking up cluster deployment")
 	}
@@ -356,9 +358,9 @@ func (m *InstallManager) Run() error {
 
 	// If the cluster provision has a prevInfraID set, this implies we failed a previous
 	// cluster provision attempt. Cleanup any resources that may have been provisioned.
-	if provision.Spec.PrevInfraID != nil {
+	if m.ClusterProvision.Spec.PrevInfraID != nil {
 		m.log.Info("cleaning up resources from previous provision attempt")
-		if err := m.cleanupFailedInstall(cd, *provision.Spec.PrevInfraID, *provision.Spec.PrevProvisionName, m.Namespace); err != nil {
+		if err := m.cleanupFailedInstall(cd, *m.ClusterProvision.Spec.PrevInfraID, *m.ClusterProvision.Spec.PrevProvisionName, m.Namespace); err != nil {
 			m.log.WithError(err).Error("error while trying to preemptively clean up")
 			return err
 		}
@@ -370,12 +372,12 @@ func (m *InstallManager) Run() error {
 	// provision. The infraID is an immutable write-once field, as we need it to clean
 	// up provisioned resources from a failed provision. So if infraID is already set,
 	// we do not proceed further and fail the provision.
-	if provision.Spec.InfraID != nil {
+	if m.ClusterProvision.Spec.InfraID != nil {
 		// This error won't be displayed as condition message on the cluster provision
 		// because install log is not generated until we run installer binary. We do
 		// have the option of faking an install log that can then be regexed.
 		m.log.Error("infraID is already set on the ClusterProvision. Unexpected install pod restart detected. Cleaning up resources from previous install attempt")
-		if err := m.cleanupFailedInstall(cd, *provision.Spec.InfraID, m.ClusterProvisionName, m.Namespace); err != nil {
+		if err := m.cleanupFailedInstall(cd, *m.ClusterProvision.Spec.InfraID, m.ClusterProvisionName, m.Namespace); err != nil {
 			m.log.WithError(err).Error("error while trying to preemptively clean up")
 			return err
 		}
@@ -395,7 +397,7 @@ func (m *InstallManager) Run() error {
 	m.log.Info("generating assets")
 	if err := m.generateAssets(cd, workerMachinePool); err != nil {
 		m.log.Info("reading installer log")
-		installLog, readErr := m.readInstallerLog(provision, m, scrubInstallLog)
+		installLog, readErr := m.readInstallerLog(m, scrubInstallLog)
 		if readErr != nil {
 			m.log.WithError(readErr).Error("error reading asset generation log")
 			return err
@@ -403,7 +405,6 @@ func (m *InstallManager) Run() error {
 
 		m.log.Info("updating clusterprovision")
 		if err := m.updateClusterProvision(
-			provision,
 			m,
 			func(provision *hivev1.ClusterProvision) {
 				provision.Spec.InstallLog = pointer.StringPtr(installLog)
@@ -420,24 +421,23 @@ func (m *InstallManager) Run() error {
 	// to extract the infra ID and upload it, this is a critical failure and we
 	// should restart. No cloud resources have been provisioned at this point.
 	m.log.Info("setting cluster metadata")
-	metadataBytes, metadata, err := m.readClusterMetadata(provision, m)
+	metadataBytes, metadata, err := m.readClusterMetadata(m)
 	if err != nil {
 		m.log.WithError(err).Error("error reading cluster metadata")
 		return errors.Wrap(err, "error reading cluster metadata")
 	}
-	kubeconfigSecret, err := m.uploadAdminKubeconfig(provision, m)
+	kubeconfigSecret, err := m.uploadAdminKubeconfig(m)
 	if err != nil {
 		m.log.WithError(err).Error("error uploading admin kubeconfig")
 		return errors.Wrap(err, "error trying to save admin kubeconfig")
 	}
 
-	passwordSecret, err := m.uploadAdminPassword(provision, m)
+	passwordSecret, err := m.uploadAdminPassword(m)
 	if err != nil {
 		m.log.WithError(err).Error("error uploading admin password")
 		return errors.Wrap(err, "error trying to save admin password")
 	}
 	if err := m.updateClusterProvision(
-		provision,
 		m,
 		func(provision *hivev1.ClusterProvision) {
 			provision.Spec.Metadata = &runtime.RawExtension{Raw: metadataBytes}
@@ -457,7 +457,7 @@ func (m *InstallManager) Run() error {
 	}
 
 	m.log.Info("waiting for ClusterProvision to transition to provisioning")
-	if err := m.waitForProvisioningStage(provision, m); err != nil {
+	if err := m.waitForProvisioningStage(m); err != nil {
 		m.log.WithError(err).Error("ClusterProvision failed to transition to provisioning")
 		return errors.Wrap(err, "failed to transition to provisioning")
 	}
@@ -492,13 +492,12 @@ func (m *InstallManager) Run() error {
 		if m.actuator == nil {
 			m.log.Debug("Unable to find log storage actuator. Disabling gathering logs.")
 		} else {
-			m.gatherLogs(provision, cd, sshKeyPath, sshAgentSetupErr)
+			m.gatherLogs(cd, sshKeyPath, sshAgentSetupErr)
 		}
 	}
 
-	if installLog, err := m.readInstallerLog(provision, m, scrubInstallLog); err == nil {
+	if installLog, err := m.readInstallerLog(m, scrubInstallLog); err == nil {
 		if err := m.updateClusterProvision(
-			provision,
 			m,
 			func(provision *hivev1.ClusterProvision) {
 				provision.Spec.InstallLog = pointer.StringPtr(installLog)
@@ -1043,7 +1042,7 @@ func (m *InstallManager) tailFullInstallLog(scrubInstallLog bool) {
 	}
 }
 
-func readClusterMetadata(provision *hivev1.ClusterProvision, m *InstallManager) ([]byte, *installertypes.ClusterMetadata, error) {
+func readClusterMetadata(m *InstallManager) ([]byte, *installertypes.ClusterMetadata, error) {
 	m.log.Infoln("extracting cluster ID and uploading cluster metadata")
 	fullMetadataPath := filepath.Join(m.WorkDir, metadataRelativePath)
 	if _, err := os.Stat(fullMetadataPath); os.IsNotExist(err) {
@@ -1073,17 +1072,17 @@ func readClusterMetadata(provision *hivev1.ClusterProvision, m *InstallManager) 
 	return metadataBytes, md, nil
 }
 
-func (m *InstallManager) loadClusterProvision(provision *hivev1.ClusterProvision) error {
-	if err := m.DynamicClient.Get(context.TODO(), types.NamespacedName{Namespace: m.Namespace, Name: m.ClusterProvisionName}, provision); err != nil {
+func (m *InstallManager) loadClusterProvision() error {
+	if err := m.DynamicClient.Get(context.TODO(), types.NamespacedName{Namespace: m.Namespace, Name: m.ClusterProvisionName}, m.ClusterProvision); err != nil {
 		m.log.WithError(err).Error("error getting cluster provision")
 		return err
 	}
 	return nil
 }
 
-func (m *InstallManager) loadClusterDeployment(provision *hivev1.ClusterProvision) (*hivev1.ClusterDeployment, error) {
+func (m *InstallManager) loadClusterDeployment() (*hivev1.ClusterDeployment, error) {
 	cd := &hivev1.ClusterDeployment{}
-	if err := m.DynamicClient.Get(context.Background(), types.NamespacedName{Namespace: m.Namespace, Name: provision.Spec.ClusterDeploymentRef.Name}, cd); err != nil {
+	if err := m.DynamicClient.Get(context.Background(), types.NamespacedName{Namespace: m.Namespace, Name: m.ClusterProvision.Spec.ClusterDeploymentRef.Name}, cd); err != nil {
 		m.log.WithError(err).Error("error getting cluster deployment")
 		return nil, err
 	}
@@ -1111,7 +1110,7 @@ func (m *InstallManager) loadWorkerMachinePool(cd *hivev1.ClusterDeployment) (*h
 // If neither succeeds we do not consider this a fatal error,
 // we're just gathering as much information as we can and then proceeding with cleanup
 // so we can re-try.
-func (m *InstallManager) gatherLogs(provision *hivev1.ClusterProvision, cd *hivev1.ClusterDeployment, sshPrivKeyPath string, sshAgentSetupErr error) {
+func (m *InstallManager) gatherLogs(cd *hivev1.ClusterDeployment, sshPrivKeyPath string, sshAgentSetupErr error) {
 	if !m.isBootstrapComplete() {
 		if sshAgentSetupErr != nil {
 			m.log.Warn("unable to fetch logs from bootstrap node as SSH agent was not configured")
@@ -1136,7 +1135,7 @@ func (m *InstallManager) gatherLogs(provision *hivev1.ClusterProvision, cd *hive
 	// Gather the filenames
 	files, err := ioutil.ReadDir(m.LogsDir)
 	if err != nil {
-		m.log.WithError(err).WithField("clusterprovision", types.NamespacedName{Name: provision.Name, Namespace: provision.Namespace}).Error("error reading Logsdir")
+		m.log.WithError(err).WithField("clusterprovision", types.NamespacedName{Name: m.ClusterProvision.Name, Namespace: m.ClusterProvision.Namespace}).Error("error reading Logsdir")
 		return
 	}
 
@@ -1150,7 +1149,7 @@ func (m *InstallManager) gatherLogs(provision *hivev1.ClusterProvision, cd *hive
 		filepaths = append(filepaths, filepath.Join(m.LogsDir, file.Name()))
 	}
 
-	uploadErr := m.actuator.UploadLogs(cd.Spec.ClusterName, provision, m.DynamicClient, m.log, filepaths...)
+	uploadErr := m.actuator.UploadLogs(cd.Spec.ClusterName, m.ClusterProvision, m.DynamicClient, m.log, filepaths...)
 	if uploadErr != nil {
 		m.log.WithError(uploadErr).Error("error uploading logs")
 	}
@@ -1286,7 +1285,7 @@ func (m *InstallManager) initSSHAgent(sshKeyPaths []string) (func(), error) {
 	return sshAgentCleanup, nil
 }
 
-func readInstallerLog(provision *hivev1.ClusterProvision, m *InstallManager, scrubInstallLog bool) (string, error) {
+func readInstallerLog(m *InstallManager, scrubInstallLog bool) (string, error) {
 	m.log.Infoln("saving installer output")
 
 	if _, err := os.Stat(installerConsoleLogFilePath); os.IsNotExist(err) {
@@ -1348,7 +1347,7 @@ func (m *InstallManager) isBootstrapComplete() bool {
 	return cmd.Run() == nil
 }
 
-func uploadAdminKubeconfig(provision *hivev1.ClusterProvision, m *InstallManager) (*corev1.Secret, error) {
+func uploadAdminKubeconfig(m *InstallManager) (*corev1.Secret, error) {
 	m.log.Infoln("uploading admin kubeconfig")
 
 	var kubeconfigSecret *corev1.Secret
@@ -1376,10 +1375,10 @@ func uploadAdminKubeconfig(provision *hivev1.ClusterProvision, m *InstallManager
 	}
 
 	m.log.WithField("derivedObject", kubeconfigSecret.Name).Debug("Setting labels on derived object")
-	kubeconfigSecret.Labels = k8slabels.AddLabel(kubeconfigSecret.Labels, constants.ClusterProvisionNameLabel, provision.Name)
+	kubeconfigSecret.Labels = k8slabels.AddLabel(kubeconfigSecret.Labels, constants.ClusterProvisionNameLabel, m.ClusterProvision.Name)
 	kubeconfigSecret.Labels = k8slabels.AddLabel(kubeconfigSecret.Labels, constants.SecretTypeLabel, constants.SecretTypeKubeConfig)
 
-	provisionGVK, err := apiutil.GVKForObject(provision, scheme.Scheme)
+	provisionGVK, err := apiutil.GVKForObject(m.ClusterProvision, scheme.Scheme)
 	if err != nil {
 		m.log.WithError(err).Errorf("error getting GVK for provision")
 		return nil, err
@@ -1388,8 +1387,8 @@ func uploadAdminKubeconfig(provision *hivev1.ClusterProvision, m *InstallManager
 	kubeconfigSecret.OwnerReferences = []metav1.OwnerReference{{
 		APIVersion:         provisionGVK.GroupVersion().String(),
 		Kind:               provisionGVK.Kind,
-		Name:               provision.Name,
-		UID:                provision.UID,
+		Name:               m.ClusterProvision.Name,
+		UID:                m.ClusterProvision.UID,
 		BlockOwnerDeletion: pointer.BoolPtr(true),
 	}}
 
@@ -1422,7 +1421,7 @@ func loadAdminPassword(m *InstallManager) (string, error) {
 	return password, nil
 }
 
-func uploadAdminPassword(provision *hivev1.ClusterProvision, m *InstallManager) (*corev1.Secret, error) {
+func uploadAdminPassword(m *InstallManager) (*corev1.Secret, error) {
 	m.log.Infoln("uploading admin username/password")
 
 	// Need to trim trailing newlines from the password
@@ -1443,10 +1442,10 @@ func uploadAdminPassword(provision *hivev1.ClusterProvision, m *InstallManager) 
 	}
 
 	m.log.WithField("derivedObject", s.Name).Debug("Setting labels on derived object")
-	s.Labels = k8slabels.AddLabel(s.Labels, constants.ClusterProvisionNameLabel, provision.Name)
+	s.Labels = k8slabels.AddLabel(s.Labels, constants.ClusterProvisionNameLabel, m.ClusterProvision.Name)
 	s.Labels = k8slabels.AddLabel(s.Labels, constants.SecretTypeLabel, constants.SecretTypeKubeAdminCreds)
 
-	provisionGVK, err := apiutil.GVKForObject(provision, scheme.Scheme)
+	provisionGVK, err := apiutil.GVKForObject(m.ClusterProvision, scheme.Scheme)
 	if err != nil {
 		m.log.WithError(err).Errorf("error getting GVK for provision")
 		return nil, err
@@ -1455,8 +1454,8 @@ func uploadAdminPassword(provision *hivev1.ClusterProvision, m *InstallManager) 
 	s.OwnerReferences = []metav1.OwnerReference{{
 		APIVersion:         provisionGVK.GroupVersion().String(),
 		Kind:               provisionGVK.Kind,
-		Name:               provision.Name,
-		UID:                provision.UID,
+		Name:               m.ClusterProvision.Name,
+		UID:                m.ClusterProvision.UID,
 		BlockOwnerDeletion: pointer.BoolPtr(true),
 	}}
 
@@ -1532,7 +1531,7 @@ func (m *InstallManager) deleteAnyExistingObject(namespacedName types.Namespaced
 	return err
 }
 
-func waitForProvisioningStage(provision *hivev1.ClusterProvision, m *InstallManager) error {
+func waitForProvisioningStage(m *InstallManager) error {
 	waitContext, cancel := context.WithTimeout(context.Background(), provisioningTransitionTimeout)
 	defer cancel()
 
@@ -1554,8 +1553,8 @@ func waitForProvisioningStage(provision *hivev1.ClusterProvision, m *InstallMana
 		cache.NewListWatchFromClient(
 			restClient,
 			"clusterprovisions",
-			provision.Namespace,
-			fields.OneTermEqualSelector("metadata.name", provision.Name),
+			m.ClusterProvision.Namespace,
+			fields.OneTermEqualSelector("metadata.name", m.ClusterProvision.Name),
 		),
 		&hivev1.ClusterProvision{},
 		nil,
@@ -1606,18 +1605,18 @@ func (m *InstallManager) writeSSHKnownHosts(homeDir string, knownHosts []string)
 
 type provisionMutation func(provision *hivev1.ClusterProvision)
 
-func updateClusterProvisionWithRetries(provision *hivev1.ClusterProvision, m *InstallManager, mutation provisionMutation) error {
+func updateClusterProvisionWithRetries(m *InstallManager, mutation provisionMutation) error {
 	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		// read in a fresh clusterprovision
-		if err := m.loadClusterProvision(provision); err != nil {
+		if err := m.loadClusterProvision(); err != nil {
 			m.log.WithError(err).Warn("error reading in fresh clusterprovision")
 			return err
 		}
 
 		// make the needed modifications to the clusterprovision
-		mutation(provision)
+		mutation(m.ClusterProvision)
 
-		if err := m.DynamicClient.Update(context.Background(), provision); err != nil {
+		if err := m.DynamicClient.Update(context.Background(), m.ClusterProvision); err != nil {
 			m.log.WithError(err).Warn("error updating clusterprovision")
 			return err
 		}

--- a/pkg/installmanager/installmanager_test.go
+++ b/pkg/installmanager/installmanager_test.go
@@ -199,7 +199,7 @@ func TestInstallManager(t *testing.T) {
 			}
 			im.Complete([]string{})
 
-			im.waitForProvisioningStage = func(*hivev1.ClusterProvision, *InstallManager) error { return nil }
+			im.waitForProvisioningStage = func(*InstallManager) error { return nil }
 
 			if !assert.NoError(t, writeFakeBinary(filepath.Join(tempDir, installerBinary),
 				fmt.Sprintf(fakeInstallerBinary, tempDir))) {
@@ -212,38 +212,38 @@ func TestInstallManager(t *testing.T) {
 			}
 
 			if test.failedMetadataRead {
-				im.readClusterMetadata = func(*hivev1.ClusterProvision, *InstallManager) ([]byte, *installertypes.ClusterMetadata, error) {
+				im.readClusterMetadata = func(*InstallManager) ([]byte, *installertypes.ClusterMetadata, error) {
 					return nil, nil, fmt.Errorf("failed to save metadata")
 				}
 			}
 
 			if test.failedKubeconfigSave {
-				im.uploadAdminKubeconfig = func(*hivev1.ClusterProvision, *InstallManager) (*corev1.Secret, error) {
+				im.uploadAdminKubeconfig = func(*InstallManager) (*corev1.Secret, error) {
 					return nil, fmt.Errorf("failed to save admin kubeconfig")
 				}
 			}
 
 			if test.failedAdminPasswordSave {
-				im.uploadAdminPassword = func(*hivev1.ClusterProvision, *InstallManager) (*corev1.Secret, error) {
+				im.uploadAdminPassword = func(*InstallManager) (*corev1.Secret, error) {
 					return nil, fmt.Errorf("failed to save admin password")
 				}
 			}
 
 			if test.failedInstallerLogRead {
-				im.readInstallerLog = func(*hivev1.ClusterProvision, *InstallManager, bool) (string, error) {
+				im.readInstallerLog = func(*InstallManager, bool) (string, error) {
 					return "", fmt.Errorf("failed to save install log")
 				}
 			}
 
 			if test.failedProvisionUpdate != nil {
 				calls := int32(0)
-				im.updateClusterProvision = func(provision *hivev1.ClusterProvision, im *InstallManager, mutation provisionMutation) error {
+				im.updateClusterProvision = func(im *InstallManager, mutation provisionMutation) error {
 					callNumber := calls
 					calls = calls + 1
 					if callNumber == *test.failedProvisionUpdate {
 						return fmt.Errorf("failed to update provision")
 					}
-					return updateClusterProvisionWithRetries(provision, im, mutation)
+					return updateClusterProvisionWithRetries(im, mutation)
 				}
 			}
 


### PR DESCRIPTION
Add support for a `hive.openshift.io/additional-log-fields` annotation
on hive-owned CRs. If present, it is parsed as a JSON map containing
arbitrary key/value pairs which are included in all log lines for
controllers handling the CR. They are also appended to log lines from installer pods.

The assumption is that this is being used for log aggregation by an external consumer that needs to know which logs came from which component. Thus, if the value of the annotation is nonempty and parseable, we will add `component=hive` to whatever it contains when logging from controllers; and `component=installer` when decorating installer logs.

PROVISOS [1]:

- Our controllers currently reconcile on all and only the following
objects (so annotating others will have no effect):
  - ClusterClaim
  - ClusterDeployment
  - ClusterDeprovision
  - ClusterPool
  - ClusterProvision
  - DNSZone
  - FakeClusterInstall
  - MachinePool
  The clusterpoolnamespace controller reconciles on Namespace; but we
  *do not* support these annotations there.

- Log fields are added to the logger for a given controller once it has
loaded the CR. So there may be a couple of log messages that will be
missed. They should be unimportant for consumers -- things like the
initial "Reconciling $namespace/$name".

- The hive code *generates* CRs in certain circumstances.
  - ClusterProvision and ClusterDeprovision are generated when the CD is
  created or deleted, respectively. They inherit the annotation *at the
  time they are generated*. If you want the fields updated after that,
  you must edit the ClusterProvision/ClusterDeprovision object directly.
  - DNSZone can be generated if not already present for clusters with
  managed DNS. The clusterdeployment controller will generate the
  DNSZone with the annotation from the CD, but will also *sync* it from
  the CD on each reconcile.
  - The ClusterPool controller generates ClusterDeployments. We do *not*
  copy the annotation from the ClusterPool.Metadata; you would have to
  put it into ClusterPool.Spec.Annotations instead.
  - ClusterDeployment and MachinePool are generated by `hiveutil create
  cluster`. You can use the `-a/--annotations` flag to initialize the
  ClusterDeployment with the annotation [2]. The machinepool controller
  will *sync* it from the CD to the MachinePool on each reconcile.
  - We currently do *not* support passing (any) annotations into
  `hiveutil clusterpool create-pool` or `hiveutil clusterpool claim`. In
  the future we may wish to add `-a/--annotations` like we have for
  `create cluster`.

[1] https://www.youtube.com/watch?v=pb0PuaikL4w
[2] The CLI syntax is a bit tricky. This wfm:
`--annotations '"hive.openshift.io/additional-log-fields={""HELLO"":""WORLD""}"'`

[HIVE-1966](https://issues.redhat.com//browse/HIVE-1966)