### PR TITLE
add namespace parameter to sample adoption cmd

### DIFF
--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -1196,7 +1196,7 @@ spec:
 [hiveutil](hiveutil.md) is a development focused CLI tool which can be built from the hive repo. To adopt a cluster specify the following flags:
 
 ```bash
-bin/hiveutil create-cluster --base-domain=example.com mycluster --adopt --adopt-admin-kubeconfig=/path/to/cluster/admin/kubeconfig --adopt-infra-id=[INFRAID] --adopt-cluster-id=[CLUSTERID]
+bin/hiveutil create-cluster --namespace=namespace-to-adopt-into --base-domain=example.com mycluster --adopt --adopt-admin-kubeconfig=/path/to/cluster/admin/kubeconfig --adopt-infra-id=[INFRAID] --adopt-cluster-id=[CLUSTERID]
 ```
 
 ## Configuration Management


### PR DESCRIPTION
This PR adds the namespace parameter to the sample cmd to adopt a hive cluster. During an adoption process in production we accidentally adopted a hive into the default namespace. This parameter will specify the namespace  