### PR TITLE
Revert hiveutil create-cluster's default AWS volumeType back to gp2.

### DIFF
--- a/pkg/clusterresource/aws.go
+++ b/pkg/clusterresource/aws.go
@@ -17,9 +17,8 @@ import (
 
 const (
 	awsInstanceType = "m4.xlarge"
-	volumeIOPS      = 100
 	volumeSize      = 22
-	volumeType      = "gp3"
+	volumeType      = "gp2"
 )
 
 var _ CloudBuilder = (*AWSCloudBuilder)(nil)
@@ -99,7 +98,6 @@ func (p *AWSCloudBuilder) addMachinePoolPlatform(o *Builder, mp *hivev1.MachineP
 	mp.Spec.Platform.AWS = &hivev1aws.MachinePoolPlatform{
 		InstanceType: awsInstanceType,
 		EC2RootVolume: hivev1aws.EC2RootVolume{
-			IOPS: volumeIOPS,
 			Size: volumeSize,
 			Type: volumeType,
 		},
@@ -119,7 +117,6 @@ func (p *AWSCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installertype
 	mpp := &awsinstallertypes.MachinePool{
 		InstanceType: awsInstanceType,
 		EC2RootVolume: awsinstallertypes.EC2RootVolume{
-			IOPS: volumeIOPS,
 			Size: volumeSize,
 			Type: volumeType,
 		},


### PR DESCRIPTION
https://github.com/openshift/hive/pull/1806 updated the default volume type for install config MachinePools (created by `hiveutil create-cluster`) to gp3. Alas, installers at and before 4.9 don't know about this type, so trying to install OpenShift at those versions results in the following error:

```
Error: expected root_block_device.0.volume_type to be one of [standard io1 gp2 sc1 st1], got gp3
```

We can effectively use the previous default volume type of gp2 which [provides a baseline minimum of 100 iops](https://aws.amazon.com/blogs/storage/migrate-your-amazon-ebs-volumes-from-gp2-to-gp3-and-save-up-to-20-on-costs/) and I have tested that the gp2 volumeType can be used with 4.8->4.11 installers.

The [gp3 volume type performs better and is cheaper](https://aws.amazon.com/blogs/storage/migrate-your-amazon-ebs-volumes-from-gp2-to-gp3-and-save-up-to-20-on-costs/). It would be preferable to use gp3 as the default volumeType but Hive's clusterresourcebuilder can't make decisions based on the cluster version at present so I think Hive's default should use gp2 w/ no configured iops as the common denominator.

[HIVE-1958](https://issues.redhat.com//browse/HIVE-1958)