### PR TITLE
Explicit pod security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,11 @@ COPY --from=builder /go/src/github.com/openshift/hive/bin/hiveadmission /opt/ser
 COPY --from=builder /go/src/github.com/openshift/hive/bin/hiveutil /usr/bin
 COPY --from=builder /go/src/github.com/openshift/hive/bin/operator /opt/services/hive-operator
 
+RUN chgrp -R 0 /opt/services && \
+    chmod -R g=u /opt/services && \
+    chgrp 0 /usr/bin/hiveutil && \
+    chmod g=u /usr/bin/hiveutil
+
 # Hacks to allow writing known_hosts, homedir is / by default in OpenShift.
 # Bare metal installs need to write to $HOME/.cache, and $HOME/.ssh for as long as
 # we're hitting libvirt over ssh. OpenShift will not let you write these directories

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -21,6 +21,11 @@ COPY --from=builder /go/src/github.com/openshift/hive/bin/hiveadmission /opt/ser
 COPY --from=builder /go/src/github.com/openshift/hive/bin/hiveutil /usr/bin
 COPY --from=builder /go/src/github.com/openshift/hive/bin/operator /opt/services/hive-operator
 
+RUN chgrp -R 0 /opt/services && \
+    chmod -R g=u /opt/services && \
+    chgrp 0 /usr/bin/hiveutil && \
+    chmod g=u /usr/bin/hiveutil
+
 # Hacks to allow writing known_hosts, homedir is / by default in OpenShift.
 # Bare metal installs need to write to $HOME/.cache, and $HOME/.ssh for as long as
 # we're hitting libvirt over ssh. OpenShift will not let you write these directories

--- a/build/fedora-dev/Dockerfile.dev
+++ b/build/fedora-dev/Dockerfile.dev
@@ -5,10 +5,17 @@
 
 FROM hive-fedora-dev-base:latest
 
+RUN mkdir -p /opt/services
+
 ADD bin/hiveadmission /opt/services/
 ADD bin/operator /opt/services/hive-operator
 ADD bin/manager /opt/services/
 ADD bin/hiveutil /usr/bin/
+
+RUN chgrp -R 0 /opt/services && \
+    chmod -R g=u /opt/services && \
+    chgrp 0 /usr/bin/hiveutil && \
+    chmod g=u /usr/bin/hiveutil
 
 # TODO: should this be the operator?
 ENTRYPOINT ["/opt/services/manager"]

--- a/build/fedora-dev/Dockerfile.dev
+++ b/build/fedora-dev/Dockerfile.dev
@@ -5,8 +5,6 @@
 
 FROM hive-fedora-dev-base:latest
 
-RUN mkdir -p /opt/services
-
 ADD bin/hiveadmission /opt/services/
 ADD bin/operator /opt/services/hive-operator
 ADD bin/manager /opt/services/

--- a/build/fedora-dev/Dockerfile.devbase
+++ b/build/fedora-dev/Dockerfile.devbase
@@ -1,6 +1,6 @@
 # Base OS image for Hive development containers FROM on Fedora.
 
-FROM fedora:33
+FROM fedora:36
 
 # ssh-agent required for gathering logs in some situations:
 RUN if ! rpm -q openssh-clients; then dnf install -y openssh-clients && dnf clean all && rm -rf /var/cache/dnf/*; fi

--- a/config/clustersync/statefulset.yaml
+++ b/config/clustersync/statefulset.yaml
@@ -17,6 +17,10 @@ spec:
         control-plane: clustersync
         controller-tools.k8s.io: "1.0"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       topologySpreadConstraints: # this forces the clustersync pods to be on separate nodes.
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname
@@ -72,3 +76,7 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]

--- a/config/clustersync/statefulset.yaml
+++ b/config/clustersync/statefulset.yaml
@@ -19,8 +19,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       topologySpreadConstraints: # this forces the clustersync pods to be on separate nodes.
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname

--- a/config/controllers/deployment.yaml
+++ b/config/controllers/deployment.yaml
@@ -23,8 +23,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       serviceAccountName: hive-controllers
       volumes:
       - name: kubectl-cache

--- a/config/controllers/deployment.yaml
+++ b/config/controllers/deployment.yaml
@@ -21,6 +21,10 @@ spec:
         control-plane: controller-manager
         controller-tools.k8s.io: "1.0"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: hive-controllers
       volumes:
       - name: kubectl-cache
@@ -57,4 +61,8 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
       terminationGracePeriodSeconds: 10

--- a/config/hiveadmission/deployment.yaml
+++ b/config/hiveadmission/deployment.yaml
@@ -25,6 +25,10 @@ spec:
         app: hiveadmission
         hiveadmission: "true"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: hiveadmission
       containers:
       - name: hiveadmission
@@ -50,6 +54,10 @@ spec:
             path: /healthz
             port: 9443
             scheme: HTTPS
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
       volumes:
       - name: serving-cert
         secret:

--- a/config/hiveadmission/deployment.yaml
+++ b/config/hiveadmission/deployment.yaml
@@ -27,8 +27,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       serviceAccountName: hiveadmission
       containers:
       - name: hiveadmission

--- a/config/operator/operator_deployment.yaml
+++ b/config/operator/operator_deployment.yaml
@@ -28,8 +28,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       serviceAccountName: hive-operator
       volumes:
       - name: kubectl-cache

--- a/config/operator/operator_deployment.yaml
+++ b/config/operator/operator_deployment.yaml
@@ -26,6 +26,10 @@ spec:
         control-plane: hive-operator
         controller-tools.k8s.io: "1.0"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: hive-operator
       volumes:
       - name: kubectl-cache
@@ -65,4 +69,8 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
       terminationGracePeriodSeconds: 10

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -7232,9 +7232,18 @@ objects:
             requests:
               cpu: 100m
               memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           volumeMounts:
           - mountPath: /var/cache/kubectl
             name: kubectl-cache
+        securityContext:
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         serviceAccountName: hive-operator
         terminationGracePeriodSeconds: 10
         volumes:

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -7242,8 +7242,6 @@ objects:
             name: kubectl-cache
         securityContext:
           runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
         serviceAccountName: hive-operator
         terminationGracePeriodSeconds: 10
         volumes:

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -479,6 +479,10 @@ const (
 	// generating installer manifests. This will be effective in-cluster credentials mode. The valid values for
 	// credentials mode are "Manual", "Mint" and "Passthrough"
 	OverrideInClusterCredentialsModeAnnotation = "hive.openshift.io/override-in-cluster-credentials-mode"
+
+	// SCCUIDRangeAnnotation is the annotation configured within Namespace annotations that indicates the allowed UID range
+	// for containers belonging to pods within the Namespace.
+	SCCUIDRangeAnnotation = "openshift.io/sa.scc.uid-range"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -2978,6 +2978,19 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				}
 				`, string(b)))
 			}
+			test.existing = append(test.existing, &corev1.Namespace{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Namespace",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testNamespace,
+					UID:  types.UID("1234"),
+					Annotations: map[string]string{
+						constants.SCCUIDRangeAnnotation: "1000640000/10000",
+					},
+				},
+			})
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(test.existing...).Build()
 			controllerExpectations := controllerutils.NewExpectations(logger)
 			mockCtrl := gomock.NewController(t)

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller_test.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller_test.go
@@ -279,7 +279,19 @@ func TestClusterDeprovisionReconcile(t *testing.T) {
 					return
 				}
 			}
-			existing := append(test.existing, test.deprovision, test.deployment)
+			existing := append(test.existing, test.deprovision, test.deployment, &corev1.Namespace{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Namespace",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testNamespace,
+					UID:  types.UID("1234"),
+					Annotations: map[string]string{
+						constants.SCCUIDRangeAnnotation: "1000640000/10000",
+					},
+				},
+			})
 
 			mocks := setupDefaultMocks(t, test.mockDeleteFailure, existing...)
 
@@ -374,7 +386,7 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 // specified conditions.
 func testUninstallJob(conditions ...batchv1.JobCondition) *batchv1.Job {
 	uninstallJob, _ := install.GenerateUninstallerJobForDeprovision(testClusterDeprovision(),
-		"someserviceaccount", "", "", "", nil)
+		"someserviceaccount", "", "", "", nil, nil)
 	hash, err := controllerutils.CalculateJobSpecHash(uninstallJob)
 	if err != nil {
 		panic("should never get error calculating job spec hash")

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -405,9 +405,6 @@ func applyContainerSecurity(c *corev1.Container) {
 func ApplyPodSecurity(podSpec *corev1.PodSpec) {
 	podSpec.SecurityContext = &corev1.PodSecurityContext{
 		RunAsNonRoot: pointer.Bool(true),
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
 	}
 	for i := range podSpec.InitContainers {
 		applyContainerSecurity(&podSpec.InitContainers[i])

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -395,7 +395,7 @@ func applyContainerSecurity(c *corev1.Container) {
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
-		RunAsNonRoot: pointer.Bool(true),
+		RunAsUser: pointer.Int64Ptr(1000620001),
 	}
 
 }
@@ -404,7 +404,7 @@ func applyContainerSecurity(c *corev1.Container) {
 // to conform to pod security admission rules.
 func ApplyPodSecurity(podSpec *corev1.PodSpec) {
 	podSpec.SecurityContext = &corev1.PodSecurityContext{
-		RunAsNonRoot: pointer.Bool(true),
+		RunAsUser: pointer.Int64Ptr(1000620001),
 	}
 	for i := range podSpec.InitContainers {
 		applyContainerSecurity(&podSpec.InitContainers[i])

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -385,6 +386,34 @@ func SetProxyEnvVars(podSpec *corev1.PodSpec, httpProxy, httpsProxy, noProxy str
 	}
 	if noProxy != "" {
 		setEnvVarOnContainers(podSpec, "NO_PROXY", noProxy)
+	}
+}
+
+func applyContainerSecurity(c *corev1.Container) {
+	c.SecurityContext = &corev1.SecurityContext{
+		AllowPrivilegeEscalation: pointer.Bool(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		RunAsNonRoot: pointer.Bool(true),
+	}
+
+}
+
+// ApplyPodSecurity ensures that the pod and its containers have explicit restrictive securityContext
+// to conform to pod security admission rules.
+func ApplyPodSecurity(podSpec *corev1.PodSpec) {
+	podSpec.SecurityContext = &corev1.PodSecurityContext{
+		RunAsNonRoot: pointer.Bool(true),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+	for i := range podSpec.InitContainers {
+		applyContainerSecurity(&podSpec.InitContainers[i])
+	}
+	for i := range podSpec.Containers {
+		applyContainerSecurity(&podSpec.Containers[i])
 	}
 }
 

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -395,7 +395,7 @@ func applyContainerSecurity(c *corev1.Container) {
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
-		RunAsUser: pointer.Int64Ptr(1000620001),
+		RunAsUser: pointer.Int64Ptr(1000670001),
 	}
 
 }
@@ -404,7 +404,7 @@ func applyContainerSecurity(c *corev1.Container) {
 // to conform to pod security admission rules.
 func ApplyPodSecurity(podSpec *corev1.PodSpec) {
 	podSpec.SecurityContext = &corev1.PodSecurityContext{
-		RunAsUser: pointer.Int64Ptr(1000620001),
+		RunAsUser: pointer.Int64Ptr(1000670001),
 	}
 	for i := range podSpec.InitContainers {
 		applyContainerSecurity(&podSpec.InitContainers[i])

--- a/pkg/imageset/generate.go
+++ b/pkg/imageset/generate.go
@@ -24,7 +24,7 @@ const (
 
 // GenerateImageSetJob creates a job to determine the installer image for a ClusterImageSet
 // given a release image
-func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAccountName, httpProxy, httpsProxy, noProxy string) *batchv1.Job {
+func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAccountName, httpProxy, httpsProxy, noProxy string, uid *int64) *batchv1.Job {
 	logger := log.WithFields(log.Fields{
 		"clusterdeployment": types.NamespacedName{Namespace: cd.Namespace, Name: cd.Name}.String(),
 	})
@@ -122,7 +122,7 @@ func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAcco
 		},
 	}
 	controllerutils.AddLogFieldsEnvVar(cd, job)
-	controllerutils.ApplyPodSecurity(&job.Spec.Template.Spec)
+	controllerutils.ApplyPodSecurity(uid, &job.Spec.Template.Spec)
 	return job
 }
 

--- a/pkg/imageset/generate.go
+++ b/pkg/imageset/generate.go
@@ -122,7 +122,7 @@ func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAcco
 		},
 	}
 	controllerutils.AddLogFieldsEnvVar(cd, job)
-
+	controllerutils.ApplyPodSecurity(&job.Spec.Template.Spec)
 	return job
 }
 

--- a/pkg/imageset/generate_test.go
+++ b/pkg/imageset/generate_test.go
@@ -6,6 +6,7 @@ import (
 	hiveassert "github.com/openshift/hive/pkg/test/assert"
 	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/utils/pointer"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 )
@@ -17,7 +18,7 @@ const (
 )
 
 func TestGenerateImageSetJob(t *testing.T) {
-	job := GenerateImageSetJob(testClusterDeployment(), testImageSet().Spec.ReleaseImage, "test-service-account", testHttpProxy, testHttpsProxy, testNoProxy)
+	job := GenerateImageSetJob(testClusterDeployment(), testImageSet().Spec.ReleaseImage, "test-service-account", testHttpProxy, testHttpsProxy, testNoProxy, pointer.Int64Ptr(10000000000))
 	assert.Equal(t, GetImageSetJobName(testClusterDeployment().Name), job.Name, "unexpected job name")
 	assert.Equal(t, testClusterDeployment().Namespace, job.Namespace, "unexpected job namespace")
 	assert.Len(t, job.Spec.Template.Spec.InitContainers, 1, "unexpected number of init containers")

--- a/pkg/imageset/generate_test.go
+++ b/pkg/imageset/generate_test.go
@@ -26,6 +26,7 @@ func TestGenerateImageSetJob(t *testing.T) {
 	hiveassert.AssertAllContainersHaveEnvVar(t, &job.Spec.Template.Spec, "HTTP_PROXY", testHttpProxy)
 	hiveassert.AssertAllContainersHaveEnvVar(t, &job.Spec.Template.Spec, "HTTPS_PROXY", testHttpsProxy)
 	hiveassert.AssertAllContainersHaveEnvVar(t, &job.Spec.Template.Spec, "NO_PROXY", testNoProxy)
+	hiveassert.AssertSecurityContexts(t, &job.Spec.Template.Spec)
 }
 
 func testClusterDeployment() *hivev1.ClusterDeployment {

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -118,6 +118,7 @@ func InstallerPodSpec(
 	releaseImage,
 	serviceAccountName,
 	httpProxy, httpsProxy, noProxy string,
+	runAsUserID *int64,
 	extraEnvVars []corev1.EnvVar,
 ) (*corev1.PodSpec, error) {
 
@@ -362,7 +363,7 @@ func InstallerPodSpec(
 		ImagePullSecrets:   []corev1.LocalObjectReference{{Name: constants.GetMergedPullSecretName(cd)}},
 	}
 	controllerutils.SetProxyEnvVars(podSpec, httpProxy, httpsProxy, noProxy)
-	controllerutils.ApplyPodSecurity(podSpec)
+	controllerutils.ApplyPodSecurity(runAsUserID, podSpec)
 	return podSpec, nil
 }
 
@@ -420,6 +421,7 @@ func GetUninstallJobName(name string) string {
 func GenerateUninstallerJobForDeprovision(
 	req *hivev1.ClusterDeprovision,
 	serviceAccountName, httpProxy, httpsProxy, noProxy string,
+	runAsUserID *int64,
 	extraEnvVars []corev1.EnvVar) (*batchv1.Job, error) {
 
 	restartPolicy := corev1.RestartPolicyOnFailure
@@ -480,7 +482,7 @@ func GenerateUninstallerJobForDeprovision(
 	}
 	controllerutils.SetProxyEnvVars(&job.Spec.Template.Spec, httpProxy, httpsProxy, noProxy)
 	controllerutils.AddLogFieldsEnvVar(req, job)
-	controllerutils.ApplyPodSecurity(&job.Spec.Template.Spec)
+	controllerutils.ApplyPodSecurity(runAsUserID, &job.Spec.Template.Spec)
 	return job, nil
 }
 

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -362,6 +362,7 @@ func InstallerPodSpec(
 		ImagePullSecrets:   []corev1.LocalObjectReference{{Name: constants.GetMergedPullSecretName(cd)}},
 	}
 	controllerutils.SetProxyEnvVars(podSpec, httpProxy, httpsProxy, noProxy)
+	controllerutils.ApplyPodSecurity(podSpec)
 	return podSpec, nil
 }
 
@@ -479,7 +480,7 @@ func GenerateUninstallerJobForDeprovision(
 	}
 	controllerutils.SetProxyEnvVars(&job.Spec.Template.Spec, httpProxy, httpsProxy, noProxy)
 	controllerutils.AddLogFieldsEnvVar(req, job)
-
+	controllerutils.ApplyPodSecurity(&job.Spec.Template.Spec)
 	return job, nil
 }
 

--- a/pkg/install/generate_test.go
+++ b/pkg/install/generate_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
 
 var (
@@ -29,7 +30,7 @@ func init() {
 
 func TestGenerateDeprovision(t *testing.T) {
 	dr := testClusterDeprovision()
-	job, err := GenerateUninstallerJobForDeprovision(dr, "someseviceaccount", testHttpProxy, testHttpsProxy, testNoProxy, nil)
+	job, err := GenerateUninstallerJobForDeprovision(dr, "someseviceaccount", testHttpProxy, testHttpsProxy, testNoProxy, nil, nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, job)
 	hiveassert.AssertAllContainersHaveEnvVar(t, &job.Spec.Template.Spec, "HTTP_PROXY", testHttpProxy)
@@ -118,6 +119,7 @@ func TestInstallerPodSpec(t *testing.T) {
 				testHttpProxy,
 				testHttpsProxy,
 				testNoProxy,
+				pointer.Int64Ptr(10000000000),
 				test.extraEnvVars)
 
 			// Assert

--- a/pkg/install/generate_test.go
+++ b/pkg/install/generate_test.go
@@ -35,6 +35,7 @@ func TestGenerateDeprovision(t *testing.T) {
 	hiveassert.AssertAllContainersHaveEnvVar(t, &job.Spec.Template.Spec, "HTTP_PROXY", testHttpProxy)
 	hiveassert.AssertAllContainersHaveEnvVar(t, &job.Spec.Template.Spec, "HTTPS_PROXY", testHttpsProxy)
 	hiveassert.AssertAllContainersHaveEnvVar(t, &job.Spec.Template.Spec, "NO_PROXY", testNoProxy)
+	hiveassert.AssertSecurityContexts(t, &job.Spec.Template.Spec)
 }
 
 func testClusterDeprovision() *hivev1.ClusterDeprovision {
@@ -124,6 +125,8 @@ func TestInstallerPodSpec(t *testing.T) {
 			hiveassert.AssertAllContainersHaveEnvVar(t, actualPodSpec, "HTTP_PROXY", testHttpProxy)
 			hiveassert.AssertAllContainersHaveEnvVar(t, actualPodSpec, "HTTPS_PROXY", testHttpsProxy)
 			hiveassert.AssertAllContainersHaveEnvVar(t, actualPodSpec, "NO_PROXY", testNoProxy)
+			hiveassert.AssertSecurityContexts(t, actualPodSpec)
+
 		})
 	}
 }

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -145,8 +145,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       topologySpreadConstraints: # this forces the clustersync pods to be on separate nodes.
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname
@@ -432,8 +430,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       serviceAccountName: hiveadmission
       containers:
       - name: hiveadmission
@@ -850,8 +846,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       serviceAccountName: hive-controllers
       volumes:
       - name: kubectl-cache

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -143,6 +143,10 @@ spec:
         control-plane: clustersync
         controller-tools.k8s.io: "1.0"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       topologySpreadConstraints: # this forces the clustersync pods to be on separate nodes.
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname
@@ -198,6 +202,10 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
 `)
 
 func configClustersyncStatefulsetYamlBytes() ([]byte, error) {
@@ -422,6 +430,10 @@ spec:
         app: hiveadmission
         hiveadmission: "true"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: hiveadmission
       containers:
       - name: hiveadmission
@@ -447,6 +459,10 @@ spec:
             path: /healthz
             port: 9443
             scheme: HTTPS
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
       volumes:
       - name: serving-cert
         secret:
@@ -832,6 +848,10 @@ spec:
         control-plane: controller-manager
         controller-tools.k8s.io: "1.0"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: hive-controllers
       volumes:
       - name: kubectl-cache
@@ -868,6 +888,10 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
       terminationGracePeriodSeconds: 10
 `)
 

--- a/pkg/test/assert/assertions.go
+++ b/pkg/test/assert/assertions.go
@@ -57,13 +57,13 @@ func assertContainerSecurityContext(t *testing.T, c *corev1.Container) {
 			testifyassert.Equal(t, 1, len(sc.Capabilities.Drop), "container %s capabilities.drop should have exactly one element", c.Name) {
 			testifyassert.Equal(t, corev1.Capability("ALL"), sc.Capabilities.Drop[0], "container %s should drop ALL capabilities", c.Name)
 		}
-		testifyassert.NotNil(t, *sc.RunAsUser, "container runAsUser should be non nil")
+		testifyassert.True(t, sc.RunAsUser != nil || sc.RunAsNonRoot != nil, "container must set runAsUser or runAsNonRoot within SecurityContext")
 	}
 }
 
 func AssertSecurityContexts(t *testing.T, podSpec *corev1.PodSpec) {
 	sc := podSpec.SecurityContext
-	testifyassert.NotNil(t, *sc.RunAsUser, "pod runAsUser should be non nil")
+	testifyassert.True(t, sc.RunAsNonRoot != nil || sc.RunAsUser != nil, "pod must set runAsUser or runAsNonRoot within SecurityContext")
 	for _, c := range podSpec.InitContainers {
 		assertContainerSecurityContext(t, &c)
 	}

--- a/pkg/test/assert/assertions.go
+++ b/pkg/test/assert/assertions.go
@@ -57,13 +57,13 @@ func assertContainerSecurityContext(t *testing.T, c *corev1.Container) {
 			testifyassert.Equal(t, 1, len(sc.Capabilities.Drop), "container %s capabilities.drop should have exactly one element", c.Name) {
 			testifyassert.Equal(t, corev1.Capability("ALL"), sc.Capabilities.Drop[0], "container %s should drop ALL capabilities", c.Name)
 		}
-		testifyassert.True(t, *sc.RunAsNonRoot, "container runAsNonRoot should be &true")
+		testifyassert.NotNil(t, *sc.RunAsUser, "container runAsUser should be non nil")
 	}
 }
 
 func AssertSecurityContexts(t *testing.T, podSpec *corev1.PodSpec) {
 	sc := podSpec.SecurityContext
-	testifyassert.True(t, *sc.RunAsNonRoot, "pod runAsNonRoot should be &true")
+	testifyassert.NotNil(t, *sc.RunAsUser, "pod runAsUser should be non nil")
 	for _, c := range podSpec.InitContainers {
 		assertContainerSecurityContext(t, &c)
 	}

--- a/pkg/test/assert/assertions.go
+++ b/pkg/test/assert/assertions.go
@@ -64,7 +64,6 @@ func assertContainerSecurityContext(t *testing.T, c *corev1.Container) {
 func AssertSecurityContexts(t *testing.T, podSpec *corev1.PodSpec) {
 	sc := podSpec.SecurityContext
 	testifyassert.True(t, *sc.RunAsNonRoot, "pod runAsNonRoot should be &true")
-	testifyassert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, sc.SeccompProfile.Type, "pod seccompProfile type should be RuntimeDefault")
 	for _, c := range podSpec.InitContainers {
 		assertContainerSecurityContext(t, &c)
 	}

--- a/pkg/test/assert/assertions.go
+++ b/pkg/test/assert/assertions.go
@@ -45,6 +45,34 @@ func AssertAllContainersHaveEnvVar(t *testing.T, podSpec *corev1.PodSpec, key, v
 	}
 }
 
+func assertContainerSecurityContext(t *testing.T, c *corev1.Container) {
+	sc := c.SecurityContext
+	if testifyassert.NotNil(t, sc, "container %s must have securityContext", c.Name) {
+		if testifyassert.NotNil(t, sc.AllowPrivilegeEscalation, "container %s must set allowPrivilegeEscalation", c.Name) {
+			testifyassert.False(t, *sc.AllowPrivilegeEscalation, "container %s allowPrivilegeEscalation should be &false", c.Name)
+		}
+		if testifyassert.NotNil(t,
+			sc.Capabilities, "container %s capabilities should be populated", c.Name) &&
+			testifyassert.NotNil(t, sc.Capabilities.Drop, "container %s capabilities should have 'drop'", c.Name) &&
+			testifyassert.Equal(t, 1, len(sc.Capabilities.Drop), "container %s capabilities.drop should have exactly one element", c.Name) {
+			testifyassert.Equal(t, corev1.Capability("ALL"), sc.Capabilities.Drop[0], "container %s should drop ALL capabilities", c.Name)
+		}
+		testifyassert.True(t, *sc.RunAsNonRoot, "container runAsNonRoot should be &true")
+	}
+}
+
+func AssertSecurityContexts(t *testing.T, podSpec *corev1.PodSpec) {
+	sc := podSpec.SecurityContext
+	testifyassert.True(t, *sc.RunAsNonRoot, "pod runAsNonRoot should be &true")
+	testifyassert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, sc.SeccompProfile.Type, "pod seccompProfile type should be RuntimeDefault")
+	for _, c := range podSpec.InitContainers {
+		assertContainerSecurityContext(t, &c)
+	}
+	for _, c := range podSpec.Containers {
+		assertContainerSecurityContext(t, &c)
+	}
+}
+
 // findClusterDeploymentCondition finds the specified condition type in the given list of cluster deployment conditions.
 // If none exists, then returns nil.
 func findClusterDeploymentCondition(conditions []hivev1.ClusterDeploymentCondition, conditionType hivev1.ClusterDeploymentConditionType) *hivev1.ClusterDeploymentCondition {


### PR DESCRIPTION
This PR unreverts #1884 and removes `seccompProfile` settings from deployments. Versions prior to 4.11 do not have a restricted SCC that allows setting `seccompProfile`.

[HIVE-2023](https://issues.redhat.com/browse/HIVE-2023)