### PR TITLE
Set ulimit for image build.

### DIFF
--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -99,7 +99,7 @@ else
 fi
 
 # build the image
-CONTAINER_BUILD_FLAGS="--file ./Dockerfile.ubi" make IMG="$IMG" GO_REQUIRED_MIN_VERSION:= docker-build
+CONTAINER_BUILD_FLAGS="--file ./Dockerfile.ubi --ulimit nofile=10240:10240" make IMG="$IMG" GO_REQUIRED_MIN_VERSION:= docker-build
 
 # push the image
 make IMG="$IMG" docker-push


### PR DESCRIPTION
Potential fix for "too many open files" on our [downstream build](https://ci.int.devshift.net/job/openshift-hive-gh-build-master/).