### PR TITLE
OCPBUGS-8386: Add ResourceGroupName to Azure platform.

### DIFF
--- a/apis/hive/v1/azure/platform.go
+++ b/apis/hive/v1/azure/platform.go
@@ -30,7 +30,7 @@ type Platform struct {
 	// ownership of all resources in the resource group. Destroying the cluster using installer will delete this
 	// resource group.
 	// This resource group must be empty with no other resources when trying to use it for creating a cluster.
-	// If empty, a new resource group will created for the cluster.
+	// If this field is empty/omitted, a new resource group will created for the cluster.
 	//
 	// +optional
 	ResourceGroupName string `json:"resourceGroupName,omitempty"`

--- a/apis/hive/v1/azure/platform.go
+++ b/apis/hive/v1/azure/platform.go
@@ -24,6 +24,16 @@ type Platform struct {
 	// If empty, the value is equal to "AzurePublicCloud".
 	// +optional
 	CloudName CloudEnvironment `json:"cloudName,omitempty"`
+
+	// ResourceGroupName is the name of an already existing resource group where the cluster should be installed.
+	// This resource group should only be used for this specific cluster and the cluster components will assume
+	// ownership of all resources in the resource group. Destroying the cluster using installer will delete this
+	// resource group.
+	// This resource group must be empty with no other resources when trying to use it for creating a cluster.
+	// If empty, a new resource group will created for the cluster.
+	//
+	// +optional
+	ResourceGroupName string `json:"resourceGroupName,omitempty"`
 }
 
 // CloudEnvironment is the name of the Azure cloud environment

--- a/apis/hive/v1/clusterdeprovision_types.go
+++ b/apis/hive/v1/clusterdeprovision_types.go
@@ -89,10 +89,10 @@ type AzureClusterDeprovision struct {
 	// If empty, the value is equal to "AzurePublicCloud".
 	// +optional
 	CloudName *azure.CloudEnvironment `json:"cloudName,omitempty"`
-	// ResourceGroupName is the name of an already existing resource group where the cluster was installed.
-	// This resource group should only be used for this specific cluster and the cluster components will assume
-	// ownership of all resources in the resource group. Destroying the cluster using installer will delete this
-	// resource group.
+	// ResourceGroupName is the name of the resource group where the cluster was installed.
+	// Required if the cluster was created using a pre-existing resource group rather than having
+	// allowed the installer to create one.
+	// This resource group will be deleted when the cluster is destroyed.
 	// +optional
 	ResourceGroupName string `json:"resourceGroupName,omitempty"`
 }

--- a/apis/hive/v1/clusterdeprovision_types.go
+++ b/apis/hive/v1/clusterdeprovision_types.go
@@ -89,6 +89,12 @@ type AzureClusterDeprovision struct {
 	// If empty, the value is equal to "AzurePublicCloud".
 	// +optional
 	CloudName *azure.CloudEnvironment `json:"cloudName,omitempty"`
+	// ResourceGroupName is the name of an already existing resource group where the cluster was installed.
+	// This resource group should only be used for this specific cluster and the cluster components will assume
+	// ownership of all resources in the resource group. Destroying the cluster using installer will delete this
+	// resource group.
+	// +optional
+	ResourceGroupName string `json:"resourceGroupName,omitempty"`
 }
 
 // GCPClusterDeprovision contains GCP-specific configuration for a ClusterDeprovision

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -598,6 +598,17 @@ spec:
                         description: Region specifies the Azure region where the cluster
                           will be created.
                         type: string
+                      resourceGroupName:
+                        description: ResourceGroupName is the name of an already existing
+                          resource group where the cluster should be installed. This
+                          resource group should only be used for this specific cluster
+                          and the cluster components will assume ownership of all
+                          resources in the resource group. Destroying the cluster
+                          using installer will delete this resource group. This resource
+                          group must be empty with no other resources when trying
+                          to use it for creating a cluster. If empty, a new resource
+                          group will created for the cluster.
+                        type: string
                     required:
                     - credentialsSecretRef
                     - region

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -606,8 +606,8 @@ spec:
                           resources in the resource group. Destroying the cluster
                           using installer will delete this resource group. This resource
                           group must be empty with no other resources when trying
-                          to use it for creating a cluster. If empty, a new resource
-                          group will created for the cluster.
+                          to use it for creating a cluster. If this field is empty/omitted,
+                          a new resource group will created for the cluster.
                         type: string
                     required:
                     - credentialsSecretRef

--- a/config/crds/hive.openshift.io_clusterdeprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterdeprovisions.yaml
@@ -151,6 +151,14 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                      resourceGroupName:
+                        description: ResourceGroupName is the name of an already existing
+                          resource group where the cluster was installed. This resource
+                          group should only be used for this specific cluster and
+                          the cluster components will assume ownership of all resources
+                          in the resource group. Destroying the cluster using installer
+                          will delete this resource group.
+                        type: string
                     type: object
                   gcp:
                     description: GCP contains GCP-specific deprovision settings

--- a/config/crds/hive.openshift.io_clusterdeprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterdeprovisions.yaml
@@ -152,12 +152,11 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       resourceGroupName:
-                        description: ResourceGroupName is the name of an already existing
-                          resource group where the cluster was installed. This resource
-                          group should only be used for this specific cluster and
-                          the cluster components will assume ownership of all resources
-                          in the resource group. Destroying the cluster using installer
-                          will delete this resource group.
+                        description: ResourceGroupName is the name of the resource
+                          group where the cluster was installed. Required if the cluster
+                          was created using a pre-existing resource group rather than
+                          having allowed the installer to create one. This resource
+                          group will be deleted when the cluster is destroyed.
                         type: string
                     type: object
                   gcp:

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -370,6 +370,17 @@ spec:
                         description: Region specifies the Azure region where the cluster
                           will be created.
                         type: string
+                      resourceGroupName:
+                        description: ResourceGroupName is the name of an already existing
+                          resource group where the cluster should be installed. This
+                          resource group should only be used for this specific cluster
+                          and the cluster components will assume ownership of all
+                          resources in the resource group. Destroying the cluster
+                          using installer will delete this resource group. This resource
+                          group must be empty with no other resources when trying
+                          to use it for creating a cluster. If empty, a new resource
+                          group will created for the cluster.
+                        type: string
                     required:
                     - credentialsSecretRef
                     - region

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -378,8 +378,8 @@ spec:
                           resources in the resource group. Destroying the cluster
                           using installer will delete this resource group. This resource
                           group must be empty with no other resources when trying
-                          to use it for creating a cluster. If empty, a new resource
-                          group will created for the cluster.
+                          to use it for creating a cluster. If this field is empty/omitted,
+                          a new resource group will created for the cluster.
                         type: string
                     required:
                     - credentialsSecretRef

--- a/contrib/pkg/deprovision/azure.go
+++ b/contrib/pkg/deprovision/azure.go
@@ -16,8 +16,9 @@ import (
 
 // AzureOptions is the set of options to deprovision an Azure cluster
 type AzureOptions struct {
-	logLevel  string
-	cloudName string
+	logLevel          string
+	cloudName         string
+	resourceGroupName string
 }
 
 // NewDeprovisionAzureCommand is the entrypoint to create the azure deprovision subcommand
@@ -28,7 +29,7 @@ func NewDeprovisionAzureCommand() *cobra.Command {
 		Short: "Deprovision Azure assets (as created by openshift-installer)",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			uninstaller, err := completeAzureUninstaller(opt.logLevel, opt.cloudName, args)
+			uninstaller, err := completeAzureUninstaller(opt.logLevel, opt.cloudName, opt.resourceGroupName, args)
 			if err != nil {
 				log.WithError(err).Error("Cannot complete command")
 				return
@@ -45,7 +46,8 @@ func NewDeprovisionAzureCommand() *cobra.Command {
 	}
 	flags := cmd.Flags()
 	flags.StringVar(&opt.logLevel, "loglevel", "info", "log level, one of: debug, info, warn, error, fatal, panic")
-	flags.StringVar(&opt.cloudName, "azure-cloud-name", installertypesazure.PublicCloud.Name(), "cloudName is the name of the Azure cloud environment used to configure the Azure SDK")
+	flags.StringVar(&opt.cloudName, "azure-cloud-name", installertypesazure.PublicCloud.Name(), "azure-cloud-name is the name of the Azure cloud environment used to configure the Azure SDK")
+	flags.StringVar(&opt.resourceGroupName, "azure-resource-group-name", "", "azure-resource-group-name is the name of the custom Azure resource group in which the cluster was created when not using the default installer-created resource group")
 	return cmd
 }
 
@@ -58,7 +60,7 @@ func validate() error {
 	return nil
 }
 
-func completeAzureUninstaller(logLevel, cloudName string, args []string) (providers.Destroyer, error) {
+func completeAzureUninstaller(logLevel, cloudName, resourceGroupName string, args []string) (providers.Destroyer, error) {
 
 	logger, err := utils.NewLogger(logLevel)
 	if err != nil {
@@ -75,7 +77,8 @@ func completeAzureUninstaller(logLevel, cloudName string, args []string) (provid
 		InfraID: args[0],
 		ClusterPlatformMetadata: types.ClusterPlatformMetadata{
 			Azure: &installertypesazure.Metadata{
-				CloudName: installertypesazure.CloudEnvironment(cloudName),
+				CloudName:         installertypesazure.CloudEnvironment(cloudName),
+				ResourceGroupName: resourceGroupName,
 			},
 		},
 	}

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -988,8 +988,9 @@ objects:
                             of all resources in the resource group. Destroying the
                             cluster using installer will delete this resource group.
                             This resource group must be empty with no other resources
-                            when trying to use it for creating a cluster. If empty,
-                            a new resource group will created for the cluster.
+                            when trying to use it for creating a cluster. If this
+                            field is empty/omitted, a new resource group will created
+                            for the cluster.
                           type: string
                       required:
                       - credentialsSecretRef
@@ -1771,12 +1772,12 @@ objects:
                           type: object
                           x-kubernetes-map-type: atomic
                         resourceGroupName:
-                          description: ResourceGroupName is the name of an already
-                            existing resource group where the cluster was installed.
-                            This resource group should only be used for this specific
-                            cluster and the cluster components will assume ownership
-                            of all resources in the resource group. Destroying the
-                            cluster using installer will delete this resource group.
+                          description: ResourceGroupName is the name of the resource
+                            group where the cluster was installed. Required if the
+                            cluster was created using a pre-existing resource group
+                            rather than having allowed the installer to create one.
+                            This resource group will be deleted when the cluster is
+                            destroyed.
                           type: string
                       type: object
                     gcp:
@@ -2420,8 +2421,9 @@ objects:
                             of all resources in the resource group. Destroying the
                             cluster using installer will delete this resource group.
                             This resource group must be empty with no other resources
-                            when trying to use it for creating a cluster. If empty,
-                            a new resource group will created for the cluster.
+                            when trying to use it for creating a cluster. If this
+                            field is empty/omitted, a new resource group will created
+                            for the cluster.
                           type: string
                       required:
                       - credentialsSecretRef

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -980,6 +980,17 @@ objects:
                           description: Region specifies the Azure region where the
                             cluster will be created.
                           type: string
+                        resourceGroupName:
+                          description: ResourceGroupName is the name of an already
+                            existing resource group where the cluster should be installed.
+                            This resource group should only be used for this specific
+                            cluster and the cluster components will assume ownership
+                            of all resources in the resource group. Destroying the
+                            cluster using installer will delete this resource group.
+                            This resource group must be empty with no other resources
+                            when trying to use it for creating a cluster. If empty,
+                            a new resource group will created for the cluster.
+                          type: string
                       required:
                       - credentialsSecretRef
                       - region
@@ -2392,6 +2403,17 @@ objects:
                         region:
                           description: Region specifies the Azure region where the
                             cluster will be created.
+                          type: string
+                        resourceGroupName:
+                          description: ResourceGroupName is the name of an already
+                            existing resource group where the cluster should be installed.
+                            This resource group should only be used for this specific
+                            cluster and the cluster components will assume ownership
+                            of all resources in the resource group. Destroying the
+                            cluster using installer will delete this resource group.
+                            This resource group must be empty with no other resources
+                            when trying to use it for creating a cluster. If empty,
+                            a new resource group will created for the cluster.
                           type: string
                       required:
                       - credentialsSecretRef

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -1770,6 +1770,14 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                        resourceGroupName:
+                          description: ResourceGroupName is the name of an already
+                            existing resource group where the cluster was installed.
+                            This resource group should only be used for this specific
+                            cluster and the cluster components will assume ownership
+                            of all resources in the resource group. Destroying the
+                            cluster using installer will delete this resource group.
+                          type: string
                       type: object
                     gcp:
                       description: GCP contains GCP-specific deprovision settings

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -1805,6 +1805,7 @@ func generateDeprovision(cd *hivev1.ClusterDeployment) (*hivev1.ClusterDeprovisi
 		req.Spec.Platform.Azure = &hivev1.AzureClusterDeprovision{
 			CredentialsSecretRef: &cd.Spec.Platform.Azure.CredentialsSecretRef,
 			CloudName:            &cd.Spec.Platform.Azure.CloudName,
+			ResourceGroupName:    cd.Spec.Platform.Azure.ResourceGroupName,
 		}
 	case cd.Spec.Platform.GCP != nil:
 		req.Spec.Platform.GCP = &hivev1.GCPClusterDeprovision{

--- a/pkg/controller/machinepool/azureactuator.go
+++ b/pkg/controller/machinepool/azureactuator.go
@@ -65,9 +65,9 @@ func (a *AzureActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *
 		Platform: installertypes.Platform{
 			Azure: &installertypesazure.Platform{
 				Region: cd.Spec.Platform.Azure.Region,
-				// ResourceGroupName may be overridden within the install-config but
-				// must also be set within ClusterDeployment Azure platform to be
-				// picked up by the install-config created here for MachineSet generation.
+				// ResourceGroupName may be overridden within the install-config and
+				// must be set within ClusterDeployment Azure platform to be picked
+				// up by the install-config created here for MachineSet generation.
 				ResourceGroupName: cd.Spec.Platform.Azure.ResourceGroupName,
 			},
 		},

--- a/pkg/controller/machinepool/azureactuator.go
+++ b/pkg/controller/machinepool/azureactuator.go
@@ -111,9 +111,9 @@ func (a *AzureActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *
 		// to determine if we should allow resultant machinesets to consume a "gen2" image.
 		gen2ImageExists, err := a.gen2ImageExists(cd.Spec.ClusterMetadata.InfraID, ic.Platform.Azure.ClusterResourceGroupName(cd.Spec.ClusterMetadata.InfraID))
 		if err != nil {
-			return nil, false, errors.Wrap(err, `error listing images in resource group, set resourceGroupName
-				                                 within ClusterDeployment platform (cd.Spec.Platform.Azure.ResourceGroupName)
-				                                 if custom resource group specified in install config`)
+			return nil, false, errors.Wrap(err, "error listing images in resource group, set resourceGroupName "+
+				"within ClusterDeployment platform (cd.Spec.Platform.Azure.ResourceGroupName) "+
+				"if custom resource group specified in install config")
 		}
 		if !gen2ImageExists {
 			// Modify capabilities to ensure that a V1 image is chosen by installazure.MachineSets()

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -600,6 +600,9 @@ func completeAzureDeprovisionJob(req *hivev1.ClusterDeprovision, job *batchv1.Jo
 	if req.Spec.Platform.Azure.CloudName != nil {
 		containers[0].Args = append(containers[0].Args, "--azure-cloud-name", req.Spec.Platform.Azure.CloudName.Name())
 	}
+	if req.Spec.Platform.Azure.ResourceGroupName != "" {
+		containers[0].Args = append(containers[0].Args, "--azure-resource-group-name", req.Spec.Platform.Azure.ResourceGroupName)
+	}
 	job.Spec.Template.Spec.Containers = containers
 	job.Spec.Template.Spec.Volumes = volumes
 

--- a/vendor/github.com/openshift/hive/apis/hive/v1/azure/platform.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/azure/platform.go
@@ -30,7 +30,7 @@ type Platform struct {
 	// ownership of all resources in the resource group. Destroying the cluster using installer will delete this
 	// resource group.
 	// This resource group must be empty with no other resources when trying to use it for creating a cluster.
-	// If empty, a new resource group will created for the cluster.
+	// If this field is empty/omitted, a new resource group will created for the cluster.
 	//
 	// +optional
 	ResourceGroupName string `json:"resourceGroupName,omitempty"`

--- a/vendor/github.com/openshift/hive/apis/hive/v1/azure/platform.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/azure/platform.go
@@ -24,6 +24,16 @@ type Platform struct {
 	// If empty, the value is equal to "AzurePublicCloud".
 	// +optional
 	CloudName CloudEnvironment `json:"cloudName,omitempty"`
+
+	// ResourceGroupName is the name of an already existing resource group where the cluster should be installed.
+	// This resource group should only be used for this specific cluster and the cluster components will assume
+	// ownership of all resources in the resource group. Destroying the cluster using installer will delete this
+	// resource group.
+	// This resource group must be empty with no other resources when trying to use it for creating a cluster.
+	// If empty, a new resource group will created for the cluster.
+	//
+	// +optional
+	ResourceGroupName string `json:"resourceGroupName,omitempty"`
 }
 
 // CloudEnvironment is the name of the Azure cloud environment

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeprovision_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeprovision_types.go
@@ -89,10 +89,10 @@ type AzureClusterDeprovision struct {
 	// If empty, the value is equal to "AzurePublicCloud".
 	// +optional
 	CloudName *azure.CloudEnvironment `json:"cloudName,omitempty"`
-	// ResourceGroupName is the name of an already existing resource group where the cluster was installed.
-	// This resource group should only be used for this specific cluster and the cluster components will assume
-	// ownership of all resources in the resource group. Destroying the cluster using installer will delete this
-	// resource group.
+	// ResourceGroupName is the name of the resource group where the cluster was installed.
+	// Required if the cluster was created using a pre-existing resource group rather than having
+	// allowed the installer to create one.
+	// This resource group will be deleted when the cluster is destroyed.
 	// +optional
 	ResourceGroupName string `json:"resourceGroupName,omitempty"`
 }

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeprovision_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeprovision_types.go
@@ -89,6 +89,12 @@ type AzureClusterDeprovision struct {
 	// If empty, the value is equal to "AzurePublicCloud".
 	// +optional
 	CloudName *azure.CloudEnvironment `json:"cloudName,omitempty"`
+	// ResourceGroupName is the name of an already existing resource group where the cluster was installed.
+	// This resource group should only be used for this specific cluster and the cluster components will assume
+	// ownership of all resources in the resource group. Destroying the cluster using installer will delete this
+	// resource group.
+	// +optional
+	ResourceGroupName string `json:"resourceGroupName,omitempty"`
 }
 
 // GCPClusterDeprovision contains GCP-specific configuration for a ClusterDeprovision


### PR DESCRIPTION
If `ResourceGroupName` is overridden within the install-config then `ResourceGroupName` must also be set within ClusterDeployment platform for Azure (`cd.Spec.Platform.Azure.ResourceGroupName`) so that `MachineSet` generation can utilize the override to look for images within the custom resource group as well as to configure `MachineSets` with the custom resource group.

[OCPBUGS-8386](https://issues.redhat.com//browse/OCPBUGS-8386)