### PR TITLE
CD.Spec.Provisioning.CLIImageOverride

### DIFF
--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -231,6 +231,11 @@ type Provisioning struct {
 	// +optional
 	InstallerImageOverride string `json:"installerImageOverride,omitempty"`
 
+	// CLIImageOverride allows specifying a URI for the CLI image (containing the `oc` binary),
+	// normally gleaned from the metadata within the ReleaseImage.
+	// +optional
+	CLIImageOverride string `json:"cliImageOverride,omitempty"`
+
 	// ImageSetRef is a reference to a ClusterImageSet. If a value is specified for ReleaseImage,
 	// that will take precedence over the one from the ClusterImageSet.
 	ImageSetRef *ClusterImageSetReference `json:"imageSetRef,omitempty"`

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -807,6 +807,11 @@ spec:
                 description: Provisioning contains settings used only for initial
                   cluster provisioning. May be unset in the case of adopted clusters.
                 properties:
+                  cliImageOverride:
+                    description: CLIImageOverride allows specifying a URI for the
+                      CLI image (containing the `oc` binary), normally gleaned from
+                      the metadata within the ReleaseImage.
+                    type: string
                   imageSetRef:
                     description: ImageSetRef is a reference to a ClusterImageSet.
                       If a value is specified for ReleaseImage, that will take precedence

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -1207,6 +1207,11 @@ objects:
                   description: Provisioning contains settings used only for initial
                     cluster provisioning. May be unset in the case of adopted clusters.
                   properties:
+                    cliImageOverride:
+                      description: CLIImageOverride allows specifying a URI for the
+                        CLI image (containing the `oc` binary), normally gleaned from
+                        the metadata within the ReleaseImage.
+                      type: string
                     imageSetRef:
                       description: ImageSetRef is a reference to a ClusterImageSet.
                         If a value is specified for ReleaseImage, that will take precedence

--- a/pkg/imageset/updateinstaller.go
+++ b/pkg/imageset/updateinstaller.go
@@ -180,11 +180,18 @@ func (o *UpdateInstallerImageOptions) Run() (returnErr error) {
 		o.log.WithField("installerImage", installerImage).Info("installer image found")
 	}
 
-	cliImage, err := findImageSpec(is, "cli")
-	if err != nil {
-		return errors.Wrap(err, "could not get cli image")
+	var cliImage string
+	// There should be no way we get here with Provisioning == nil, but better safe.
+	if cd.Spec.Provisioning != nil && cd.Spec.Provisioning.CLIImageOverride != "" {
+		cliImage = cd.Spec.Provisioning.CLIImageOverride
+		o.log.WithField("cliImage", cliImage).Info("CLI image overridden")
+	} else {
+		cliImage, err = findImageSpec(is, "cli")
+		if err != nil {
+			return errors.Wrap(err, "could not get cli image")
+		}
+		o.log.WithField("cliImage", cliImage).Info("cli image found")
 	}
-	o.log.WithField("cliImage", cliImage).Info("cli image found")
 
 	releaseMetadataRaw, err := ioutil.ReadFile(filepath.Join(o.WorkDir, releaseMetadataFilename))
 	if err != nil {

--- a/pkg/imageset/updateinstaller_test.go
+++ b/pkg/imageset/updateinstaller_test.go
@@ -31,6 +31,7 @@ const (
 	testCLIImage           = "registry.io/test-cli-image:latest"
 	testReleaseVersion     = "v0.0.0-test-version"
 	installerImageOverride = "quay.io/foo/bar:baz"
+	cliImageOverride       = "quay.io/foo/cli:blah"
 )
 
 func TestUpdateInstallerImageCommand(t *testing.T) {
@@ -52,7 +53,7 @@ func TestUpdateInstallerImageCommand(t *testing.T) {
 				"installer": testInstallerImage,
 				"cli":       testCLIImage,
 			},
-			validateClusterDeployment: validateSuccessfulExecution(testInstallerImage, ""),
+			validateClusterDeployment: validateSuccessfulExecution(testInstallerImage, testCLIImage, ""),
 		},
 		{
 			name:                      "failure execution missing cli",
@@ -70,7 +71,7 @@ func TestUpdateInstallerImageCommand(t *testing.T) {
 				"installer": testInstallerImage,
 				"cli":       testCLIImage,
 			},
-			validateClusterDeployment: validateSuccessfulExecution(testInstallerImage, installerImageResolvedReason),
+			validateClusterDeployment: validateSuccessfulExecution(testInstallerImage, testCLIImage, installerImageResolvedReason),
 		},
 		{
 			name: "successful execution baremetal platform",
@@ -83,7 +84,7 @@ func TestUpdateInstallerImageCommand(t *testing.T) {
 				"baremetal-installer": testInstallerImage,
 				"cli":                 testCLIImage,
 			},
-			validateClusterDeployment: validateSuccessfulExecution(testInstallerImage, ""),
+			validateClusterDeployment: validateSuccessfulExecution(testInstallerImage, testCLIImage, ""),
 		},
 		{
 			name:                      "successful execution with version in release metadata",
@@ -93,7 +94,7 @@ func TestUpdateInstallerImageCommand(t *testing.T) {
 				"cli":       testCLIImage,
 			},
 			version:                   testReleaseVersion,
-			validateClusterDeployment: validateSuccessfulExecution(testInstallerImage, ""),
+			validateClusterDeployment: validateSuccessfulExecution(testInstallerImage, testCLIImage, ""),
 		},
 		{
 			name:                      "installer image override",
@@ -102,7 +103,16 @@ func TestUpdateInstallerImageCommand(t *testing.T) {
 				"installer": testInstallerImage,
 				"cli":       testCLIImage,
 			},
-			validateClusterDeployment: validateSuccessfulExecution(installerImageOverride, ""),
+			validateClusterDeployment: validateSuccessfulExecution(installerImageOverride, testCLIImage, ""),
+		},
+		{
+			name:                      "CLI image override",
+			existingClusterDeployment: testClusterDeploymentWithCLIImageOverride(cliImageOverride),
+			images: map[string]string{
+				"installer": testInstallerImage,
+				"cli":       testCLIImage,
+			},
+			validateClusterDeployment: validateSuccessfulExecution(testInstallerImage, cliImageOverride, ""),
 		},
 	}
 
@@ -161,11 +171,22 @@ func testClusterDeploymentWithInstallerImageOverride(override string) *hivev1.Cl
 	return cd
 }
 
+func testClusterDeploymentWithCLIImageOverride(override string) *hivev1.ClusterDeployment {
+	cd := testClusterDeployment()
+	cd.Spec.Provisioning = &hivev1.Provisioning{
+		CLIImageOverride: override,
+	}
+	return cd
+}
+
 // If expectedReason is empty, we won't check it.
-func validateSuccessfulExecution(expectedInstallerImage, expectedReason string) func(*testing.T, *hivev1.ClusterDeployment) {
+func validateSuccessfulExecution(expectedInstallerImage, expectedCLIImage, expectedReason string) func(*testing.T, *hivev1.ClusterDeployment) {
 	return func(t *testing.T, clusterDeployment *hivev1.ClusterDeployment) {
 		if assert.NotNil(t, clusterDeployment.Status.InstallerImage, "did not get an installer image in status") {
 			assert.Equal(t, expectedInstallerImage, *clusterDeployment.Status.InstallerImage, "did not get expected installer image in status")
+		}
+		if assert.NotNil(t, clusterDeployment.Status.CLIImage, "did not get a CLI image in status") {
+			assert.Equal(t, expectedCLIImage, *clusterDeployment.Status.CLIImage, "did not get expected CLI image in status")
 		}
 		condition := controllerutils.FindCondition(clusterDeployment.Status.Conditions, hivev1.InstallerImageResolutionFailedCondition)
 		if assert.NotNil(t, condition, "could not find InstallerImageResolutionFailed condition") {

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -231,6 +231,11 @@ type Provisioning struct {
 	// +optional
 	InstallerImageOverride string `json:"installerImageOverride,omitempty"`
 
+	// CLIImageOverride allows specifying a URI for the CLI image (containing the `oc` binary),
+	// normally gleaned from the metadata within the ReleaseImage.
+	// +optional
+	CLIImageOverride string `json:"cliImageOverride,omitempty"`
+
 	// ImageSetRef is a reference to a ClusterImageSet. If a value is specified for ReleaseImage,
 	// that will take precedence over the one from the ClusterImageSet.
 	ImageSetRef *ClusterImageSetReference `json:"imageSetRef,omitempty"`


### PR DESCRIPTION
Allow overriding the CLI image (the one with the `oc` binary) in the
same manner as we allow overriding the Installer image.

[HIVE-2014](https://issues.redhat.com//browse/HIVE-2014)