### PR TITLE
Fix nil pointer exception looking up no workers

### DIFF
--- a/pkg/controller/clusterprovision/clusterprovision_controller.go
+++ b/pkg/controller/clusterprovision/clusterprovision_controller.go
@@ -608,7 +608,11 @@ func (r *ReconcileClusterProvision) getWorkers(cd hivev1.ClusterDeployment) stri
 		r.logger.WithError(err).Error("could not unmarshal InstallConfig")
 		return "unknown"
 	}
-	return strconv.FormatInt(*ic.WorkerMachinePool().Replicas, 10)
+	mp := ic.WorkerMachinePool()
+	if mp == nil || mp.Replicas == nil {
+		return "0"
+	}
+	return strconv.FormatInt(*mp.Replicas, 10)
 }
 
 func (r *ReconcileClusterProvision) logProvisionSuccessFailureMetric(


### PR DESCRIPTION
Customer reports a panic in:

```
github.com/openshift/hive/pkg/controller/clusterprovision.(*ReconcileClusterProvision).getWorkers(_, {{{0x4581c54, 0x11}, {0xc003588a20, 0x14}}, {{0xc00562e9d6, 0x9}, {0x0, 0x0}, {0xc00562e9e0, ...}, ...}, ...})
        github.com/openshift/hive/pkg/controller/clusterprovision/clusterprovision_controller.go:611 +0x263
```

(This is running hive commit cef3cb07)

This can happen if the install-config.yaml is improperly formatted in any of several ways:
- There is no `compute` section.
- The `compute` section has no item with `name: worker`.
- That section has no `replicas` field.

This commit adds some simple nil checking and reports zero workers in those scenarios.

[HIVE-2200](https://issues.redhat.com//browse/HIVE-2200)

(cherry picked from commit 243608d0131a229d7cf0a4c19f852068a7ef1434)