### PR TITLE
Add support for custom http error pages

### DIFF
--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -675,6 +676,10 @@ type ClusterIngress struct {
 	// should be used for this Ingress
 	// +optional
 	ServingCertificate string `json:"servingCertificate,omitempty"`
+
+	// HttpErrorCodePages allows configuring custom HTTP error pages using the IngressController object
+	// +optional
+	HttpErrorCodePages configv1.ConfigMapNameReference `json:"httpErrorCodePages,omitempty"`
 }
 
 // ControlPlaneConfigSpec contains additional configuration settings for a target

--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -679,7 +679,7 @@ type ClusterIngress struct {
 
 	// HttpErrorCodePages allows configuring custom HTTP error pages using the IngressController object
 	// +optional
-	HttpErrorCodePages configv1.ConfigMapNameReference `json:"httpErrorCodePages,omitempty"`
+	HttpErrorCodePages *configv1.ConfigMapNameReference `json:"httpErrorCodePages,omitempty"`
 }
 
 // ControlPlaneConfigSpec contains additional configuration settings for a target

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -287,6 +287,17 @@ spec:
                         full DNS suffix that the resulting IngressController object
                         will service (eg abcd.mycluster.mydomain.com).
                       type: string
+                    httpErrorCodePages:
+                      description: HttpErrorCodePages allows configuring custom HTTP
+                        error pages using the IngressController object
+                      properties:
+                        name:
+                          description: name is the metadata.name of the referenced
+                            config map
+                          type: string
+                      required:
+                      - name
+                      type: object
                     name:
                       description: Name of the ClusterIngress object to create.
                       type: string

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -679,6 +679,17 @@ objects:
                           full DNS suffix that the resulting IngressController object
                           will service (eg abcd.mycluster.mydomain.com).
                         type: string
+                      httpErrorCodePages:
+                        description: HttpErrorCodePages allows configuring custom
+                          HTTP error pages using the IngressController object
+                        properties:
+                          name:
+                            description: name is the metadata.name of the referenced
+                              config map
+                            type: string
+                        required:
+                        - name
+                        type: object
                       name:
                         description: Name of the ClusterIngress object to create.
                         type: string

--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -339,9 +339,10 @@ func createIngressController(cd *hivev1.ClusterDeployment, ingress hivev1.Cluste
 			Namespace: remoteIngressControllerNamespace,
 		},
 		Spec: ingresscontroller.IngressControllerSpec{
-			Domain:            ingress.Domain,
-			RouteSelector:     ingress.RouteSelector,
-			NamespaceSelector: ingress.NamespaceSelector,
+			Domain:             ingress.Domain,
+			RouteSelector:      ingress.RouteSelector,
+			NamespaceSelector:  ingress.NamespaceSelector,
+			HttpErrorCodePages: ingress.HttpErrorCodePages,
 		},
 	}
 

--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -339,10 +339,9 @@ func createIngressController(cd *hivev1.ClusterDeployment, ingress hivev1.Cluste
 			Namespace: remoteIngressControllerNamespace,
 		},
 		Spec: ingresscontroller.IngressControllerSpec{
-			Domain:             ingress.Domain,
-			RouteSelector:      ingress.RouteSelector,
-			NamespaceSelector:  ingress.NamespaceSelector,
-			HttpErrorCodePages: ingress.HttpErrorCodePages,
+			Domain:            ingress.Domain,
+			RouteSelector:     ingress.RouteSelector,
+			NamespaceSelector: ingress.NamespaceSelector,
 		},
 	}
 
@@ -358,6 +357,10 @@ func createIngressController(cd *hivev1.ClusterDeployment, ingress hivev1.Cluste
 				break
 			}
 		}
+	}
+
+	if ingress.HttpErrorCodePages != nil {
+		newIngress.Spec.HttpErrorCodePages = *ingress.HttpErrorCodePages
 	}
 
 	return &newIngress

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -675,6 +676,10 @@ type ClusterIngress struct {
 	// should be used for this Ingress
 	// +optional
 	ServingCertificate string `json:"servingCertificate,omitempty"`
+
+	// HttpErrorCodePages allows configuring custom HTTP error pages using the IngressController object
+	// +optional
+	HttpErrorCodePages configv1.ConfigMapNameReference `json:"httpErrorCodePages,omitempty"`
 }
 
 // ControlPlaneConfigSpec contains additional configuration settings for a target

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -679,7 +679,7 @@ type ClusterIngress struct {
 
 	// HttpErrorCodePages allows configuring custom HTTP error pages using the IngressController object
 	// +optional
-	HttpErrorCodePages configv1.ConfigMapNameReference `json:"httpErrorCodePages,omitempty"`
+	HttpErrorCodePages *configv1.ConfigMapNameReference `json:"httpErrorCodePages,omitempty"`
 }
 
 // ControlPlaneConfigSpec contains additional configuration settings for a target


### PR DESCRIPTION
This PR adds support to override HttpErrorCodePages field in IngressController CR made via ClusterDeployment using Syncset. 

ref: https://issues.redhat.com/browse/HIVE-2040 