### PR TITLE
Add regex to catch another occurence of AWSInsufficientPermissions

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -133,7 +133,7 @@ data:
       installFailingMessage: AWS Subnet Does Not Exist
     # iam:CreateServiceLinkedRole is a super powerful permission that we don't give to STS clusters. We require it's done as a one-time prereq.
     # This is the error we see when the prereq step was missed.
-    - name: NATGatewayFailed 
+    - name: NATGatewayFailed
       searchRegexStrings:
       - "Error waiting for NAT Gateway (.*) to become available"
       installFailingReason: NATGatewayFailed
@@ -146,6 +146,7 @@ data:
     - name: AWSInsufficientPermissions
       searchRegexStrings:
       - "current credentials insufficient for performing cluster installation"
+      - "UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure message"
       installFailingReason: AWSInsufficientPermissions
       installFailingMessage: AWS credentials are insufficient for performing cluster installation
     - name: VcpuLimitExceeded
@@ -225,7 +226,7 @@ data:
       installFailingReason: GCPNoWorkerNodes
       installFailingMessage: No worker nodes could be created. Check the machine-api logs.
 
-    
+
     # Bare Metal
     - name: LibvirtSSHKeyPermissionDenied
       searchRegexStrings:
@@ -243,7 +244,7 @@ data:
     - name: ProxyTimeout
       searchRegexStrings:
       - "error pinging docker registry .+ proxyconnect tcp: dial tcp [^ ]+: i/o timeout"
-      - "error pinging docker registry .+ proxyconnect tcp: dial tcp [^ ]+: connect: connection refused"      
+      - "error pinging docker registry .+ proxyconnect tcp: dial tcp [^ ]+: connect: connection refused"
       - "error pinging docker registry .+ proxyconnect tcp: dial tcp [^ ]+: connect: no route to host"
       installFailingReason: ProxyTimeout
       installFailingMessage: The cluster is installing via a proxy, however the proxy server is refusing or timing out connections. Verify that the proxy is running and would be accessible from the cluster's private subnet(s).

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1727,7 +1727,7 @@ data:
       installFailingMessage: AWS Subnet Does Not Exist
     # iam:CreateServiceLinkedRole is a super powerful permission that we don't give to STS clusters. We require it's done as a one-time prereq.
     # This is the error we see when the prereq step was missed.
-    - name: NATGatewayFailed 
+    - name: NATGatewayFailed
       searchRegexStrings:
       - "Error waiting for NAT Gateway (.*) to become available"
       installFailingReason: NATGatewayFailed
@@ -1740,6 +1740,7 @@ data:
     - name: AWSInsufficientPermissions
       searchRegexStrings:
       - "current credentials insufficient for performing cluster installation"
+      - "UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure message"
       installFailingReason: AWSInsufficientPermissions
       installFailingMessage: AWS credentials are insufficient for performing cluster installation
     - name: VcpuLimitExceeded
@@ -1819,7 +1820,7 @@ data:
       installFailingReason: GCPNoWorkerNodes
       installFailingMessage: No worker nodes could be created. Check the machine-api logs.
 
-    
+
     # Bare Metal
     - name: LibvirtSSHKeyPermissionDenied
       searchRegexStrings:
@@ -1837,7 +1838,7 @@ data:
     - name: ProxyTimeout
       searchRegexStrings:
       - "error pinging docker registry .+ proxyconnect tcp: dial tcp [^ ]+: i/o timeout"
-      - "error pinging docker registry .+ proxyconnect tcp: dial tcp [^ ]+: connect: connection refused"      
+      - "error pinging docker registry .+ proxyconnect tcp: dial tcp [^ ]+: connect: connection refused"
       - "error pinging docker registry .+ proxyconnect tcp: dial tcp [^ ]+: connect: no route to host"
       installFailingReason: ProxyTimeout
       installFailingMessage: The cluster is installing via a proxy, however the proxy server is refusing or timing out connections. Verify that the proxy is running and would be accessible from the cluster's private subnet(s).


### PR DESCRIPTION
Per OSD-13578, we've identified another way that an install will fail on AWS due to insufficient permissions via logs like:

```
time="2022-10-14T18:40:17Z" level=error msg="Error: Error launching source instance: UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure message: ${encoded stuff}
```

So I added a regex search to `AWSInsufficientPermissions`

I will make a separate PR for the other failure method identified due to a blocking SCP since we will be able to give the customer a more specific error message in that case since they may have tried to give the necessary permissions, but are being blocked by an organizational SCP that they have forgotten about.