### PR TITLE
Trigger CI to update to go 1.19.

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.12
 
 # setting Git username and email for workaround of
 # https://github.com/jenkinsci/docker/issues/519


### PR DESCRIPTION
Bumping in the build Dockerfile similar to #1680 to make some change that should allow the subsequent update (with the rest of the Dockerfiles) to go in #1907.