### PR TITLE
AWS MachinePool: Allow public and/or private subnets

### DIFF
--- a/apis/hive/v1/aws/machinepool.go
+++ b/apis/hive/v1/aws/machinepool.go
@@ -6,9 +6,14 @@ type MachinePoolPlatform struct {
 	// Zones is list of availability zones that can be used.
 	Zones []string `json:"zones,omitempty"`
 
-	// Subnets is the list of subnets to which to attach the machines.
-	// There must be exactly one private subnet for each availability zone used.
-	// If public subnets are specified, there must be exactly one private and one public subnet specified for each availability zone.
+	// Subnets is the list of IDs of subnets to which to attach the machines.
+	// There must be exactly one subnet for each availability zone used.
+	// These subnets may be public or private.
+	// As a special case, for consistency with install-config, you may specify exactly one
+	// private and one public subnet for each availability zone. In this case, the public
+	// subnets will be filtered out and only the private subnets will be used.
+	// If empty/omitted, we will look for subnets in each availability zone tagged with
+	// Name=<clusterID>-private-<az>.
 	Subnets []string `json:"subnets,omitempty"`
 
 	// InstanceType defines the ec2 instance type.

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -172,11 +172,15 @@ spec:
                             type: string
                         type: object
                       subnets:
-                        description: Subnets is the list of subnets to which to attach
-                          the machines. There must be exactly one private subnet for
-                          each availability zone used. If public subnets are specified,
-                          there must be exactly one private and one public subnet
-                          specified for each availability zone.
+                        description: Subnets is the list of IDs of subnets to which
+                          to attach the machines. There must be exactly one subnet
+                          for each availability zone used. These subnets may be public
+                          or private. As a special case, for consistency with install-config,
+                          you may specify exactly one private and one public subnet
+                          for each availability zone. In this case, the public subnets
+                          will be filtered out and only the private subnets will be
+                          used. If empty/omitted, we will look for subnets in each
+                          availability zone tagged with Name=<clusterID>-private-<az>.
                         items:
                           type: string
                         type: array

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -4944,11 +4944,16 @@ objects:
                               type: string
                           type: object
                         subnets:
-                          description: Subnets is the list of subnets to which to
-                            attach the machines. There must be exactly one private
-                            subnet for each availability zone used. If public subnets
-                            are specified, there must be exactly one private and one
-                            public subnet specified for each availability zone.
+                          description: Subnets is the list of IDs of subnets to which
+                            to attach the machines. There must be exactly one subnet
+                            for each availability zone used. These subnets may be
+                            public or private. As a special case, for consistency
+                            with install-config, you may specify exactly one private
+                            and one public subnet for each availability zone. In this
+                            case, the public subnets will be filtered out and only
+                            the private subnets will be used. If empty/omitted, we
+                            will look for subnets in each availability zone tagged
+                            with Name=<clusterID>-private-<az>.
                           items:
                             type: string
                           type: array

--- a/vendor/github.com/openshift/hive/apis/hive/v1/aws/machinepool.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/aws/machinepool.go
@@ -6,9 +6,14 @@ type MachinePoolPlatform struct {
 	// Zones is list of availability zones that can be used.
 	Zones []string `json:"zones,omitempty"`
 
-	// Subnets is the list of subnets to which to attach the machines.
-	// There must be exactly one private subnet for each availability zone used.
-	// If public subnets are specified, there must be exactly one private and one public subnet specified for each availability zone.
+	// Subnets is the list of IDs of subnets to which to attach the machines.
+	// There must be exactly one subnet for each availability zone used.
+	// These subnets may be public or private.
+	// As a special case, for consistency with install-config, you may specify exactly one
+	// private and one public subnet for each availability zone. In this case, the public
+	// subnets will be filtered out and only the private subnets will be used.
+	// If empty/omitted, we will look for subnets in each availability zone tagged with
+	// Name=<clusterID>-private-<az>.
 	Subnets []string `json:"subnets,omitempty"`
 
 	// InstanceType defines the ec2 instance type.


### PR DESCRIPTION
Previously, via [HIVE-1224](https://issues.redhat.com//browse/HIVE-1224) / #1234 / a27ef2e, we started filtering out public subnets if they were provided in an AWS MachinePool. This led to two issues:
- Users could not create machines in public subnets at all ([HIVE-2196](https://issues.redhat.com//browse/HIVE-2196)).
- In PrivateLink, subnets are always private, even though they may appear public based on their attributes ([HIVE-1805](https://issues.redhat.com//browse/HIVE-1805)).

With this commit, we relax the restrictions such that, if the number of subnets matches the number of availability zones, we allow them whether they're public or private.

Here's a complete description of the new behavior:
- We still accept an empty Subnets list, as before.
- If the number of subnets matches the number of availability zones, we allow them, whether they're public or private. (We still validate that we were given exactly one subnet per AZ.)
- If the number of subnets is double the number of availability zones, we follow the existing behavior: filter out the ones we detect are public and pass through only the private ones.
- Any other number of subnets is an error.

[HIVE-1805](https://issues.redhat.com//browse/HIVE-1805)
[HIVE-2196](https://issues.redhat.com//browse/HIVE-2196)