### PR TITLE
Log ProvisionFailedTerminal metric if DNSZoneFailedToReconcile or DNSNotReadyTimedOut

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -4086,6 +4086,10 @@ func TestEnsureManagedDNSZone(t *testing.T) {
 					Type:   hivev1.DNSNotReadyCondition,
 					Status: corev1.ConditionUnknown,
 				}),
+				testclusterdeployment.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.ProvisionStoppedCondition,
+					Status: corev1.ConditionUnknown,
+				}),
 			),
 			expectedUpdated: true,
 			expectedResult:  reconcile.Result{Requeue: true, RequeueAfter: defaultDNSNotReadyTimeout},
@@ -4127,6 +4131,10 @@ func TestEnsureManagedDNSZone(t *testing.T) {
 					LastProbeTime:      metav1.Time{Time: time.Now().Add(-20 * time.Minute)},
 					LastTransitionTime: metav1.Time{Time: time.Now().Add(-20 * time.Minute)},
 				}),
+				testclusterdeployment.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.ProvisionStoppedCondition,
+					Status: corev1.ConditionUnknown,
+				}),
 			),
 			expectedUpdated: true,
 			expectedResult:  reconcile.Result{Requeue: true},
@@ -4147,6 +4155,10 @@ func TestEnsureManagedDNSZone(t *testing.T) {
 					Type:   hivev1.DNSNotReadyCondition,
 					Status: corev1.ConditionTrue,
 					Reason: dnsNotReadyTimedoutReason,
+				}),
+				testclusterdeployment.WithCondition(hivev1.ClusterDeploymentCondition{
+					Type:   hivev1.ProvisionStoppedCondition,
+					Status: corev1.ConditionUnknown,
 				}),
 			),
 			expectedDNSNotReadyCondition: &hivev1.ClusterDeploymentCondition{

--- a/pkg/controller/clusterdeployment/clusterinstalls.go
+++ b/pkg/controller/clusterdeployment/clusterinstalls.go
@@ -271,7 +271,7 @@ func (r *ReconcileClusterDeployment) reconcileExistingInstallingClusterInstall(c
 		}
 		// If we declared the provision terminally failed, bump our metric
 		if provisionFailedTerminal {
-			incProvisionFailedTerminal(cd, logger)
+			incProvisionFailedTerminal(cd)
 		}
 	}
 

--- a/pkg/controller/clusterdeployment/clusterprovisions.go
+++ b/pkg/controller/clusterdeployment/clusterprovisions.go
@@ -91,7 +91,7 @@ func (r *ReconcileClusterDeployment) startNewProvision(
 				logger.WithError(err).Log(controllerutils.LogLevel(err), "failed to update cluster deployment status")
 				return reconcile.Result{}, err
 			}
-			incProvisionFailedTerminal(cd, logger)
+			incProvisionFailedTerminal(cd)
 		}
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controller/clusterdeployment/metrics.go
+++ b/pkg/controller/clusterdeployment/metrics.go
@@ -52,7 +52,7 @@ var (
 	metricProvisionFailedTerminal hivemetrics.CounterVecWithDynamicLabels
 )
 
-func incProvisionFailedTerminal(cd *hivev1.ClusterDeployment, log log.FieldLogger) {
+func incProvisionFailedTerminal(cd *hivev1.ClusterDeployment) {
 	poolNSName := ""
 	if poolRef := cd.Spec.ClusterPoolRef; poolRef != nil {
 		poolNSName = poolRef.Namespace + "/" + poolRef.PoolName


### PR DESCRIPTION
hive_cluster_deployments_provision_failed_terminal_total should be logged everytime we set ProvisionStopped condition to true, however it was found that logging of this metric was skipped when DNSZoneFailedToReconcile and DNSNotReadyTimedOut. This commit fixes that.

xref: https://issues.redhat.com/browse/HIVE-2056

/assign @2uasimojo 