### PR TITLE
Prompt CI to bump to golang 1.20

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.12
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-4.14
 
 # setting Git username and email for workaround of
 # https://github.com/jenkinsci/docker/issues/519

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -4001,13 +4001,13 @@ func TestCopyInstallLogSecret(t *testing.T) {
 				remoteClusterAPIClientBuilder: func(*hivev1.ClusterDeployment) remoteclient.Builder { return mockRemoteClientBuilder },
 			}
 
-			for _, envVar := range test.existingEnvVars {
+			for i, envVar := range test.existingEnvVars {
 				if err := os.Setenv(envVar.Name, envVar.Value); err == nil {
-					defer func() {
-						if err := os.Unsetenv(envVar.Name); err != nil {
+					defer func(evar corev1.EnvVar) {
+						if err := os.Unsetenv(evar.Name); err != nil {
 							t.Error(err)
 						}
-					}()
+					}(test.existingEnvVars[i])
 				} else {
 					t.Error(err)
 				}


### PR DESCRIPTION
This is the weird thing where we have to change the golang version in one file and then merge and then CI will let us change it in all the other files.

To `verify` under go 1.20, we also have to fix the following new `go vet` error:

```
 # github.com/openshift/hive/pkg/controller/clusterdeployment
 pkg/controller/clusterdeployment/clusterdeployment_controller_test.go:4007:29: loop variable envVar captured by func literal
```

[HIVE-2193](https://issues.redhat.com//browse/HIVE-2193)