### PR TITLE
Assume hibernation-unsupported clusters are always running

### DIFF
--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -301,7 +301,7 @@ func (r *ReconcileClusterPool) Reconcile(ctx context.Context, request reconcile.
 	logger = controllerutils.AddLogFields(controllerutils.MetaObjectLogTagger{Object: clp}, logger)
 
 	if clp.Spec.RunningCount != clp.Spec.Size && poolAlwaysRunning(clp) {
-		return reconcile.Result{}, errors.New("Hibernation is not supported on Openstack, VShpere and Ovirt, unless runningCount==size")
+		return reconcile.Result{}, errors.New("Hibernation is not supported on Openstack, VShpere and Ovirt. Must set runningCount==size.")
 	}
 
 	// Initialize cluster pool conditions if not set

--- a/pkg/controller/clusterpool/clusterpool_controller_test.go
+++ b/pkg/controller/clusterpool/clusterpool_controller_test.go
@@ -445,7 +445,7 @@ func TestReconcileClusterPool(t *testing.T) {
 				testclaim.FullBuilder(testNamespace, "test", scheme).Build(testclaim.WithPool(testLeasePoolName)),
 				unclaimedCDBuilder("c1").Build(
 					testcd.Installed(),
-					testcd.WithStatusPowerState(hivev1.ClusterPowerStateHibernating),
+					testcd.Running(),
 					testcd.WithCustomization("test-cdc-1"),
 				),
 			},

--- a/pkg/controller/clusterpool/collections.go
+++ b/pkg/controller/clusterpool/collections.go
@@ -337,7 +337,7 @@ func getAllClusterDeploymentsForPool(c client.Client, pool *hivev1.ClusterPool, 
 			if isBroken(&cd, pool, logger) {
 				cdCol.broken = append(cdCol.broken, ref)
 			} else if cd.Spec.Installed {
-				if cd.Status.PowerState == hivev1.ClusterPowerStateRunning || poolAlwaysRunning(pool) {
+				if cd.Status.PowerState == hivev1.ClusterPowerStateRunning {
 					cdCol.assignable = append(cdCol.assignable, ref)
 				} else {
 					cdCol.standby = append(cdCol.standby, ref)

--- a/pkg/controller/hibernation/hibernation_controller_test.go
+++ b/pkg/controller/hibernation/hibernation_controller_test.go
@@ -125,13 +125,8 @@ func TestReconcile(t *testing.T) {
 				require.NotNil(t, cond)
 				assert.Equal(t, hivev1.HibernatingReasonUnsupported, cond.Reason)
 				require.NotNil(t, runCond)
-				// FIXME: https://issues.redhat.com/browse/HIVE-2016
-				//        CDs with hibernation unsupported should report Running as soon
-				//        as they're Installed.
-				// assert.Equal(t, hivev1.ReadyReasonRunning, runCond.Reason)
-				// assert.Equal(t, hivev1.ClusterPowerStateRunning, cd.Status.PowerState)
-				assert.Equal(t, hivev1.InitializedConditionReason, runCond.Reason)
-				assert.Equal(t, hivev1.ClusterPowerState(""), cd.Status.PowerState)
+				assert.Equal(t, hivev1.ReadyReasonRunning, runCond.Reason)
+				assert.Equal(t, hivev1.ClusterPowerStateRunning, cd.Status.PowerState)
 			},
 		},
 		{


### PR DESCRIPTION
Platforms that don't have a hibernation actuator...

- BareMetal
- OpenStack
- VSphere
- Ovirt
- AgentBareMetal
- None

...used to show up with their PowerState empty. With this commit, we
assume they are running, since we can't actually tell. It's possible
this is a lie -- e.g. if the instances get shut down from the cloud
provider -- but a) this is a better UX than empty; and b) it makes other
bits of the code operate correctly.

[HIVE-2016](https://issues.redhat.com//browse/HIVE-2016)