### PR TITLE
Merge Labels/Taints of MachineSets

### DIFF
--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -703,7 +703,7 @@ openstack:
 
 A MachinePool for the worker machinesets is not required. If the user creates a MachinePool for the worker MachineSets, then Hive will manage the worker MachineSets.
 
-MachinePool reconciliation is limited to updating MachineSet replicas to match the replicas configured for the MachinePool. Additionally, When `Labels` or `Taints` are configured for a MachinePool, Hive will completely override any existing `Label` or `Taints` configurations on the associated MachineSets, see [HIVE-2035](https://issues.redhat.com/browse/HIVE-2035).
+MachinePool reconciliation is limited to updating MachineSet replicas to match the replicas configured for the MachinePool. Additionally, any existing `Labels` or `Taints` on the MachineSets will be overridden if they clash with those on the MachinePool.
 
 MachinePool platform is immutable and any changes made to `MachinePool.spec.platform` are blocked by a validating webhook. The Machine Config Operator does not support updating existing machines when platform details are changed in a MachineSet and consequently Hive does not support making such changes to MachinePool platform, see [HIVE-2024](https://issues.redhat.com/browse/HIVE-2024).
 

--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -581,19 +581,23 @@ func (r *ReconcileMachinePool) syncMachineSets(
 					}
 				}
 
-				// Update if the labels on the remote machineset are different than the labels on the generated machineset.
+				// Merge the labels on the remote machineset, if different from the labels on the generated machineset.
 				// If the length of both labels is zero, then they match, even if one is a nil map and the other is an empty map.
-				if rl, l := rMS.Spec.Template.Spec.Labels, ms.Spec.Template.Spec.Labels; (len(rl) != 0 || len(l) != 0) && !reflect.DeepEqual(rl, l) {
+				if rl, l := rMS.Spec.Template.Spec.Labels, ms.Spec.Template.Spec.Labels; !reflect.DeepEqual(rl, l) {
 					msLog.WithField("desired", l).WithField("observed", rl).Info("labels out of sync")
-					rMS.Spec.Template.Spec.Labels = l
+					for key, value := range l {
+						rMS.Spec.Template.Spec.Labels[key] = value
+					}
 					objectModified = true
 				}
 
-				// Update if the taints on the remote machineset are different than the taints on the generated machineset.
+				// Merge the taints on the remote machineset, if different from the taints on the generated machineset.
 				// If the length of both taints is zero, then they match, even if one is a nil slice and the other is an empty slice.
-				if rt, t := rMS.Spec.Template.Spec.Taints, ms.Spec.Template.Spec.Taints; (len(rt) != 0 || len(t) != 0) && !reflect.DeepEqual(rt, t) {
+				if rt, t := rMS.Spec.Template.Spec.Taints, ms.Spec.Template.Spec.Taints; !reflect.DeepEqual(rt, t) {
 					msLog.WithField("desired", t).WithField("observed", rt).Info("taints out of sync")
-					rMS.Spec.Template.Spec.Taints = t
+					for key, value := range t {
+						rMS.Spec.Template.Spec.Taints[key] = value
+					}
 					objectModified = true
 				}
 


### PR DESCRIPTION
When MachineSets were generated, we overrode the existing labels and taints on the remoteMachineSet to reflect what was present on the MachinePool. This commit preserves the existing labels and taints on the MachineSet as long as they do not clash with those on MachinePool.

/assign @abutcher 

xref: https://issues.redhat.com/browse/HIVE-2035