### PR TITLE
Add new installer failure reason when AWS has insufficient capacity

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -11,6 +11,11 @@ data:
       installFailingReason: SCACertsPullFailed
       installFailingMessage: Cannot pull SCA certificates. Make sure SCA is enabled and try again. See https://access.redhat.com/articles/simple-content-access.
     # AWS Specific:
+    - name: AWSInsufficientCapacity
+      searchRegexStrings:
+      - "Error: .*InsufficientInstanceCapacity.* Our system will be working on provisioning additional capacity"
+      installFailingReason: AWSInsufficientCapacity
+      installFailingMessage: AWS currently does not have sufficient capacity to provision the requested EC2 instances in the specified Availability Zone. Please try again later or in a different Availability Zone.
     - name: AWSEC2QuotaExceeded
       searchRegexStrings:
       - "failed to generate asset.*Platform Quota Check.*MissingQuota.*ec2"

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -59,14 +59,15 @@ const (
 	// NOTE: This embedded newline matters: our regex must be able to match the two chunks of the message on separate lines.
 	noWorkerNodesFmt = `time="2021-12-09T10:51:06Z" level=debug msg="Symlinking plugin terraform-provider-%s src: \"/usr/bin/openshift-install\" dst: \"/tmp/openshift-install-cluster-723469510/plugins/terraform-provider-%s\""
 time="2021-12-09T10:53:06Z" level=error msg="blahblah. Got 0 worker nodes, 3 master nodes blah"`
-	targetGroupNotFound   = "level=error msg=Error: error updating LB Target Group (arn:aws:elasticloadbalancing:us-east-1:xxxx:targetgroup/aaaabbbbcccc/dddd) tags: error tagging resource (arn:aws:elasticloadbalancing:us-east-1:0123445698:targetgroup/aaaabbbbcccc/dddd): TargetGroupNotFound: Target groups 'arn:aws:elasticloadbalancing:us-east-1:xxxx:targetgroup/aaaabbbbcccc/dddd' not found"
-	errorCreatingNLB      = "time=\"2022-01-27T03:33:08Z\" level=error msg=\"Error: Error creating network Load Balancer: InternalFailure: \""
-	terraformFailedDelete = "level=fatal msg=terraform destroy: failed to destroy using Terraform"
-	noMatchLog            = "an example of something that doesn't match the log regexes"
-	bootstrapFailed       = "time=\"2022-01-27T03:33:08Z\" level=error msg=\"Failed to wait for bootstrapping to complete. This error usually happens when there is a problem with control plane hosts that prevents the control plane operators from creating the control plane.\""
-	awsDeniedByScp        = "AccessDenied: entity is not authorized to perform: iam:PressTheButton on resource: Thing with an explicit deny in a service control policy"
-	scaNotAvailableLog    = "msg=Cluster operator insights SCANotAvailable is True with NotFound: Failed to pull SCA certs from https://api.openshift.com/api/accounts_mgmt/v1/certificates: OCM API https://api.openshift.com/api/accounts_mgmt/v1/certificates returned HTTP 404: {\"id\":\"7\",\"kind\":\"Error\",\"href\":\"/api/accounts_mgmt/v1/errors/7\",\"code\":\"ACCT-MGMT-7\",\"reason\":\"The organization (id= whatever) does not have any certificate of type sca. Enable SCA at https://access.redhat.com/management.\",\"operation_id\":\"ce804952-8012-4f78-9d6d-a5538dc35e3a\"}\nlevel=info"
-	scaAvailableLog       = "Cluster operator insights SCAAvailable is False with NonHTTPError: Failed to pull SCA certs from https://api.openshift.com/api/accounts_mgmt/v1/certificates: unable to retrieve SCA certs data from https://api.openshift.com/api/accounts_mgmt/v1/certificates: Post \"https://api.openshift.com/api/accounts_mgmt/v1/certificates\""
+	targetGroupNotFound     = "level=error msg=Error: error updating LB Target Group (arn:aws:elasticloadbalancing:us-east-1:xxxx:targetgroup/aaaabbbbcccc/dddd) tags: error tagging resource (arn:aws:elasticloadbalancing:us-east-1:0123445698:targetgroup/aaaabbbbcccc/dddd): TargetGroupNotFound: Target groups 'arn:aws:elasticloadbalancing:us-east-1:xxxx:targetgroup/aaaabbbbcccc/dddd' not found"
+	errorCreatingNLB        = "time=\"2022-01-27T03:33:08Z\" level=error msg=\"Error: Error creating network Load Balancer: InternalFailure: \""
+	terraformFailedDelete   = "level=fatal msg=terraform destroy: failed to destroy using Terraform"
+	noMatchLog              = "an example of something that doesn't match the log regexes"
+	bootstrapFailed         = "time=\"2022-01-27T03:33:08Z\" level=error msg=\"Failed to wait for bootstrapping to complete. This error usually happens when there is a problem with control plane hosts that prevents the control plane operators from creating the control plane.\""
+	awsDeniedByScp          = "AccessDenied: entity is not authorized to perform: iam:PressTheButton on resource: Thing with an explicit deny in a service control policy"
+	scaNotAvailableLog      = "msg=Cluster operator insights SCANotAvailable is True with NotFound: Failed to pull SCA certs from https://api.openshift.com/api/accounts_mgmt/v1/certificates: OCM API https://api.openshift.com/api/accounts_mgmt/v1/certificates returned HTTP 404: {\"id\":\"7\",\"kind\":\"Error\",\"href\":\"/api/accounts_mgmt/v1/errors/7\",\"code\":\"ACCT-MGMT-7\",\"reason\":\"The organization (id= whatever) does not have any certificate of type sca. Enable SCA at https://access.redhat.com/management.\",\"operation_id\":\"ce804952-8012-4f78-9d6d-a5538dc35e3a\"}\nlevel=info"
+	scaAvailableLog         = "Cluster operator insights SCAAvailable is False with NonHTTPError: Failed to pull SCA certs from https://api.openshift.com/api/accounts_mgmt/v1/certificates: unable to retrieve SCA certs data from https://api.openshift.com/api/accounts_mgmt/v1/certificates: Post \"https://api.openshift.com/api/accounts_mgmt/v1/certificates\""
+	awsInsufficientCapacity = "level=error msg=\"failed to fetch Cluster: failed to generate asset \"Cluster\": failure applying terraform for \"cluster\" stage: failed to create cluster: failed to apply Terraform: exit status 1\n\nError: Error launching source instance: InsufficientInstanceCapacity: We currently do not have sufficient m5.2xlarge capacity in the Availability Zone you requested (eu-south-1b). Our system will be working on provisioning additional capacity. You can currently get m5.2xlarge capacity by not specifying an Availability Zone in your request or choosing eu-south-1a, eu-south-1c."
 )
 
 func TestParseInstallLog(t *testing.T) {
@@ -78,6 +79,11 @@ func TestParseInstallLog(t *testing.T) {
 		expectedReason  string
 		expectedMessage *string
 	}{
+		{
+			name:           "AWSInsufficientCapacity",
+			log:            pointer.StringPtr(awsInsufficientCapacity),
+			expectedReason: "AWSInsufficientCapacity",
+		},
 		{
 			name:           "SCANotAvailable is True",
 			log:            pointer.StringPtr(scaNotAvailableLog),

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1613,6 +1613,11 @@ data:
       installFailingReason: SCACertsPullFailed
       installFailingMessage: Cannot pull SCA certificates. Make sure SCA is enabled and try again. See https://access.redhat.com/articles/simple-content-access.
     # AWS Specific:
+    - name: AWSInsufficientCapacity
+      searchRegexStrings:
+      - "Error: .*InsufficientInstanceCapacity.* Our system will be working on provisioning additional capacity"
+      installFailingReason: AWSInsufficientCapacity
+      installFailingMessage: AWS currently does not have sufficient capacity to provision the requested EC2 instances in the specified Availability Zone. Please try again later or in a different Availability Zone.
     - name: AWSEC2QuotaExceeded
       searchRegexStrings:
       - "failed to generate asset.*Platform Quota Check.*MissingQuota.*ec2"


### PR DESCRIPTION
For OSD-13928, we found that sometimes AWS runs out of EC2 capacity in a specific availability zone without a specific error message. This creates one and the plan is to add it as a retry reason to SREP's HiveConfig next. Even if it continues to fail through the retries, the hope is that this error code/message makes a lot more sense for the user and/or SREP if it ends up paging us.