### PR TITLE
Add support to override effective in-cluster credentials mode

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -441,6 +441,11 @@ const (
 	// cluster. When this annotation is set to a truthy value, hive will parse the installer image URI and use its domain
 	// (everything up to the first `/`) for the CLI image, discarding whatever domain was gleaned from the release image.
 	CopyCLIImageDomainFromInstallerImage = "hive.openshift.io/cli-domain-from-installer-image"
+
+	// OverrideInClusterCredentialsModeAnnotation can be set to override credentials mode in the install config after
+	// generating installer manifests. This will be effective in-cluster credentials mode. The valid values for
+	// credentials mode are "Manual", "Mint" and "Passthrough"
+	OverrideInClusterCredentialsModeAnnotation = "hive.openshift.io/override-in-cluster-credentials-mode"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment


### PR DESCRIPTION
ARO requires a different set of credentials for installer and in-cluster 
operations. This commit adds an annotation that would override 
the existing credentials mode in the install-config. The reason we 
do this hack is because in ARO we do not want to pass installer 
credentials inside the cluster. This is done by setting credentials 
mode to `Manual`. We want to instead pass the credentials 
supplied by manifestSecretRef and use the same by overriding 
credentials mode from `Manual` to `Passthrough`.

[HIVE-1989](https://issues.redhat.com//browse/HIVE-1989)