### PR TITLE
e2e-pool: rename cdc-* clusters => hiveci-cdc-*

### DIFF
--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -228,7 +228,8 @@ oc get clusterpool ${REAL_POOL_NAME} -o json \
   | oc apply -f -
 
 # Add customization to REAL POOL
-NEW_CLUSTER_NAME="cdc-$(cat /dev/urandom | tr -dc 'a-z' | fold -w 8 | head -n 1)"
+# NOTE: Use the hiveci- prefix for cluster names so they get caught by our leak detector.
+NEW_CLUSTER_NAME="hiveci-cdc-$(cat /dev/urandom | tr -dc 'a-z' | fold -w 4 | head -n 1)"
 create_customization "cdc-test" "${CLUSTER_NAMESPACE}" "${NEW_CLUSTER_NAME}"
 oc patch cp -n $CLUSTER_NAMESPACE $REAL_POOL_NAME --type=merge -p '{"spec": {"inventory": [{"name": "cdc-test"}]}}'
 


### PR DESCRIPTION
Mysterious cdc-* clusters started appearing in our running instance reports, but not our CI leak reports. We believe these are from e2e-pool runs where customized clusters weren't getting cleaned up when tests timed out prematurely. To make them show up in our leak reports, change the names to be prefixed with `hiveci-`.