### PR TITLE
Tech Debt: Remove mockctrl.Finish()

### DIFF
--- a/pkg/controller/argocdregister/argocdregister_controller_test.go
+++ b/pkg/controller/argocdregister/argocdregister_controller_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
@@ -201,8 +200,6 @@ func TestArgoCDRegisterReconcile(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			logger := log.WithField("controller", "argocdregister")
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(test.existing...).Build()
-			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 
 			if test.argoCDEnabled {
 				os.Setenv(constants.ArgoCDEnvVar, "true")

--- a/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
@@ -1741,7 +1741,6 @@ users:
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			mockedAWSClient := mock.NewMockClient(mockCtrl)
 
 			if test.configureAWSClient != nil {

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -2981,7 +2981,6 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(test.existing...).Build()
 			controllerExpectations := controllerutils.NewExpectations(logger)
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 
 			mockRemoteClientBuilder := remoteclientmock.NewMockBuilder(mockCtrl)
 
@@ -3071,7 +3070,6 @@ func TestClusterDeploymentReconcileResults(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(test.existing...).Build()
 			controllerExpectations := controllerutils.NewExpectations(logger)
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			mockRemoteClientBuilder := remoteclientmock.NewMockBuilder(mockCtrl)
 			rcd := &ReconcileClusterDeployment{
 				Client:                        fakeClient,
@@ -3762,7 +3760,6 @@ func TestUpdatePullSecretInfo(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(test.existingCD...).Build()
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			mockRemoteClientBuilder := remoteclientmock.NewMockBuilder(mockCtrl)
 			rcd := &ReconcileClusterDeployment{
 				Client:                        fakeClient,
@@ -3926,7 +3923,6 @@ func TestMergePullSecrets(t *testing.T) {
 			}
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(test.existingObjs...).Build()
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			mockRemoteClientBuilder := remoteclientmock.NewMockBuilder(mockCtrl)
 			rcd := &ReconcileClusterDeployment{
 				Client:                        fakeClient,
@@ -3993,7 +3989,6 @@ func TestCopyInstallLogSecret(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(test.existingObjs...).Build()
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			mockRemoteClientBuilder := remoteclientmock.NewMockBuilder(mockCtrl)
 			rcd := &ReconcileClusterDeployment{
 				Client:                        fakeClient,
@@ -4164,7 +4159,6 @@ func TestEnsureManagedDNSZone(t *testing.T) {
 			existingObjs := append(test.existingObjs, test.clusterDeployment)
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(existingObjs...).Build()
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			mockRemoteClientBuilder := remoteclientmock.NewMockBuilder(mockCtrl)
 			rcd := &ReconcileClusterDeployment{
 				Client:                        fakeClient,

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller_test.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller_test.go
@@ -284,7 +284,6 @@ func TestClusterDeprovisionReconcile(t *testing.T) {
 			mocks := setupDefaultMocks(t, test.mockDeleteFailure, existing...)
 
 			// This is necessary for the mocks to report failures like methods not being called an expected number of times.
-			defer mocks.mockCtrl.Finish()
 
 			if test.mockGetCallerIdentity {
 				mocks.mockAWSClient.EXPECT().

--- a/pkg/controller/clusterrelocate/clusterrelocate_controller_test.go
+++ b/pkg/controller/clusterrelocate/clusterrelocate_controller_test.go
@@ -770,7 +770,6 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 			destClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.destResources...).Build()
 
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 
 			mockRemoteClientBuilder := remoteclientmock.NewMockBuilder(mockCtrl)
 			mockRemoteClientBuilder.EXPECT().Build().Return(destClient, nil).AnyTimes()
@@ -1120,7 +1119,6 @@ func TestReconcileClusterRelocate_Reconcile_RelocateStatus(t *testing.T) {
 			destClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.destResources...).Build()
 
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 
 			mockRemoteClientBuilder := remoteclientmock.NewMockBuilder(mockCtrl)
 			mockRemoteClientBuilder.EXPECT().Build().Return(destClient, nil).AnyTimes()

--- a/pkg/controller/clusterstate/clusterstate_controller_test.go
+++ b/pkg/controller/clusterstate/clusterstate_controller_test.go
@@ -161,7 +161,6 @@ func TestClusterStateReconcile(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(test.existing...).Build()
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			mockRemoteClientBuilder := remoteclientmock.NewMockBuilder(mockCtrl)
 			if !test.noRemoteCall {
 				mockRemoteClientBuilder.EXPECT().Build().Return(fake.NewClientBuilder().WithRuntimeObjects(test.remote...).Build(), nil)

--- a/pkg/controller/clustersync/clustersync_controller_test.go
+++ b/pkg/controller/clustersync/clustersync_controller_test.go
@@ -239,7 +239,6 @@ func areSyncStatusesEqual(t *testing.T, syncSetType string, expectedStatuses, ac
 
 func TestReconcileClusterSync_NewClusterDeployment(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	rt := newReconcileTest(t, mockCtrl, scheme,
 		cdBuilder(scheme).Build(),
@@ -306,7 +305,6 @@ func TestReconcileClusterSync_NoWorkToDo(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			var existing []runtime.Object
 			if tc.cd != nil {
 				existing = append(existing,
@@ -340,7 +338,6 @@ func TestReconcileClusterSync_ApplyResource(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(string(tc.applyMode), func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			scheme := newScheme()
 			resourceToApply := testConfigMap("dest-namespace", "dest-name")
 			syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
@@ -419,7 +416,6 @@ func TestGetAndCheckClustersyncStatefulSet(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Arrange
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			rt := newReconcileTest(t, mockCtrl, scheme, tc.existingObjects...)
 
 			// Act
@@ -530,7 +526,6 @@ func TestIsSyncAssignedToMe(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Arrange
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			rt := newReconcileTest(t, mockCtrl, scheme)
 			rt.r.ordinalID = tc.ordinalID
 
@@ -566,7 +561,6 @@ func TestReconcileClusterSync_ApplySecret(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(string(tc.applyMode), func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			scheme := newScheme()
 			syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
 				testsyncset.ForClusterDeployments(testCDName),
@@ -618,7 +612,6 @@ func TestReconcileClusterSync_ApplyPatch(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(string(tc.applyMode), func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			scheme := newScheme()
 			syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
 				testsyncset.ForClusterDeployments(testCDName),
@@ -671,7 +664,6 @@ func TestReconcileClusterSync_ApplyAllTypes(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(string(tc.applyMode), func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			scheme := newScheme()
 			resourceToApply := testConfigMap("resource-namespace", "resource-name")
 			syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
@@ -764,7 +756,6 @@ func TestReconcileClusterSync_Reapply(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			scheme := newScheme()
 			resourceToApply := testConfigMap("dest-namespace", "dest-name")
 			syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
@@ -805,7 +796,6 @@ func TestReconcileClusterSync_Reapply(t *testing.T) {
 
 func TestReconcileClusterSync_NewSyncSetApplied(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	existingResource := testConfigMap("dest-namespace", "dest-name")
 	existingSyncSet := testsyncset.FullBuilder(testNamespace, "existing-syncset", scheme).Build(
@@ -844,7 +834,6 @@ func TestReconcileClusterSync_NewSyncSetApplied(t *testing.T) {
 
 func TestReconcileClusterSync_SyncSetRenamed(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 
 	// clustersync exists for old syncset
@@ -917,7 +906,6 @@ func TestReconcileClusterSync_SyncSetDeleted(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			scheme := newScheme()
 			existingSyncStatusBuilder := newSyncStatusBuilder("test-syncset").Options(
 				withTransitionInThePast(),
@@ -972,7 +960,6 @@ func TestReconcileClusterSync_ResourceRemovedFromSyncSet(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			scheme := newScheme()
 			resourceToApply := testConfigMap("dest-namespace", "retained-resource")
 			resourceToApply2 := testConfigMap("another-namespace", "another-resource")
@@ -1055,7 +1042,6 @@ func TestReconcileClusterSync_ResourceRemovedFromSyncSet(t *testing.T) {
 
 func TestReconcileClusterSync_ErrorApplyingResource(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	resourceToApply := testConfigMap("dest-namespace", "dest-name")
 	syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
@@ -1084,7 +1070,6 @@ func TestReconcileClusterSync_ErrorApplyingResource(t *testing.T) {
 
 func TestReconcileClusterSync_ErrorDecodingResource(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
 		testsyncset.ForClusterDeployments(testCDName),
@@ -1109,7 +1094,6 @@ func TestReconcileClusterSync_ErrorDecodingResource(t *testing.T) {
 
 func TestReconcileClusterSync_ErrorApplyingSecret(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
 		testsyncset.ForClusterDeployments(testCDName),
@@ -1150,7 +1134,6 @@ func TestReconcileClusterSync_ErrorApplyingSecret(t *testing.T) {
 
 func TestReconcileClusterSync_ErrorApplyingPatch(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
 		testsyncset.ForClusterDeployments(testCDName),
@@ -1254,7 +1237,6 @@ func TestReconcileClusterSync_SkipAfterFailingResource(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			scheme := newScheme()
 			resourcesToApply := make([]hivev1.MetaRuntimeObject, 3)
 			for i := range resourcesToApply {
@@ -1430,7 +1412,6 @@ func TestReconcileClusterSync_ResourcesToDeleteAreOrdered(t *testing.T) {
 			}
 			t.Run(fmt.Sprintf("permutation %03d", permutation), func(t *testing.T) {
 				mockCtrl := gomock.NewController(t)
-				defer mockCtrl.Finish()
 				syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
 					testsyncset.ForClusterDeployments(testCDName),
 					testsyncset.WithGeneration(2),
@@ -1543,7 +1524,6 @@ func TestReconcileClusterSync_FailingSyncSetDoesNotBlockOtherSyncSets(t *testing
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			scheme := newScheme()
 			resourcesToApply := make([]hivev1.MetaRuntimeObject, 3)
 			for i := range resourcesToApply {
@@ -1634,7 +1614,6 @@ func TestReconcileClusterSync_FailureMessage(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			scheme := newScheme()
 			syncSets := make([]runtime.Object, tc.failingSyncSets)
 			for i := range syncSets {
@@ -1728,7 +1707,6 @@ func TestReconcileClusterSync_PartialApply(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			scheme := newScheme()
 			resourceToApply := testConfigMap("dest-namespace", "dest-name")
 			syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
@@ -1756,7 +1734,6 @@ func TestReconcileClusterSync_PartialApply(t *testing.T) {
 
 func TestReconcileClusterSync_ErrorDeleting(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	existingSyncStatus := buildSyncStatus("test-syncset",
 		withResourcesToDelete(testConfigMapRef("dest-namespace", "dest-name")),
@@ -1805,7 +1782,6 @@ func TestReconcileClusterSync_DeleteErrorDoesNotBlockOtherDeletes(t *testing.T) 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			scheme := newScheme()
 			existingSyncStatus := buildSyncStatus("test-syncset",
 				withResourcesToDelete(
@@ -1879,7 +1855,6 @@ func TestReconcileClusterSync_ApplyBehavior(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(string(tc.applyBehavior), func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			scheme := newScheme()
 			resourceToApply := testConfigMap("resource-namespace", "resource-name")
 			syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
@@ -1944,7 +1919,6 @@ func TestReconcileClusterSync_ApplyBehavior(t *testing.T) {
 
 func TestReconcileClusterSync_IgnoreNotApplicableSyncSets(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	syncSetResourceToApply := testConfigMap("dest-namespace", "resource-from-applicable-syncset")
 	applicableSyncSet := testsyncset.FullBuilder(testNamespace, "applicable-syncset", scheme).Build(
@@ -1993,7 +1967,6 @@ func TestReconcileClusterSync_IgnoreNotApplicableSyncSets(t *testing.T) {
 
 func TestReconcileClusterSync_ApplySecretForSelectorSyncSet(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	cd := cdBuilder(scheme).Build(testcd.WithLabel("test-label-key", "test-label-value"))
 	selectorSyncSet := testselectorsyncset.FullBuilder("test-selectorsyncset", scheme).Build(
@@ -2032,7 +2005,6 @@ func TestReconcileClusterSync_ApplySecretForSelectorSyncSet(t *testing.T) {
 
 func TestReconcileClusterSync_MissingSecretNamespaceForSelectorSyncSet(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	cd := cdBuilder(scheme).Build(testcd.WithLabel("test-label-key", "test-label-value"))
 	selectorSyncSet := testselectorsyncset.FullBuilder("test-selectorsyncset", scheme).Build(
@@ -2064,7 +2036,6 @@ func TestReconcileClusterSync_MissingSecretNamespaceForSelectorSyncSet(t *testin
 
 func TestReconcileClusterSync_ValidSecretNamespaceForSyncSet(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
 		testsyncset.ForClusterDeployments(testCDName),
@@ -2102,7 +2073,6 @@ func TestReconcileClusterSync_ValidSecretNamespaceForSyncSet(t *testing.T) {
 
 func TestReconcileClusterSync_InvalidSecretNamespaceForSyncSet(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
 		testsyncset.ForClusterDeployments(testCDName),
@@ -2136,7 +2106,6 @@ func TestReconcileClusterSync_InvalidSecretNamespaceForSyncSet(t *testing.T) {
 
 func TestReconcileClusterSync_MissingSourceSecret(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
 		testsyncset.ForClusterDeployments(testCDName),
@@ -2164,7 +2133,6 @@ func TestReconcileClusterSync_MissingSourceSecret(t *testing.T) {
 
 func TestReconcileClusterSync_ConditionNotMutatedWhenMessageNotChanged(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	resourceToApply := testConfigMap("dest-namespace", "dest-name")
 	syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
@@ -2216,7 +2184,6 @@ func TestReconcileClusterSync_ConditionNotMutatedWhenMessageNotChanged(t *testin
 
 func TestReconcileClusterSync_FirstSuccessTime(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	cd := cdBuilder(scheme).Options(testcd.InstalledTimestamp(timeInThePast.Time.Add(-time.Minute * 15).Truncate(time.Second))).Build()
 	resourceToApply := testConfigMap("dest-namespace", "dest-name")
@@ -2272,7 +2239,6 @@ func TestReconcileClusterSync_FirstSuccessTime(t *testing.T) {
 
 func TestReconcileClusterSync_NoFirstSuccessTimeSet(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	cd := cdBuilder(scheme).Options(testcd.InstalledTimestamp(timeInThePast.Time.Add(-time.Minute * 15).Truncate(time.Second))).Build()
 	syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
@@ -2321,7 +2287,6 @@ func TestReconcileClusterSync_NoFirstSuccessTimeSet(t *testing.T) {
 
 func TestReconcileClusterSync_FirstSuccessTimeSetWithNoSyncSets(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	cd := cdBuilder(scheme).Options(testcd.InstalledTimestamp(timeInThePast.Time.Add(-time.Minute * 15).Truncate(time.Second))).Build()
 	clusterSync := clusterSyncBuilder(scheme).Build()
@@ -2350,7 +2315,6 @@ func TestReconcileClusterSync_FirstSuccessTimeSetWithNoSyncSets(t *testing.T) {
 
 func TestReconcileClusterSync_SyncToUpsertResourceApplyMode(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	resourcesToApply := testConfigMap("dest-namespace", "dest-name")
 	syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(
@@ -2405,7 +2369,6 @@ func TestReconcileClusterSync_SyncToUpsertResourceApplyMode(t *testing.T) {
 
 func TestReconcileClusterSync_UpsertToSyncResourceApplyMode(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	scheme := newScheme()
 	resourcesToApply := testConfigMap("dest-namespace", "dest-name")
 	syncSet := testsyncset.FullBuilder(testNamespace, "test-syncset", scheme).Build(

--- a/pkg/controller/clusterversion/clusterversion_controller_test.go
+++ b/pkg/controller/clusterversion/clusterversion_controller_test.go
@@ -84,7 +84,6 @@ func TestClusterVersionReconcile(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(test.existing...).Build()
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			mockRemoteClientBuilder := remoteclientmock.NewMockBuilder(mockCtrl)
 			if !test.noRemoteCall {
 				mockRemoteClientBuilder.EXPECT().Build().Return(testRemoteClusterAPIClient(), nil)

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -169,9 +168,6 @@ func TestReconcileControlPlaneCerts(t *testing.T) {
 				),
 			)
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(test.existing...).Build()
-
-			mockController := gomock.NewController(t)
-			defer mockController.Finish()
 
 			applier := &fakeApplier{}
 			r := &ReconcileControlPlaneCerts{

--- a/pkg/controller/dnsendpoint/dnsendpoint_controller_test.go
+++ b/pkg/controller/dnsendpoint/dnsendpoint_controller_test.go
@@ -410,7 +410,6 @@ func TestDNSEndpointReconcile(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			logger := log.WithField("controller", ControllerName)
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(tc.dnsZone).Build()
 			mockQuery := mock.NewMockQuery(mockCtrl)

--- a/pkg/controller/dnsendpoint/nameserver/aws_test.go
+++ b/pkg/controller/dnsendpoint/nameserver/aws_test.go
@@ -174,7 +174,6 @@ func TestAWSGet(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			mockAWSClient := mock.NewMockClient(mockCtrl)
 			awsQuery := &awsQuery{
 				getAWSClient: func() (awsclient.Client, error) {

--- a/pkg/controller/dnsendpoint/nameserver/azure_test.go
+++ b/pkg/controller/dnsendpoint/nameserver/azure_test.go
@@ -74,7 +74,6 @@ func TestAzureGet(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			mockAzureClient := mock.NewMockClient(mockCtrl)
 
 			azureQuery := &azureQuery{

--- a/pkg/controller/dnsendpoint/nameserver/gcp_test.go
+++ b/pkg/controller/dnsendpoint/nameserver/gcp_test.go
@@ -167,7 +167,6 @@ func TestGCPGet(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			mockGCPClient := mock.NewMockClient(mockCtrl)
 			gcpQuery := &gcpQuery{
 				getGCPClient: func() (gcpclient.Client, error) {

--- a/pkg/controller/dnsendpoint/nameserverscraper_test.go
+++ b/pkg/controller/dnsendpoint/nameserverscraper_test.go
@@ -716,7 +716,6 @@ func TestScrape(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			mockQuery := mock.NewMockQuery(mockCtrl)
 			tc.configureQuery(mockQuery)
 			changeNotifications := make(chan client.Object, 100)

--- a/pkg/controller/dnszone/dnszone_controller_test.go
+++ b/pkg/controller/dnszone/dnszone_controller_test.go
@@ -196,7 +196,6 @@ func TestReconcileDNSProviderForAWS(t *testing.T) {
 			}
 
 			// This is necessary for the mocks to report failures like methods not being called an expected number of times.
-			defer mocks.mockCtrl.Finish()
 
 			setFakeDNSZoneInKube(mocks, tc.dnsZone)
 
@@ -347,7 +346,6 @@ func TestReconcileDNSProviderForGCP(t *testing.T) {
 			}
 
 			// This is necessary for the mocks to report failures like methods not being called an expected number of times.
-			defer mocks.mockCtrl.Finish()
 
 			err := setFakeDNSZoneInKube(mocks, tc.dnsZone)
 			require.NoError(t, err, "failed to create DNSZone into fake client")
@@ -482,7 +480,6 @@ func TestReconcileDNSProviderForAzure(t *testing.T) {
 			}
 
 			// This is necessary for the mocks to report failures like methods not being called an expected number of times.
-			defer mocks.mockCtrl.Finish()
 
 			setFakeDNSZoneInKube(mocks, tc.dnsZone)
 
@@ -594,7 +591,6 @@ func TestReconcileDNSProviderForAWSWithConditions(t *testing.T) {
 			}
 
 			// This is necessary for the mocks to report failures like methods not being called an expected number of times.
-			defer mocks.mockCtrl.Finish()
 
 			setFakeDNSZoneInKube(mocks, tc.dnsZone)
 
@@ -1064,7 +1060,6 @@ func TestSetConditionsForErrorForAWS(t *testing.T) {
 			zr.dnsZone = tc.dnsZone
 
 			// This is necessary for the mocks to report failures like methods not being called an expected number of times.
-			defer mocks.mockCtrl.Finish()
 
 			// Act
 			zr.SetConditionsForError(tc.error)

--- a/pkg/controller/hibernation/alibabacloud_actuator_test.go
+++ b/pkg/controller/hibernation/alibabacloud_actuator_test.go
@@ -133,7 +133,6 @@ func TestAlibabaCloudStopAndStartMachines(t *testing.T) {
 			} else {
 				assert.Nil(t, err)
 			}
-			ctrl.Finish()
 		})
 	}
 

--- a/pkg/controller/hibernation/aws_actuator_test.go
+++ b/pkg/controller/hibernation/aws_actuator_test.go
@@ -230,7 +230,6 @@ func TestMachinesStoppedAndRunning(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			awsClient := mockawsclient.NewMockClient(ctrl)
 			setupClientInstances(awsClient, test.instances)
 			if test.setupClient != nil {

--- a/pkg/controller/hibernation/gcp_actuator_test.go
+++ b/pkg/controller/hibernation/gcp_actuator_test.go
@@ -116,7 +116,6 @@ func TestGCPStopAndStartMachines(t *testing.T) {
 				t.Fatal("Invalid function to test")
 			}
 			assert.Nil(t, err)
-			ctrl.Finish()
 		})
 	}
 

--- a/pkg/controller/hibernation/hibernation_controller_test.go
+++ b/pkg/controller/hibernation/hibernation_controller_test.go
@@ -988,7 +988,6 @@ func TestReconcile(t *testing.T) {
 				require.Nil(t, err)
 				test.validate(t, cd)
 			}
-			ctrl.Finish()
 		})
 	}
 
@@ -1186,7 +1185,6 @@ func TestHibernateAfter(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockActuator := mock.NewMockHibernationActuator(ctrl)
 			mockActuator.EXPECT().CanHandle(gomock.Any()).AnyTimes().Return(!test.hibernationUnsupported)
 			if test.setupActuator != nil {

--- a/pkg/controller/hibernation/ibmcloud_actuator_test.go
+++ b/pkg/controller/hibernation/ibmcloud_actuator_test.go
@@ -149,7 +149,6 @@ func TestIBMCloudStopAndStartMachines(t *testing.T) {
 			} else {
 				assert.Nil(t, err)
 			}
-			ctrl.Finish()
 		})
 	}
 

--- a/pkg/controller/machinepool/alibabacloudactuator_test.go
+++ b/pkg/controller/machinepool/alibabacloudactuator_test.go
@@ -95,7 +95,6 @@ func TestAlibabaCloudActuator(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 
 			alibabaClient := mockalibabacloud.NewMockAPI(mockCtrl)
 

--- a/pkg/controller/machinepool/awsactuator_test.go
+++ b/pkg/controller/machinepool/awsactuator_test.go
@@ -546,7 +546,6 @@ func TestAWSActuator(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 
 			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(test.machinePool).Build()
 			awsClient := mockaws.NewMockClient(mockCtrl)

--- a/pkg/controller/machinepool/azureactuator_test.go
+++ b/pkg/controller/machinepool/azureactuator_test.go
@@ -257,7 +257,6 @@ func TestAzureActuator(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 
 			aClient := mockazure.NewMockClient(mockCtrl)
 

--- a/pkg/controller/machinepool/gcpactuator_test.go
+++ b/pkg/controller/machinepool/gcpactuator_test.go
@@ -177,7 +177,6 @@ func TestGCPActuator(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 
 			gClient := mockgcp.NewMockClient(mockCtrl)
 			clusterDeployment := testGCPClusterDeployment(testName, testInfraID)

--- a/pkg/controller/machinepool/ibmcloudactuator_test.go
+++ b/pkg/controller/machinepool/ibmcloudactuator_test.go
@@ -119,7 +119,6 @@ func TestIBMCloudActuator(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 
 			ibmcloudClient := mockibm.NewMockAPI(mockCtrl)
 

--- a/pkg/controller/machinepool/machinepool_controller_test.go
+++ b/pkg/controller/machinepool/machinepool_controller_test.go
@@ -773,7 +773,6 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 			remoteFakeClient := fake.NewClientBuilder().WithRuntimeObjects(test.remoteExisting...).Build()
 
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 
 			mockActuator := mock.NewMockActuator(mockCtrl)
 			if test.generatedMachineSets != nil {

--- a/pkg/controller/machinepool/openstackactuator_test.go
+++ b/pkg/controller/machinepool/openstackactuator_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,10 +38,6 @@ func BROKEN__TestOpenStackActuator(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
-			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
-
 			actuator := &OpenStackActuator{
 				logger: log.WithField("actuator", "openstackactuator_test"),
 			}

--- a/pkg/controller/machinepool/ovirt_test.go
+++ b/pkg/controller/machinepool/ovirt_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -69,10 +68,6 @@ func TestOvirtActuator(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
-			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
-
 			actuator := &OvirtActuator{
 				logger: log.WithField("actuator", "ovirtactuator_test"),
 			}

--- a/pkg/controller/machinepool/vsphereactuator_test.go
+++ b/pkg/controller/machinepool/vsphereactuator_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -43,9 +42,6 @@ func TestVSphereActuator(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			machineapi.AddToScheme(scheme.Scheme)
-
-			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 
 			actuator, err := NewVSphereActuator(test.masterMachine, scheme.Scheme, log.WithField("actuator", "vsphereactuator_test"))
 			assert.NoError(t, err, "unexpected error creating VSphereActuator")

--- a/pkg/controller/unreachable/unreachable_controller_test.go
+++ b/pkg/controller/unreachable/unreachable_controller_test.go
@@ -237,7 +237,6 @@ func TestReconcile(t *testing.T) {
 			hivev1.AddToScheme(scheme)
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(test.cd).Build()
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			mockRemoteClientBuilder := remoteclientmock.NewMockBuilder(mockCtrl)
 			if test.errorConnecting != nil {
 				mockRemoteClientBuilder.EXPECT().UsePrimaryAPIURL().Return(mockRemoteClientBuilder)

--- a/pkg/controller/velerobackup/velerobackup_controller_test.go
+++ b/pkg/controller/velerobackup/velerobackup_controller_test.go
@@ -66,7 +66,6 @@ func TestNewReconciler(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// Arrange
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 			mockManager := mock.NewMockManager(mockCtrl)
 			mockManager.EXPECT().GetScheme().Return(nil)
 			test.setup()

--- a/pkg/installmanager/ibm_metadata_test.go
+++ b/pkg/installmanager/ibm_metadata_test.go
@@ -59,7 +59,6 @@ func TestGetCISInstanceCRN(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 
 			ibmcloudClient := mockibm.NewMockAPI(mockCtrl)
 
@@ -98,7 +97,6 @@ func TestGetAccountID(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
 
 			ibmcloudClient := mockibm.NewMockAPI(mockCtrl)
 

--- a/pkg/installmanager/installmanager_test.go
+++ b/pkg/installmanager/installmanager_test.go
@@ -174,7 +174,6 @@ func TestInstallManager(t *testing.T) {
 			mocks := setupDefaultMocks(t, existing...)
 
 			// This is necessary for the mocks to report failures like methods not being called an expected number of times.
-			defer mocks.mockCtrl.Finish()
 
 			// create a fake install-config
 			mountedInstallConfigFile := filepath.Join(tempDir, "mounted-install-config.yaml")

--- a/pkg/installmanager/s3loguploaderactuator_test.go
+++ b/pkg/installmanager/s3loguploaderactuator_test.go
@@ -50,7 +50,6 @@ func TestUploadLogs(t *testing.T) {
 			mocks := setupDefaultMocks(t, test.existing...)
 
 			// This is necessary for the mocks to report failures like methods not being called an expected number of times.
-			defer mocks.mockCtrl.Finish()
 
 			// The aws actuator won't run without this set.
 			if test.setupEnvVars {


### PR DESCRIPTION
As of go 1.14, it is no longer necessary to call mockctrl.Finish(). We're on 1.19. Clean 'em up.

Note: this brought to light a handful of places where we didn't need the mock controller at all. It is removed from those places.