### PR TITLE
Name inventory test cluster to be caught by lambda

### DIFF
--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -228,8 +228,8 @@ oc get clusterpool ${REAL_POOL_NAME} -o json \
   | oc apply -f -
 
 # Add customization to REAL POOL
-# NOTE: Use the hiveci- prefix for cluster names so they get caught by our leak detector.
-NEW_CLUSTER_NAME="hiveci-cdc-$(cat /dev/urandom | tr -dc 'a-z' | fold -w 4 | head -n 1)"
+# NOTE: Use the cdcci- prefix for this cluster name so it gets caught by our leak detector.
+NEW_CLUSTER_NAME=cdcci-${$CLUSTER_NAME#*-}
 create_customization "cdc-test" "${CLUSTER_NAMESPACE}" "${NEW_CLUSTER_NAME}"
 oc patch cp -n $CLUSTER_NAMESPACE $REAL_POOL_NAME --type=merge -p '{"spec": {"inventory": [{"name": "cdc-test"}]}}'
 

--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -229,7 +229,7 @@ oc get clusterpool ${REAL_POOL_NAME} -o json \
 
 # Add customization to REAL POOL
 # NOTE: Use the cdcci- prefix for this cluster name so it gets caught by our leak detector.
-NEW_CLUSTER_NAME=cdcci-${$CLUSTER_NAME#*-}
+NEW_CLUSTER_NAME=cdcci-${CLUSTER_NAME#*-}
 create_customization "cdc-test" "${CLUSTER_NAMESPACE}" "${NEW_CLUSTER_NAME}"
 oc patch cp -n $CLUSTER_NAMESPACE $REAL_POOL_NAME --type=merge -p '{"spec": {"inventory": [{"name": "cdc-test"}]}}'
 


### PR DESCRIPTION
1eb917189 / #1918 tried to rename the cluster we generate for testing ClusterPool inventory so it would be caught by our leak detector lambda. We erroneously thought all we had to do was prefix the name with `hiveci-` when in fact the whole name gets parsed to glean the timestamp (when the test started) and the PR number under test. As such, when one of these clusters leaked, it was causing an exception in the lambda function like:

```
Traceback (most recent call last):
  File "/var/task/ci_monitor_lambda_function.py", line 58, in lambda_handler
    formatted, count = build_report_text(vpcs, debug=debug)
  File "/var/task/ci_monitor_lambda_function.py", line 84, in build_report_text
    parsed = parse_vpc(vpc)
  File "/var/task/ci_monitor_lambda_function.py", line 23, in parse_vpc
    ret['pr'] = int(hex_pr, 16)
```

Due to length constraints, we can't use a suffix; so instead we're going to update the lambda to recognize an additional prefix, `cdcci-` and keep the rest of the cluster name the same.