### PR TITLE
Add timestamps to messages in e2e tests

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -1,3 +1,7 @@
+# Add timestamps to our output
+shopt -s expand_aliases
+alias echo='/bin/echo -n `date -Ins --universal`"  "; /bin/echo'
+
 ###
 # TEMPORARY workaround for https://issues.redhat.com/browse/DPTP-2871
 # The configured job timeout after isn't signaling the test script like it


### PR DESCRIPTION
Debugging e2e failures -- especially those with a timing component -- will be easier if we have date stamps on our output messages. Make it so.

Note that this commit is only overriding the `echo` command. Output from subcommands won't be affected. That may turn out to be a problem, but it's one we can solve later.