### PR TITLE
hiveadmission: enable API Priority and Fairness

### DIFF
--- a/config/hiveadmission/hiveadmission_rbac_role.yaml
+++ b/config/hiveadmission/hiveadmission_rbac_role.yaml
@@ -43,4 +43,12 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
-
+- apiGroups:
+  - flowcontrol.apiserver.k8s.io
+  resources:
+  - prioritylevelconfigurations
+  - flowschemas
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/operator/operator_role.yaml
+++ b/config/operator/operator_role.yaml
@@ -218,3 +218,12 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - flowcontrol.apiserver.k8s.io
+  resources:
+  - prioritylevelconfigurations
+  - flowschemas
+  verbs:
+  - get
+  - list
+  - watch

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -7158,6 +7158,15 @@ objects:
     - update
     - patch
     - delete
+  - apiGroups:
+    - flowcontrol.apiserver.k8s.io
+    resources:
+    - prioritylevelconfigurations
+    - flowschemas
+    verbs:
+    - get
+    - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -561,7 +561,15 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
-
+- apiGroups:
+  - flowcontrol.apiserver.k8s.io
+  resources:
+  - prioritylevelconfigurations
+  - flowschemas
+  verbs:
+  - get
+  - list
+  - watch
 `)
 
 func configHiveadmissionHiveadmission_rbac_roleYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Make hiveadmission logs stop saying things like

```
W1107 19:49:51.940311       1 reflector.go:324] k8s.io/client-go@v12.0.0+incompatible/tools/cache/reflector.go:167: failed to list *v1beta2.PriorityLevelConfiguration: prioritylevelconfigurations.flowcontrol.apiserver.k8s.io is forbidden: User "system:serviceaccount:hc-hs1:hiveadmission" cannot list resource "prioritylevelconfigurations" in API group "flowcontrol.apiserver.k8s.io" at the cluster scope
E1107 19:49:51.940382       1 reflector.go:138] k8s.io/client-go@v12.0.0+incompatible/tools/cache/reflector.go:167: Failed to watch *v1beta2.PriorityLevelConfiguration: failed to list *v1beta2.PriorityLevelConfiguration: prioritylevelconfigurations.flowcontrol.apiserver.k8s.io is forbidden: User "system:serviceaccount:hc-hs1:hiveadmission" cannot list resource "prioritylevelconfigurations" in API group "flowcontrol.apiserver.k8s.io" at the cluster scope
W1107 19:50:08.250374       1 reflector.go:324] k8s.io/client-go@v12.0.0+incompatible/tools/cache/reflector.go:167: failed to list *v1beta2.FlowSchema: flowschemas.flowcontrol.apiserver.k8s.io is forbidden: User "system:serviceaccount:hc-hs1:hiveadmission" cannot list resource "flowschemas" in API group "flowcontrol.apiserver.k8s.io" at the cluster scope
E1107 19:50:08.250416       1 reflector.go:138] k8s.io/client-go@v12.0.0+incompatible/tools/cache/reflector.go:167: Failed to watch *v1beta2.FlowSchema: failed to list *v1beta2.FlowSchema: flowschemas.flowcontrol.apiserver.k8s.io is forbidden: User "system:serviceaccount:hc-hs1:hiveadmission" cannot list resource "flowschemas" in API group "flowcontrol.apiserver.k8s.io" at the cluster scope
```

and instead say this:

```
I1107 19:50:52.685933       1 apf_controller.go:322] Running API Priority and Fairness config worker
```

[HIVE-2057](https://issues.redhat.com//browse/HIVE-2057)