### PR TITLE
Get rid of OpenShift 3.11 cruft

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,10 +105,9 @@ manifests: crd
 
 # controller-gen is adding a yaml break (---) at the beginning of each file. OLM does not like this break.
 # We use yq to strip out the yaml break by having yq replace each file with yq's formatting.
-# This also removes the spec.validation.openAPIV3Schema.type field which OpenShift 3.11 does not like.
 # $1 - CRD file
 define strip-yaml-break
-	@$(YQ) d -i $(1) spec.validation.openAPIV3Schema.type
+	@$(YQ) m -i $(1) $(1)
 
 endef
 

--- a/config/operator/operator_role.yaml
+++ b/config/operator/operator_role.yaml
@@ -92,8 +92,7 @@ rules:
   - update
   - patch
   - delete
-# Allow get on CRDs so we can check for 4.x ClusterVersion to determine if running on 3.11 or not.
-# Allow create and update until the OLM CRD update bug is fixed.
+# Allow read on CRDs so we can check for supported contracts.
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -102,10 +101,6 @@ rules:
   - get
   - list
   - watch
-  - create
-  - update
-  - patch
-  - delete
 # Allow creating ClusterRoles and Bindings for the hive-admin role.
 - apiGroups:
   - rbac.authorization.k8s.io

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -7044,10 +7044,6 @@ objects:
     - get
     - list
     - watch
-    - create
-    - update
-    - patch
-    - delete
   - apiGroups:
     - rbac.authorization.k8s.io
     resources:

--- a/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook.go
+++ b/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook.go
@@ -723,14 +723,6 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateDelete(request *admis
 		"method":    "validateDelete",
 	})
 
-	// If running on OpenShift 3.11, OldObject will not be populated. All we can do is accept the DELETE request.
-	if len(request.OldObject.Raw) == 0 {
-		logger.Info("Cannot validate the DELETE since OldObject is empty")
-		return &admissionv1beta1.AdmissionResponse{
-			Allowed: true,
-		}
-	}
-
 	oldObject := &hivev1.ClusterDeployment{}
 	if err := a.decoder.DecodeRaw(request.OldObject, oldObject); err != nil {
 		logger.Errorf("Failed unmarshaling Object: %v", err.Error())

--- a/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook_test.go
@@ -986,12 +986,6 @@ func TestClusterDeploymentValidate(t *testing.T) {
 			expectedAllowed: true,
 		},
 		{
-			name:            "Test delete on OpenShift 3.11",
-			oldObject:       nil,
-			operation:       admissionv1beta1.Delete,
-			expectedAllowed: true,
-		},
-		{
 			name:            "vSphere create valid",
 			newObject:       validVSphereClusterDeployment(),
 			operation:       admissionv1beta1.Create,


### PR DESCRIPTION
We had some checks and tweaks for OpenShift 3.11, which has been EOL for a looong time. Clean up.

Of note: We also remove our write RBAC for CRDs. The reader perms were used to determine 3.11-ness, but are still used to determine supported contracts for ClusterInstall. The writer perms became obsolete at some point when we stopped doing
[this](https://github.com/openshift/hive/pull/385/files#diff-5b450b52ce1d65cb9d1e448269a23d1fc71a200dfa6462a5bc0a3cd2019fafa7R77-R88), but were never removed.

Of note: This partially reverts 5fecbe55 / #990, which added some yq magic to remove a field from our CRDs because 3.11 didn't like it. However, it seems controller-gen stopped generating that field anyway at some point, so this bit no longer had any effect anyway.