### PR TITLE
Add featureset flag to hiveutil

### DIFF
--- a/contrib/pkg/createcluster/create.go
+++ b/contrib/pkg/createcluster/create.go
@@ -171,6 +171,7 @@ type Options struct {
 	SkipMachinePools                  bool
 	AdditionalTrustBundle             string
 	Internal                          bool
+	FeatureSet                        string
 
 	// AWS
 	AWSUserTags    []string
@@ -315,6 +316,7 @@ This option is redundant (but permitted) for following clouds, which always use 
 	flags.BoolVar(&opt.SkipMachinePools, "skip-machine-pools", false, "Skip generation of Hive MachinePools for day 2 MachineSet management")
 	flags.BoolVar(&opt.Internal, "internal", false, `When set, it configures the install-config.yaml's publish field to Internal.
 OpenShift Installer publishes all the services of the cluster like API server and ingress to internal network and not the Internet.`)
+	flags.StringVar(&opt.FeatureSet, "featureset", "", "FeatureSet to pass to the installer.")
 
 	// Flags related to adoption.
 	flags.BoolVar(&opt.Adopt, "adopt", false, "Enable adoption mode for importing a pre-existing cluster into Hive. Will require additional flags for adoption info.")
@@ -596,6 +598,7 @@ func (o *Options) GenerateObjects() ([]runtime.Object, error) {
 		MachineNetwork:        o.MachineNetwork,
 		SkipMachinePools:      o.SkipMachinePools,
 		AdditionalTrustBundle: additionalTrustBundle,
+		FeatureSet:            o.FeatureSet,
 	}
 	if o.Adopt {
 		kubeconfigBytes, err := os.ReadFile(o.AdoptAdminKubeConfig)

--- a/pkg/clusterresource/builder.go
+++ b/pkg/clusterresource/builder.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	yamlpatch "github.com/krishicks/yaml-patch"
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/ipnet"
 	installertypes "github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/validate"
@@ -109,6 +110,9 @@ type Builder struct {
 	// AdoptAdminPassword is the admin password for an adopted cluster, typically written to disk
 	// after openshift-install create-cluster. This field is optional when adopting.
 	AdoptAdminPassword string
+
+	// FeatureSet defines the featureSet for the install-config.
+	FeatureSet string
 
 	// InstallerManifests is a map of filename strings to bytes for files to inject into the installers
 	// manifests dir before launching create-cluster.
@@ -399,6 +403,7 @@ func (o *Builder) generateInstallConfigSecret() (*corev1.Secret, error) {
 		},
 		AdditionalTrustBundle: o.AdditionalTrustBundle,
 		Publish:               installertypes.PublishingStrategy(o.PublishStrategy),
+		FeatureSet:            configv1.FeatureSet(o.FeatureSet),
 	}
 
 	if o.CredentialsMode != "" {


### PR DESCRIPTION
Add a featureset flag to the hiveutil command. The string value provided will be passed directly into the installconfig.