### PR TITLE
hive-operator: Ignore "no such CRD" errors with monitoring disabled

### DIFF
--- a/pkg/operator/util/apply.go
+++ b/pkg/operator/util/apply.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"strings"
+
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -133,4 +135,15 @@ func readRuntimeObject(assetPath string) (runtime.Object, error) {
 	obj, _, err := serializer.NewCodecFactory(scheme.Scheme).UniversalDeserializer().
 		Decode(assets.MustAsset(assetPath), nil, nil)
 	return obj, err
+}
+
+// IsNoSuchCRD inspects an error and determines whether it is similar to this:
+// "could not get mapping: no matches for kind \"ServiceMonitor\" in version \"monitoring.coreos.com/v1\""
+// In certain circumstances -- e.g. deploying hive on non-openshift with monitoring disabled -- these
+// errors may be spurious and ignorable.
+func IsNoSuchCRD(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "no matches for kind")
 }


### PR DESCRIPTION
To enable monitoring (HiveConfig.Spec.ExportMetrics) we use
ServiceMonitor, which is an OpenShift-specific kind [1]. When monitoring
is disabled, we attempt to delete these resources idempotently (i.e.
no-op if they already don't exist). But on non-OpenShift clusters, this
would generate errors like the following:

```
time="2022-07-26T09:37:36Z" level=error msg="error deleting object with namespace override" controller=hive error="unable to delete asset: config/monitoring/hive_clustersync_servicemonitor.yaml: could not get mapping: no matches for kind \"ServiceMonitor\" in version \"monitoring.coreos.com/v1\""
```

In the case where monitoring is disabled, we can ignore this message
because we don't want the ServiceMonitor to exist anyway. This commit
makes it so.

[1] As a side effect, we only support monitoring on OpenShift. Has it
always been thus?

Fixes #1831