### PR TITLE
Update ClusterPool status counts while deleting

### DIFF
--- a/pkg/controller/clusterpool/clusterpool_controller_test.go
+++ b/pkg/controller/clusterpool/clusterpool_controller_test.go
@@ -1107,7 +1107,9 @@ func TestReconcileClusterPool(t *testing.T) {
 			// DeletionTimestamp, isn't getting garbage collected by the fake client. This is the expected result once
 			// the issue is fixed:
 			// expectedTotalClusters: 2,
-			expectedTotalClusters:   3,
+			expectedTotalClusters: 3,
+			// But this one is right
+			expectedObservedSize:    2,
 			expectedCDCurrentStatus: corev1.ConditionUnknown,
 			expectedDeletionPossibleCondition: &hivev1.ClusterPoolCondition{
 				Status:  corev1.ConditionFalse,

--- a/pkg/controller/clusterpool/collections.go
+++ b/pkg/controller/clusterpool/collections.go
@@ -616,6 +616,7 @@ func (cds *cdCollection) Delete(c client.Client, cdName string) error {
 	cds.deleting = append(cds.deleting, cd)
 	// Remove from any of the other lists it might be in
 	removeCDsFromSlice(&cds.assignable, cdName)
+	removeCDsFromSlice(&cds.standby, cdName)
 	removeCDsFromSlice(&cds.installing, cdName)
 	removeCDsFromSlice(&cds.broken, cdName)
 	removeCDsFromSlice(&cds.unknownPoolVersion, cdName)


### PR DESCRIPTION
ClusterPool status fields Size, Standby, and Ready were being ignored in the deletion path for the ClusterPool, and we never noticed because the ClusterPool was disappearing (see referenced card). Fix.

[HIVE-1557](https://issues.redhat.com//browse/HIVE-1557)