### PR TITLE
Bump to go 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.12 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-4.14 as builder
 RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.19-openshift-4.12 as builder
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-4.14 as builder
 RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/hive/apis
 
-go 1.19
+go 1.20
 
 require (
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -40,7 +40,7 @@
 
 - Git
 - Make
-- A recent Go distribution (>=1.19)
+- A recent Go distribution (>=1.20)
 
 ### External tools
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/hive
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Azure/azure-sdk-for-go v63.1.0+incompatible

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9110,7 +9110,7 @@ github.com/openshift/generic-admission-server/pkg/cmd
 github.com/openshift/generic-admission-server/pkg/cmd/server
 github.com/openshift/generic-admission-server/pkg/registry/admissionreview
 # github.com/openshift/hive/apis v0.0.0 => ./apis
-## explicit; go 1.19
+## explicit; go 1.20
 github.com/openshift/hive/apis
 github.com/openshift/hive/apis/helpers
 github.com/openshift/hive/apis/hive/v1


### PR DESCRIPTION
Step 3/3 (I think) in getting to go 1.20.

NOTE: The builder image in the dockerfiles says 4.14 even though we're actually using 4.12 in CI. There should be no impact on the build artifacts themselves.

[HIVE-2193](https://issues.redhat.com//browse/HIVE-2193)