### PR TITLE
Add Gp3VolumeLimitExceeded install failure reason

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -159,6 +159,11 @@ data:
       - "VcpuLimitExceeded"
       installFailingReason: VcpuLimitExceeded
       installFailingMessage: The install requires more vCPU capacity than your current vCPU limit
+    - name: Gp3VolumeLimitExceeded
+      searchRegexStrings:
+      - "VolumeLimitExceeded: You have exceeded your maximum gp3 storage limit"
+      installFailingReason: Gp3VolumeLimitExceeded
+      installFailingMessage: "The installation failed due to insufficient gp3 storage quota in the region (QuotaCode L-7A658B76)"
     - name: UserInitiatedShutdown
       searchRegexStrings:
       - "Error waiting for instance .* to become ready .* User initiated shutdown"
@@ -261,7 +266,7 @@ data:
 
 
     # Generic OpenShift Install
-    
+
     - name: KubeAPIWaitTimeout
       searchRegexStrings:
       - "waiting for Kubernetes API: context deadline exceeded"

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -66,6 +66,7 @@ time="2021-12-09T10:53:06Z" level=error msg="blahblah. Got 0 worker nodes, 3 mas
 	bootstrapFailed         = "time=\"2022-01-27T03:33:08Z\" level=error msg=\"Failed to wait for bootstrapping to complete. This error usually happens when there is a problem with control plane hosts that prevents the control plane operators from creating the control plane.\""
 	awsDeniedByScp          = "AccessDenied: entity is not authorized to perform: iam:PressTheButton on resource: Thing with an explicit deny in a service control policy"
 	awsInsufficientCapacity = "level=error msg=\"failed to fetch Cluster: failed to generate asset \"Cluster\": failure applying terraform for \"cluster\" stage: failed to create cluster: failed to apply Terraform: exit status 1\n\nError: Error launching source instance: InsufficientInstanceCapacity: We currently do not have sufficient m5.2xlarge capacity in the Availability Zone you requested (eu-south-1b). Our system will be working on provisioning additional capacity. You can currently get m5.2xlarge capacity by not specifying an Availability Zone in your request or choosing eu-south-1a, eu-south-1c."
+	gp3VolumeLimitExceeded  = "Error launching source instance: VolumeLimitExceeded: You have exceeded your maximum gp3 storage limit of 50 TiB in this region. Please contact AWS Support to request an Elastic Block Store service limit increase."
 )
 
 func TestParseInstallLog(t *testing.T) {
@@ -77,6 +78,11 @@ func TestParseInstallLog(t *testing.T) {
 		expectedReason  string
 		expectedMessage *string
 	}{
+		{
+			name:           "Gp3VolumeLimitExceeded",
+			log:            pointer.StringPtr(gp3VolumeLimitExceeded),
+			expectedReason: "Gp3VolumeLimitExceeded",
+		},
 		{
 			name:           "AWSInsufficientCapacity",
 			log:            pointer.StringPtr(awsInsufficientCapacity),

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1761,6 +1761,11 @@ data:
       - "VcpuLimitExceeded"
       installFailingReason: VcpuLimitExceeded
       installFailingMessage: The install requires more vCPU capacity than your current vCPU limit
+    - name: Gp3VolumeLimitExceeded
+      searchRegexStrings:
+      - "VolumeLimitExceeded: You have exceeded your maximum gp3 storage limit"
+      installFailingReason: Gp3VolumeLimitExceeded
+      installFailingMessage: "The installation failed due to insufficient gp3 storage quota in the region (QuotaCode L-7A658B76)"
     - name: UserInitiatedShutdown
       searchRegexStrings:
       - "Error waiting for instance .* to become ready .* User initiated shutdown"
@@ -1863,7 +1868,7 @@ data:
 
 
     # Generic OpenShift Install
-    
+
     - name: KubeAPIWaitTimeout
       searchRegexStrings:
       - "waiting for Kubernetes API: context deadline exceeded"


### PR DESCRIPTION
In [OSD-14978](https://issues.redhat.com//browse/OSD-14978) we learned about a new way installs can fail.

> Why `Gp3VolumeLimitExceeded` and not `VolumeLimitExceeded`?

I would like to be able to give the customer the exact quota to increase, in this case: "L-7A658B76"

