### PR TITLE
Update Hive AWS STS doc.

### DIFF
--- a/docs/aws-sts-provisioning.md
+++ b/docs/aws-sts-provisioning.md
@@ -2,73 +2,55 @@
 
 It is possible to use Hive to provision clusters configured to use Amazon's Security Token Service, where cluster components use short lived credentials that are rotated frequently, and the cluster does not have an admin level AWS credential. This feature was added to the in-cluster OpenShift components in 4.7, see documentation [here](https://docs.openshift.com/container-platform/4.7/authentication/managing_cloud_provider_credentials/cco-mode-sts.html).
 
-At present Hive does not automate the STS setup, rather we assume the user configures STS components manually and provides information to Hive. The following instructions refer to the 'ccoctl' tool coming in OpenShift 4.8 with the Cloud Credential Operator. This tool is not yet released but development is underway [here](https://github.com/openshift/cloud-credential-operator) and can be compiled from source, and used to prepare for provisioning 4.7 clusters.
+At present Hive does not automate the STS setup, rather we assume the user configures STS components manually and provides information to Hive. The following instructions refer to the `ccoctl` tool. This tool can be extracted from the OpenShift release image. See steps below.
 
 ## Extract Credentials Requests from Desired OpenShift Release Image
 
-These vary from release to release, so be sure to use the same release image here as you plan to use for your ClusterDeployment:
+CredentialsRequests vary from release to release, so be sure to use the same release image here as you plan to use for your ClusterDeployment.
+
+`$RELEASE_IMAGE` should be a recent and supported OpenShift release image that you want to deploy in your cluster.
+Please refer to the [support matrix](../README.md#support-matrix) for compatibilities.
+
+A sample release image would be `RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:${RHOCP_version}-${Arch}`
+
+Where `RHOCP_version` is the OpenShift version (e.g `4.10.0-fc.4` or `4.9.3`) and the `Arch` is the architecture type (e.g `x86_64`)
 
 ```bash
 $ mkdir credrequests/
-$ oc adm release extract quay.io/openshift-release-dev/ocp-release:4.7.1-x86_64 --credentials-requests --cloud=aws > credrequests/credrequests.yaml
+$ oc adm release extract $RELEASE_IMAGE --credentials-requests --cloud=aws --to=./credrequests
 ```
 
+## Extract the `ccoctl` binary from the release image.
+
+`$PULL_SECRET` should be the path to your pull secret required for pulling the release image.
+
+```
+CCO_IMAGE=$(oc adm release info --image-for='cloud-credential-operator' ${RELEASE_IMAGE}) && oc image extract ${CCO_IMAGE} --file='/usr/bin/ccoctl' --registry-config=${PULL_SECRET}
+chmod u+x ccoctl
+```
 
 ## Setup STS Infrastructure
 
-```bash
-$ ccoctl create key-pair
-$ ccoctl create identity-provider --name-prefix mystsprefix --public-key-file serviceaccount-signer.public --region us-east-1
-$ ccoctl create iam-roles --credentials-requests-dir credrequests/ --identity-provider-arn <IdentityProviderARN> --name-prefix mystsprefix --region us-east-1
+Create AWS resources using the [ccoctl](ccoctl.md#steps-create) tool (you will need aws credentials with sufficient permissions). The command below will generate public/private ServiceAccount signing keys, create the S3 bucket (with public read-only access), upload the OIDC config into the bucket, set up an IAM Identity Provider that trusts that bucket configuration, and create IAM Roles for each AWS CredentialsRequest extracted above. It will also dump the files needed by the installer in the `_output` directory. Installation secret manifests will be found within `_output/manifests`.
+```
+./ccoctl aws create-all --name <aws_infra_name> --region <aws_region> --credentials-requests-dir ./credrequests --output-dir _output/
 ```
 
-## Create Credentials Secret Manifests
-
-Hive allows passing in arbitrary Kubernetes resource manifests to pass through to the install process. We will leverage this to inject the Secrets and configuration required for an STS cluster.
-
-ccoctl will soon have a command to generate these Secrets but this is not implemented yet. For now you can follow the [manual STS documentation](https://docs.openshift.com/container-platform/4.7/authentication/managing_cloud_provider_credentials/cco-mode-sts.html) for how to create each Secret manually for the CredentialsRequests in your release image.
-
-Use the Role ARN's printed by `ccoctl create iam-roles` and the relevant target Secret namespace/name for each CredentialsRequest you extracted.
-
-Example:
-
-```yaml
-apiVersion: v1
-stringData:
-  credentials: |-
-    [default]
-    role_arn = arn:aws:iam::125931421481:role/mystsprefix-openshift-image-registry-installer-cloud-credentials
-    web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
-kind: Secret
-metadata:
-  name: installer-cloud-credentials
-  namespace: openshift-image-registry
-type: Opaque
-```
-
-
-### Create Authentication Manifest
-
-In the same directory as your Secret manifests, add another file named `cluster-authentication-02-config.yaml` to configure the OpenShift Authentication operator to use the S3 OIDC provider created by `ccoctl create identity-provider`.
-
-```yaml
-apiVersion: config.openshift.io/v1
-kind: Authentication
-metadata:
-  name: cluster
-spec:
-  serviceAccountIssuer: https://mystsprefix-oidc.s3.us-east-1.amazonaws.com
-```
-
-May also soon be automated by ccoctl.
+Hive allows passing in arbitrary Kubernetes resource manifests to pass through to the install process. We will leverage this to inject the Secrets and configuration required for an STS cluster by creating a secret containing these manifests in the steps below. The manifests secret will be referenced from the ClusterDeployment.
 
 ## Create Hive ClusterDeployment
 
 Create a ClusterDeployment normally with the following changes:
 
-  1. Create a Secret for your private service account signing key created with ccoctl key-pair above: `kubectl create secret generic bound-service-account-signing-key --from-file=bound-service-account-signing-key.key=serviceaccount-signer.private`
-  1. Create a Secret for your installer manifests (credential role Secrets, Authentication config): `kubectl create secret generic cluster-manifests --from-file=manifests/`
+  1. Create a Secret for your private service account signing key created with `ccoctl aws create-all` above.
+  ```
+  kubectl create secret generic bound-service-account-signing-key --from-file=bound-service-account-signing-key.key=_output/serviceaccount-signer.private
+  ```
+  1. Create a Secret for your installer manifests (credential role Secrets, Authentication config)
+  ```
+  kubectl create secret generic cluster-manifests --from-file=_output/manifests/
+  ```
   1. In your InstallConfig set `credentialsMode: Manual`
-  1. In your ClusterDeployment set `spec.boundServiceAccountSigningKeySecretRef.name` to point to the Secret created above. (bound-service-account-signing-key)
-  1. In your ClusterDeployment set `spec.provisioning.manifestsConfigMapRef` to point to the ConfigMap created above. (cluster-manifests)
+  1. In your ClusterDeployment set `spec.boundServiceAccountSigningKeySecretRef.name` to point to the Secret created above (`bound-service-account-signing-key`).
+  1. In your ClusterDeployment set `spec.provisioning.manifestsSecretRef` to point to the Secret created above (`cluster-manifests`).
   1. Create your ClusterDeployment + InstallConfig to provision your STS cluster.

--- a/docs/aws-sts-provisioning.md
+++ b/docs/aws-sts-provisioning.md
@@ -36,7 +36,7 @@ Create AWS resources using the [ccoctl](ccoctl.md#steps-create) tool (you will n
 ./ccoctl aws create-all --name <aws_infra_name> --region <aws_region> --credentials-requests-dir ./credrequests --output-dir _output/
 ```
 
-Hive allows passing in arbitrary Kubernetes resource manifests to pass through to the install process. We will leverage this to inject the Secrets and configuration required for an STS cluster by creating a secret containing these manifests in the steps below. The manifests secret will be referenced from the ClusterDeployment.
+Hive allows providing arbitrary Kubernetes resource manifests to pass through to the install process. We will leverage this to inject the Secrets and configuration required for an STS cluster by creating a secret containing these manifests in the steps below. The manifests secret will be referenced from the ClusterDeployment.
 
 ## Create Hive ClusterDeployment
 


### PR DESCRIPTION
The previous doc in the repo was created prior to `ccoctl` being built into the release image (around the 4.7 timeframe) so the steps did not include how to obtain `ccoctl` or commands like `ccoctl aws create-all` which creates the key, s3 bucket, IAM roles and secrets.