### PR TITLE
Add hack/create-service-account-secrets.sh script to create service account secrets.

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -148,6 +148,12 @@ NOTE: If you are running on Kubernetes or kind, (not OpenShift), you will also n
 ./hack/hiveadmission-dev-cert.sh
 ```
 
+NOTE: If you are running on Kubernetes or kind >= version 1.24, (not OpenShift), you will also need to create secrets for serviceaccounts after running make deploy for the first time:
+
+```bash
+./hack/create-service-account-secrets.sh
+```
+
 ### Fedora Development Container Build
 
 This approach is much faster than a full container build as it uses a base OS image, and binaries compiled on your host OS and then added to the container. *At present this is best suited for Fedora 33+.*

--- a/hack/create-service-account-secrets.sh
+++ b/hack/create-service-account-secrets.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#
+# Secrets are no longer automatically created for service accounts in Kube 1.24+.
+# This script creates service account secrets for the following serviceaccounts.
+# - hiveadmission
+# - hive-controllers
+#
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Secret
+  type: kubernetes.io/service-account-token
+  metadata:
+    name: hiveadmission
+    namespace: hive
+    annotations:
+      kubernetes.io/service-account.name: "hiveadmission"
+- apiVersion: v1
+  kind: Secret
+  type: kubernetes.io/service-account-token
+  metadata:
+    name: hive-controllers
+    namespace: hive
+    annotations:
+      kubernetes.io/service-account.name: "hive-controllers"
+EOF


### PR DESCRIPTION
Service account secrets are not automatically created on Kubernetes >= version v1.24. Add a script to create service account secrets for non-OpenShift Hive deployments (like kind) and point to the script in developing docs.

Fixes #1832