### PR TITLE
Fix CDC restoration of finalizers

### DIFF
--- a/pkg/controller/clusterpool/collections.go
+++ b/pkg/controller/clusterpool/collections.go
@@ -925,8 +925,8 @@ func (cdcs *cdcCollection) SyncClusterDeploymentCustomizationAssignments(c clien
 				}
 			}
 		} else {
-			// Ensure the finalizer is present if the CDC is not deleted, OR if it is reserved
-			if !hasFinalizer {
+			// Ensure the finalizer is present if the CDC is in this pool inventory
+			if _, ok := cdcs.byCDCName[cdc.Name]; !hasFinalizer && ok {
 				controllerutils.AddFinalizer(cdc, poolFinalizer)
 				if err := c.Update(context.Background(), cdc); err != nil {
 					return err


### PR DESCRIPTION
When finalizer is missing in a CDC, then only add a finalizer if it is in the pool inventory