### PR TITLE
Syncset Testing PR #1

### DIFF
--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -223,6 +223,20 @@ func AddToManager(mgr manager.Manager, r *ReconcileClusterSync, concurrentReconc
 		return err
 	}
 
+	// Watch for changes to ClusterSync. These have the same name/namespace as the relevant
+	// ClusterDeployment, so when a ClusterSync watch triggers, the CD of the same name will be reconciled.
+	// When the CD reconciles, it will look up the related ClusterSync.
+	if err := c.Watch(&source.Kind{Type: &hiveintv1alpha1.ClusterSync{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+
+	// Watch for changes to ClusterSyncLease. These have the same name/namespace as the relevant
+	// ClusterDeployment, so when a ClusterSyncLease watch triggers, the CD of the same name will be reconciled.
+	// When the CD reconciles, it will look up the related ClusterSyncLease.
+	if err := c.Watch(&source.Kind{Type: &hiveintv1alpha1.ClusterSyncLease{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -407,7 +421,6 @@ func (r *ReconcileClusterSync) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, err
 	}
 
-	needToCreateClusterSync := false
 	clusterSync := &hiveintv1alpha1.ClusterSync{}
 	switch err := r.Get(context.Background(), request.NamespacedName, clusterSync); {
 	case apierrors.IsNotFound(err):
@@ -417,13 +430,17 @@ func (r *ReconcileClusterSync) Reconcile(ctx context.Context, request reconcile.
 		ownerRef := metav1.NewControllerRef(cd, cd.GroupVersionKind())
 		ownerRef.Controller = nil
 		clusterSync.OwnerReferences = []metav1.OwnerReference{*ownerRef}
-		if err := r.Create(context.Background(), clusterSync); err != nil {
+		switch err := r.Create(context.Background(), clusterSync); {
+		case apierrors.IsAlreadyExists(err):
+			// race condition, just proceed
+		case err != nil:
 			logger.WithError(err).Log(controllerutils.LogLevel(err), "could not create ClusterSync")
 			return reconcile.Result{}, err
+		default: // clusterSync was created successfully
+			recobsrv.SetOutcome(hivemetrics.ReconcileOutcomeClusterSyncCreated)
+			// requeue immediately so that we reconcile soon after the ClusterSync is created
+			return reconcile.Result{Requeue: true}, nil
 		}
-		recobsrv.SetOutcome(hivemetrics.ReconcileOutcomeClusterSyncCreated)
-		// requeue immediately so that we reconcile soon after the ClusterSync is created
-		return reconcile.Result{Requeue: true}, nil
 	case err != nil:
 		logger.WithError(err).Log(controllerutils.LogLevel(err), "could not get ClusterSync")
 		return reconcile.Result{}, err
@@ -453,10 +470,15 @@ func (r *ReconcileClusterSync) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, err
 	}
 
-	needToDoFullReapply := needToCreateClusterSync || r.timeUntilFullReapply(lease) <= 0
-	if needToDoFullReapply {
-		logger.Info("need to reapply all syncsets")
+	needToRenew := r.timeUntilRenew(lease) <= 0
+
+	if needToCreateLease {
+		logger.Info("need to reapply all syncsets (missing lease)")
+	} else if needToRenew {
+		logger.Info("need to reapply all syncsets (time to renew)")
 	}
+
+	needToDoFullReapply := needToCreateLease || needToRenew
 	recobsrv.SetOutcome(hivemetrics.ReconcileOutcomeFullSync)
 
 	// Apply SyncSets
@@ -525,7 +547,7 @@ func (r *ReconcileClusterSync) Reconcile(ctx context.Context, request reconcile.
 		}
 	}
 
-	result := reconcile.Result{Requeue: true, RequeueAfter: r.timeUntilFullReapply(lease)}
+	result := reconcile.Result{Requeue: true, RequeueAfter: r.timeUntilRenew(lease)}
 	if syncSetsNeedRequeue || selectorSyncSetsNeedRequeue {
 		result.RequeueAfter = 0
 	}
@@ -1131,7 +1153,7 @@ func orderResources(a, b hiveintv1alpha1.SyncResourceReference) bool {
 	return a.Name < b.Name
 }
 
-func (r *ReconcileClusterSync) timeUntilFullReapply(lease *hiveintv1alpha1.ClusterSyncLease) time.Duration {
+func (r *ReconcileClusterSync) timeUntilRenew(lease *hiveintv1alpha1.ClusterSyncLease) time.Duration {
 	timeUntilNext := r.reapplyInterval - time.Since(lease.Spec.RenewTime.Time) +
 		time.Duration(reapplyIntervalJitter*rand.Float64()*r.reapplyInterval.Seconds())*time.Second
 	if timeUntilNext < 0 {

--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -946,16 +946,17 @@ func applyToTargetCluster(
 		return err
 	}
 
+	logger.WithField("uid", obj.GetUID()).WithField("resource_version", obj.GetResourceVersion()).Info("attempting to apply resource")
 	applyResult, err := applyFn(bytes)
 	// Record the amount of time we took to apply this specific resource. When combined with the metric for duration of
 	// our kube client requests, we can get an idea how much time we're spending cpu bound vs network bound.
 	applyTime := metav1.Now().Sub(startTime).Seconds()
 	if err != nil {
-		logger.WithError(err).Warn("error applying resource")
+		logger.WithError(err).WithField("uid", obj.GetUID()).WithField("resource_version", obj.GetResourceVersion()).WithField("applyTime", applyTime).Warn("error applying resource")
 		metricResourcesApplied.WithLabelValues(applyFnMetricLabel, metricResultError).Inc()
 		metricTimeToApplySyncSetResource.WithLabelValues(applyFnMetricLabel, metricResultError).Observe(applyTime)
 	} else {
-		logger.WithField("applyResult", applyResult).Debug("resource applied")
+		logger.WithField("applyResult", applyResult).WithField("uid", obj.GetUID()).WithField("resource_version", obj.GetResourceVersion()).WithField("applyTime", applyTime).Info("resource applied")
 		metricResourcesApplied.WithLabelValues(applyFnMetricLabel, metricResultSuccess).Inc()
 		metricTimeToApplySyncSetResource.WithLabelValues(applyFnMetricLabel, metricResultSuccess).Observe(applyTime)
 	}


### PR DESCRIPTION
This PR adds re-adds the functionality that was reverted in #1914, additionally adding some logs to better capture what's really going on in the stage environment.  There are 2 more subsequent related PRs:
* #1923 - reverts the functional changes included in this PR but retains the logging
* #1924 - reverts the non-functional logging changes included in this PR

These PRs are supersets of this PR and contain the same commit SHAs.  They should be merged in order.