### PR TITLE
Make ProvisionStopped terminal (f'real this time)

### DIFF
--- a/pkg/controller/clusterdeployment/clusterprovisions.go
+++ b/pkg/controller/clusterdeployment/clusterprovisions.go
@@ -41,6 +41,12 @@ func (r *ReconcileClusterDeployment) startNewProvision(
 	releaseImage string,
 	logger log.FieldLogger,
 ) (result reconcile.Result, returnedErr error) {
+	// Preflight; If we've reached ProvisionStopped for any reason, bail
+	if pfcond := controllerutils.FindCondition(cd.Status.Conditions, hivev1.ProvisionStoppedCondition); pfcond != nil && pfcond.Status == corev1.ConditionTrue {
+		logger.Debug("ProvisionStopped is True; not creating a new provision")
+		return reconcile.Result{}, nil
+	}
+
 	existingProvisions, err := r.existingProvisions(cd, logger)
 	if err != nil {
 		return reconcile.Result{}, err


### PR DESCRIPTION
ProvisionStopped is supposed to be terminal. That is, once you're in
that state, you should never leave it.

In certain circumstances, like reconciling DNSZones under managed DNS,
it was possible to reach ProvisionStopped without ever having created a
ClusterProvision. The logic that decides whether to "retry" provisioning
would happily do so in this case. The result would be that the
ProvisionStopped condition would be cleared (possibly to return later).

This commit adds an early check for the ProvisionStopped condition and
refuses to proceed if it's True.

[HIVE-1881](https://issues.redhat.com//browse/HIVE-1881)