### PR TITLE
s,gopkg.in/yaml.v2,sigs.k8s.io/yaml for json-tagged structs

### DIFF
--- a/pkg/controller/clusterdeployment/installconfigvalidation.go
+++ b/pkg/controller/clusterdeployment/installconfigvalidation.go
@@ -2,7 +2,7 @@ package clusterdeployment
 
 import (
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 
 	installertypes "github.com/openshift/installer/pkg/types"
 

--- a/pkg/controller/clusterprovision/clusterprovision_controller.go
+++ b/pkg/controller/clusterprovision/clusterprovision_controller.go
@@ -3,7 +3,6 @@ package clusterprovision
 import (
 	"context"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"strconv"
 	"time"
 
@@ -25,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+	"sigs.k8s.io/yaml"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"


### PR DESCRIPTION
We recently discovered that `gopkg.in/yaml.v2` doesn't work properly in
cases where the struct being unmarshalled to has only `json` tags. An
important example is unmarshalling install-config. The reason can be
found in this blog post [1].

Swap to `sigs.k8s.io/yaml` in the couple of places where this applies.
(Notably, we're leaving alone places where the target struct has `yaml`
tags, as the interface between the two libraries is not fully
compatible.)

[1] https://web.archive.org/web/20190603050330/http://ghodss.com/2014/the-right-way-to-handle-yaml-in-golang/

[HIVE-2205](https://issues.redhat.com//browse/HIVE-2205)