### PR TITLE
Trigger CI to bump to go1.18

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.16
+FROM registry.ci.openshift.org/openshift/release:golang-1.18
 
 # setting Git username and email for workaround of
 # https://github.com/jenkinsci/docker/issues/519


### PR DESCRIPTION
Needed for [HIVE-1997](https://issues.redhat.com//browse/HIVE-1997)