### PR TITLE
Refine error checks

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -255,16 +255,26 @@ data:
 
     # Generic OpenShift Install
     
-    - name: BootstrapFailed
-      searchRegexStrings:
-      - "Bootstrap failed to complete"
-      installFailingReason: BootstrapFailed
-      installFailingMessage: Installation Bootstrap failed to complete. Verify the networking configuration and account permissions and try again.
     - name: KubeAPIWaitTimeout
       searchRegexStrings:
       - "waiting for Kubernetes API: context deadline exceeded"
       installFailingReason: KubeAPIWaitTimeout
       installFailingMessage: Timeout waiting for the Kubernetes API to begin responding
+    - name: KubeAPIWaitFailed
+      searchRegexStrings:
+      - "Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane"
+      installFailingReason: KubeAPIWaitFailed
+      installFailingMessage: Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane
+    - name: BootstrapFailed
+      searchRegexStrings:
+      - "Failed to wait for bootstrapping to complete. This error usually happens when there is a problem with control plane hosts that prevents the control plane operators from creating the control plane."
+      installFailingReason: BootstrapFailed
+      installFailingMessage: Failed to wait for bootstrapping to complete. This error usually happens when there is a problem with control plane hosts that prevents the control plane operators from creating the control plane. Verify the networking configuration and account permissions and try again.
+    - name: GenericBootstrapFailed
+      searchRegexStrings:
+      - "Bootstrap failed to complete"
+      installFailingReason: GenericBootstrapFailed
+      installFailingMessage: Installation Bootstrap failed to complete. Verify the networking configuration and account permissions and try again.
     - name: MonitoringOperatorStillUpdating
       searchRegexStrings:
       - "failed to initialize the cluster: Cluster operator monitoring is still updating"
@@ -285,11 +295,6 @@ data:
       - "failed to initialize the cluster: Some cluster operators are still updating:"
       installFailingReason: GeneralClusterOperatorsStillUpdating
       installFailingMessage: Timeout waiting for all cluster operators to become ready
-    - name: KubeAPIWaitFailed
-      searchRegexStrings:
-      - "Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane"
-      installFailingReason: KubeAPIWaitFailed
-      installFailingMessage: Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane
     - name: SCACertPullFailed
       searchRegexStrings:
       - "Failed to pull SCA certs from"

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -50,7 +50,7 @@ const (
 	proxyConnectionRefused      = "time=\"2021-11-17T03:56:25Z\" level=info msg=\"[pull.q1w2.quay.rhcloud.com/openshift-release-dev/ocp-release@sha256:53576e4df71a5f00f77718f25aec6ac7946eaaab998d99d3e3f03fcb403364db: error pinging docker registry pull.q1w2.quay.rhcloud.com: Get \\\"https://pull.q1w2.quay.rhcloud.com/v2/\\\": proxyconnect tcp: dial tcp 10.0.125.189:8080: connect: connection refused]): quay.io/openshift-release-dev/ocp-release@sha256:53576e4df71a5f00f77718f25aec6ac7946eaaab998d99d3e3f03fcb403364db: error pinging docker registry quay.io: Get \\\"https://quay.io/v2/\\\": proxyconnect tcp: dial tcp 10.0.125.189:8080: connect: connection refused"
 	proxyInvalidCABundleLog     = "time=\"2021-08-27T05:56:50Z\" level=info msg=\"[pull.q1w2.quay.rhcloud.com/openshift-release-dev/ocp-release@sha256:7047acb946649cc1f54d98a1c28dd7b487fe91479aa52c13c971ea014a66c8a8: error pinging docker registry pull.q1w2.quay.rhcloud.com: Get \\\"https://pull.q1w2.quay.rhcloud.com/v2/\\\": proxyconnect tcp: x509: certificate signed by unknown authority]): quay.io/openshift-release-dev/ocp-release@sha256:7047acb946649cc1f54d98a1c28dd7b487fe91479aa52c13c971ea014a66c8a8: error pinging docker registry quay.io: Get \\\"https://quay.io/v2/\\\": proxyconnect tcp: x509: certificate signed by unknown authority"
 	awsEC2QuotaExceeded         = "time=\"2021-12-12T12:54:36Z\" level=fatal msg=\"failed to fetch Cluster: failed to fetch dependency of \"Cluster\": failed to generate asset \"Platform Quota Check\": error(MissingQuota): ec2/L-1234A56B is not available in us-east-1 because the required number of resources (36) is more than the limit of 32\""
-	bootstrapFailed             = "time=\"2022-01-26T17:44:03Z\" level=error msg=\"Bootstrap failed to complete: Get \"https://api.blahblah.kay6.p1.openshiftapps.com:6443/version?timeout=32s\": dial tcp 12.23.34.45:6443: connect: connection refused\""
+	genericBootstrapFailed      = "time=\"2022-01-26T17:44:03Z\" level=error msg=\"Bootstrap failed to complete: Get \"https://api.blahblah.kay6.p1.openshiftapps.com:6443/version?timeout=32s\": dial tcp 12.23.34.45:6443: connect: connection refused\""
 	awsInvalidVpcId             = "time=\"2022-01-11T18:25:33Z\" level=error msg=\"Error: InvalidVpcID.NotFound: The vpc ID 'vpc-whatever' does not exist\""
 	route53Timeout              = "level=error\nlevel=error msg=Error: error waiting for Route53 Hosted Zone (Z1234567890ACBD) creation: timeout while waiting for state to become 'INSYNC' (last state: 'PENDING', timeout: 15m0s)\nlevel=error\nlevel=error msg= on ../tmp/openshift-install-cluster-260510522/route53/base.tf line 22, in resource \"aws_route53_zone\" \"new_int\":\nlevel=error msg= 22: resource \"aws_route53_zone\" \"new_int\""
 	inconsistentTerraformResult = "time=\"2021-12-01T16:08:46Z\" level=error msg=\"Error: Provider produced inconsistent result after apply\""
@@ -64,6 +64,7 @@ time="2021-12-09T10:53:06Z" level=error msg="blahblah. Got 0 worker nodes, 3 mas
 	terraformFailedDelete = "level=fatal msg=terraform destroy: failed to destroy using Terraform"
 	noMatchLog            = "an example of something that doesn't match the log regexes"
 	scaCertPullFailedLog  = "Cluster operator insights SCAAvailable is False with NonHTTPError: Failed to pull SCA certs from https://api.openshift.com/api/accounts_mgmt/v1/certificates: unable to retrieve SCA certs data from https://api.openshift.com/api/accounts_mgmt/v1/certificates: Post \"https://api.openshift.com/api/accounts_mgmt/v1/certificates\""
+	bootstrapFailed       = "time=\"2022-01-27T03:33:08Z\" level=error msg=\"Failed to wait for bootstrapping to complete. This error usually happens when there is a problem with control plane hosts that prevents the control plane operators from creating the control plane.\""
 )
 
 func TestParseInstallLog(t *testing.T) {
@@ -365,6 +366,16 @@ func TestParseInstallLog(t *testing.T) {
 			name:           "BootstrapFailed",
 			log:            pointer.StringPtr(bootstrapFailed),
 			expectedReason: "BootstrapFailed",
+		},
+		{
+			name:           "KubeAPIWaitFailed",
+			log:            pointer.StringPtr(kubeAPIWaitFailedLog),
+			expectedReason: "KubeAPIWaitFailed",
+		},
+		{
+			name:           "GenericBootstrapFailed",
+			log:            pointer.StringPtr(genericBootstrapFailed),
+			expectedReason: "GenericBootstrapFailed",
 		},
 		{
 			name:           "AWSRoute53Timeout",

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1849,16 +1849,26 @@ data:
 
     # Generic OpenShift Install
     
-    - name: BootstrapFailed
-      searchRegexStrings:
-      - "Bootstrap failed to complete"
-      installFailingReason: BootstrapFailed
-      installFailingMessage: Installation Bootstrap failed to complete. Verify the networking configuration and account permissions and try again.
     - name: KubeAPIWaitTimeout
       searchRegexStrings:
       - "waiting for Kubernetes API: context deadline exceeded"
       installFailingReason: KubeAPIWaitTimeout
       installFailingMessage: Timeout waiting for the Kubernetes API to begin responding
+    - name: KubeAPIWaitFailed
+      searchRegexStrings:
+      - "Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane"
+      installFailingReason: KubeAPIWaitFailed
+      installFailingMessage: Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane
+    - name: BootstrapFailed
+      searchRegexStrings:
+      - "Failed to wait for bootstrapping to complete. This error usually happens when there is a problem with control plane hosts that prevents the control plane operators from creating the control plane."
+      installFailingReason: BootstrapFailed
+      installFailingMessage: Failed to wait for bootstrapping to complete. This error usually happens when there is a problem with control plane hosts that prevents the control plane operators from creating the control plane. Verify the networking configuration and account permissions and try again.
+    - name: GenericBootstrapFailed
+      searchRegexStrings:
+      - "Bootstrap failed to complete"
+      installFailingReason: GenericBootstrapFailed
+      installFailingMessage: Installation Bootstrap failed to complete. Verify the networking configuration and account permissions and try again.
     - name: MonitoringOperatorStillUpdating
       searchRegexStrings:
       - "failed to initialize the cluster: Cluster operator monitoring is still updating"
@@ -1879,11 +1889,6 @@ data:
       - "failed to initialize the cluster: Some cluster operators are still updating:"
       installFailingReason: GeneralClusterOperatorsStillUpdating
       installFailingMessage: Timeout waiting for all cluster operators to become ready
-    - name: KubeAPIWaitFailed
-      searchRegexStrings:
-      - "Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane"
-      installFailingReason: KubeAPIWaitFailed
-      installFailingMessage: Failed waiting for Kubernetes API. This error usually happens when there is a problem on the bootstrap host that prevents creating a temporary control plane
     - name: SCACertPullFailed
       searchRegexStrings:
       - "Failed to pull SCA certs from"


### PR DESCRIPTION
Currently, the checks for BootstrapFailed are only checking for the generic error message. The installer checks to see if the API came up and if the status is set to complete
in the bootstrap config map before exiting with BootstrapFailed error and this can be checked to possibly see if the API came up before it errored out.

xref: https://issues.redhat.com/browse/HIVE-2047