### PR TITLE
Fix typo in sample install-config.yaml

### DIFF
--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -417,7 +417,7 @@ networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-  machineCIDR: 10.0.0.0/16
+  machineNetwork: 10.0.0.0/16
   networkType: OpenShiftSDN
   serviceNetwork:
   - 172.30.0.0/16


### PR DESCRIPTION
Signed-off-by: chuckersjp <cdouglas@redhat.com>

Per [recent docs](https://docs.openshift.com/container-platform/4.11/installing/installing_aws/installing-aws-network-customizations.html#nw-network-config_installing-aws-network-customizations) the proper stanza is
`networking.machineNetwork` 