### PR TITLE
Quiet down "no additional log fields" message

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -118,6 +118,13 @@ function save_hive_logs() {
       fi
     done
   done
+  # Let's try to save any prov/deprov pod logs
+  oc get po -A -l hive.openshift.io/install=true -o custom-columns=:.metadata.namespace,:.metadata.name --no-headers | while read ns po; do
+    oc logs -n $ns $po -c hive > ${ARTIFACT_DIR}/${ns}-${po}.log
+  done
+  oc get po -A -l hive.openshift.io/uninstall=true -o custom-columns=:.metadata.namespace,:.metadata.name --no-headers | while read ns po; do
+    oc logs -n $ns $po > ${ARTIFACT_DIR}/${ns}-${po}.log
+  done
 }
 # The consumer of this lib can set up its own exit trap, but this basic one will at least help
 # debug e.g. problems from `make deploy` and managed DNS setup.

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -1001,9 +1001,12 @@ func (m *InstallManager) tailFullInstallLog(scrubInstallLog bool) {
 
 	// Set up additional log fields
 	suffix := ""
-	if fields, err := utils.ExtractLogFields(utils.MetaObjectLogTagger{Object: m.ClusterProvision}); err != nil {
+	switch fields, err := utils.ExtractLogFields(utils.MetaObjectLogTagger{Object: m.ClusterProvision}); {
+	case err != nil:
 		m.log.WithError(err).Warning("failed to extract additional log fields -- ignoring")
-	} else {
+	case fields == nil:
+		m.log.Debug("no additional log fields found")
+	default:
 		// We should get this with component=hive; override to indicate that the component
 		// being tagged now is the installer
 		fields["component"] = "installer"


### PR DESCRIPTION
We were overenthusiastic with this message when adding support for
additional log fields: we would emit it as a Warning even when the
annotation was absent from the CR being reconciled. Example:

```
time="2022-08-09T10:20:09.286Z" level=warning msg="failed to extract additional log fields -- ignoring" clusterPool=default/mihuang-pool-1 controller=clusterpool error="no additional log fields found" reconcileID=nskm25td
```

This commit takes that down to Debug level.

[HIVE-1966](https://issues.redhat.com//browse/HIVE-1966)