### PR TITLE
Revert "Explicit pod security"

### DIFF
--- a/config/clustersync/statefulset.yaml
+++ b/config/clustersync/statefulset.yaml
@@ -17,10 +17,6 @@ spec:
         control-plane: clustersync
         controller-tools.k8s.io: "1.0"
     spec:
-      securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       topologySpreadConstraints: # this forces the clustersync pods to be on separate nodes.
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname
@@ -76,7 +72,3 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]

--- a/config/controllers/deployment.yaml
+++ b/config/controllers/deployment.yaml
@@ -21,10 +21,6 @@ spec:
         control-plane: controller-manager
         controller-tools.k8s.io: "1.0"
     spec:
-      securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       serviceAccountName: hive-controllers
       volumes:
       - name: kubectl-cache
@@ -61,8 +57,4 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
       terminationGracePeriodSeconds: 10

--- a/config/hiveadmission/deployment.yaml
+++ b/config/hiveadmission/deployment.yaml
@@ -25,10 +25,6 @@ spec:
         app: hiveadmission
         hiveadmission: "true"
     spec:
-      securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       serviceAccountName: hiveadmission
       containers:
       - name: hiveadmission
@@ -54,10 +50,6 @@ spec:
             path: /healthz
             port: 9443
             scheme: HTTPS
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
       volumes:
       - name: serving-cert
         secret:

--- a/config/operator/operator_deployment.yaml
+++ b/config/operator/operator_deployment.yaml
@@ -26,10 +26,6 @@ spec:
         control-plane: hive-operator
         controller-tools.k8s.io: "1.0"
     spec:
-      securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       serviceAccountName: hive-operator
       volumes:
       - name: kubectl-cache
@@ -69,8 +65,4 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
       terminationGracePeriodSeconds: 10

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -7227,18 +7227,9 @@ objects:
             requests:
               cpu: 100m
               memory: 256Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
           volumeMounts:
           - mountPath: /var/cache/kubectl
             name: kubectl-cache
-        securityContext:
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
         serviceAccountName: hive-operator
         terminationGracePeriodSeconds: 10
         volumes:

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -386,34 +385,6 @@ func SetProxyEnvVars(podSpec *corev1.PodSpec, httpProxy, httpsProxy, noProxy str
 	}
 	if noProxy != "" {
 		setEnvVarOnContainers(podSpec, "NO_PROXY", noProxy)
-	}
-}
-
-func applyContainerSecurity(c *corev1.Container) {
-	c.SecurityContext = &corev1.SecurityContext{
-		AllowPrivilegeEscalation: pointer.Bool(false),
-		Capabilities: &corev1.Capabilities{
-			Drop: []corev1.Capability{"ALL"},
-		},
-		RunAsNonRoot: pointer.Bool(true),
-	}
-
-}
-
-// ApplyPodSecurity ensures that the pod and its containers have explicit restrictive securityContext
-// to conform to pod security admission rules.
-func ApplyPodSecurity(podSpec *corev1.PodSpec) {
-	podSpec.SecurityContext = &corev1.PodSecurityContext{
-		RunAsNonRoot: pointer.Bool(true),
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
-	}
-	for i := range podSpec.InitContainers {
-		applyContainerSecurity(&podSpec.InitContainers[i])
-	}
-	for i := range podSpec.Containers {
-		applyContainerSecurity(&podSpec.Containers[i])
 	}
 }
 

--- a/pkg/imageset/generate.go
+++ b/pkg/imageset/generate.go
@@ -122,7 +122,7 @@ func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAcco
 		},
 	}
 	controllerutils.AddLogFieldsEnvVar(cd, job)
-	controllerutils.ApplyPodSecurity(&job.Spec.Template.Spec)
+
 	return job
 }
 

--- a/pkg/imageset/generate_test.go
+++ b/pkg/imageset/generate_test.go
@@ -26,7 +26,6 @@ func TestGenerateImageSetJob(t *testing.T) {
 	hiveassert.AssertAllContainersHaveEnvVar(t, &job.Spec.Template.Spec, "HTTP_PROXY", testHttpProxy)
 	hiveassert.AssertAllContainersHaveEnvVar(t, &job.Spec.Template.Spec, "HTTPS_PROXY", testHttpsProxy)
 	hiveassert.AssertAllContainersHaveEnvVar(t, &job.Spec.Template.Spec, "NO_PROXY", testNoProxy)
-	hiveassert.AssertSecurityContexts(t, &job.Spec.Template.Spec)
 }
 
 func testClusterDeployment() *hivev1.ClusterDeployment {

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -607,7 +607,6 @@ func InstallerPodSpec(
 		ImagePullSecrets:   []corev1.LocalObjectReference{{Name: constants.GetMergedPullSecretName(cd)}},
 	}
 	controllerutils.SetProxyEnvVars(podSpec, httpProxy, httpsProxy, noProxy)
-	controllerutils.ApplyPodSecurity(podSpec)
 	return podSpec, nil
 }
 
@@ -725,7 +724,7 @@ func GenerateUninstallerJobForDeprovision(
 	}
 	controllerutils.SetProxyEnvVars(&job.Spec.Template.Spec, httpProxy, httpsProxy, noProxy)
 	controllerutils.AddLogFieldsEnvVar(req, job)
-	controllerutils.ApplyPodSecurity(&job.Spec.Template.Spec)
+
 	return job, nil
 }
 

--- a/pkg/install/generate_test.go
+++ b/pkg/install/generate_test.go
@@ -35,7 +35,6 @@ func TestGenerateDeprovision(t *testing.T) {
 	hiveassert.AssertAllContainersHaveEnvVar(t, &job.Spec.Template.Spec, "HTTP_PROXY", testHttpProxy)
 	hiveassert.AssertAllContainersHaveEnvVar(t, &job.Spec.Template.Spec, "HTTPS_PROXY", testHttpsProxy)
 	hiveassert.AssertAllContainersHaveEnvVar(t, &job.Spec.Template.Spec, "NO_PROXY", testNoProxy)
-	hiveassert.AssertSecurityContexts(t, &job.Spec.Template.Spec)
 }
 
 func testClusterDeprovision() *hivev1.ClusterDeprovision {
@@ -125,8 +124,6 @@ func TestInstallerPodSpec(t *testing.T) {
 			hiveassert.AssertAllContainersHaveEnvVar(t, actualPodSpec, "HTTP_PROXY", testHttpProxy)
 			hiveassert.AssertAllContainersHaveEnvVar(t, actualPodSpec, "HTTPS_PROXY", testHttpsProxy)
 			hiveassert.AssertAllContainersHaveEnvVar(t, actualPodSpec, "NO_PROXY", testNoProxy)
-			hiveassert.AssertSecurityContexts(t, actualPodSpec)
-
 		})
 	}
 }

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -143,10 +143,6 @@ spec:
         control-plane: clustersync
         controller-tools.k8s.io: "1.0"
     spec:
-      securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       topologySpreadConstraints: # this forces the clustersync pods to be on separate nodes.
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname
@@ -202,10 +198,6 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
 `)
 
 func configClustersyncStatefulsetYamlBytes() ([]byte, error) {
@@ -430,10 +422,6 @@ spec:
         app: hiveadmission
         hiveadmission: "true"
     spec:
-      securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       serviceAccountName: hiveadmission
       containers:
       - name: hiveadmission
@@ -459,10 +447,6 @@ spec:
             path: /healthz
             port: 9443
             scheme: HTTPS
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
       volumes:
       - name: serving-cert
         secret:
@@ -840,10 +824,6 @@ spec:
         control-plane: controller-manager
         controller-tools.k8s.io: "1.0"
     spec:
-      securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       serviceAccountName: hive-controllers
       volumes:
       - name: kubectl-cache
@@ -880,10 +860,6 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
       terminationGracePeriodSeconds: 10
 `)
 

--- a/pkg/test/assert/assertions.go
+++ b/pkg/test/assert/assertions.go
@@ -45,34 +45,6 @@ func AssertAllContainersHaveEnvVar(t *testing.T, podSpec *corev1.PodSpec, key, v
 	}
 }
 
-func assertContainerSecurityContext(t *testing.T, c *corev1.Container) {
-	sc := c.SecurityContext
-	if testifyassert.NotNil(t, sc, "container %s must have securityContext", c.Name) {
-		if testifyassert.NotNil(t, sc.AllowPrivilegeEscalation, "container %s must set allowPrivilegeEscalation", c.Name) {
-			testifyassert.False(t, *sc.AllowPrivilegeEscalation, "container %s allowPrivilegeEscalation should be &false", c.Name)
-		}
-		if testifyassert.NotNil(t,
-			sc.Capabilities, "container %s capabilities should be populated", c.Name) &&
-			testifyassert.NotNil(t, sc.Capabilities.Drop, "container %s capabilities should have 'drop'", c.Name) &&
-			testifyassert.Equal(t, 1, len(sc.Capabilities.Drop), "container %s capabilities.drop should have exactly one element", c.Name) {
-			testifyassert.Equal(t, corev1.Capability("ALL"), sc.Capabilities.Drop[0], "container %s should drop ALL capabilities", c.Name)
-		}
-		testifyassert.True(t, *sc.RunAsNonRoot, "container runAsNonRoot should be &true")
-	}
-}
-
-func AssertSecurityContexts(t *testing.T, podSpec *corev1.PodSpec) {
-	sc := podSpec.SecurityContext
-	testifyassert.True(t, *sc.RunAsNonRoot, "pod runAsNonRoot should be &true")
-	testifyassert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, sc.SeccompProfile.Type, "pod seccompProfile type should be RuntimeDefault")
-	for _, c := range podSpec.InitContainers {
-		assertContainerSecurityContext(t, &c)
-	}
-	for _, c := range podSpec.Containers {
-		assertContainerSecurityContext(t, &c)
-	}
-}
-
 // findClusterDeploymentCondition finds the specified condition type in the given list of cluster deployment conditions.
 // If none exists, then returns nil.
 func findClusterDeploymentCondition(conditions []hivev1.ClusterDeploymentCondition, conditionType hivev1.ClusterDeploymentConditionType) *hivev1.ClusterDeploymentCondition {


### PR DESCRIPTION
This reverts commit a76ba2ff6cc663eb1672c7f3203439a8a81e2048.

Pods won't run with these changes on clusters with version 4.10 and below. There is no restricted SCC that allows setting `seccompProfile` `RuntimeDefault`. Reverting and investigating options for either conditionally deploying with these settings or creating an SCC that allows pods to run with this `securityContext`.
