### PR TITLE
Upgrade build-machinery-go for `make vulncheck`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.24.1
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
-	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
+	github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533
 	github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20220323121149-e3f2850dd519
 	github.com/openshift/cluster-autoscaler-operator v0.0.0-20211006175002-fe524080b551
 	github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87

--- a/go.sum
+++ b/go.sum
@@ -1037,8 +1037,8 @@ github.com/openshift/baremetal-operator/apis v0.0.0-20220128094204-28771f489634/
 github.com/openshift/baremetal-operator/pkg/hardwareutils v0.0.0-20220128094204-28771f489634 h1:sGL5yvlRTpCVM2Ck47Tn09PPSgSTLq2V+B2nSNkBDIs=
 github.com/openshift/baremetal-operator/pkg/hardwareutils v0.0.0-20220128094204-28771f489634/go.mod h1:/PSTQInIZmfuOmAp/pSgZAs4txs6T49woC0MYIa4QzE=
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
-github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR4ah7FfaPR1WePizm0jlrsbmPu91xQZnAsVVreQV1k=
-github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
+github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533 h1:mh3ZYs7kPIIe3UUY6tJcTExmtjnXXUu0MrBuK2W/Qvw=
+github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20210730113412-1811c1b3fc0e/go.mod h1:P1pjphFOgm/nYjmtouHGaSLGtdP25dQICJnYtcYhfEs=
 github.com/openshift/client-go v0.0.0-20211025111749-96ca2abfc56c/go.mod h1:xigLF97kzy1PZuDsC0Lfu6GlzChRt62+2Ts/nG3sPHY=
 github.com/openshift/client-go v0.0.0-20221019143426-16aed247da5c h1:CV76yFOTXmq9VciBR3Bve5ZWzSxdft7gaMVB3kS0rwg=

--- a/vendor/github.com/openshift/build-machinery-go/make/default.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/default.example.mk.help.log
@@ -24,3 +24,4 @@ verify-gofmt
 verify-golang-versions
 verify-golint
 verify-govet
+vulncheck

--- a/vendor/github.com/openshift/build-machinery-go/make/golang.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/golang.example.mk.help.log
@@ -13,3 +13,4 @@ verify-gofmt
 verify-golang-versions
 verify-golint
 verify-govet
+vulncheck

--- a/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
@@ -31,3 +31,4 @@ verify-golang-versions
 verify-golint
 verify-govet
 verify-profile-manifests
+vulncheck

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/test-unit.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/test-unit.mk
@@ -4,11 +4,11 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 
 test-unit:
 ifndef JUNITFILE
-	$(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) $(GO_TEST_PACKAGES)
+	$(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) $(GO_TEST_PACKAGES) $(GO_TEST_ARGS)
 else
 ifeq (, $(shell which gotest2junit 2>/dev/null))
 	$(error gotest2junit not found! Get it by `go get -mod='' -u github.com/openshift/release/tools/gotest2junit`.)
 endif
-	set -o pipefail; $(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) -json $(GO_TEST_PACKAGES) | gotest2junit > $(JUNITFILE)
+	set -o pipefail; $(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) -json $(GO_TEST_PACKAGES) $(GO_TEST_ARGS) | gotest2junit > $(JUNITFILE)
 endif
 .PHONY: test-unit

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/vulncheck.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/vulncheck.mk
@@ -1,0 +1,31 @@
+scripts_dir :=$(shell realpath $(dir $(lastword $(MAKEFILE_LIST)))../../../scripts)
+
+# `make vulncheck` will emit a report similar to:
+# 
+# [
+#   "golang.org/x/net",
+#   "v0.5.0",
+#   "v0.7.0"
+# ]
+# [
+#   "stdlib",
+#   "go1.19.3",
+#   "go1.20.1"
+# ]
+# [
+#   "stdlib",
+#   "go1.19.3",
+#   "go1.19.4"
+# ]
+# 
+# Each stanza lists
+# - where the vulnerability exists
+# - the version it was found in
+# - the version it's fixed in
+# 
+# If the report contains any entries that are not in stdlib, the check
+# will fail (exit nonzero). Otherwise it will succeed -- i.e. the stdlib
+# entries are only warnings.
+vulncheck:
+	bash $(scripts_dir)/vulncheck.sh
+.PHONY: vulncheck

--- a/vendor/github.com/openshift/build-machinery-go/scripts/vulncheck.sh
+++ b/vendor/github.com/openshift/build-machinery-go/scripts/vulncheck.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+### Use govulncheck to check for known vulnerabilities in the project.
+### Fail if vulnerabilities are found in module dependencies.
+### Warn (but do not fail) on stdlib vulnerabilities.
+### TODO: Include useful information (ID, URL) about the vulnerability.
+
+go install golang.org/x/vuln/cmd/govulncheck@latest
+
+report=`mktemp`
+trap "rm $report" EXIT
+
+govulncheck -json ./... > $report
+
+modvulns=$(jq -r '.Vulns[].Modules[] | select(.Path != "stdlib") | [.Path, .FoundVersion, .FixedVersion]' < $report)
+libvulns=$(jq -r '.Vulns[].Modules[] | select(.Path == "stdlib") | [.Path, .FoundVersion, .FixedVersion]' < $report)
+
+echo "$modvulns"
+echo "$libvulns"
+
+# Exit nonzero iff there are any vulnerabilities in module dependencies
+test -z "$modvulns"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9058,7 +9058,7 @@ github.com/openshift/api/template
 github.com/openshift/api/template/v1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
+# github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533
 ## explicit; go 1.13
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make


### PR DESCRIPTION
Bring in the latest BMG so we can now `make vulncheck` to get a preview of what dependabot might complain about.