### PR TITLE
StringPtr deprecated in favor of String

### DIFF
--- a/pkg/controller/argocdregister/argocdregister_controller_test.go
+++ b/pkg/controller/argocdregister/argocdregister_controller_test.go
@@ -303,8 +303,8 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 
 	cd.Status = hivev1.ClusterDeploymentStatus{
 		APIURL:         "http://test-api.test.com",
-		InstallerImage: pointer.StringPtr("installer-image:latest"),
-		CLIImage:       pointer.StringPtr("cli:latest"),
+		InstallerImage: pointer.String("installer-image:latest"),
+		CLIImage:       pointer.String("cli:latest"),
 	}
 
 	return cd

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -703,8 +703,8 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testInstallConfigSecret(),
 				func() *hivev1.ClusterDeployment {
 					cd := testClusterDeploymentWithDefaultConditions(testClusterDeploymentWithInitializedConditions(testClusterDeployment()))
-					cd.Status.InstallerImage = pointer.StringPtr("test-installer-image")
-					cd.Status.CLIImage = pointer.StringPtr("test-cli-image")
+					cd.Status.InstallerImage = pointer.String("test-installer-image")
+					cd.Status.CLIImage = pointer.String("test-cli-image")
 					cd.Spec.Provisioning.ImageSetRef = &hivev1.ClusterImageSetReference{Name: testClusterImageSetName}
 					cd.Status.Conditions = addOrUpdateClusterDeploymentCondition(*cd, hivev1.InstallImagesNotResolvedCondition,
 						corev1.ConditionTrue, "test-reason", "test-message")
@@ -727,8 +727,8 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testInstallConfigSecret(),
 				func() *hivev1.ClusterDeployment {
 					cd := testClusterDeploymentWithDefaultConditions(testClusterDeploymentWithInitializedConditions(testClusterDeployment()))
-					cd.Status.InstallerImage = pointer.StringPtr("test-installer-image")
-					cd.Status.CLIImage = pointer.StringPtr("test-cli-image")
+					cd.Status.InstallerImage = pointer.String("test-installer-image")
+					cd.Status.CLIImage = pointer.String("test-cli-image")
 					cd.Spec.Provisioning.ImageSetRef = &hivev1.ClusterImageSetReference{Name: testClusterImageSetName}
 					return cd
 				}(),
@@ -780,7 +780,7 @@ func TestClusterDeploymentReconcile(t *testing.T) {
 				testInstallConfigSecret(),
 				func() *hivev1.ClusterDeployment {
 					cd := testClusterDeploymentWithDefaultConditions(testClusterDeploymentWithInitializedConditions(testClusterDeployment()))
-					cd.Status.InstallerImage = pointer.StringPtr("test-installer-image:latest")
+					cd.Status.InstallerImage = pointer.String("test-installer-image:latest")
 					cd.Spec.Provisioning.ImageSetRef = &hivev1.ClusterImageSetReference{Name: testClusterImageSetName}
 					return cd
 				}(),
@@ -3318,8 +3318,8 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 	cd.Labels[hivev1.HiveClusterRegionLabel] = "us-east-1"
 
 	cd.Status = hivev1.ClusterDeploymentStatus{
-		InstallerImage: pointer.StringPtr("installer-image:latest"),
-		CLIImage:       pointer.StringPtr("cli:latest"),
+		InstallerImage: pointer.String("installer-image:latest"),
+		CLIImage:       pointer.String("cli:latest"),
 	}
 
 	return cd
@@ -3814,7 +3814,7 @@ func getCDWithoutPullSecret() *hivev1.ClusterDeployment {
 		},
 	}
 	cd.Status = hivev1.ClusterDeploymentStatus{
-		InstallerImage: pointer.StringPtr("installer-image:latest"),
+		InstallerImage: pointer.String("installer-image:latest"),
 	}
 	return cd
 }

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -80,97 +80,97 @@ func TestParseInstallLog(t *testing.T) {
 	}{
 		{
 			name:           "Gp3VolumeLimitExceeded",
-			log:            pointer.StringPtr(gp3VolumeLimitExceeded),
+			log:            pointer.String(gp3VolumeLimitExceeded),
 			expectedReason: "Gp3VolumeLimitExceeded",
 		},
 		{
 			name:           "AWSInsufficientCapacity",
-			log:            pointer.StringPtr(awsInsufficientCapacity),
+			log:            pointer.String(awsInsufficientCapacity),
 			expectedReason: "AWSInsufficientCapacity",
 		},
 		{
 			name:           "load balancer service linked role prereq",
-			log:            pointer.StringPtr(accessDeniedSLR),
+			log:            pointer.String(accessDeniedSLR),
 			expectedReason: "AWSAccessDeniedSLR",
 		},
 		{
 			name:           "DNS already exists",
-			log:            pointer.StringPtr(dnsAlreadyExistsLog),
+			log:            pointer.String(dnsAlreadyExistsLog),
 			expectedReason: "DNSAlreadyExists",
 		},
 		{
 			name:           "PendingVerification",
-			log:            pointer.StringPtr(pendingVerificationLog),
+			log:            pointer.String(pendingVerificationLog),
 			expectedReason: "PendingVerification",
 		},
 		{
 			name:           "Wildcard",
-			log:            pointer.StringPtr(gcpInvalidProjectIDLog),
+			log:            pointer.String(gcpInvalidProjectIDLog),
 			expectedReason: "GCPInvalidProjectID",
 		},
 		{
 			name:           "Escaped single quotes",
-			log:            pointer.StringPtr(gcpSSDQUotaLog),
+			log:            pointer.String(gcpSSDQUotaLog),
 			expectedReason: "GCPQuotaSSDTotalGBExceeded",
 		},
 		{
 			name:           "AWSNATGatewayLimitExceeded",
-			log:            pointer.StringPtr(natGatewayLimitExceeded),
+			log:            pointer.String(natGatewayLimitExceeded),
 			expectedReason: "AWSNATGatewayLimitExceeded",
 		},
 		{
 			name:           "AWSVPCLimitExceeded",
-			log:            pointer.StringPtr(vpcLimitExceeded),
+			log:            pointer.String(vpcLimitExceeded),
 			expectedReason: "AWSVPCLimitExceeded",
 		},
 		{
 			name:           "AWSRoute53LimitExceeded",
-			log:            pointer.StringPtr(route53LimitExceeded),
+			log:            pointer.String(route53LimitExceeded),
 			expectedReason: "TooManyRoute53Zones",
 		},
 		{
 			name:           "Generic ResourceLimitExceeded",
-			log:            pointer.StringPtr(genericLimitExceeded),
+			log:            pointer.String(genericLimitExceeded),
 			expectedReason: "FallbackResourceLimitExceeded",
 		},
 		{
 			name:           "Credentials are invalid",
-			log:            pointer.StringPtr(invalidCredentials),
+			log:            pointer.String(invalidCredentials),
 			expectedReason: "InvalidCredentials",
 		},
 		{
 			name:           "Failed waiting for Kubernetes API",
-			log:            pointer.StringPtr(kubeAPIWaitFailedLog),
+			log:            pointer.String(kubeAPIWaitFailedLog),
 			expectedReason: "KubeAPIWaitFailed",
 		},
 		{
 			name:           "ProxyTimeout",
-			log:            pointer.StringPtr(proxyTimeoutLog),
+			log:            pointer.String(proxyTimeoutLog),
 			expectedReason: "ProxyTimeout",
 		},
 		{
 			name:           "Proxy Connection Refused",
-			log:            pointer.StringPtr(proxyConnectionRefused),
+			log:            pointer.String(proxyConnectionRefused),
 			expectedReason: "ProxyTimeout",
 		},
 		{
 			name:           "Proxy No Route To Host",
-			log:            pointer.StringPtr(proxyNoRouteToHost),
+			log:            pointer.String(proxyNoRouteToHost),
 			expectedReason: "ProxyTimeout",
 		},
 		{
 			name:           "ProxyInvalidCABundle",
-			log:            pointer.StringPtr(proxyInvalidCABundleLog),
+			log:            pointer.String(proxyInvalidCABundleLog),
 			expectedReason: "ProxyInvalidCABundle",
 		},
 		{
 			name:           "AWSDeniedBySCP",
-			log:            pointer.StringPtr(awsDeniedByScp),
+			log:            pointer.String(awsDeniedByScp),
 			expectedReason: "AWSDeniedBySCP",
 		},
 		{
 			name: "KubeAPIWaitTimeout from additional regex entries",
-			log:  pointer.StringPtr(kubeAPIWaitTimeoutLog),
+			log:  pointer.String(kubeAPIWaitTimeoutLog),
 			existing: []runtime.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -207,7 +207,7 @@ func TestParseInstallLog(t *testing.T) {
 		},
 		{
 			name: "regexes take precedence over additionalRegexes",
-			log:  pointer.StringPtr(kubeAPIWaitTimeoutLog),
+			log:  pointer.String(kubeAPIWaitTimeoutLog),
 			existing: []runtime.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -248,19 +248,19 @@ func TestParseInstallLog(t *testing.T) {
 		},
 		{
 			name:            "no matching log",
-			log:             pointer.StringPtr(noMatchLog),
+			log:             pointer.String(noMatchLog),
 			expectedReason:  unknownReason,
-			expectedMessage: pointer.StringPtr(noMatchLog),
+			expectedMessage: pointer.String(noMatchLog),
 		},
 		{
 			name:           "missing regex configmap",
-			log:            pointer.StringPtr(dnsAlreadyExistsLog),
+			log:            pointer.String(dnsAlreadyExistsLog),
 			existing:       []runtime.Object{},
 			expectedReason: unknownReason,
 		},
 		{
 			name: "missing regexes data entry",
-			log:  pointer.StringPtr(dnsAlreadyExistsLog),
+			log:  pointer.String(dnsAlreadyExistsLog),
 			existing: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      regexConfigMapName,
@@ -271,7 +271,7 @@ func TestParseInstallLog(t *testing.T) {
 		},
 		{
 			name: "malformed regex",
-			log:  pointer.StringPtr(dnsAlreadyExistsLog),
+			log:  pointer.String(dnsAlreadyExistsLog),
 			existing: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      regexConfigMapName,
@@ -285,7 +285,7 @@ func TestParseInstallLog(t *testing.T) {
 		},
 		{
 			name: "skip bad regex entry",
-			log:  pointer.StringPtr(dnsAlreadyExistsLog),
+			log:  pointer.String(dnsAlreadyExistsLog),
 			existing: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      regexConfigMapName,
@@ -310,7 +310,7 @@ func TestParseInstallLog(t *testing.T) {
 		},
 		{
 			name: "skip bad search string",
-			log:  pointer.StringPtr(dnsAlreadyExistsLog),
+			log:  pointer.String(dnsAlreadyExistsLog),
 			existing: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      regexConfigMapName,
@@ -331,102 +331,102 @@ func TestParseInstallLog(t *testing.T) {
 		},
 		{
 			name:           "GCP compute quota",
-			log:            pointer.StringPtr(gcpCPUQuotaLog),
+			log:            pointer.String(gcpCPUQuotaLog),
 			expectedReason: "GCPComputeQuotaExceeded",
 		},
 		{
 			name:           "GCP service account quota",
-			log:            pointer.StringPtr(gcpServiceAccountQuotaLog),
+			log:            pointer.String(gcpServiceAccountQuotaLog),
 			expectedReason: "GCPServiceAccountQuotaExceeded",
 		},
 		{
 			name:           "Can't delete IAM role",
-			log:            pointer.StringPtr(awsDeleteRoleFailed),
+			log:            pointer.String(awsDeleteRoleFailed),
 			expectedReason: "ErrorDeletingIAMRole",
 		},
 		{
 			name:           "AWSSubnetDoesNotExist",
-			log:            pointer.StringPtr(subnetDoesNotExist),
+			log:            pointer.String(subnetDoesNotExist),
 			expectedReason: "AWSSubnetDoesNotExist",
 		},
 		{
 			name:           "NATGatewayFailed",
-			log:            pointer.StringPtr(natGateWayFailed),
+			log:            pointer.String(natGateWayFailed),
 			expectedReason: "NATGatewayFailed",
 		},
 		{
 			name:           "AWSInsufficientPermissions",
-			log:            pointer.StringPtr(insufficientPermissions),
+			log:            pointer.String(insufficientPermissions),
 			expectedReason: "AWSInsufficientPermissions",
 		},
 		{
 			name:           "LoadBalancerLimitExceeded",
-			log:            pointer.StringPtr(loadBalancerLimitExceeded),
+			log:            pointer.String(loadBalancerLimitExceeded),
 			expectedReason: "LoadBalancerLimitExceeded",
 		},
 		{
 			name:           "AWSEC2QuotaExceeded",
-			log:            pointer.StringPtr(awsEC2QuotaExceeded),
+			log:            pointer.String(awsEC2QuotaExceeded),
 			expectedReason: "AWSEC2QuotaExceeded",
 		},
 		{
 			name:           "AWSNoWorkerNodes",
-			log:            pointer.StringPtr(fmt.Sprintf(noWorkerNodesFmt, "aws", "aws")),
+			log:            pointer.String(fmt.Sprintf(noWorkerNodesFmt, "aws", "aws")),
 			expectedReason: "AWSNoWorkerNodes",
 		},
 		{
 			name:           "GCPNoWorkerNodes",
-			log:            pointer.StringPtr(fmt.Sprintf(noWorkerNodesFmt, "gcp", "gcp")),
+			log:            pointer.String(fmt.Sprintf(noWorkerNodesFmt, "gcp", "gcp")),
 			expectedReason: "GCPNoWorkerNodes",
 		},
 		{
 			name:           "BootstrapFailed",
-			log:            pointer.StringPtr(bootstrapFailed),
+			log:            pointer.String(bootstrapFailed),
 			expectedReason: "BootstrapFailed",
 		},
 		{
 			name:           "KubeAPIWaitFailed",
-			log:            pointer.StringPtr(kubeAPIWaitFailedLog),
+			log:            pointer.String(kubeAPIWaitFailedLog),
 			expectedReason: "KubeAPIWaitFailed",
 		},
 		{
 			name:           "GenericBootstrapFailed",
-			log:            pointer.StringPtr(genericBootstrapFailed),
+			log:            pointer.String(genericBootstrapFailed),
 			expectedReason: "GenericBootstrapFailed",
 		},
 		{
 			name:           "AWSRoute53Timeout",
-			log:            pointer.StringPtr(route53Timeout),
+			log:            pointer.String(route53Timeout),
 			expectedReason: "AWSRoute53Timeout",
 		},
 		{
 			name:           "InconsistentTerraformResult",
-			log:            pointer.StringPtr(inconsistentTerraformResult),
+			log:            pointer.String(inconsistentTerraformResult),
 			expectedReason: "InconsistentTerraformResult",
 		},
 		{
 			name:           "MultipleRoute53ZonesFound",
-			log:            pointer.StringPtr(multipleRoute53ZonesFound),
+			log:            pointer.String(multipleRoute53ZonesFound),
 			expectedReason: "MultipleRoute53ZonesFound",
 		},
 		{
 			name:           "AWSVPCDoesNotExist",
-			log:            pointer.StringPtr(awsInvalidVpcId),
+			log:            pointer.String(awsInvalidVpcId),
 			expectedReason: "AWSVPCDoesNotExist",
 		},
 		{
 			name:           "TargetGroupNotFound",
-			log:            pointer.StringPtr(targetGroupNotFound),
+			log:            pointer.String(targetGroupNotFound),
 			expectedReason: "TargetGroupNotFound",
 		},
 		{
 			name:           "ErrorCreatingNetworkLoadBalancer",
-			log:            pointer.StringPtr(errorCreatingNLB),
+			log:            pointer.String(errorCreatingNLB),
 			expectedReason: "ErrorCreatingNetworkLoadBalancer",
 		},
 		{
 			name:           "ErrorDestroyingBootstrapResources",
-			log:            pointer.StringPtr(terraformFailedDelete),
+			log:            pointer.String(terraformFailedDelete),
 			expectedReason: "InstallerFailedToDestroyResources",
 		},
 	}

--- a/pkg/controller/dnsendpoint/nameserver/aws_test.go
+++ b/pkg/controller/dnsendpoint/nameserver/aws_test.go
@@ -182,12 +182,12 @@ func TestAWSGet(t *testing.T) {
 			}
 			for i, out := range tc.listHostedZonesOutputs {
 				in := &route53.ListHostedZonesByNameInput{
-					DNSName:  pointer.StringPtr("test-domain."),
-					MaxItems: pointer.StringPtr("5"),
+					DNSName:  pointer.String("test-domain."),
+					MaxItems: pointer.String("5"),
 				}
 				if i > 0 {
-					in.DNSName = pointer.StringPtr("next-dns-name")
-					in.HostedZoneId = pointer.StringPtr("next-hosted-zone-id")
+					in.DNSName = pointer.String("next-dns-name")
+					in.HostedZoneId = pointer.String("next-hosted-zone-id")
 				}
 				mockAWSClient.EXPECT().
 					ListHostedZonesByName(gomock.Eq(in)).
@@ -195,12 +195,12 @@ func TestAWSGet(t *testing.T) {
 			}
 			for i, out := range tc.listResourceRecordSetsOutputs {
 				in := &route53.ListResourceRecordSetsInput{
-					HostedZoneId: pointer.StringPtr("test-zone-id"),
-					MaxItems:     pointer.StringPtr("100"),
+					HostedZoneId: pointer.String("test-zone-id"),
+					MaxItems:     pointer.String("100"),
 				}
 				if i > 0 {
-					in.StartRecordName = pointer.StringPtr("next-record-name")
-					in.StartRecordType = pointer.StringPtr("next-record-type")
+					in.StartRecordName = pointer.String("next-record-name")
+					in.StartRecordType = pointer.String("next-record-type")
 				}
 				mockAWSClient.EXPECT().
 					ListResourceRecordSets(gomock.Eq(in)).
@@ -236,8 +236,8 @@ func withHostedZones(hostedZones ...*route53.HostedZone) listHostedZonesOutputOp
 func hzTruncated() listHostedZonesOutputOption {
 	return func(out *route53.ListHostedZonesByNameOutput) {
 		out.IsTruncated = pointer.BoolPtr(true)
-		out.NextDNSName = pointer.StringPtr("next-dns-name")
-		out.NextHostedZoneId = pointer.StringPtr("next-hosted-zone-id")
+		out.NextDNSName = pointer.String("next-dns-name")
+		out.NextHostedZoneId = pointer.String("next-hosted-zone-id")
 	}
 }
 
@@ -282,8 +282,8 @@ func withRecordSets(recordSets ...*route53.ResourceRecordSet) listResourceRecord
 func rrsTruncated() listResourceRecordSetsOutputOption {
 	return func(out *route53.ListResourceRecordSetsOutput) {
 		out.IsTruncated = pointer.BoolPtr(true)
-		out.NextRecordName = pointer.StringPtr("next-record-name")
-		out.NextRecordType = pointer.StringPtr("next-record-type")
+		out.NextRecordName = pointer.String("next-record-name")
+		out.NextRecordType = pointer.String("next-record-type")
 	}
 }
 
@@ -295,7 +295,7 @@ func testRecordSet(name string, recordType string, values ...string) *route53.Re
 	}
 	for i, value := range values {
 		recordSet.ResourceRecords[i] = &route53.ResourceRecord{
-			Value: pointer.StringPtr(value),
+			Value: pointer.String(value),
 		}
 	}
 	return recordSet

--- a/pkg/controller/hibernation/azure_actuator_test.go
+++ b/pkg/controller/hibernation/azure_actuator_test.go
@@ -208,12 +208,12 @@ func setupAzureClientInstances(client *mockazureclient.MockClient, instances map
 			name := fmt.Sprintf("%s-%d", state, i)
 			instanceViewStatus := []compute.InstanceViewStatus{
 				{
-					Code: pointer.StringPtr("PowerState/" + state),
+					Code: pointer.String("PowerState/" + state),
 				},
 			}
 			vms = append(vms, compute.VirtualMachine{
-				Name: pointer.StringPtr(name),
-				ID:   pointer.StringPtr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s", azureTestSubscription, azureTestResourceGroup, name)),
+				Name: pointer.String(name),
+				ID:   pointer.String(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s", azureTestSubscription, azureTestResourceGroup, name)),
 				VirtualMachineProperties: &compute.VirtualMachineProperties{
 					InstanceView: &compute.VirtualMachineInstanceView{
 						Statuses: &instanceViewStatus,

--- a/pkg/controller/hibernation/ibmcloud_actuator_test.go
+++ b/pkg/controller/hibernation/ibmcloud_actuator_test.go
@@ -250,9 +250,9 @@ func setupIBMCloudClientInstances(ibmCloudClient *mockibmclient.MockAPI, statuse
 	for status, count := range statuses {
 		for i := 0; i < count; i++ {
 			instances = append(instances, vpcv1.Instance{
-				Name:   pointer.StringPtr(fmt.Sprintf("%s-%d", status, i)),
-				ID:     pointer.StringPtr(fmt.Sprintf("%s-%d", status, i)),
-				Status: pointer.StringPtr(status),
+				Name:   pointer.String(fmt.Sprintf("%s-%d", status, i)),
+				ID:     pointer.String(fmt.Sprintf("%s-%d", status, i)),
+				Status: pointer.String(status),
 			})
 		}
 	}

--- a/pkg/controller/machinepool/awsactuator_test.go
+++ b/pkg/controller/machinepool/awsactuator_test.go
@@ -64,7 +64,7 @@ func TestAWSActuator(t *testing.T) {
 				generateAWSMachineSetName("zone1"): 3,
 			},
 			expectedAMI: &machineapi.AWSResourceReference{
-				ID: pointer.StringPtr(testAMI),
+				ID: pointer.String(testAMI),
 			},
 		},
 		{
@@ -81,7 +81,7 @@ func TestAWSActuator(t *testing.T) {
 				generateAWSMachineSetName("zone3"): 1,
 			},
 			expectedAMI: &machineapi.AWSResourceReference{
-				ID: pointer.StringPtr(testAMI),
+				ID: pointer.String(testAMI),
 			},
 		},
 		{
@@ -99,7 +99,7 @@ func TestAWSActuator(t *testing.T) {
 				generateAWSMachineSetName("zone3"): 1,
 			},
 			expectedAMI: &machineapi.AWSResourceReference{
-				ID: pointer.StringPtr(testAMI),
+				ID: pointer.String(testAMI),
 			},
 		},
 		{
@@ -133,7 +133,7 @@ func TestAWSActuator(t *testing.T) {
 			},
 			expectedSubnetIDInMachineSet: true,
 			expectedAMI: &machineapi.AWSResourceReference{
-				ID: pointer.StringPtr(testAMI),
+				ID: pointer.String(testAMI),
 			},
 		},
 		{
@@ -146,7 +146,7 @@ func TestAWSActuator(t *testing.T) {
 			},
 			expectedErr: true,
 			expectedAMI: &machineapi.AWSResourceReference{
-				ID: pointer.StringPtr(testAMI),
+				ID: pointer.String(testAMI),
 			},
 		},
 		{
@@ -169,7 +169,7 @@ func TestAWSActuator(t *testing.T) {
 				Reason: "SubnetsNotFound",
 			},
 			expectedAMI: &machineapi.AWSResourceReference{
-				ID: pointer.StringPtr(testAMI),
+				ID: pointer.String(testAMI),
 			},
 		},
 		{
@@ -198,7 +198,7 @@ func TestAWSActuator(t *testing.T) {
 				Reason: "MoreThanOneSubnetForZone",
 			},
 			expectedAMI: &machineapi.AWSResourceReference{
-				ID: pointer.StringPtr(testAMI),
+				ID: pointer.String(testAMI),
 			},
 		},
 		{
@@ -226,7 +226,7 @@ func TestAWSActuator(t *testing.T) {
 				Reason: "NoSubnetForAvailabilityZone",
 			},
 			expectedAMI: &machineapi.AWSResourceReference{
-				ID: pointer.StringPtr(testAMI),
+				ID: pointer.String(testAMI),
 			},
 		},
 		{
@@ -255,7 +255,7 @@ func TestAWSActuator(t *testing.T) {
 				Reason: "InsufficientPublicSubnets",
 			},
 			expectedAMI: &machineapi.AWSResourceReference{
-				ID: pointer.StringPtr(testAMI),
+				ID: pointer.String(testAMI),
 			},
 		},
 		{
@@ -289,7 +289,7 @@ func TestAWSActuator(t *testing.T) {
 			},
 			expectedSubnetIDInMachineSet: true,
 			expectedAMI: &machineapi.AWSResourceReference{
-				ID: pointer.StringPtr(testAMI),
+				ID: pointer.String(testAMI),
 			},
 		},
 		{
@@ -323,7 +323,7 @@ func TestAWSActuator(t *testing.T) {
 			},
 			expectedSubnetIDInMachineSet: true,
 			expectedAMI: &machineapi.AWSResourceReference{
-				ID: pointer.StringPtr(testAMI),
+				ID: pointer.String(testAMI),
 			},
 		},
 		{
@@ -338,7 +338,7 @@ func TestAWSActuator(t *testing.T) {
 				generateAWSMachineSetName("zone1"): 3,
 			},
 			expectedAMI: &machineapi.AWSResourceReference{
-				ID: pointer.StringPtr(testAMI),
+				ID: pointer.String(testAMI),
 			},
 		},
 		{
@@ -352,7 +352,7 @@ func TestAWSActuator(t *testing.T) {
 				Reason: "UnsupportedSpotMarketOptions",
 			},
 			expectedAMI: &machineapi.AWSResourceReference{
-				ID: pointer.StringPtr(testAMI),
+				ID: pointer.String(testAMI),
 			},
 		},
 		{
@@ -368,7 +368,7 @@ func TestAWSActuator(t *testing.T) {
 			},
 			expectedKMSKey: fakeKMSKeyARN,
 			expectedAMI: &machineapi.AWSResourceReference{
-				ID: pointer.StringPtr(testAMI),
+				ID: pointer.String(testAMI),
 			},
 		},
 		{
@@ -395,7 +395,7 @@ func TestAWSActuator(t *testing.T) {
 				Reason: "ConfigurationSupported",
 			},
 			expectedAMI: &machineapi.AWSResourceReference{
-				ID: pointer.StringPtr(testAMI),
+				ID: pointer.String(testAMI),
 			},
 		},
 		{
@@ -409,7 +409,7 @@ func TestAWSActuator(t *testing.T) {
 				Reason: "UnsupportedSpotMarketOptions",
 			},
 			expectedAMI: &machineapi.AWSResourceReference{
-				ID: pointer.StringPtr(testAMI),
+				ID: pointer.String(testAMI),
 			},
 		},
 		{
@@ -491,7 +491,7 @@ func TestAWSActuator(t *testing.T) {
 				generateAWSMachineSetName("zone2"): 1,
 			},
 			expectedAMI: &machineapi.AWSResourceReference{
-				ID: pointer.StringPtr(testAMI),
+				ID: pointer.String(testAMI),
 			},
 			expectedSGFilters: []machineapi.Filter{
 				{
@@ -656,8 +656,8 @@ func validateAWSMachineSets(t *testing.T, mSets []*machineapi.MachineSet, expect
 func mockDescribeAvailabilityZones(client *mockaws.MockClient, zones []string) *gomock.Call {
 	input := &ec2.DescribeAvailabilityZonesInput{
 		Filters: []*ec2.Filter{{
-			Name:   pointer.StringPtr("region-name"),
-			Values: []*string{pointer.StringPtr(testRegion)},
+			Name:   pointer.String("region-name"),
+			Values: []*string{pointer.String(testRegion)},
 		}},
 	}
 	availabilityZones := make([]*ec2.AvailabilityZone, len(zones))

--- a/pkg/controller/machinepool/azureactuator_test.go
+++ b/pkg/controller/machinepool/azureactuator_test.go
@@ -531,10 +531,10 @@ func mockListResourceSKUs(mockCtrl *gomock.Controller, client *mockazure.MockCli
 	page.EXPECT().Values().Return(
 		[]compute.ResourceSku{
 			{
-				Name: pointer.StringPtr(testInstanceType),
+				Name: pointer.String(testInstanceType),
 				LocationInfo: &[]compute.ResourceSkuLocationInfo{
 					{
-						Location: pointer.StringPtr(testRegion),
+						Location: pointer.String(testRegion),
 						Zones:    &zones,
 					},
 				},

--- a/pkg/controller/machinepool/machinepool_controller_test.go
+++ b/pkg/controller/machinepool/machinepool_controller_test.go
@@ -917,8 +917,8 @@ func Test_summarizeMachinesError(t *testing.T) {
 			testMachineSetMachine("machine-1", "worker", testName),
 			func() *machineapi.Machine {
 				m := testMachineSetMachine("machine-2", "worker", testName)
-				m.Status.ErrorReason = (*machineapi.MachineStatusError)(pointer.StringPtr("GoneNotComingBack"))
-				m.Status.ErrorMessage = pointer.StringPtr("The machine is not found")
+				m.Status.ErrorReason = (*machineapi.MachineStatusError)(pointer.String("GoneNotComingBack"))
+				m.Status.ErrorMessage = pointer.String("The machine is not found")
 				return m
 			}(),
 			testMachineSetMachine("machine-3", "worker", testName),
@@ -933,14 +933,14 @@ func Test_summarizeMachinesError(t *testing.T) {
 			testMachineSetMachine("machine-1", "worker", testName),
 			func() *machineapi.Machine {
 				m := testMachineSetMachine("machine-2", "worker", testName)
-				m.Status.ErrorReason = (*machineapi.MachineStatusError)(pointer.StringPtr("GoneNotComingBack"))
-				m.Status.ErrorMessage = pointer.StringPtr("The machine is not found")
+				m.Status.ErrorReason = (*machineapi.MachineStatusError)(pointer.String("GoneNotComingBack"))
+				m.Status.ErrorMessage = pointer.String("The machine is not found")
 				return m
 			}(),
 			func() *machineapi.Machine {
 				m := testMachineSetMachine("machine-3", "worker", testName)
-				m.Status.ErrorReason = (*machineapi.MachineStatusError)(pointer.StringPtr("InsufficientResources"))
-				m.Status.ErrorMessage = pointer.StringPtr("No available quota")
+				m.Status.ErrorReason = (*machineapi.MachineStatusError)(pointer.String("InsufficientResources"))
+				m.Status.ErrorMessage = pointer.String("No available quota")
 				return m
 			}(),
 			testMachineSet(testName, "worker", false, 3, 0),

--- a/pkg/installmanager/helper_test.go
+++ b/pkg/installmanager/helper_test.go
@@ -58,7 +58,7 @@ func testClusterProvisionWithInfraIDSet() *hivev1.ClusterProvision {
 				Name: testDeploymentName,
 			},
 			Stage:   hivev1.ClusterProvisionStageProvisioning,
-			InfraID: pointer.StringPtr("dummy-infra-id"),
+			InfraID: pointer.String("dummy-infra-id"),
 		},
 	}
 }

--- a/pkg/installmanager/ibm_metadata_test.go
+++ b/pkg/installmanager/ibm_metadata_test.go
@@ -89,7 +89,7 @@ func TestGetAccountID(t *testing.T) {
 		{
 			name: "AccountID Found",
 			existingAPIKey: &iamidentityv1.APIKey{
-				AccountID: pointer.StringPtr("testaccountid"),
+				AccountID: pointer.String("testaccountid"),
 			},
 			expectErr: false,
 		},

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -416,7 +416,7 @@ func (m *InstallManager) Run() error {
 		if err := m.updateClusterProvision(
 			m,
 			func(provision *hivev1.ClusterProvision) {
-				provision.Spec.InstallLog = pointer.StringPtr(installLog)
+				provision.Spec.InstallLog = pointer.String(installLog)
 			},
 		); err != nil {
 			m.log.WithError(err).Error("error updating cluster provision with asset generation log")
@@ -450,8 +450,8 @@ func (m *InstallManager) Run() error {
 		m,
 		func(provision *hivev1.ClusterProvision) {
 			provision.Spec.Metadata = &runtime.RawExtension{Raw: metadataBytes}
-			provision.Spec.InfraID = pointer.StringPtr(metadata.InfraID)
-			provision.Spec.ClusterID = pointer.StringPtr(metadata.ClusterID)
+			provision.Spec.InfraID = pointer.String(metadata.InfraID)
+			provision.Spec.ClusterID = pointer.String(metadata.ClusterID)
 
 			provision.Spec.AdminKubeconfigSecretRef = &corev1.LocalObjectReference{
 				Name: kubeconfigSecret.Name,
@@ -509,7 +509,7 @@ func (m *InstallManager) Run() error {
 		if err := m.updateClusterProvision(
 			m,
 			func(provision *hivev1.ClusterProvision) {
-				provision.Spec.InstallLog = pointer.StringPtr(installLog)
+				provision.Spec.InstallLog = pointer.String(installLog)
 			},
 		); err != nil {
 			m.log.WithError(err).Warning("error updating cluster provision with installer log")

--- a/pkg/test/clusterprovision/clusterprovision.go
+++ b/pkg/test/clusterprovision/clusterprovision.go
@@ -100,8 +100,8 @@ func WithStage(stage hivev1.ClusterProvisionStage) Option {
 func Successful(clusterID, infraID, kubeconfigSecretName, passwordSecretName string) Option {
 	return func(clusterProvision *hivev1.ClusterProvision) {
 		clusterProvision.Spec.Stage = hivev1.ClusterProvisionStageComplete
-		clusterProvision.Spec.ClusterID = pointer.StringPtr(clusterID)
-		clusterProvision.Spec.InfraID = pointer.StringPtr(infraID)
+		clusterProvision.Spec.ClusterID = pointer.String(clusterID)
+		clusterProvision.Spec.InfraID = pointer.String(infraID)
 		clusterProvision.Spec.AdminKubeconfigSecretRef = &corev1.LocalObjectReference{Name: kubeconfigSecretName}
 		clusterProvision.Spec.AdminPasswordSecretRef = &corev1.LocalObjectReference{Name: passwordSecretName}
 	}

--- a/pkg/validating-webhooks/hive/v1/clusterprovision_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/clusterprovision_validating_admission_hook_test.go
@@ -233,7 +233,7 @@ func Test_ClusterProvisionAdmission_Validate_Create(t *testing.T) {
 			name: "prev cluster ID set for pre-installed",
 			provision: func() *hivev1.ClusterProvision {
 				p := testPreInstalledClusterProvision()
-				p.Spec.PrevClusterID = pointer.StringPtr("test-cluster-id")
+				p.Spec.PrevClusterID = pointer.String("test-cluster-id")
 				return p
 			}(),
 		},
@@ -241,7 +241,7 @@ func Test_ClusterProvisionAdmission_Validate_Create(t *testing.T) {
 			name: "prev infra ID set for pre-installed",
 			provision: func() *hivev1.ClusterProvision {
 				p := testPreInstalledClusterProvision()
-				p.Spec.PrevInfraID = pointer.StringPtr("test-infra-id")
+				p.Spec.PrevInfraID = pointer.String("test-infra-id")
 				return p
 			}(),
 		},
@@ -329,7 +329,7 @@ func Test_ClusterProvisionAdmission_Validate_Update(t *testing.T) {
 			old:  testClusterProvision(),
 			new: func() *hivev1.ClusterProvision {
 				p := testClusterProvision()
-				p.Spec.ClusterID = pointer.StringPtr("new-cluster-id")
+				p.Spec.ClusterID = pointer.String("new-cluster-id")
 				return p
 			}(),
 			expectAllowed: true,
@@ -339,7 +339,7 @@ func Test_ClusterProvisionAdmission_Validate_Update(t *testing.T) {
 			old:  testCompletedClusterProvision(),
 			new: func() *hivev1.ClusterProvision {
 				p := testCompletedClusterProvision()
-				p.Spec.ClusterID = pointer.StringPtr("new-cluster-id")
+				p.Spec.ClusterID = pointer.String("new-cluster-id")
 				return p
 			}(),
 		},
@@ -348,7 +348,7 @@ func Test_ClusterProvisionAdmission_Validate_Update(t *testing.T) {
 			old:  testClusterProvision(),
 			new: func() *hivev1.ClusterProvision {
 				p := testClusterProvision()
-				p.Spec.InfraID = pointer.StringPtr("new-infra-id")
+				p.Spec.InfraID = pointer.String("new-infra-id")
 				return p
 			}(),
 			expectAllowed: true,
@@ -358,7 +358,7 @@ func Test_ClusterProvisionAdmission_Validate_Update(t *testing.T) {
 			old:  testCompletedClusterProvision(),
 			new: func() *hivev1.ClusterProvision {
 				p := testCompletedClusterProvision()
-				p.Spec.InfraID = pointer.StringPtr("new-infra-id")
+				p.Spec.InfraID = pointer.String("new-infra-id")
 				return p
 			}(),
 		},
@@ -367,7 +367,7 @@ func Test_ClusterProvisionAdmission_Validate_Update(t *testing.T) {
 			old:  testClusterProvision(),
 			new: func() *hivev1.ClusterProvision {
 				p := testClusterProvision()
-				p.Spec.InstallLog = pointer.StringPtr("new-install-log")
+				p.Spec.InstallLog = pointer.String("new-install-log")
 				return p
 			}(),
 			expectAllowed: true,
@@ -377,7 +377,7 @@ func Test_ClusterProvisionAdmission_Validate_Update(t *testing.T) {
 			old:  testCompletedClusterProvision(),
 			new: func() *hivev1.ClusterProvision {
 				p := testCompletedClusterProvision()
-				p.Spec.InstallLog = pointer.StringPtr("new-install-log")
+				p.Spec.InstallLog = pointer.String("new-install-log")
 				return p
 			}(),
 			expectAllowed: true,
@@ -445,7 +445,7 @@ func Test_ClusterProvisionAdmission_Validate_Update(t *testing.T) {
 			old:  testClusterProvision(),
 			new: func() *hivev1.ClusterProvision {
 				p := testClusterProvision()
-				p.Spec.PrevClusterID = pointer.StringPtr("new-prev-cluster-id")
+				p.Spec.PrevClusterID = pointer.String("new-prev-cluster-id")
 				return p
 			}(),
 		},
@@ -454,7 +454,7 @@ func Test_ClusterProvisionAdmission_Validate_Update(t *testing.T) {
 			old:  testCompletedClusterProvision(),
 			new: func() *hivev1.ClusterProvision {
 				p := testCompletedClusterProvision()
-				p.Spec.PrevClusterID = pointer.StringPtr("new-prev-cluster-id")
+				p.Spec.PrevClusterID = pointer.String("new-prev-cluster-id")
 				return p
 			}(),
 		},
@@ -463,7 +463,7 @@ func Test_ClusterProvisionAdmission_Validate_Update(t *testing.T) {
 			old:  testClusterProvision(),
 			new: func() *hivev1.ClusterProvision {
 				p := testClusterProvision()
-				p.Spec.PrevInfraID = pointer.StringPtr("new-prev-infra-id")
+				p.Spec.PrevInfraID = pointer.String("new-prev-infra-id")
 				return p
 			}(),
 		},
@@ -472,7 +472,7 @@ func Test_ClusterProvisionAdmission_Validate_Update(t *testing.T) {
 			old:  testCompletedClusterProvision(),
 			new: func() *hivev1.ClusterProvision {
 				p := testCompletedClusterProvision()
-				p.Spec.PrevInfraID = pointer.StringPtr("new-prev-infra-id")
+				p.Spec.PrevInfraID = pointer.String("new-prev-infra-id")
 				return p
 			}(),
 		},
@@ -589,8 +589,8 @@ func testClusterProvision() *hivev1.ClusterProvision {
 			},
 			Attempt:       0,
 			Stage:         hivev1.ClusterProvisionStageInitializing,
-			PrevClusterID: pointer.StringPtr("test-prev-cluster-id"),
-			PrevInfraID:   pointer.StringPtr("test-prev-infra-id"),
+			PrevClusterID: pointer.String("test-prev-cluster-id"),
+			PrevInfraID:   pointer.String("test-prev-infra-id"),
 		},
 	}
 }
@@ -598,14 +598,14 @@ func testClusterProvision() *hivev1.ClusterProvision {
 func testCompletedClusterProvision() *hivev1.ClusterProvision {
 	provision := testClusterProvision()
 	provision.Spec.Stage = hivev1.ClusterProvisionStageComplete
-	provision.Spec.ClusterID = pointer.StringPtr("test-cluster-id")
-	provision.Spec.InfraID = pointer.StringPtr("test-infra-id")
-	provision.Spec.InstallLog = pointer.StringPtr("test-install-log")
+	provision.Spec.ClusterID = pointer.String("test-cluster-id")
+	provision.Spec.InfraID = pointer.String("test-infra-id")
+	provision.Spec.InstallLog = pointer.String("test-install-log")
 	provision.Spec.Metadata = &runtime.RawExtension{Raw: []byte("\"test-metadata\"")}
 	provision.Spec.AdminKubeconfigSecretRef = &corev1.LocalObjectReference{Name: "test-admin-kubeconfig"}
 	provision.Spec.AdminPasswordSecretRef = &corev1.LocalObjectReference{Name: "test-admin-password"}
-	provision.Spec.PrevClusterID = pointer.StringPtr("test-prev-cluster-id")
-	provision.Spec.PrevInfraID = pointer.StringPtr("test-prev-infra-id")
+	provision.Spec.PrevClusterID = pointer.String("test-prev-cluster-id")
+	provision.Spec.PrevInfraID = pointer.String("test-prev-infra-id")
 	return provision
 }
 
@@ -619,8 +619,8 @@ func testPreInstalledClusterProvision() *hivev1.ClusterProvision {
 				Name: "test-deployment",
 			},
 			Stage:                    hivev1.ClusterProvisionStageComplete,
-			ClusterID:                pointer.StringPtr("test-prev-cluster-id"),
-			InfraID:                  pointer.StringPtr("test-prev-infra-id"),
+			ClusterID:                pointer.String("test-prev-cluster-id"),
+			InfraID:                  pointer.String("test-prev-infra-id"),
 			AdminKubeconfigSecretRef: &corev1.LocalObjectReference{Name: "test-admin-kubeconfig"},
 			AdminPasswordSecretRef:   &corev1.LocalObjectReference{Name: "test-admin-password"},
 		},

--- a/test/e2e/postinstall/machinesets/infra_test.go
+++ b/test/e2e/postinstall/machinesets/infra_test.go
@@ -286,10 +286,10 @@ func TestAutoscalingMachinePool(t *testing.T) {
 	if clusterAutoscaler.Spec.ScaleDown == nil {
 		clusterAutoscaler.Spec.ScaleDown = &autoscalingv1.ScaleDownConfig{}
 	}
-	clusterAutoscaler.Spec.ScaleDown.DelayAfterAdd = pointer.StringPtr("10s")
-	clusterAutoscaler.Spec.ScaleDown.DelayAfterDelete = pointer.StringPtr("10s")
-	clusterAutoscaler.Spec.ScaleDown.DelayAfterFailure = pointer.StringPtr("10s")
-	clusterAutoscaler.Spec.ScaleDown.UnneededTime = pointer.StringPtr("10s")
+	clusterAutoscaler.Spec.ScaleDown.DelayAfterAdd = pointer.String("10s")
+	clusterAutoscaler.Spec.ScaleDown.DelayAfterDelete = pointer.String("10s")
+	clusterAutoscaler.Spec.ScaleDown.DelayAfterFailure = pointer.String("10s")
+	clusterAutoscaler.Spec.ScaleDown.UnneededTime = pointer.String("10s")
 	err = rc.Update(context.Background(), clusterAutoscaler)
 	require.NoError(t, err, "could not update the cluster autoscaler")
 


### PR DESCRIPTION
Noticed that `pointer.StringPtr` has been deprecated for `pointer.String` as well: https://pkg.go.dev/k8s.io/utils/pointer#StringPtr so just a bit of a cleanup PR while doing #1946 