### PR TITLE
[OSD-13716] Deduplicate and consolidate SCACertsPullFailed error

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -7,7 +7,7 @@ data:
   regexes: |
     - name: SCACertsPullFailed
       searchRegexStrings:
-      - "SCAAvailable is False with NonHTTPError: Failed to pull SCA certs from"
+      - "Failed to pull SCA certs from"
       installFailingReason: SCACertsPullFailed
       installFailingMessage: Cannot pull SCA certificates. Make sure SCA is enabled and try again. See https://access.redhat.com/articles/simple-content-access.
     # AWS Specific:
@@ -302,11 +302,6 @@ data:
       - "failed to initialize the cluster: Some cluster operators are still updating:"
       installFailingReason: GeneralClusterOperatorsStillUpdating
       installFailingMessage: Timeout waiting for all cluster operators to become ready
-    - name: SCACertPullFailed
-      searchRegexStrings:
-      - "Failed to pull SCA certs from"
-      installFailingReason: SCACertPullFailed
-      installFailingMessage: Failed to pull SCA certs
 
     # Keep these at the bottom so that they're only hit if nothing above matches.
     # We don't want to show these to users unless it's a last resort. It's barely better than "unknown error".

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1601,7 +1601,7 @@ data:
   regexes: |
     - name: SCACertsPullFailed
       searchRegexStrings:
-      - "SCAAvailable is False with NonHTTPError: Failed to pull SCA certs from"
+      - "Failed to pull SCA certs from"
       installFailingReason: SCACertsPullFailed
       installFailingMessage: Cannot pull SCA certificates. Make sure SCA is enabled and try again. See https://access.redhat.com/articles/simple-content-access.
     # AWS Specific:
@@ -1896,11 +1896,6 @@ data:
       - "failed to initialize the cluster: Some cluster operators are still updating:"
       installFailingReason: GeneralClusterOperatorsStillUpdating
       installFailingMessage: Timeout waiting for all cluster operators to become ready
-    - name: SCACertPullFailed
-      searchRegexStrings:
-      - "Failed to pull SCA certs from"
-      installFailingReason: SCACertPullFailed
-      installFailingMessage: Failed to pull SCA certs
 
     # Keep these at the bottom so that they're only hit if nothing above matches.
     # We don't want to show these to users unless it's a last resort. It's barely better than "unknown error".


### PR DESCRIPTION
`SCACertsPullFailed` and `SCACertPullFailed` were distinct error messages, but targeting the same error.

Kind of funnily there are two main status conditions that have been observed recently that indicate this failure:
* `SCAAvailable is False` and
* `SCANotAvailable is True`

but the latter was getting overruled since it didn't match the first regex and getting caught as `BootstrapFailed` instead due to the ordering/priority in install log regexes.

This PR consolidates the two error messages into one and keeps the more generic regex so that both cases can be correctly identified. I kept `SCACertsPullFailed` because it already corresponds to the OCM error code `OCM3050`