### PR TITLE
Only Watch Proxy when running on OpenShift

### DIFF
--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -315,11 +315,7 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 		"config/rbac/hive_admin_role_binding.yaml",
 		"config/rbac/hive_reader_role_binding.yaml",
 	}
-	isOpenShift, err := r.runningOnOpenShift(hLog)
-	if err != nil {
-		return err
-	}
-	if isOpenShift {
+	if r.isOpenShift {
 		hLog.Info("deploying OpenShift specific assets")
 		for _, a := range openshiftSpecificAssets {
 			err = util.ApplyAssetWithGC(h, a, instance, hLog)
@@ -444,15 +440,15 @@ func (r *ReconcileHiveConfig) includeGlobalPullSecret(hLog log.FieldLogger, h re
 	hiveContainer.Env = append(hiveContainer.Env, globalPullSecretEnvVar)
 }
 
-func (r *ReconcileHiveConfig) runningOnOpenShift(hLog log.FieldLogger) (bool, error) {
+func (r *ReconcileHiveConfig) runningOnOpenShift() (bool, error) {
 	deploymentConfigGroupVersion := oappsv1.GroupVersion.String()
 	list, err := r.discoveryClient.ServerResourcesForGroupVersion(deploymentConfigGroupVersion)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			hLog.WithError(err).Debug("DeploymentConfig objects not found, not running on OpenShift")
+			log.WithError(err).Debug("DeploymentConfig objects not found, not running on OpenShift")
 			return false, nil
 		}
-		hLog.WithError(err).Error("Error determining whether running on OpenShift")
+		log.WithError(err).Error("Error determining whether running on OpenShift")
 		return false, err
 	}
 

--- a/pkg/operator/hive/hive_controller.go
+++ b/pkg/operator/hive/hive_controller.go
@@ -242,11 +242,13 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// If the cluster proxy changes, we'll redeploy with the new values in the controllers' envs.
 	// There's just one Proxy object; and there's just one HiveConfig -- map any activity on the
-	// former to the latter.
-	err = c.Watch(&source.Kind{Type: &configv1.Proxy{}},
-		handler.EnqueueRequestsFromMapFunc(mapToHiveConfig("Proxy")))
-	if err != nil {
-		return err
+	// former to the latter. Note that Proxy is Openshift-specific.
+	if r.(*ReconcileHiveConfig).isOpenShift {
+		err = c.Watch(&source.Kind{Type: &configv1.Proxy{}},
+			handler.EnqueueRequestsFromMapFunc(mapToHiveConfig("Proxy")))
+		if err != nil {
+			return err
+		}
 	}
 
 	// Monitor the hive namespace so we can reconcile labels for monitoring. We do this with a map

--- a/pkg/operator/hive/hive_controller.go
+++ b/pkg/operator/hive/hive_controller.go
@@ -115,6 +115,11 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	r.(*ReconcileHiveConfig).isOpenShift, err = r.(*ReconcileHiveConfig).runningOnOpenShift()
+	if err != nil {
+		return err
+	}
+
 	// Regular manager client is not fully initialized here, create our own for some
 	// initialization API communication:
 	tempClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
@@ -338,6 +343,7 @@ type ReconcileHiveConfig struct {
 	hiveSecretLister                  corev1listers.SecretLister
 	secretWatchEstablishedInNamespace string
 	mgr                               manager.Manager
+	isOpenShift                       bool
 }
 
 // Reconcile reads that state of the cluster for a Hive object and makes changes based on the state read

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -157,11 +157,7 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h resour
 	// the cluster CA and inject into the webhooks.
 	// NOTE: If this is vanilla kube, you will also need to manually create a certificate
 	// secret, see hack/hiveadmission-dev-cert.sh. (TODO: automate -- see HIVE-1449.)
-	isOpenShift, err := r.runningOnOpenShift(hLog)
-	if err != nil {
-		return err
-	}
-	if !isOpenShift {
+	if !r.isOpenShift {
 		hLog.Debug("non-OpenShift 4.x cluster detected, modifying hiveadmission webhooks for CA certs")
 		err = r.injectCerts(apiService, validatingWebhooks, nil, hiveNSName, hLog)
 		if err != nil {


### PR DESCRIPTION
[HIVE-2198](https://issues.redhat.com//browse/HIVE-2198) / #1999 / 253408e introduced a `Watch()` on `Proxy` so we can
update environment variables and CA bundles when it changes. But `Proxy`
is an OpenShift CRD, so that `Watch()` blows up the operator when
running on vanilla k8s (and similar).

This commit conditions that `Watch()` such that we only add it if we're
running on OpenShift.

[HIVE-2210](https://issues.redhat.com//browse/HIVE-2210)