### PR TITLE
Beef up clusterwide proxy support

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -23,6 +23,7 @@ import (
 
 	oappsv1 "github.com/openshift/api/apps/v1"
 	orbacv1 "github.com/openshift/api/authorization/v1"
+	oconfigv1 "github.com/openshift/api/config/v1"
 	_ "github.com/openshift/generic-admission-server/pkg/cmd"
 
 	"github.com/openshift/hive/apis"
@@ -114,6 +115,10 @@ func newRootCommand() *cobra.Command {
 				}
 
 				if err := orbacv1.Install(mgr.GetScheme()); err != nil {
+					log.Fatal(err)
+				}
+
+				if err := oconfigv1.Install(mgr.GetScheme()); err != nil {
 					log.Fatal(err)
 				}
 

--- a/config/operator/operator_role.yaml
+++ b/config/operator/operator_role.yaml
@@ -227,3 +227,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - proxies
+  verbs:
+  - get
+  - list
+  - watch

--- a/contrib/pkg/utils/alibabacloud/alibabacloud.go
+++ b/contrib/pkg/utils/alibabacloud/alibabacloud.go
@@ -56,4 +56,6 @@ func ConfigureCreds(c client.Client) {
 	if secret := string(credsSecret.Data[constants.AlibabaCloudAccessKeySecretSecretKey]); secret != "" {
 		os.Setenv("ALIBABA_CLOUD_ACCESS_KEY_SECRET", secret)
 	}
+	// Install cluster proxy trusted CA bundle
+	utils.InstallCerts(constants.TrustedCABundleDir)
 }

--- a/contrib/pkg/utils/aws/aws.go
+++ b/contrib/pkg/utils/aws/aws.go
@@ -67,4 +67,6 @@ func ConfigureCreds(c client.Client) {
 	}
 	// Allow credential_process in the config file
 	os.Setenv("AWS_SDK_LOAD_CONFIG", "true")
+	// Install cluster proxy trusted CA bundle
+	utils.InstallCerts(constants.TrustedCABundleDir)
 }

--- a/contrib/pkg/utils/azure/azure.go
+++ b/contrib/pkg/utils/azure/azure.go
@@ -38,4 +38,6 @@ func ConfigureCreds(c client.Client) {
 	}
 	utils.ProjectToDir(credsSecret, constants.AzureCredentialsDir)
 	os.Setenv(constants.AzureCredentialsEnvVar, constants.AzureCredentialsDir+"/"+constants.AzureCredentialsName)
+	// Install cluster proxy trusted CA bundle
+	utils.InstallCerts(constants.TrustedCABundleDir)
 }

--- a/contrib/pkg/utils/gcp/gcp.go
+++ b/contrib/pkg/utils/gcp/gcp.go
@@ -39,4 +39,6 @@ func ConfigureCreds(c client.Client) {
 	}
 	utils.ProjectToDir(credsSecret, constants.GCPCredentialsDir)
 	os.Setenv("GOOGLE_CREDENTIALS", constants.GCPCredentialsDir+"/"+constants.GCPCredentialsName)
+	// Install cluster proxy trusted CA bundle
+	utils.InstallCerts(constants.TrustedCABundleDir)
 }

--- a/contrib/pkg/utils/ibmcloud/ibmcloud.go
+++ b/contrib/pkg/utils/ibmcloud/ibmcloud.go
@@ -16,4 +16,6 @@ func ConfigureCreds(c client.Client) {
 			os.Setenv(constants.IBMCloudAPIKeyEnvVar, key)
 		}
 	}
+	// Install cluster proxy trusted CA bundle
+	utils.InstallCerts(constants.TrustedCABundleDir)
 }

--- a/contrib/pkg/utils/openstack/openstack.go
+++ b/contrib/pkg/utils/openstack/openstack.go
@@ -45,4 +45,6 @@ func ConfigureCreds(c client.Client) {
 		utils.ProjectToDir(certsSecret, constants.OpenStackCertificatesDir)
 		utils.InstallCerts(constants.OpenStackCertificatesDir)
 	}
+	// Install cluster proxy trusted CA bundle
+	utils.InstallCerts(constants.TrustedCABundleDir)
 }

--- a/contrib/pkg/utils/ovirt/ovirt.go
+++ b/contrib/pkg/utils/ovirt/ovirt.go
@@ -43,4 +43,6 @@ func ConfigureCreds(c client.Client) {
 		utils.ProjectToDir(certsSecret, constants.OvirtCertificatesDir)
 		utils.InstallCerts(constants.OvirtCertificatesDir)
 	}
+	// Install cluster proxy trusted CA bundle
+	utils.InstallCerts(constants.TrustedCABundleDir)
 }

--- a/contrib/pkg/utils/vsphere/vsphere.go
+++ b/contrib/pkg/utils/vsphere/vsphere.go
@@ -27,4 +27,6 @@ func ConfigureCreds(c client.Client) {
 		utils.ProjectToDir(certsSecret, constants.VSphereCertificatesDir)
 		utils.InstallCerts(constants.VSphereCertificatesDir)
 	}
+	// Install cluster proxy trusted CA bundle
+	utils.InstallCerts(constants.TrustedCABundleDir)
 }

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -7264,6 +7264,14 @@ objects:
     - get
     - list
     - watch
+  - apiGroups:
+    - config.openshift.io
+    resources:
+    - proxies
+    verbs:
+    - get
+    - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -502,6 +502,13 @@ const (
 	// there is a risk for the metric to be defined with fewer labels than expected. Set this constant as the default
 	// value when the value is unknown
 	MetricLabelDefaultValue = "unspecified"
+
+	// TrustedCAConfigMapName is the name of the ConfigMap containing the merged CA bundle including the trustedCA from the
+	// cluster proxy object. We'll use this to name the mount also.
+	TrustedCAConfigMapName = "hive-trusted-cabundle"
+
+	// TrustedCABundleDir is the path into which the merged CA bundle will be mounted.
+	TrustedCABundleDir = "/hive-trusted-cabundle"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -106,7 +106,8 @@ const (
 	deleteAfterAnnotation    = "hive.openshift.io/delete-after" // contains a duration after which the cluster should be cleaned up.
 	tryInstallOnceAnnotation = "hive.openshift.io/try-install-once"
 
-	regionUnknown = "unknown"
+	regionUnknown     = "unknown"
+	injectCABundleKey = "config.openshift.io/inject-trusted-cabundle"
 )
 
 // Add creates a new ClusterDeployment controller and adds it to the manager with default RBAC.
@@ -706,6 +707,11 @@ func (r *ReconcileClusterDeployment) reconcile(request reconcile.Request, cd *hi
 		// The controller will not automatically requeue the cluster deployment
 		// since the controller is not watching for secrets. So, requeue manually.
 		return reconcile.Result{Requeue: true}, nil
+	}
+
+	if err := r.ensureTrustedCABundleConfigMap(cd.Namespace); err != nil {
+		cdLog.WithError(err).Error("Failed to create or verify the trusted CA bundle ConfigMap")
+		return reconcile.Result{}, err
 	}
 
 	// let's verify the release image before using it here.
@@ -1986,6 +1992,36 @@ func (r *ReconcileClusterDeployment) updatePullSecretInfo(pullSecret string, cd 
 		cdLog.WithField("secretName", mergedSecretName).Info("Created the merged pull secret object successfully")
 	}
 	return true, nil
+}
+
+// ensureTrustedCABundleConfigMap makes sure there is a ConfigMap in the CD's namespace with the magical
+// config.opesnhift.io/inject-trusted-cabundle="true" label, which causes the Cluster Network Operator to
+// populate it with a merged CA bundle including the cluster proxy's trustedCA if configured. We'll mount
+// this ConfigMap on all prov/deprov pods. See https://docs.openshift.com/container-platform/4.12/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki
+func (r *ReconcileClusterDeployment) ensureTrustedCABundleConfigMap(namespace string) error {
+	cm := &corev1.ConfigMap{}
+	if err := r.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: constants.TrustedCAConfigMapName}, cm); err != nil {
+		if apierrors.IsNotFound(err) {
+			cm.Name = constants.TrustedCAConfigMapName
+			cm.Namespace = namespace
+			if cm.Labels == nil {
+				cm.Labels = make(map[string]string)
+			}
+			cm.Labels[injectCABundleKey] = "true"
+			if err := r.Create(context.TODO(), cm); err != nil {
+				return errors.Wrap(err, "Failed to create the trusted CA bundle ConfigMap")
+			}
+		} else {
+			return errors.Wrap(err, "Failed to retrieve trusted CA bundle ConfigMap")
+		}
+	}
+	if cm.Labels[injectCABundleKey] != "true" {
+		cm.Labels[injectCABundleKey] = "true"
+		if err := r.Update(context.TODO(), cm); err != nil {
+			return errors.Wrap(err, "Failed to update the trusted CA bundle ConfigMap")
+		}
+	}
+	return nil
 }
 
 func calculateNextProvisionTime(failureTime time.Time, retries int, cdLog log.FieldLogger) time.Time {

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -37,6 +37,8 @@ const (
 	// deprovisionJobDeadline is the maximum time that deprovision job will be allowed to run.
 	// when this deadline is reached, the deprovision attempt will be marked failed.
 	deprovisionJobDeadline = 1 * time.Hour
+	// Data key within the trusted CA bundle ConfigMap containing the certificate data.
+	caBundleKey = "ca-bundle.crt"
 )
 
 func AWSAssumeRoleSecretName(secretPrefix string) string {
@@ -270,8 +272,7 @@ func InstallerPodSpec(
 	}
 
 	// Create all the empty directories we need
-	volumes := []corev1.Volume{}
-	volumeMounts := []corev1.VolumeMount{}
+	volumes, volumeMounts := baseVolumesAndMounts()
 	for volname, dir := range emptyDirs {
 		volumes = append(volumes, corev1.Volume{
 			Name: volname,
@@ -483,6 +484,36 @@ func GenerateUninstallerJobForDeprovision(
 	return job, nil
 }
 
+func baseVolumesAndMounts() ([]corev1.Volume, []corev1.VolumeMount) {
+	// All prov/deprov pods get the clusterwide certificate bundle, which includes
+	// the proxy trustedCA if configured. See https://docs.openshift.com/container-platform/4.12/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki
+	volumes := []corev1.Volume{
+		{
+			Name: constants.TrustedCAConfigMapName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: constants.TrustedCAConfigMapName,
+					},
+					Items: []corev1.KeyToPath{
+						{
+							Key:  caBundleKey,
+							Path: caBundleKey,
+						},
+					},
+				},
+			},
+		},
+	}
+	volumeMounts := []corev1.VolumeMount{
+		{
+			Name:      constants.TrustedCAConfigMapName,
+			MountPath: constants.TrustedCABundleDir,
+		},
+	}
+	return volumes, volumeMounts
+}
+
 // envAndVolumes creates lists of EnvVar, Volume, and VolumeMount suitable for including in a Pod spec
 // that's going to run a hiveutil deprovision command (including aws-tag-deprovision).
 // Args:
@@ -495,8 +526,7 @@ func GenerateUninstallerJobForDeprovision(
 //     "CREDS_SECRET_NAME" EnvVar; otherwise no such env var is included.
 //   - certsVolName, certsDir, certsName: Same as their creds* counterparts, but for certificates.
 func envAndVolumes(ns, credsVolName, credsDir, credsName, certsVolName, certsDir, certsName string) ([]corev1.EnvVar, []corev1.Volume, []corev1.VolumeMount) {
-	volumes := []corev1.Volume{}
-	volumeMounts := []corev1.VolumeMount{}
+	volumes, volumeMounts := baseVolumesAndMounts()
 	env := []corev1.EnvVar{
 		{
 			Name:  "CLUSTERDEPLOYMENT_NAMESPACE",

--- a/pkg/operator/hive/dynamicclient.go
+++ b/pkg/operator/hive/dynamicclient.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 
+	configv1 "github.com/openshift/api/config/v1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 )
 
@@ -35,6 +36,8 @@ func (r *ReconcileHiveConfig) clientFor(blankObj runtime.Object, namespace strin
 		c = dc.Resource(corev1.SchemeGroupVersion.WithResource("configmaps"))
 	case *corev1.NamespaceList, *corev1.Namespace:
 		c = dc.Resource(corev1.SchemeGroupVersion.WithResource("namespaces"))
+	case *configv1.ProxyList, *configv1.Proxy:
+		c = dc.Resource(configv1.SchemeGroupVersion.WithResource("proxies"))
 	}
 	if c == nil {
 		panic(fmt.Sprintf("You forgot to make a case for clients of type %T", blankObj))

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -12,11 +12,13 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
+	configv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	oappsv1 "github.com/openshift/api/apps/v1"
@@ -256,10 +258,16 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 	if hiveDeployment.Spec.Template.Annotations == nil {
 		hiveDeployment.Spec.Template.Annotations = make(map[string]string, 1)
 	}
-	hiveDeployment.Spec.Template.Annotations[hiveConfigHashAnnotation] = computeHash("", configHashes...)
 
-	utils.SetProxyEnvVars(&hiveDeployment.Spec.Template.Spec,
-		os.Getenv("HTTP_PROXY"), os.Getenv("HTTPS_PROXY"), os.Getenv("NO_PROXY"))
+	httpProxy, httpsProxy, noProxy, err := r.discoverProxyVars()
+	if err != nil {
+		return err
+	}
+	utils.SetProxyEnvVars(&hiveDeployment.Spec.Template.Spec, httpProxy, httpsProxy, noProxy)
+
+	// Include the proxy vars in the hash so we redeploy if they change
+	hiveDeployment.Spec.Template.Annotations[hiveConfigHashAnnotation] = computeHash(
+		httpProxy+httpsProxy+noProxy, configHashes...)
 
 	// Load namespaced assets, decode them, set to our target namespace, and apply:
 	for _, assetPath := range namespacedAssets {
@@ -540,4 +548,23 @@ func (r *ReconcileHiveConfig) deleteAllSyncSetInstances(hLog log.FieldLogger) (n
 		listOptions.Continue = cont
 	}
 	return
+}
+
+func (r *ReconcileHiveConfig) discoverProxyVars() (string, string, string, error) {
+	httpProxy, httpsProxy, noProxy := os.Getenv("HTTP_PROXY"), os.Getenv("HTTPS_PROXY"), os.Getenv("NO_PROXY")
+
+	// We'll assume that if *any* of these are set, we don't need to read the cluster proxy object
+	if httpProxy+httpsProxy+noProxy != "" {
+		return httpProxy, httpsProxy, noProxy, nil
+	}
+
+	proxy := &configv1.Proxy{}
+	if err := r.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, proxy); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("No cluster proxy found")
+			return "", "", "", nil
+		}
+		return "", "", "", errors.Wrap(err, "Failed to load cluster proxy object")
+	}
+	return proxy.Status.HTTPProxy, proxy.Status.HTTPSProxy, proxy.Status.NoProxy, nil
 }


### PR DESCRIPTION
This commit rounds out our support for clusterwide proxies by doing two
things:
- Previously, we relied on an outside agent (typically OLM) to set
`HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables on the
hive-operator deployment  We would pass these values down to the
controllers and thence to workload pods such as provisioner and
deprovisioner. This commit adds logic to discover those values from the
cluster proxy object if not already set.
- Install the cluster proxy's trusted CA bundle in all provision and
deprovision pods. The ultimate source of this bundle is the ConfigMap
referenced by the proxy's spec.trustedCA.name. We take advantage of the
Cluster Network Operator's facility [1] to inject the merged CA bundle --
which includes the proxy's trusted CA bundle -- into a ConfigMap in the
appropriate namespace and mount that ConfigMap on the pods.

TODO: I tried to add a `Watch()` for `Proxy` to hive-operator (so we can
redeploy the controllers if the proxy changes) but this caused the
operator to hang on startup. Couldn't figure it out this time around.

[1] https://docs.openshift.com/container-platform/4.12/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki

[HIVE-2198](https://issues.redhat.com//browse/HIVE-2198)