### PR TITLE
Dummy ca-bundle.crt for non-OpenShift

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -509,6 +509,9 @@ const (
 
 	// TrustedCABundleDir is the path into which the merged CA bundle will be mounted.
 	TrustedCABundleDir = "/hive-trusted-cabundle"
+
+	// TrustedCABundleFile is the name of the file (and corresponding ConfigMap key) containing the merged CA bundle.
+	TrustedCABundleFile = "ca-bundle.crt"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -37,8 +37,6 @@ const (
 	// deprovisionJobDeadline is the maximum time that deprovision job will be allowed to run.
 	// when this deadline is reached, the deprovision attempt will be marked failed.
 	deprovisionJobDeadline = 1 * time.Hour
-	// Data key within the trusted CA bundle ConfigMap containing the certificate data.
-	caBundleKey = "ca-bundle.crt"
 )
 
 func AWSAssumeRoleSecretName(secretPrefix string) string {
@@ -497,8 +495,8 @@ func baseVolumesAndMounts() ([]corev1.Volume, []corev1.VolumeMount) {
 					},
 					Items: []corev1.KeyToPath{
 						{
-							Key:  caBundleKey,
-							Path: caBundleKey,
+							Key:  constants.TrustedCABundleFile,
+							Path: constants.TrustedCABundleFile,
 						},
 					},
 				},


### PR DESCRIPTION
If we're not running on OpenShift, the magic label doesn't cause OpenShift to populate the merged CA bundle ConfigMap. This would cause the ConfigMap mount to fail, and provisions wouldn't start. This commit defaults that key to empty so the file will always exist and the mount will work. (Note that `update-ca-trust` properly ignores an empty file.)

[HIVE-2210](https://issues.redhat.com//browse/HIVE-2210)