### PR TITLE
e2e-pool: minor fixes

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -1,3 +1,7 @@
+# Add timestamps to our output
+shopt -s expand_aliases
+alias echo='/bin/echo -n `date -Ins --universal`"  "; /bin/echo'
+
 ###
 # TEMPORARY workaround for https://issues.redhat.com/browse/DPTP-2871
 # The configured job timeout after isn't signaling the test script like it


### PR DESCRIPTION
- Fix a logic bug where we were redundantly hibernating a cluster in the fake pool while it was still in the pool and thus already hibernating. Now we claim a cluster, validate that it's Running by the time the claim is fulfilled, then hibernate it.
- Also add resuming the above.
- Also add deleting the claim and verifying that the claimed CD gets deleted.