### PR TITLE
Add AWSDeniedBySCP failed install reason and regex

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -149,6 +149,11 @@ data:
       - "UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure message"
       installFailingReason: AWSInsufficientPermissions
       installFailingMessage: AWS credentials are insufficient for performing cluster installation
+    - name: AWSDeniedBySCP
+      searchRegexStrings:
+      - "AccessDenied: .* with an explicit deny in a service control policy"
+      installFailingReason: AWSDeniedBySCP
+      installFailingMessage: "A service control policy (SCP) is too restrictive for performing cluster installation"
     - name: VcpuLimitExceeded
       searchRegexStrings:
       - "VcpuLimitExceeded"

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -66,6 +66,7 @@ time="2021-12-09T10:53:06Z" level=error msg="blahblah. Got 0 worker nodes, 3 mas
 	noMatchLog            = "an example of something that doesn't match the log regexes"
 	scaCertPullFailedLog  = "Cluster operator insights SCAAvailable is False with NonHTTPError: Failed to pull SCA certs from https://api.openshift.com/api/accounts_mgmt/v1/certificates: unable to retrieve SCA certs data from https://api.openshift.com/api/accounts_mgmt/v1/certificates: Post \"https://api.openshift.com/api/accounts_mgmt/v1/certificates\""
 	bootstrapFailed       = "time=\"2022-01-27T03:33:08Z\" level=error msg=\"Failed to wait for bootstrapping to complete. This error usually happens when there is a problem with control plane hosts that prevents the control plane operators from creating the control plane.\""
+	awsDeniedByScp        = "AccessDenied: entity is not authorized to perform: iam:PressTheButton on resource: Thing with an explicit deny in a service control policy"
 )
 
 func TestParseInstallLog(t *testing.T) {
@@ -156,6 +157,11 @@ func TestParseInstallLog(t *testing.T) {
 			name:           "ProxyInvalidCABundle",
 			log:            pointer.StringPtr(proxyInvalidCABundleLog),
 			expectedReason: "ProxyInvalidCABundle",
+		},
+		{
+			name:           "AWSDeniedBySCP",
+			log:            pointer.StringPtr(awsDeniedByScp),
+			expectedReason: "AWSDeniedBySCP",
 		},
 		{
 			name: "KubeAPIWaitTimeout from additional regex entries",

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1743,6 +1743,11 @@ data:
       - "UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure message"
       installFailingReason: AWSInsufficientPermissions
       installFailingMessage: AWS credentials are insufficient for performing cluster installation
+    - name: AWSDeniedBySCP
+      searchRegexStrings:
+      - "AccessDenied: .* with an explicit deny in a service control policy"
+      installFailingReason: AWSDeniedBySCP
+      installFailingMessage: "A service control policy (SCP) is too restrictive for performing cluster installation"
     - name: VcpuLimitExceeded
       searchRegexStrings:
       - "VcpuLimitExceeded"


### PR DESCRIPTION
Per OSD-13578, sometimes installs can fail due to a service control policy (SCP) that the customer may unknowingly be restricted by.

I chose to make this its own error message rather than bundling it into `AWSInsufficientPermissions` because the customer may have set up the roles as documented, but a different internal team may be responsible for an SCP, which isn't as obvious to them as a possible reason if we send the message: `AWS credentials are insufficient for performing cluster installation`