### PR TITLE
Revert "Set ulimit for image build."

### DIFF
--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -99,7 +99,7 @@ else
 fi
 
 # build the image
-CONTAINER_BUILD_FLAGS="--file ./Dockerfile.ubi --ulimit nofile=10240:10240" make IMG="$IMG" GO_REQUIRED_MIN_VERSION:= docker-build
+CONTAINER_BUILD_FLAGS="--file ./Dockerfile.ubi" make IMG="$IMG" GO_REQUIRED_MIN_VERSION:= docker-build
 
 # push the image
 make IMG="$IMG" docker-push


### PR DESCRIPTION
Revert bumping the ulimit in our build command. The build nodes have had their [default ulimit increased](https://gitlab.cee.redhat.com/app-sre/infra/-/merge_requests/610/diffs) within `/usr/share/containers/containers.conf` so we no longer need to set here.

This reverts commit 8473f52536cd9f168ab47d393fd42aacd098666e, reversing changes made to c2d531b75f71d28730a1bf8a751998e94f2c5434.