### PR TITLE
HIVE-2090: Add ResourcePool field to hive's MachinePool CRD

### DIFF
--- a/apis/hive/v1/vsphere/machinepools.go
+++ b/apis/hive/v1/vsphere/machinepools.go
@@ -3,6 +3,11 @@ package vsphere
 // MachinePool stores the configuration for a machine pool installed
 // on vSphere.
 type MachinePool struct {
+	// ResourcePool is the name of the resource pool that will be used for virtual machines.
+	// If it is not present, a default value will be used.
+	// +optional
+	ResourcePool string `json:"resourcePool,omitempty"`
+
 	// NumCPUs is the total number of virtual processor cores to assign a vm.
 	NumCPUs int32 `json:"cpus"`
 

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -511,6 +511,11 @@ spec:
                         required:
                         - diskSizeGB
                         type: object
+                      resourcePool:
+                        description: ResourcePool is the name of the resource pool
+                          that will be used for virtual machines. If it is not present,
+                          a default value will be used.
+                        type: string
                     required:
                     - coresPerSocket
                     - cpus

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -5314,6 +5314,11 @@ objects:
                           required:
                           - diskSizeGB
                           type: object
+                        resourcePool:
+                          description: ResourcePool is the name of the resource pool
+                            that will be used for virtual machines. If it is not present,
+                            a default value will be used.
+                          type: string
                       required:
                       - coresPerSocket
                       - cpus

--- a/pkg/controller/machinepool/vsphereactuator.go
+++ b/pkg/controller/machinepool/vsphereactuator.go
@@ -92,6 +92,7 @@ func (a *VSphereActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool
 							ComputeCluster: setComputeClusterPath(cd.Spec.Platform.VSphere.Cluster, cd.Spec.Platform.VSphere.Datacenter, logger),
 							Networks:       []string{cd.Spec.Platform.VSphere.Network},
 							Template:       a.osImage,
+							ResourcePool:   pool.Spec.Platform.VSphere.ResourcePool,
 						},
 					},
 				},

--- a/pkg/controller/machinepool/vsphereactuator_test.go
+++ b/pkg/controller/machinepool/vsphereactuator_test.go
@@ -73,6 +73,8 @@ func validateVSphereMachineSets(t *testing.T, mSets []*machineapi.MachineSet, ex
 			assert.Equal(t, int32(4), vsphereProvider.NumCPUs, "unexpected NumCPUs")
 			assert.Equal(t, int32(4), vsphereProvider.NumCoresPerSocket, "unexpected NumCoresPerSocket")
 			assert.Equal(t, int32(512), vsphereProvider.DiskGiB, "unexpected DiskGiB")
+			assert.Equal(t, "/vsphere-datacenter/vm/vsphere-folder", vsphereProvider.Workspace.Folder, "unexpected Folder")
+			assert.Equal(t, "/vsphere-datacenter/host/vsphere-cluster/Resources/vsphere-pool", vsphereProvider.Workspace.ResourcePool, "unexpected ResourcePool")
 		}
 	}
 }
@@ -81,6 +83,7 @@ func testVSpherePool() *hivev1.MachinePool {
 	p := testMachinePool()
 	p.Spec.Platform = hivev1.MachinePoolPlatform{
 		VSphere: &hivev1vsphere.MachinePool{
+			ResourcePool:      "/vsphere-datacenter/host/vsphere-cluster/Resources/vsphere-pool",
 			MemoryMiB:         32 * 1024,
 			NumCPUs:           4,
 			NumCoresPerSocket: 4,
@@ -99,6 +102,7 @@ func testVSphereClusterDeployment() *hivev1.ClusterDeployment {
 			CredentialsSecretRef: corev1.LocalObjectReference{
 				Name: "vsphere-credentials",
 			},
+			Folder: "/vsphere-datacenter/vm/vsphere-folder",
 		},
 	}
 	return cd

--- a/vendor/github.com/openshift/hive/apis/hive/v1/vsphere/machinepools.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/vsphere/machinepools.go
@@ -3,6 +3,11 @@ package vsphere
 // MachinePool stores the configuration for a machine pool installed
 // on vSphere.
 type MachinePool struct {
+	// ResourcePool is the name of the resource pool that will be used for virtual machines.
+	// If it is not present, a default value will be used.
+	// +optional
+	ResourcePool string `json:"resourcePool,omitempty"`
+
 	// NumCPUs is the total number of virtual processor cores to assign a vm.
 	NumCPUs int32 `json:"cpus"`
 


### PR DESCRIPTION
xref: [HIVE-2090](https://issues.redhat.com//browse/HIVE-2090)

This will allow a user of hive to supply their own resource pool as part of the spec