### PR TITLE
Add install success/fail metrics

### DIFF
--- a/pkg/controller/clusterprovision/metrics.go
+++ b/pkg/controller/clusterprovision/metrics.go
@@ -1,0 +1,30 @@
+package clusterprovision
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	metricInstallFailureSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "hive_cluster_deployment_install_failure_total",
+		Help:    "Time taken before a cluster provision failed to install",
+		Buckets: []float64{30, 120, 300, 600, 1800},
+	},
+		[]string{"cluster_type", "platform", "region", "cluster_version", "workers", "install_attempt"},
+	)
+
+	metricInstallSuccessSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "hive_cluster_deployment_install_success_total",
+		Help:    "Time taken before a cluster provision succeeded to install",
+		Buckets: []float64{1800, 2400, 3000, 3600},
+	},
+		[]string{"cluster_type", "platform", "region", "cluster_version", "workers", "install_attempt"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(metricInstallFailureSeconds)
+	metrics.Registry.MustRegister(metricInstallSuccessSeconds)
+}


### PR DESCRIPTION
Add hive_cluster_deployment_install_failure_total and
hive_cluster_deployment_install_success_total metrics, which also report
on the cluster_type, cloud platform, region, cluster version, count of
replicas/workers and the number of install attempt pertaining to the
provision attempt

xref: https://issues.redhat.com/browse/HIVE-2006