### PR TITLE
Move secret/configmap retrieval to hiveutil for prov/deprov

### DIFF
--- a/contrib/pkg/deprovision/alibabacloud.go
+++ b/contrib/pkg/deprovision/alibabacloud.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 
 	"github.com/openshift/hive/contrib/pkg/utils"
+	aliutils "github.com/openshift/hive/contrib/pkg/utils/alibabacloud"
 	"github.com/openshift/installer/pkg/destroy/alibabacloud"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -55,6 +57,11 @@ func NewDeprovisionAlibabaCloudCommand() *cobra.Command {
 // Complete finishes parsing arguments for the command
 func (o *alibabaCloudDeprovisionOptions) Complete(cmd *cobra.Command, args []string) error {
 	o.infraID = args[0]
+	client, err := utils.GetClient()
+	if err != nil {
+		return errors.Wrap(err, "failed to get client")
+	}
+	aliutils.ConfigureCreds(client)
 	return nil
 }
 

--- a/contrib/pkg/deprovision/awstagdeprovision.go
+++ b/contrib/pkg/deprovision/awstagdeprovision.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/hive/contrib/pkg/utils"
+	awsutils "github.com/openshift/hive/contrib/pkg/utils/aws"
 	"github.com/openshift/installer/pkg/destroy/aws"
 )
 
@@ -59,6 +61,12 @@ func completeAWSUninstaller(o *aws.ClusterUninstaller, logLevel string, args []s
 	if o.Logger, err = utils.NewLogger(logLevel); err != nil {
 		return err
 	}
+
+	client, err := utils.GetClient()
+	if err != nil {
+		return errors.Wrap(err, "failed to get client")
+	}
+	awsutils.ConfigureCreds(client)
 
 	return nil
 }

--- a/contrib/pkg/deprovision/azure.go
+++ b/contrib/pkg/deprovision/azure.go
@@ -28,13 +28,13 @@ func NewDeprovisionAzureCommand() *cobra.Command {
 		Short: "Deprovision Azure assets (as created by openshift-installer)",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := validate(); err != nil {
-				log.WithError(err).Fatal("Failed validating Azure credentials")
-			}
 			uninstaller, err := completeAzureUninstaller(opt.logLevel, opt.cloudName, args)
 			if err != nil {
 				log.WithError(err).Error("Cannot complete command")
 				return
+			}
+			if err := validate(); err != nil {
+				log.WithError(err).Fatal("Failed validating Azure credentials")
 			}
 
 			// ClusterQuota stomped in return
@@ -64,6 +64,12 @@ func completeAzureUninstaller(logLevel, cloudName string, args []string) (provid
 	if err != nil {
 		return nil, err
 	}
+
+	client, err := utils.GetClient()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get client")
+	}
+	azureutils.ConfigureCreds(client)
 
 	metadata := &types.ClusterMetadata{
 		InfraID: args[0],

--- a/contrib/pkg/deprovision/gcp.go
+++ b/contrib/pkg/deprovision/gcp.go
@@ -52,6 +52,13 @@ func NewDeprovisionGCPCommand() *cobra.Command {
 // Complete finishes parsing arguments for the command
 func (o *gcpOptions) Complete(cmd *cobra.Command, args []string) error {
 	o.infraID = args[0]
+
+	client, err := utils.GetClient()
+	if err != nil {
+		return errors.Wrap(err, "failed to get client")
+	}
+	gcputils.ConfigureCreds(client)
+
 	return nil
 }
 

--- a/contrib/pkg/deprovision/ibmcloud.go
+++ b/contrib/pkg/deprovision/ibmcloud.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/hive/contrib/pkg/utils"
+	ibmutils "github.com/openshift/hive/contrib/pkg/utils/ibmcloud"
 	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/ibmclient"
 	"github.com/openshift/installer/pkg/destroy/ibmcloud"
@@ -62,6 +63,12 @@ func NewDeprovisionIBMCloudCommand() *cobra.Command {
 // Complete finishes parsing arguments for the command
 func (o *ibmCloudDeprovisionOptions) Complete(cmd *cobra.Command, args []string) error {
 	o.infraID = args[0]
+
+	client, err := utils.GetClient()
+	if err != nil {
+		return errors.Wrap(err, "failed to get client")
+	}
+	ibmutils.ConfigureCreds(client)
 
 	// Create IBMCloud Client
 	ibmCloudAPIKey := os.Getenv(constants.IBMCloudAPIKeyEnvVar)

--- a/contrib/pkg/deprovision/openstack.go
+++ b/contrib/pkg/deprovision/openstack.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/hive/contrib/pkg/utils"
+	openstackutils "github.com/openshift/hive/contrib/pkg/utils/openstack"
 	"github.com/openshift/installer/pkg/destroy/openstack"
 	"github.com/openshift/installer/pkg/types"
 	typesopenstack "github.com/openshift/installer/pkg/types/openstack"
@@ -48,6 +50,13 @@ func NewDeprovisionOpenStackCommand() *cobra.Command {
 // Complete finishes parsing arguments for the command
 func (o *openStackOptions) Complete(cmd *cobra.Command, args []string) error {
 	o.infraID = args[0]
+
+	client, err := utils.GetClient()
+	if err != nil {
+		return errors.Wrap(err, "failed to get client")
+	}
+	openstackutils.ConfigureCreds(client)
+
 	return nil
 }
 

--- a/contrib/pkg/deprovision/ovirt.go
+++ b/contrib/pkg/deprovision/ovirt.go
@@ -1,12 +1,12 @@
 package deprovision
 
 import (
-	"errors"
-
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/hive/contrib/pkg/utils"
+	ovirtutils "github.com/openshift/hive/contrib/pkg/utils/ovirt"
 	"github.com/openshift/installer/pkg/destroy/ovirt"
 	"github.com/openshift/installer/pkg/types"
 	typesovirt "github.com/openshift/installer/pkg/types/ovirt"
@@ -47,6 +47,13 @@ func NewDeprovisionOvirtCommand() *cobra.Command {
 // Complete finishes parsing arguments for the command
 func (o *oVirtOptions) Complete(cmd *cobra.Command, args []string) error {
 	o.infraID = args[0]
+
+	client, err := utils.GetClient()
+	if err != nil {
+		return errors.Wrap(err, "failed to get client")
+	}
+	ovirtutils.ConfigureCreds(client)
+
 	return nil
 }
 

--- a/contrib/pkg/deprovision/vsphere.go
+++ b/contrib/pkg/deprovision/vsphere.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -12,6 +13,7 @@ import (
 	typesvsphere "github.com/openshift/installer/pkg/types/vsphere"
 
 	"github.com/openshift/hive/contrib/pkg/utils"
+	vsphereutils "github.com/openshift/hive/contrib/pkg/utils/vsphere"
 	"github.com/openshift/hive/pkg/constants"
 )
 
@@ -52,6 +54,13 @@ func NewDeprovisionvSphereCommand() *cobra.Command {
 // Complete finishes parsing arguments for the command
 func (o *vSphereOptions) Complete(cmd *cobra.Command, args []string) error {
 	o.infraID = args[0]
+
+	client, err := utils.GetClient()
+	if err != nil {
+		return errors.Wrap(err, "failed to get client")
+	}
+	vsphereutils.ConfigureCreds(client)
+
 	return nil
 }
 

--- a/contrib/pkg/utils/generic.go
+++ b/contrib/pkg/utils/generic.go
@@ -1,19 +1,31 @@
 package utils
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubectl/pkg/util/slice"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/resource"
+)
+
+const (
+	caTrustDir = "/etc/pki/ca-trust/source/anchors/"
 )
 
 type releasePayload struct {
@@ -96,4 +108,107 @@ func NewLogger(logLevel string) (*log.Entry, error) {
 	logger = utils.AddLogFields(utils.StringLogTagger{S: os.Getenv(constants.AdditionalLogFieldsEnvVar)}, logger)
 
 	return logger, nil
+}
+
+// LoadSecretOrDie looks for environment variables named CLUSTERDEPLOYMENT_NAMESPACE and `secretName``.
+// If either is not found, this indicates we are not supposed to use this mode and we return nil. Otherwise, we
+// attempt to load and return the designated secret. We panic if the secret fails to load for any reason.
+func LoadSecretOrDie(c client.Client, secretNameEnvKey string) *corev1.Secret {
+	secret := &corev1.Secret{}
+	if !loadOrDie(c, secretNameEnvKey, secret) {
+		return nil
+	}
+	return secret
+}
+
+// LoadConfigMapOrDie looks for environment variables named CLUSTERDEPLOYMENT_NAMESPACE and `secretName`.
+// If either is not found, this indicates we are not supposed to use this mode and we return nil. Otherwise, we
+// attempt to load and return the designated ConfigMap. We panic if the ConfigMap fails to load for any reason.
+func LoadConfigMapOrDie(c client.Client, cmNameEnvKey string) *corev1.ConfigMap {
+	cm := &corev1.ConfigMap{}
+	if !loadOrDie(c, cmNameEnvKey, cm) {
+		return nil
+	}
+	return cm
+}
+
+func loadOrDie(c client.Client, nameEnvKey string, obj client.Object) bool {
+	ns, name := os.Getenv("CLUSTERDEPLOYMENT_NAMESPACE"), os.Getenv(nameEnvKey)
+	if ns == "" || name == "" {
+		return false
+	}
+	logger := log.
+		WithField("namespace", ns).
+		WithField("name", name).
+		WithField("type", fmt.Sprintf("%T", obj))
+
+	if err := c.Get(context.TODO(), types.NamespacedName{Namespace: ns, Name: name}, obj); err != nil {
+		logger.WithError(err).Fatal("Failed to load object")
+	}
+	logger.Info("Using loaded object")
+	return true
+
+}
+
+// ProjectToDir simulates what happens when you mount a secret or configmap as a volume on a pod, creating
+// files named after each key under `dir` and populating them with the contents represented by the values.
+func ProjectToDir(obj client.Object, dir string, keys ...string) {
+	write := func(filename string, bytes []byte) {
+		if len(keys) != 0 && !slice.ContainsString(keys, filename, nil) {
+			// Skip this key
+			return
+		}
+		path := filepath.Join(dir, filename)
+		if err := os.WriteFile(path, bytes, 0400); err != nil {
+			log.WithError(err).WithField("path", path).Fatal("Failed to write file")
+		}
+	}
+	switch o := obj.(type) {
+	case *corev1.ConfigMap:
+		// ConfigMaps have data in two places:
+		// Data has string values, so we have to cast them.
+		for k, v := range o.Data {
+			write(k, ([]byte)(v))
+		}
+		// BinaryData's values are already []byte
+		for k, v := range o.BinaryData {
+			write(k, v)
+		}
+	case *corev1.Secret:
+		for k, v := range o.Data {
+			write(k, v)
+		}
+	case nil:
+		log.Fatal("Can't project nil object to directory")
+	default:
+		log.WithField("type", fmt.Sprintf("%T", o)).WithField("name", o.GetName()).Fatal("Can't project object to directory")
+	}
+}
+
+// InstallCerts copies the contents of `sourceDir` into the appropriate directory and updates the trust configuration.
+// If `sourceDir` does not exist, this func is a no-op. Other errors (e.g. `sourceDir` is a file, or you don't have
+// appropriate permissions) are fatal.
+func InstallCerts(sourceDir string) {
+	logger := log.WithField("certsDir", sourceDir)
+	fi, err := os.Stat(sourceDir)
+	if err != nil && os.IsNotExist(err) {
+		logger.Info("Certs directory does not exist -- skipping")
+		return
+	}
+	if !fi.Mode().IsDir() {
+		logger.Fatal("Not a directory")
+	}
+
+	// No built-in recursive directory copy??
+	b, err := exec.Command("cp", "-vr", sourceDir+"/.", caTrustDir).CombinedOutput()
+	if err != nil {
+		logger.WithError(err).WithField("output", string(b)).Fatal("failed to copy certs")
+	}
+	logger.WithField("output", string(b)).Info("copied certs")
+
+	b, err = exec.Command("update-ca-trust").CombinedOutput()
+	if err != nil {
+		logger.WithError(err).WithField("output", string(b)).Fatal("failed to update CA trust")
+	}
+	logger.WithField("output", string(b)).Info("updated CA trust")
 }

--- a/contrib/pkg/utils/ibmcloud/ibmcloud.go
+++ b/contrib/pkg/utils/ibmcloud/ibmcloud.go
@@ -1,0 +1,19 @@
+package ibmcloud
+
+import (
+	"os"
+
+	"github.com/openshift/hive/contrib/pkg/utils"
+	"github.com/openshift/hive/pkg/constants"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ConfigureCreds loads secrets designated by the environment variables CLUSTERDEPLOYMENT_NAMESPACE
+// and CREDS_SECRET_NAME and configures IBMCloud credential environment variables accordingly.
+func ConfigureCreds(c client.Client) {
+	if credsSecret := utils.LoadSecretOrDie(c, "CREDS_SECRET_NAME"); credsSecret != nil {
+		if key := string(credsSecret.Data[constants.IBMCloudAPIKeySecretKey]); key != "" {
+			os.Setenv(constants.IBMCloudAPIKeyEnvVar, key)
+		}
+	}
+}

--- a/contrib/pkg/utils/openstack/openstack.go
+++ b/contrib/pkg/utils/openstack/openstack.go
@@ -6,9 +6,11 @@ import (
 	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"k8s.io/client-go/util/homedir"
 
+	"github.com/openshift/hive/contrib/pkg/utils"
 	"github.com/openshift/hive/pkg/constants"
 )
 
@@ -32,4 +34,16 @@ func GetCreds(credsFile string) ([]byte, error) {
 	}
 	log.WithField("credsFile", credsFile).Info("Loading OpenStack creds")
 	return ioutil.ReadFile(credsFile)
+}
+
+// ConfigureCreds loads secrets designated by the environment variables CLUSTERDEPLOYMENT_NAMESPACE,
+// CREDS_SECRET_NAME, and CERTS_SECRET_NAME and configures OpenStack credential config files accordingly.
+func ConfigureCreds(c client.Client) {
+	if credsSecret := utils.LoadSecretOrDie(c, "CREDS_SECRET_NAME"); credsSecret != nil {
+		utils.ProjectToDir(credsSecret, constants.OpenStackCredentialsDir)
+	}
+	if certsSecret := utils.LoadSecretOrDie(c, "CERTS_SECRET_NAME"); certsSecret != nil {
+		utils.ProjectToDir(certsSecret, constants.OpenStackCertificatesDir)
+		utils.InstallCerts(constants.OpenStackCertificatesDir)
+	}
 }

--- a/contrib/pkg/utils/ovirt/ovirt.go
+++ b/contrib/pkg/utils/ovirt/ovirt.go
@@ -6,7 +6,9 @@ import (
 	"path/filepath"
 
 	"k8s.io/client-go/util/homedir"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/openshift/hive/contrib/pkg/utils"
 	"github.com/openshift/hive/pkg/constants"
 )
 
@@ -28,4 +30,18 @@ func GetCreds(credsFile string) ([]byte, error) {
 		}
 	}
 	return ioutil.ReadFile(credsFile)
+}
+
+// ConfigureCreds loads secrets designated by the environment variables CLUSTERDEPLOYMENT_NAMESPACE,
+// CREDS_SECRET_NAME, and CERTS_SECRET_NAME and configures Ovirt credential environment variables
+// and config files accordingly.
+func ConfigureCreds(c client.Client) {
+	if credsSecret := utils.LoadSecretOrDie(c, "CREDS_SECRET_NAME"); credsSecret != nil {
+		utils.ProjectToDir(credsSecret, constants.OvirtCredentialsDir)
+		os.Setenv(constants.OvirtConfigEnvVar, constants.OvirtCredentialsDir+"/"+constants.OvirtCredentialsName)
+	}
+	if certsSecret := utils.LoadSecretOrDie(c, "CERTS_SECRET_NAME"); certsSecret != nil {
+		utils.ProjectToDir(certsSecret, constants.OvirtCertificatesDir)
+		utils.InstallCerts(constants.OvirtCertificatesDir)
+	}
 }

--- a/contrib/pkg/utils/vsphere/vsphere.go
+++ b/contrib/pkg/utils/vsphere/vsphere.go
@@ -1,0 +1,30 @@
+package vsphere
+
+import (
+	"os"
+
+	"github.com/openshift/hive/contrib/pkg/utils"
+	"github.com/openshift/hive/pkg/constants"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ConfigureCreds loads secrets designated by the environment variables CLUSTERDEPLOYMENT_NAMESPACE,
+// CREDS_SECRET_NAME, and CERTS_SECRET_NAME and configures VSphere credential environment variables
+// and config files accordingly.
+func ConfigureCreds(c client.Client) {
+	if credsSecret := utils.LoadSecretOrDie(c, "CREDS_SECRET_NAME"); credsSecret != nil {
+		if username := string(credsSecret.Data[constants.UsernameSecretKey]); username != "" {
+			os.Setenv(constants.VSphereUsernameEnvVar, username)
+		}
+		if password := string(credsSecret.Data[constants.PasswordSecretKey]); password != "" {
+			os.Setenv(constants.VSpherePasswordEnvVar, password)
+		}
+		// NOTE: I think this is only used for terminateWhenFilesChange(), which we don't really
+		// care about anymore. Can we get rid of it?
+		utils.ProjectToDir(credsSecret, constants.VSphereCredentialsDir)
+	}
+	if certsSecret := utils.LoadSecretOrDie(c, "CERTS_SECRET_NAME"); certsSecret != nil {
+		utils.ProjectToDir(certsSecret, constants.VSphereCertificatesDir)
+		utils.InstallCerts(constants.VSphereCertificatesDir)
+	}
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -184,8 +184,14 @@ const (
 	// to the configmap containing the managed domain configuration.
 	ManagedDomainsVolumeName = "managed-domains"
 
+	// GCPCredentialsDir is the directory containing the GCP credentials file.
+	GCPCredentialsDir = "/.gcp"
+
 	// GCPCredentialsName is the name of the GCP credentials file or secret key.
 	GCPCredentialsName = "osServiceAccount.json"
+
+	// AzureCredentialsDir is the directory containing the Azure credentials file.
+	AzureCredentialsDir = "/.azure"
 
 	// AzureCredentialsName is the name of the Azure credentials file or secret key.
 	AzureCredentialsName = "osServicePrincipal.json"
@@ -194,16 +200,31 @@ const (
 	// where Azure credentials can be found.
 	AzureCredentialsEnvVar = "AZURE_AUTH_LOCATION"
 
+	// OpenStackCertificatesDir is the directory containing OpenStack credentials files.
+	OpenStackCredentialsDir = "/etc/openstack"
+
+	// OpenStackCertificatesDir is the directory containing OpenStack certificates files.
+	OpenStackCertificatesDir = "/etc/openstack-ca"
+
 	// OpenStackCredentialsName is the name of the OpenStack credentials file.
 	OpenStackCredentialsName = "clouds.yaml"
+
+	// SSHPrivateKeyDir is the directory containing the SSH key to be configured on cluster hosts.
+	SSHPrivateKeyDir = "/sshkeys"
 
 	// SSHPrivKeyPathEnvVar is the environment variable Hive will set for the installmanager pod to point to the
 	// path where we mount in the SSH key to be configured on the cluster hosts.
 	SSHPrivKeyPathEnvVar = "SSH_PRIV_KEY_PATH"
 
+	// LibvirtSSHPrivateKeyDir is the directory containing the libvirt SSH key to be configured on cluster hosts.
+	LibvirtSSHPrivateKeyDir = "/libvirtsshkeys"
+
 	// LibvirtSSHPrivKeyPathEnvVar is the environment variable Hive will set for the installmanager pod to point to the
 	// path where we mount in the SSH key for connecting to the bare metal libvirt provisioning host.
 	LibvirtSSHPrivKeyPathEnvVar = "LIBVIRT_SSH_PRIV_KEY_PATH"
+
+	// BoundServiceAccountSigningKeyDir is the directory containing the bound service account signing key file.
+	BoundServiceAccountSigningKeyDir = "/boundsasigningkey"
 
 	// BoundServiceAccountSigningKeyEnvVar contains the path to the bound service account signing key and
 	// is set in the install pod for AWS STS clusters.
@@ -290,6 +311,12 @@ const (
 	// VSphereDataStoreEnvVar is the environment variable specifying the vSphere default datastore.
 	VSphereDataStoreEnvVar = "GOVC_DATASTORE"
 
+	// VSphereCredentialsDir is the directory containing VSphere credentials files.
+	VSphereCredentialsDir = "/vsphere-credentials"
+
+	// VSphereCertificatesDir is the directory containing VSphere certificate files.
+	VSphereCertificatesDir = "/vsphere-certificates"
+
 	// VersionMajorLabel is a label applied to ClusterDeployments to show the version of the cluster
 	// in the form "[MAJOR]".
 	VersionMajorLabel = "hive.openshift.io/version-major"
@@ -301,6 +328,12 @@ const (
 	// VersionMajorMinorPatchLabel is a label applied to ClusterDeployments to show the version of the cluster
 	// in the form "[MAJOR].[MINOR].[PATCH]".
 	VersionMajorMinorPatchLabel = "hive.openshift.io/version-major-minor-patch"
+
+	// OvirtCredentialsDir is the directory containing Ovirt credentials files.
+	OvirtCredentialsDir = "/.ovirt"
+
+	// OvirtCertificatesDir is the directory containing Ovirt certificate files.
+	OvirtCertificatesDir = "/.ovirt-ca"
 
 	// OvirtCredentialsName is the name of the oVirt credentials file.
 	OvirtCredentialsName = "ovirt-config.yaml"

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -61,6 +61,14 @@ import (
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	contributils "github.com/openshift/hive/contrib/pkg/utils"
+	aliutils "github.com/openshift/hive/contrib/pkg/utils/alibabacloud"
+	awsutils "github.com/openshift/hive/contrib/pkg/utils/aws"
+	azureutils "github.com/openshift/hive/contrib/pkg/utils/azure"
+	gcputils "github.com/openshift/hive/contrib/pkg/utils/gcp"
+	ibmutils "github.com/openshift/hive/contrib/pkg/utils/ibmcloud"
+	openstackutils "github.com/openshift/hive/contrib/pkg/utils/openstack"
+	ovirtutils "github.com/openshift/hive/contrib/pkg/utils/ovirt"
+	vsphereutils "github.com/openshift/hive/contrib/pkg/utils/vsphere"
 	"github.com/openshift/hive/pkg/awsclient"
 	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/controller/machinepool"
@@ -113,6 +121,7 @@ type InstallManager struct {
 	PullSecretMountPath              string
 	ManifestsMountPath               string
 	DynamicClient                    client.Client
+	loadSecrets                      func(*InstallManager, *hivev1.ClusterDeployment)
 	cleanupFailedProvision           func(dynamicClient client.Client, cd *hivev1.ClusterDeployment, infraID string, logger log.FieldLogger) error
 	updateClusterProvision           func(*InstallManager, provisionMutation) error
 	readClusterMetadata              func(*InstallManager) ([]byte, *installertypes.ClusterMetadata, error)
@@ -198,6 +207,7 @@ SSH_PRIV_KEY_PATH: File system path of a file containing the SSH private key cor
 // ...except for the clusterProvision field. That's loaded up by Run(), since it involves a REST call.
 func (m *InstallManager) Complete(args []string) error {
 	// Connect up structure's function pointers
+	m.loadSecrets = loadSecrets
 	m.updateClusterProvision = updateClusterProvisionWithRetries
 	m.readClusterMetadata = readClusterMetadata
 	m.uploadAdminKubeconfig = uploadAdminKubeconfig
@@ -271,6 +281,8 @@ func (m *InstallManager) Run() error {
 		m.log.Warn("cluster is already installed, exiting")
 		os.Exit(0)
 	}
+
+	m.loadSecrets(m, cd)
 
 	// sshKeyPaths will contain paths to all ssh keys in use
 	var sshKeyPaths []string
@@ -509,6 +521,61 @@ func (m *InstallManager) Run() error {
 	m.log.Info("install completed successfully")
 
 	return nil
+}
+
+func loadSecrets(m *InstallManager, cd *hivev1.ClusterDeployment) {
+	// Configure credentials (including certs) appropriately according to the cloud provider
+	switch {
+	case cd.Spec.Platform.AlibabaCloud != nil:
+		aliutils.ConfigureCreds(m.DynamicClient)
+	case cd.Spec.Platform.AWS != nil:
+		awsutils.ConfigureCreds(m.DynamicClient)
+	case cd.Spec.Platform.Azure != nil:
+		azureutils.ConfigureCreds(m.DynamicClient)
+	case cd.Spec.Platform.GCP != nil:
+		gcputils.ConfigureCreds(m.DynamicClient)
+	case cd.Spec.Platform.OpenStack != nil:
+		openstackutils.ConfigureCreds(m.DynamicClient)
+	case cd.Spec.Platform.VSphere != nil:
+		vsphereutils.ConfigureCreds(m.DynamicClient)
+	case cd.Spec.Platform.Ovirt != nil:
+		ovirtutils.ConfigureCreds(m.DynamicClient)
+	case cd.Spec.Platform.IBMCloud != nil:
+		ibmutils.ConfigureCreds(m.DynamicClient)
+	}
+
+	// Load up the install config and pull secret. These env vars are required; else we'll panic.
+	contributils.ProjectToDir(contributils.LoadSecretOrDie(m.DynamicClient, "INSTALLCONFIG_SECRET_NAME"), "/installconfig")
+	contributils.ProjectToDir(contributils.LoadSecretOrDie(m.DynamicClient, "PULLSECRET_SECRET_NAME"), "/pullsecret")
+
+	// Additional manifests? Could come in on a Secret or a ConfigMap
+	if manSecret := contributils.LoadSecretOrDie(m.DynamicClient, "MANIFESTS_SECRET_NAME"); manSecret != nil {
+		contributils.ProjectToDir(manSecret, "/manifests")
+	} else if manCM := contributils.LoadConfigMapOrDie(m.DynamicClient, "MANIFESTS_CONFIGMAP_NAME"); manCM != nil {
+		contributils.ProjectToDir(manCM, "/manifests")
+	}
+
+	// Custom BoundServiceAccountSigningKey
+	if bsask := contributils.LoadSecretOrDie(m.DynamicClient, "BOUND_TOKEN_SIGNING_KEY_SECRET_NAME"); bsask != nil {
+		contributils.ProjectToDir(bsask, constants.BoundServiceAccountSigningKeyDir, constants.BoundServiceAccountSigningKeyFile)
+		os.Setenv(constants.BoundServiceAccountSigningKeyEnvVar,
+			constants.BoundServiceAccountSigningKeyDir+"/"+constants.BoundServiceAccountSigningKeyFile)
+	}
+
+	// SSH private key
+	if sshkey := contributils.LoadSecretOrDie(m.DynamicClient, "SSH_PRIVATE_KEY_SECRET_PATH"); sshkey != nil {
+		contributils.ProjectToDir(sshkey, constants.SSHPrivateKeyDir)
+		// TODO: Collapse this in initSSHKey
+		os.Setenv(constants.SSHPrivKeyPathEnvVar,
+			constants.SSHPrivateKeyDir+"/"+constants.SSHPrivateKeySecretKey)
+	}
+
+	// BareMetal Libvirt SSH private key
+	if sshkey := contributils.LoadSecretOrDie(m.DynamicClient, "LIBVIRT_SSH_KEYS_SECRET_NAME"); sshkey != nil {
+		contributils.ProjectToDir(sshkey, constants.LibvirtSSHPrivateKeyDir)
+		os.Setenv(constants.LibvirtSSHPrivKeyPathEnvVar,
+			constants.LibvirtSSHPrivateKeyDir+"/"+constants.SSHPrivateKeySecretKey)
+	}
 }
 
 func getActuator() LogUploaderActuator {

--- a/pkg/installmanager/installmanager_test.go
+++ b/pkg/installmanager/installmanager_test.go
@@ -199,6 +199,8 @@ func TestInstallManager(t *testing.T) {
 			}
 			im.Complete([]string{})
 
+			im.loadSecrets = func(*InstallManager, *hivev1.ClusterDeployment) {}
+
 			im.waitForProvisioningStage = func(*InstallManager) error { return nil }
 
 			if !assert.NoError(t, writeFakeBinary(filepath.Join(tempDir, installerBinary),


### PR DESCRIPTION
Pods created by hive-controllers require information from secrets and configmaps (for example, cloud credentials) in order to function. Previously these were passed into the pods from the hive-controllers side via environment variables and volumes. In scale mode (see [HIVE-1861](https://issues.redhat.com//browse/HIVE-1861)) we're going to need that same business logic -- which parts of which objects are needed in what form -- on the hiveutil side.

In order to avoid duplication of that logic, we're moving it *all* to the hiveutil side, even for non-scale mode.

The cloud credentials secret and other secrets/configmaps are no longer passed through via the pod spec. Instead, the hiveutil command itself uses a local client to load those secrets and set up the same environment variables and files that were previously passed through on the pod.

[HIVE-2021](https://issues.redhat.com//browse/HIVE-2021)