### PR TITLE
Add azure-resource-group-name flag to hiveutil

### DIFF
--- a/contrib/pkg/createcluster/create.go
+++ b/contrib/pkg/createcluster/create.go
@@ -179,6 +179,7 @@ type Options struct {
 	// Azure
 	AzureBaseDomainResourceGroupName string
 	AzureCloudName                   string
+	AzureResourceGroupName           string
 
 	// OpenStack
 	OpenStackCloud             string
@@ -331,6 +332,7 @@ OpenShift Installer publishes all the services of the cluster like API server an
 	// Azure flags
 	flags.StringVar(&opt.AzureBaseDomainResourceGroupName, "azure-base-domain-resource-group-name", "os4-common", "Resource group where the azure DNS zone for the base domain is found")
 	flags.StringVar(&opt.AzureCloudName, "azure-cloud-name", "AzurePublicCloud", "Azure Cloud in which cluster will be created")
+	flags.StringVar(&opt.AzureResourceGroupName, "azure-resource-group-name", "", "Resource group where the cluster will be installed")
 
 	// OpenStack flags
 	flags.StringVar(&opt.OpenStackCloud, "openstack-cloud", "openstack", "Section of clouds.yaml to use for API/auth")
@@ -670,6 +672,7 @@ func (o *Options) GenerateObjects() ([]runtime.Object, error) {
 			BaseDomainResourceGroupName: o.AzureBaseDomainResourceGroupName,
 			Region:                      o.Region,
 			CloudName:                   hivev1azure.CloudEnvironment(o.AzureCloudName),
+			ResourceGroupName:           o.AzureResourceGroupName,
 		}
 		builder.CloudBuilder = azureProvider
 	case cloudGCP:

--- a/pkg/clusterresource/azure.go
+++ b/pkg/clusterresource/azure.go
@@ -35,6 +35,9 @@ type AzureCloudBuilder struct {
 
 	// CloudName is the name of the Azure cloud environment which will be used for the cluster.
 	CloudName hivev1azure.CloudEnvironment
+
+	// ResourceGroupName is the resource group where the cluster will be installed.
+	ResourceGroupName string
 }
 
 func NewAzureCloudBuilderFromSecret(credsSecret *corev1.Secret) *AzureCloudBuilder {
@@ -91,6 +94,7 @@ func (p *AzureCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installerty
 			Region:                      p.Region,
 			BaseDomainResourceGroupName: p.BaseDomainResourceGroupName,
 			CloudName:                   azureinstallertypes.CloudEnvironment(p.CloudName),
+			ResourceGroupName:           p.ResourceGroupName,
 		},
 	}
 


### PR DESCRIPTION
Add a azure-resource-group-name flag to the hiveutil command. The string
value provided will be passed directly to the install config
platform.azure.resourceGroupName parameter.