### PR TITLE
Install clusterwide proxy certs for prov/deprov

### DIFF
--- a/config/controllers/hive_controllers_role.yaml
+++ b/config/controllers/hive_controllers_role.yaml
@@ -73,6 +73,8 @@ rules:
   resources:
   - roles
   - rolebindings
+  - clusterroles
+  - clusterrolebindings
   verbs:
   - get
   - list
@@ -99,3 +101,11 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - proxies
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/operator/operator_role.yaml
+++ b/config/operator/operator_role.yaml
@@ -227,3 +227,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - proxies
+  verbs:
+  - get
+  - list
+  - watch

--- a/contrib/pkg/utils/alibabacloud/alibabacloud.go
+++ b/contrib/pkg/utils/alibabacloud/alibabacloud.go
@@ -56,4 +56,5 @@ func ConfigureCreds(c client.Client) {
 	if secret := string(credsSecret.Data[constants.AlibabaCloudAccessKeySecretSecretKey]); secret != "" {
 		os.Setenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", secret)
 	}
+	utils.InstallClusterwideProxyCerts(c)
 }

--- a/contrib/pkg/utils/aws/aws.go
+++ b/contrib/pkg/utils/aws/aws.go
@@ -67,4 +67,6 @@ func ConfigureCreds(c client.Client) {
 	}
 	// Allow credential_process in the config file
 	os.Setenv("AWS_SDK_LOAD_CONFIG", "true")
+
+	utils.InstallClusterwideProxyCerts(c)
 }

--- a/contrib/pkg/utils/azure/azure.go
+++ b/contrib/pkg/utils/azure/azure.go
@@ -38,4 +38,6 @@ func ConfigureCreds(c client.Client) {
 	}
 	utils.ProjectToDir(credsSecret, constants.AzureCredentialsDir)
 	os.Setenv(constants.AzureCredentialsEnvVar, constants.AzureCredentialsDir+"/"+constants.AzureCredentialsName)
+
+	utils.InstallClusterwideProxyCerts(c)
 }

--- a/contrib/pkg/utils/gcp/gcp.go
+++ b/contrib/pkg/utils/gcp/gcp.go
@@ -39,4 +39,6 @@ func ConfigureCreds(c client.Client) {
 	}
 	utils.ProjectToDir(credsSecret, constants.GCPCredentialsDir)
 	os.Setenv("GOOGLE_CREDENTIALS", constants.GCPCredentialsDir+"/"+constants.GCPCredentialsName)
+
+	utils.InstallClusterwideProxyCerts(c)
 }

--- a/contrib/pkg/utils/ibmcloud/ibmcloud.go
+++ b/contrib/pkg/utils/ibmcloud/ibmcloud.go
@@ -16,4 +16,5 @@ func ConfigureCreds(c client.Client) {
 			os.Setenv(constants.IBMCloudAPIKeyEnvVar, key)
 		}
 	}
+	utils.InstallClusterwideProxyCerts(c)
 }

--- a/contrib/pkg/utils/openstack/openstack.go
+++ b/contrib/pkg/utils/openstack/openstack.go
@@ -45,4 +45,5 @@ func ConfigureCreds(c client.Client) {
 		utils.ProjectToDir(certsSecret, constants.OpenStackCertificatesDir)
 		utils.InstallCerts(constants.OpenStackCertificatesDir)
 	}
+	utils.InstallClusterwideProxyCerts(c)
 }

--- a/contrib/pkg/utils/ovirt/ovirt.go
+++ b/contrib/pkg/utils/ovirt/ovirt.go
@@ -43,4 +43,5 @@ func ConfigureCreds(c client.Client) {
 		utils.ProjectToDir(certsSecret, constants.OvirtCertificatesDir)
 		utils.InstallCerts(constants.OvirtCertificatesDir)
 	}
+	utils.InstallClusterwideProxyCerts(c)
 }

--- a/contrib/pkg/utils/vsphere/vsphere.go
+++ b/contrib/pkg/utils/vsphere/vsphere.go
@@ -27,4 +27,5 @@ func ConfigureCreds(c client.Client) {
 		utils.ProjectToDir(certsSecret, constants.VSphereCertificatesDir)
 		utils.InstallCerts(constants.VSphereCertificatesDir)
 	}
+	utils.InstallClusterwideProxyCerts(c)
 }

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -7264,6 +7264,14 @@ objects:
     - get
     - list
     - watch
+  - apiGroups:
+    - config.openshift.io
+    resources:
+    - proxies
+    verbs:
+    - get
+    - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:

--- a/pkg/controller/clusterdeployment/clusterprovisions.go
+++ b/pkg/controller/clusterdeployment/clusterprovisions.go
@@ -443,6 +443,10 @@ func (r *ReconcileClusterDeployment) reconcileFailedProvision(cd *hivev1.Cluster
 func (r *ReconcileClusterDeployment) reconcileCompletedProvision(cd *hivev1.ClusterDeployment, provision *hivev1.ClusterProvision, cdLog log.FieldLogger) (reconcile.Result, error) {
 	cdLog.Info("provision completed successfully")
 
+	if err := controllerutils.DisableClusterInstallServiceAccount(r.Client, cd.Namespace, cdLog); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	statusChange := false
 	if cd.Status.InstalledTimestamp == nil {
 		statusChange = true

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
@@ -30,6 +30,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
 	hivemetrics "github.com/openshift/hive/pkg/controller/metrics"
+	"github.com/openshift/hive/pkg/controller/utils"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/install"
 	k8slabels "github.com/openshift/hive/pkg/util/labels"
@@ -339,6 +340,10 @@ func (r *ReconcileClusterDeprovision) Reconcile(ctx context.Context, request rec
 
 	// Uninstall job exists, check its status and if successful, set the deprovision request status to complete
 	if controllerutils.IsSuccessful(existingJob) {
+		if err := utils.DisableClusterUninstallServiceAccount(r.Client, uninstallJob.Namespace, rLog); err != nil {
+			return reconcile.Result{}, err
+		}
+
 		rLog.Infof("uninstall job successful, setting completed status")
 		conditions, _ := controllerutils.SetClusterDeprovisionConditionWithChangeCheck(
 			instance.Status.Conditions,

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -957,6 +957,8 @@ rules:
   resources:
   - roles
   - rolebindings
+  - clusterroles
+  - clusterrolebindings
   verbs:
   - get
   - list
@@ -983,6 +985,14 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - proxies
+  verbs:
+  - get
+  - list
+  - watch
 `)
 
 func configControllersHive_controllers_roleYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Look for, load, and install the clusterwide proxy certs (as referenced by the `proxy` object named `cluster`) in provisioning and deprovisioning pods for all clouds.

[HIVE-2198](https://issues.redhat.com//browse/HIVE-2198)