### PR TITLE
Bump appsre image tag from 7 to 10c

### DIFF
--- a/hack/app_sre_build_deploy.sh
+++ b/hack/app_sre_build_deploy.sh
@@ -4,7 +4,7 @@
 
 set -exv
 
-GIT_HASH=`git rev-parse --short=7 HEAD`
+GIT_HASH=`git rev-parse --short=10 HEAD`
 IMG="quay.io/app-sre/hive:${GIT_HASH}"
 
 ### Accommodate docker or podman


### PR DESCRIPTION
We hit a case where the first 7c of the commit sha was ambiguous, so our appsre build script helpfully used 8c instead. Unfortunately, the tooling on the appsre saas deploy side doesn't have the ability to do this same disambiguation, so it tried the 7c prefix and the deploy failed.

Increase the prefix length to 10c to greatly reduce (but not eliminate, sad-face) the probability of future collisions.

[HIVE-2194](https://issues.redhat.com//browse/HIVE-2194)