### PR TITLE
hiveutil aws-tag-deprovision: don't require a cluster

### DIFF
--- a/contrib/pkg/deprovision/awstagdeprovision.go
+++ b/contrib/pkg/deprovision/awstagdeprovision.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -64,7 +63,9 @@ func completeAWSUninstaller(o *aws.ClusterUninstaller, logLevel string, args []s
 
 	client, err := utils.GetClient()
 	if err != nil {
-		return errors.Wrap(err, "failed to get client")
+		o.Logger.Warnf("Failed to get client: %v\n"+
+			"This is expected when in standalone mode. "+
+			"We expect to find your AWS credentials in one of the usual places.", err)
 	}
 	awsutils.ConfigureCreds(client)
 


### PR DESCRIPTION
Changes made via #1874 / 0f4b1de caused hiveutil deprovisioning commands to try to load up a cloud credentials secret upon startup. When run in standalone mode, this doesn't work (unless you have configured some very specific environment variables) BUT the deprovisioner is able to work without it as long as your cloud creds are in one of the usual expected places (e.g. credentials file, env vars). This is in fact how those deprovisioners have always worked when invoked standalone.

However, prior to this commit, if we're entirely unable to contact the cluster API, we would abort the command. With this commit, we instead print a warning and proceed.

Note that we're only doing this for aws-tag-deprovision at this time, as it's the only deprovisioner used in standalone mode with any regularity (to our knowledge).

[HIVE-2142](https://issues.redhat.com//browse/HIVE-2142)