### PR TITLE
Allow azure resource group to be set/updated in clusterMetadata

### DIFF
--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -1191,8 +1191,6 @@ spec:
     name: pull-secret
 ```
 
-If the cluster you are looking to adopt is on Azure and was created in a custom resource group, you'll also need to include its name in `spec.clusterMetadata.platform.azure.resourceGroupName` to ensure that the installer can find your resources when deprovisioning the cluster.
-
 If the cluster you are looking to adopt is on AWS and leverages Privatelink, you'll also need to include that setting under `spec.platform.aws` to ensure the VPC Endpoint Service for the cluster is tracked in the ClusterDeployment.
 
 ```yaml

--- a/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/pointer"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	hivev1agent "github.com/openshift/hive/apis/hive/v1/agent"
@@ -689,6 +690,132 @@ func TestClusterDeploymentValidate(t *testing.T) {
 			newObject: func() *hivev1.ClusterDeployment {
 				cd := validAzureClusterDeployment()
 				cd.Spec.Platform.Azure.Region = ""
+				return cd
+			}(),
+			operation:       admissionv1beta1.Update,
+			expectedAllowed: false,
+		},
+		{
+			name: "Azure set resource group name: installed",
+			oldObject: func() *hivev1.ClusterDeployment {
+				cd := validAzureClusterDeployment()
+				cd.Spec.Installed = true
+				cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
+					InfraID: "an-infra-id",
+				}
+				return cd
+			}(),
+			newObject: func() *hivev1.ClusterDeployment {
+				cd := validAzureClusterDeployment()
+				cd.Spec.Installed = true
+				cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
+					InfraID: "an-infra-id",
+					Platform: &hivev1.ClusterPlatformMetadata{
+						Azure: &hivev1azure.Metadata{
+							ResourceGroupName: pointer.String("my-rg"),
+						},
+					},
+				}
+				return cd
+			}(),
+			operation:       admissionv1beta1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "Azure set resource group name: not installed",
+			oldObject: func() *hivev1.ClusterDeployment {
+				cd := validAzureClusterDeployment()
+				cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
+					InfraID: "an-infra-id",
+				}
+				return cd
+			}(),
+			newObject: func() *hivev1.ClusterDeployment {
+				cd := validAzureClusterDeployment()
+				cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
+					InfraID: "an-infra-id",
+					Platform: &hivev1.ClusterPlatformMetadata{
+						Azure: &hivev1azure.Metadata{
+							ResourceGroupName: pointer.String("my-rg"),
+						},
+					},
+				}
+				return cd
+			}(),
+			operation:       admissionv1beta1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "Azure set resource group name: while setting installed",
+			oldObject: func() *hivev1.ClusterDeployment {
+				cd := validAzureClusterDeployment()
+				cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
+					InfraID: "an-infra-id",
+				}
+				return cd
+			}(),
+			newObject: func() *hivev1.ClusterDeployment {
+				cd := validAzureClusterDeployment()
+				cd.Spec.Installed = true
+				cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
+					InfraID: "an-infra-id",
+					Platform: &hivev1.ClusterPlatformMetadata{
+						Azure: &hivev1azure.Metadata{
+							ResourceGroupName: pointer.String("my-rg"),
+						},
+					},
+				}
+				return cd
+			}(),
+			operation:       admissionv1beta1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "Azure update resource group name",
+			oldObject: func() *hivev1.ClusterDeployment {
+				cd := validAzureClusterDeployment()
+				cd.Spec.Installed = true
+				cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
+					InfraID: "an-infra-id",
+				}
+				return cd
+			}(),
+			newObject: func() *hivev1.ClusterDeployment {
+				cd := validAzureClusterDeployment()
+				cd.Spec.Installed = true
+				cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
+					InfraID: "an-infra-id",
+					Platform: &hivev1.ClusterPlatformMetadata{
+						Azure: &hivev1azure.Metadata{
+							ResourceGroupName: pointer.String("my-rg"),
+						},
+					},
+				}
+				return cd
+			}(),
+			operation:       admissionv1beta1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "Azure unset resource group name",
+			oldObject: func() *hivev1.ClusterDeployment {
+				cd := validAzureClusterDeployment()
+				cd.Spec.Installed = true
+				cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
+					InfraID: "an-infra-id",
+				}
+				return cd
+			}(),
+			newObject: func() *hivev1.ClusterDeployment {
+				cd := validAzureClusterDeployment()
+				cd.Spec.Installed = true
+				cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
+					Platform: &hivev1.ClusterPlatformMetadata{
+						Azure: &hivev1azure.Metadata{
+							ResourceGroupName: pointer.String("my-rg"),
+						},
+					},
+				}
 				return cd
 			}(),
 			operation:       admissionv1beta1.Update,


### PR DESCRIPTION
Hive controllers *and* in some cases the consumer must be able to set ClusterDeployment.spec.clusterMetadata.platform.azure.resourceGroupName. Previously our "clusterMetadata is immutable" validating webhook would (uh, sometimes??) bounce such a change. Make a special case for this sub-field.

[HIVE-2222](https://issues.redhat.com//browse/HIVE-2222)