### PR TITLE
updates adoption steps for privatelink clusters/added configurations

### DIFF
--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -1203,11 +1203,7 @@ If the cluster you are looking to adopt is on AWS and leverages Privatelink, you
       region: us-east-1
 ```      
 
-It's also important to include any other configurations that may be in place in the original clusters' ClusterDeployment, such as `certificateBundles` settings or `controlPlaneConfig` settings as these are leveraged by certman-operator if in use. It's a good idea to compare your adoption manifest to your existing ClusterDeployment manifest. Any new secret refs added to your adoption manifest will require correlating secrets to live on the adopting cluster in the correct namespace.
-
 ### Adopting with hiveutil
-
-_NOTE: If you have any customizations outside of the sample manfiest (Privatelink, certificate configurations), the `hiveutil` method may not encompass all those._
 
 [hiveutil](hiveutil.md) is a development focused CLI tool which can be built from the hive repo. To adopt a cluster specify the following flags:
 

--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -1191,7 +1191,23 @@ spec:
     name: pull-secret
 ```
 
+If the cluster you are looking to adopt is on AWS and leverages Privatelink, you'll also need to include that setting under `spec.platform.aws` to ensure the VPC Endpoint Service for the cluster is tracked in the ClusterDeployment
+
+```yaml
+  platform:
+    aws:
+      credentialsSecretRef:
+        name: my-aws-cluster-creds
+      privateLink:
+        enabled: true
+      region: us-east-1
+```      
+
+It's also important to include any other configurations that may be in place in the original clusters' ClusterDeployment, such as `certificateBundles` settings or `controlPlaneConfig` settings as these are leveraged by certman-operator if in use. It's a good idea to compare your adoption manifest to your existing ClusterDeployment manifest. Any new secret refs added to your adoption manifest will require correlating secrets to live on the adopting cluster in the correct namespace.
+
 ### Adopting with hiveutil
+
+_NOTE: If you have any customizations outside of the sample manfiest (Privatelink, certificate configurations), the `hiveutil` method may not encompass all those._
 
 [hiveutil](hiveutil.md) is a development focused CLI tool which can be built from the hive repo. To adopt a cluster specify the following flags:
 


### PR DESCRIPTION
- Updates adoption info to address Privatelink clusters for ROSA as well as any extra configs that may be in use
- addresses limitations of using hiveutil as it does not support privatelink setting or any extra configurations required (which we set in FedRAMP)