### PR TITLE
ClusterPool: hold until all clusters deleted, subject to maxConcurrent

### DIFF
--- a/apis/hive/v1/clusterpool_types.go
+++ b/apis/hive/v1/clusterpool_types.go
@@ -218,8 +218,11 @@ const (
 	// ClusterPoolAllClustersCurrentCondition indicates whether all unassigned (installing or ready)
 	// ClusterDeployments in the pool match the current configuration of the ClusterPool.
 	ClusterPoolAllClustersCurrentCondition ClusterPoolConditionType = "AllClustersCurrent"
-	// ClusterPoolInventoryValidCondition is set to provide information on whether the cluster pool inventory is valid
+	// ClusterPoolInventoryValidCondition is set to provide information on whether the cluster pool inventory is valid.
 	ClusterPoolInventoryValidCondition ClusterPoolConditionType = "InventoryValid"
+	// ClusterPoolDeletionPossibleCondition gives information about a deleted ClusterPool which is pending cleanup.
+	// Note that it is normal for this condition to remain Initialized/Unknown until the ClusterPool is deleted.
+	ClusterPoolDeletionPossibleCondition ClusterPoolConditionType = "DeletionPossible"
 )
 
 const (

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -367,11 +367,7 @@ func (r *ReconcileClusterPool) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, err
 	}
 
-	origStatus := clp.Status.DeepCopy()
-	clp.Status.Size = int32(len(cds.Unassigned(true)))
-	clp.Status.Standby = int32(len(cds.Standby()))
-	clp.Status.Ready = int32(len(cds.Assignable()))
-	if !reflect.DeepEqual(origStatus, &clp.Status) {
+	if setStatusCounts(clp, cds) {
 		if err := r.Status().Update(context.Background(), clp); err != nil {
 			logger.WithError(err).Log(controllerutils.LogLevel(err), "could not update ClusterPool status")
 			return reconcile.Result{}, errors.Wrap(err, "could not update ClusterPool status")
@@ -1018,9 +1014,12 @@ func (r *ReconcileClusterPool) reconcileDeletedPool(pool *hivev1.ClusterPool, lo
 		availableConcurrent--
 	}
 
-	if err := r.setDeletionPossibleCondition(pool, cds); err != nil {
-		logger.WithError(err).Error("error setting DeletionPossible condition")
-		return err
+	changedCond := setDeletionPossibleCondition(pool, cds)
+	changedCounts := setStatusCounts(pool, cds)
+	if changedCond || changedCounts {
+		if err := r.Status().Update(context.Background(), pool); err != nil {
+			return errors.Wrap(err, "could not update ClusterPool status")
+		}
 	}
 
 	if cds.Total() != 0 {
@@ -1121,7 +1120,9 @@ func (r *ReconcileClusterPool) setAvailableCapacityCondition(pool *hivev1.Cluste
 	return nil
 }
 
-func (r *ReconcileClusterPool) setDeletionPossibleCondition(pool *hivev1.ClusterPool, cds *cdCollection) error {
+// setDeletionPossibleCondition updates the DeletionPossible condition on the pool and returns whether it
+// changed. The caller is responsible for pushing the update to the server.
+func setDeletionPossibleCondition(pool *hivev1.ClusterPool, cds *cdCollection) bool {
 	status := corev1.ConditionTrue
 	reason := "DeletionPossible"
 	message := "No ClusterDeployments pending cleanup"
@@ -1140,13 +1141,19 @@ func (r *ReconcileClusterPool) setDeletionPossibleCondition(pool *hivev1.Cluster
 		message,
 		updateConditionCheck,
 	)
-	if changed {
-		pool.Status.Conditions = conds
-		if err := r.Status().Update(context.Background(), pool); err != nil {
-			return errors.Wrap(err, "could not update ClusterPool conditions")
-		}
-	}
-	return nil
+	pool.Status.Conditions = conds
+	return changed
+}
+
+// setStatusCounts sets the Size, Standby, and Ready status fields in clp according to cds.
+// The caller is responsible for pushing the changes back to the server.
+// The return indicates whether anything changed.
+func setStatusCounts(clp *hivev1.ClusterPool, cds *cdCollection) bool {
+	origStatus := clp.Status.DeepCopy()
+	clp.Status.Size = int32(len(cds.Unassigned(true)))
+	clp.Status.Standby = int32(len(cds.Standby()))
+	clp.Status.Ready = int32(len(cds.Assignable()))
+	return !reflect.DeepEqual(origStatus, &clp.Status)
 }
 
 func (r *ReconcileClusterPool) verifyClusterImageSet(pool *hivev1.ClusterPool, logger log.FieldLogger) error {

--- a/pkg/controller/clusterpool/clusterpool_controller_test.go
+++ b/pkg/controller/clusterpool/clusterpool_controller_test.go
@@ -1049,7 +1049,9 @@ func TestReconcileClusterPool(t *testing.T) {
 			// DeletionTimestamp, isn't getting garbage collected by the fake client. This is the expected result once
 			// the issue is fixed:
 			// expectedTotalClusters: 2,
-			expectedTotalClusters:   3,
+			expectedTotalClusters: 3,
+			// But this one is right
+			expectedObservedSize:    2,
 			expectedCDCurrentStatus: corev1.ConditionUnknown,
 			expectedDeletionPossibleCondition: &hivev1.ClusterPoolCondition{
 				Status:  corev1.ConditionFalse,

--- a/pkg/controller/clusterpool/collections.go
+++ b/pkg/controller/clusterpool/collections.go
@@ -428,6 +428,16 @@ func (cds *cdCollection) Total() int {
 	return len(cds.byCDName)
 }
 
+// Names returns a lexicographically sorted list of the names of all the ClusterDeployments in the cdCollection.
+func (cds *cdCollection) Names() []string {
+	ret := []string{}
+	for cdName := range cds.byCDName {
+		ret = append(ret, cdName)
+	}
+	sort.Strings(ret)
+	return ret
+}
+
 // NumAssigned returns the number of ClusterDeployments assigned to claims.
 func (cds *cdCollection) NumAssigned() int {
 	return len(cds.byClaimName)

--- a/pkg/controller/clusterpool/collections.go
+++ b/pkg/controller/clusterpool/collections.go
@@ -616,6 +616,7 @@ func (cds *cdCollection) Delete(c client.Client, cdName string) error {
 	cds.deleting = append(cds.deleting, cd)
 	// Remove from any of the other lists it might be in
 	removeCDsFromSlice(&cds.assignable, cdName)
+	removeCDsFromSlice(&cds.standby, cdName)
 	removeCDsFromSlice(&cds.installing, cdName)
 	removeCDsFromSlice(&cds.broken, cdName)
 	removeCDsFromSlice(&cds.unknownPoolVersion, cdName)

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
@@ -218,8 +218,11 @@ const (
 	// ClusterPoolAllClustersCurrentCondition indicates whether all unassigned (installing or ready)
 	// ClusterDeployments in the pool match the current configuration of the ClusterPool.
 	ClusterPoolAllClustersCurrentCondition ClusterPoolConditionType = "AllClustersCurrent"
-	// ClusterPoolInventoryValidCondition is set to provide information on whether the cluster pool inventory is valid
+	// ClusterPoolInventoryValidCondition is set to provide information on whether the cluster pool inventory is valid.
 	ClusterPoolInventoryValidCondition ClusterPoolConditionType = "InventoryValid"
+	// ClusterPoolDeletionPossibleCondition gives information about a deleted ClusterPool which is pending cleanup.
+	// Note that it is normal for this condition to remain Initialized/Unknown until the ClusterPool is deleted.
+	ClusterPoolDeletionPossibleCondition ClusterPoolConditionType = "DeletionPossible"
 )
 
 const (


### PR DESCRIPTION
Backports commits from [HIVE-1557](https://issues.redhat.com//browse/HIVE-1557)