### PR TITLE
Create ServiceAccount token secret for hiveadmission

### DIFF
--- a/config/hiveadmission/sa-token-secret.yaml
+++ b/config/hiveadmission/sa-token-secret.yaml
@@ -1,0 +1,9 @@
+# Prior to k8s 1.24, this secret was generated automatically
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hiveadmission-sa-token
+  namespace: hive
+  annotations:
+    kubernetes.io/service-account.name: "hiveadmission"
+type: kubernetes.io/service-account-token

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -11,6 +11,7 @@
 // config/hiveadmission/hiveadmission_rbac_role.yaml
 // config/hiveadmission/hiveadmission_rbac_role_binding.yaml
 // config/hiveadmission/machinepool-webhook.yaml
+// config/hiveadmission/sa-token-secret.yaml
 // config/hiveadmission/selectorsyncset-webhook.yaml
 // config/hiveadmission/service-account.yaml
 // config/hiveadmission/service.yaml
@@ -654,6 +655,31 @@ func configHiveadmissionMachinepoolWebhookYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "config/hiveadmission/machinepool-webhook.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _configHiveadmissionSaTokenSecretYaml = []byte(`# Prior to k8s 1.24, this secret was generated automatically
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hiveadmission-sa-token
+  namespace: hive
+  annotations:
+    kubernetes.io/service-account.name: "hiveadmission"
+type: kubernetes.io/service-account-token`)
+
+func configHiveadmissionSaTokenSecretYamlBytes() ([]byte, error) {
+	return _configHiveadmissionSaTokenSecretYaml, nil
+}
+
+func configHiveadmissionSaTokenSecretYaml() (*asset, error) {
+	bytes, err := configHiveadmissionSaTokenSecretYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "config/hiveadmission/sa-token-secret.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2017,6 +2043,7 @@ var _bindata = map[string]func() (*asset, error){
 	"config/hiveadmission/hiveadmission_rbac_role.yaml":         configHiveadmissionHiveadmission_rbac_roleYaml,
 	"config/hiveadmission/hiveadmission_rbac_role_binding.yaml": configHiveadmissionHiveadmission_rbac_role_bindingYaml,
 	"config/hiveadmission/machinepool-webhook.yaml":             configHiveadmissionMachinepoolWebhookYaml,
+	"config/hiveadmission/sa-token-secret.yaml":                 configHiveadmissionSaTokenSecretYaml,
 	"config/hiveadmission/selectorsyncset-webhook.yaml":         configHiveadmissionSelectorsyncsetWebhookYaml,
 	"config/hiveadmission/service-account.yaml":                 configHiveadmissionServiceAccountYaml,
 	"config/hiveadmission/service.yaml":                         configHiveadmissionServiceYaml,
@@ -2105,6 +2132,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"hiveadmission_rbac_role.yaml":         {configHiveadmissionHiveadmission_rbac_roleYaml, map[string]*bintree{}},
 			"hiveadmission_rbac_role_binding.yaml": {configHiveadmissionHiveadmission_rbac_role_bindingYaml, map[string]*bintree{}},
 			"machinepool-webhook.yaml":             {configHiveadmissionMachinepoolWebhookYaml, map[string]*bintree{}},
+			"sa-token-secret.yaml":                 {configHiveadmissionSaTokenSecretYaml, map[string]*bintree{}},
 			"selectorsyncset-webhook.yaml":         {configHiveadmissionSelectorsyncsetWebhookYaml, map[string]*bintree{}},
 			"service-account.yaml":                 {configHiveadmissionServiceAccountYaml, map[string]*bintree{}},
 			"service.yaml":                         {configHiveadmissionServiceYaml, map[string]*bintree{}},

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -54,6 +54,11 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h resour
 	namespacedAssets := []string{
 		"config/hiveadmission/service.yaml",
 		"config/hiveadmission/service-account.yaml",
+		// This secret was automatically generated prior to k8s 1.24. We're including it to cover later versions.
+		// Note that overwriting it should have no effect as k8s will still populate it for us.
+		// Also note that this secret will be deleted automatically when the serviceaccount is deleted; our deletion
+		// is redundant, but harmless.
+		"config/hiveadmission/sa-token-secret.yaml",
 	}
 	// Delete the assets from previous target namespaces
 	assetsToClean := append(namespacedAssets, deploymentAsset)


### PR DESCRIPTION
Starting with k8s 1.24, service account token secrets are no longer created automatically by k8s. The hiveadmission service needs one, so this commit explicitly creates one. This should work for pre- and post-1.24.

[HIVE-2219](https://issues.redhat.com//browse/HIVE-2219)