### PR TITLE
ocm-2.3: build against centos:stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,8 @@ WORKDIR /go/src/github.com/openshift/hive
 COPY . .
 RUN make build
 
-FROM quay.io/centos/centos:8
+FROM quay.io/centos/centos:stream
 
-# CentOS images do not get updates as they are meant to mirror ISO content, and thus this update
-# is strongly recommended for security updates.
 RUN dnf -y update && dnf clean all
 
 # ssh-agent required for gathering logs in some situations:


### PR DESCRIPTION
We haven't had to build 2.3 since we did this to all the other branches.
Now we do.

Needed for [HIVE-1997](https://issues.redhat.com//browse/HIVE-1997)