### PR TITLE
DNM: Move secret retrieval to hiveutil for AWS prov/deprov

### DIFF
--- a/contrib/pkg/deprovision/awstagdeprovision.go
+++ b/contrib/pkg/deprovision/awstagdeprovision.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/hive/contrib/pkg/utils"
+	awsutils "github.com/openshift/hive/contrib/pkg/utils/aws"
 	"github.com/openshift/installer/pkg/destroy/aws"
 )
 
@@ -30,6 +31,12 @@ func NewDeprovisionAWSWithTagsCommand() *cobra.Command {
 			if credsDir != "" {
 				go terminateWhenFilesChange(credsDir)
 			}
+
+			client, err := utils.GetClient()
+			if err != nil {
+				log.WithError(err).Fatal("failed to get client")
+			}
+			awsutils.Hive1862Experiment(client)
 
 			// ClusterQuota stomped in return
 			if _, err := opt.Run(); err != nil {

--- a/contrib/pkg/utils/aws/aws.go
+++ b/contrib/pkg/utils/aws/aws.go
@@ -1,9 +1,16 @@
 package aws
 
 import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/openshift/hive/pkg/constants"
 	log "github.com/sirupsen/logrus"
 	ini "gopkg.in/ini.v1"
-	"os"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // GetAWSCreds reads AWS credentials either from either the specified credentials file,
@@ -38,4 +45,38 @@ func GetAWSCreds(credsFile, defaultCredsFile string) (string, string, error) {
 		log.Error("AWS credentials file missing keys in default section")
 	}
 	return accessKeyIDValue.String(), secretAccessKeyValue.String(), nil
+}
+
+func Hive1862Experiment(c client.Client) {
+	if os.Getenv("HIVE_1862_EXPERIMENT") == "" {
+		return
+	}
+	// Load up the AWS creds from the secret.
+	credsNamespace := os.Getenv("AWS_CREDS_SECRET_NAMESPACE")
+	if credsNamespace == "" {
+		log.Fatal("AWS_CREDS_SECRET_NAMESPACE environment variable is required in scale mode")
+	}
+	credsName := os.Getenv("AWS_CREDS_SECRET_NAME")
+	if credsName == "" {
+		log.Fatal("AWS_CREDS_SECRET_NAME environment variable is required in scale mode")
+	}
+	credsSecret := &corev1.Secret{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Namespace: credsNamespace, Name: credsName}, credsSecret); err != nil {
+		log.WithError(err).Fatal("Failed to load AWS credentials secret")
+	}
+	// Should we bounce if any of the following already exist?
+	if id := string(credsSecret.Data[constants.AWSAccessKeyIDSecretKey]); id != "" {
+		os.Setenv("AWS_ACCESS_KEY_ID", id)
+	}
+	if secret := string(credsSecret.Data[constants.AWSSecretAccessKeySecretKey]); secret != "" {
+		os.Setenv("AWS_SECRET_ACCESS_KEY", secret)
+	}
+	if config := credsSecret.Data[constants.AWSConfigSecretKey]; len(config) != 0 {
+		// Lay this down as a file
+		path := filepath.Join(constants.AWSCredsMount, constants.AWSConfigSecretKey)
+		if err := os.WriteFile(path, config, 0400); err != nil {
+			log.WithError(err).Fatalf("Failed to write AWS config file at %s", path)
+		}
+		os.Setenv("AWS_CONFIG_FILE", path)
+	}
 }

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -61,6 +61,7 @@ import (
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	contributils "github.com/openshift/hive/contrib/pkg/utils"
+	awsutils "github.com/openshift/hive/contrib/pkg/utils/aws"
 	"github.com/openshift/hive/pkg/awsclient"
 	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/controller/machinepool"
@@ -179,6 +180,8 @@ SSH_PRIV_KEY_PATH: File system path of a file containing the SSH private key cor
 			if err != nil {
 				im.log.WithError(err).Fatal("error creating kube clients")
 			}
+
+			awsutils.Hive1862Experiment(im.DynamicClient)
 
 			if err := im.Run(); err != nil {
 				log.WithError(err).Fatal("runtime error")


### PR DESCRIPTION
Pods created by hive-controllers require information from secrets and
configmaps (for example, cloud credentials) in order to function. Today
these are passed into the pods from the hive-controllers side via
environment variables and volumes. Working on HIVE-1862, it's looking
like we're going to need that same business logic -- which parts of
which objects are needed in what form -- on the hiveutil side when
running in scale mode. In order to avoid duplication of that logic,
we're considering moving it *all* to the hiveutil side, even for
non-scale mode.

This experiment is a proof of this concept for provision and deprovision
paths on AWS. The cloud credentials secret contents are no longer passed
through via the pod spec. Instead, the hiveutil command itself uses a
local client to load that secret and set up the same environment
variables and files that were previously passed through on the pod.

Spike related to HIVE-1862