### PR TITLE
Copy installer image domain to CLI image

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -436,6 +436,11 @@ const (
 	// nonempty, and parseable into such a map, the key/value pairs are blindly included in log lines from hive binaries
 	// (currently only hiveutil).
 	AdditionalLogFieldsEnvVar = "HIVE_ADDITIONAL_LOG_FIELDS"
+
+	// CopyCLIImageDomainFromInstallerImage affects how hive computes the URI of the CLI image when preparing to provision a
+	// cluster. When this annotation is set to a truthy value, hive will parse the installer image URI and use its domain
+	// (everything up to the first `/`) for the CLI image, discarding whatever domain was gleaned from the release image.
+	CopyCLIImageDomainFromInstallerImage = "hive.openshift.io/cli-domain-from-installer-image"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment


### PR DESCRIPTION
Look for a new annotation on ClusterDeployment,
`hive.openshift.io/cli-domain-from-installer-image`. If set to a truthy
value, slice and dice the resolved CLI image to use the same domain
(everything up to the first `/`) as the resolved or overridden installer
image.

[HIVE-2014](https://issues.redhat.com//browse/HIVE-2014)