### PR TITLE
Added hiveconfig.awsPrivateLink.SharedHostedZoneDomains

### DIFF
--- a/apis/hive/v1/hiveconfig_types.go
+++ b/apis/hive/v1/hiveconfig_types.go
@@ -192,6 +192,17 @@ type AWSPrivateLinkConfig struct {
 	// +kubebuilder:default=Alias
 	// +optional
 	DNSRecordType AWSPrivateLinkDNSRecordType `json:"dnsRecordType,omitempty"`
+
+	// SharedHostedZoneDomains is a list of domain names for private hosted
+	// zones that are to be shared by multiple clusters' privatelink
+	// records. They must exist in the same account as the Hive cluster and
+	// be associated with the privatelink VPC. When a cluster's domain is a
+	// subdomain of any item in the list, the privatelink record will be
+	// created in the zone of the item that most closely matches. Otherwise
+	// a new private hosted zone will be created for the cluster.
+	//
+	// +optional
+	SharedHostedZoneDomains []string `json:"sharedHostedZoneDomains,omitempty"`
 }
 
 // AWSPrivateLinkDNSRecordType defines what type of DNS record should be created in Private Hosted Zone

--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -170,6 +170,18 @@ spec:
                       - vpcID
                       type: object
                     type: array
+                  sharedHostedZoneDomains:
+                    description: SharedHostedZoneDomains is a list of domain names
+                      for private hosted zones that are to be shared by multiple clusters'
+                      privatelink records. They must exist in the same account as
+                      the Hive cluster and be associated with the privatelink VPC.
+                      When a cluster's domain is a subdomain of any item in the list,
+                      the privatelink record will be created in the zone of the item
+                      that most closely matches. Otherwise a new private hosted zone
+                      will be created for the cluster.
+                    items:
+                      type: string
+                    type: array
                 required:
                 - credentialsSecretRef
                 type: object

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -3996,6 +3996,18 @@ objects:
                         - vpcID
                         type: object
                       type: array
+                    sharedHostedZoneDomains:
+                      description: SharedHostedZoneDomains is a list of domain names
+                        for private hosted zones that are to be shared by multiple
+                        clusters' privatelink records. They must exist in the same
+                        account as the Hive cluster and be associated with the privatelink
+                        VPC. When a cluster's domain is a subdomain of any item in
+                        the list, the privatelink record will be created in the zone
+                        of the item that most closely matches. Otherwise a new private
+                        hosted zone will be created for the cluster.
+                      items:
+                        type: string
+                      type: array
                   required:
                   - credentialsSecretRef
                   type: object

--- a/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
@@ -192,6 +192,17 @@ type AWSPrivateLinkConfig struct {
 	// +kubebuilder:default=Alias
 	// +optional
 	DNSRecordType AWSPrivateLinkDNSRecordType `json:"dnsRecordType,omitempty"`
+
+	// SharedHostedZoneDomains is a list of domain names for private hosted
+	// zones that are to be shared by multiple clusters' privatelink
+	// records. They must exist in the same account as the Hive cluster and
+	// be associated with the privatelink VPC. When a cluster's domain is a
+	// subdomain of any item in the list, the privatelink record will be
+	// created in the zone of the item that most closely matches. Otherwise
+	// a new private hosted zone will be created for the cluster.
+	//
+	// +optional
+	SharedHostedZoneDomains []string `json:"sharedHostedZoneDomains,omitempty"`
 }
 
 // AWSPrivateLinkDNSRecordType defines what type of DNS record should be created in Private Hosted Zone


### PR DESCRIPTION
Added a new field to enable sharing of AWS dns zones for aws privatelink dns records. It is a list of domain names for private hosted zones that are to be shared by multiple clusters' privatelink records. They must exist in the same account as the Hive cluster and be associated with the privatelink VPC. When a cluster's domain is a subdomain of any item in the list, the privatelink record will be created in the zone of the item that most closely matches. Otherwise a new private hosted zone will be created for the cluster.

[HIVE-2062](https://issues.redhat.com//browse/HIVE-2062)