### PR TITLE
Enable BalanceSimilarNodeGroups for the default cluster autoscaler

### DIFF
--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -813,12 +814,23 @@ func (r *ReconcileMachinePool) syncClusterAutoscaler(
 		}
 	}
 	if defaultClusterAutoscaler != nil {
-		if spec := &defaultClusterAutoscaler.Spec; spec.ScaleDown == nil || !spec.ScaleDown.Enabled {
-			logger.Info("updaing cluster autoscaler")
-			if spec.ScaleDown == nil {
-				spec.ScaleDown = &autoscalingv1.ScaleDownConfig{}
-			}
+		spec := &defaultClusterAutoscaler.Spec
+		changed := false
+		if spec.ScaleDown == nil {
+			spec.ScaleDown = &autoscalingv1.ScaleDownConfig{}
+		}
+		// Ensure spec.ScaleDown.Enabled = true
+		if !spec.ScaleDown.Enabled {
 			spec.ScaleDown.Enabled = true
+			changed = true
+		}
+		// Default spec.BalanceSimilarNodeGroups to true if unset.
+		if spec.BalanceSimilarNodeGroups == nil {
+			spec.BalanceSimilarNodeGroups = pointer.BoolPtr(true)
+			changed = true
+		}
+		if changed {
+			logger.Info("updaing cluster autoscaler")
 			if err := remoteClusterAPIClient.Update(context.Background(), defaultClusterAutoscaler); err != nil {
 				logger.WithError(err).Error("could not update cluster autoscaler")
 				return err
@@ -834,6 +846,7 @@ func (r *ReconcileMachinePool) syncClusterAutoscaler(
 				ScaleDown: &autoscalingv1.ScaleDownConfig{
 					Enabled: true,
 				},
+				BalanceSimilarNodeGroups: pointer.BoolPtr(true),
 			},
 		}
 		if err := remoteClusterAPIClient.Create(context.Background(), defaultClusterAutoscaler); err != nil {


### PR DESCRIPTION
This change enables `BalanceSimilarNodeGroups` for the default cluster autoscaler. `BalanceSimilarNodeGroups` will be enabled for new cluster autoscalers created by Hive and existing cluster autoscalers will be updated to enable `BalanceSimilarNodeGroups` unless `BalanceSimilarNodeGroups` was previously disabled.

With `BalanceSimilarNodeGroups` enabled, the cluster autoscaler automatically identifies node groups with the same instance type and the same set of labels (except for automatically added zone label) and tries to keep the sizes of those node groups balanced. Ref: [Running ClusterAutoscaler with nodes in multiple zones for HA purposes](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#im-running-cluster-with-nodes-in-multiple-zones-for-ha-purposes-is-that-supported-by-cluster-autoscaler)

Pending discussion.
/hold

[HIVE-1976](https://issues.redhat.com//browse/HIVE-1976)