### PR TITLE
Updating the get kubeconfig command

### DIFF
--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -1014,7 +1014,7 @@ The [troubleshooting doc](troubleshooting.md#cluster-install-failure-logs) provi
 Once the cluster is provisioned, the admin kubeconfig will be stored in a secret. You can use this with:
 
 ```bash
-./hack/get-kubeconfig.sh ${CLUSTER_NAME} > ${CLUSTER_NAME}.kubeconfig
+./hack/get-admin-kubeconfig.sh ${CLUSTER_NAME} > ${CLUSTER_NAME}.kubeconfig
 export KUBECONFIG=${CLUSTER_NAME}.kubeconfig
 oc get nodes
 ```


### PR DESCRIPTION
There is no get-kubeconfig.sh, could see only  get-admin-aks-kubeconfig.sh  get-admin-kubeconfig.sh 
under Dev RP ./hack, updating the command with the correct script name.