### PR TITLE
ClusterClaim controller: Watch RoleBindings

### DIFF
--- a/pkg/controller/clusterclaim/clusterclaim_controller.go
+++ b/pkg/controller/clusterclaim/clusterclaim_controller.go
@@ -96,7 +96,7 @@ func AddToManager(mgr manager.Manager, r *ReconcileClusterClaim, concurrentRecon
 
 	// Watch for changes to the hive-claim-owner RoleBinding
 	if err := c.Watch(
-		&source.Kind{Type: &rbacv1.Role{}},
+		&source.Kind{Type: &rbacv1.RoleBinding{}},
 		handler.EnqueueRequestsFromMapFunc(requestsForRBACResources(r.Client, hiveClaimOwnerRoleBindingName, r.logger))); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix what appears to be a copy/paste miss in #1068: the ClusterClaim controller was watching `Role` twice instead of `Role` and `RoleBinding`. Fix.

Closes: #2024