### PR TITLE
Re-enable autoscale test for Azure/GCP

### DIFF
--- a/test/e2e/postinstall/machinesets/infra_test.go
+++ b/test/e2e/postinstall/machinesets/infra_test.go
@@ -242,11 +242,8 @@ func TestAutoscalingMachinePool(t *testing.T) {
 
 	switch p := cd.Spec.Platform; {
 	case p.AWS != nil:
-	// Azure and GCP have been consistently failing this test in mce-2.3 (but not master, where
-	// everything seems substantively the same). Disable while we investigate the root cause.
-	// TODO: revert!
-	//case p.Azure != nil:
-	//case p.GCP != nil:
+	case p.Azure != nil:
+	case p.GCP != nil:
 	default:
 		logger.Info("Scaling the machine pool is only implemented for AWS, Azure, and GCP")
 		return


### PR DESCRIPTION
...which was disabled via #2019 / a3963cf0d.

The only thing we've changed since then is that we're now testing against OCP 4.13 instead of 4.14, which seemed to clear up flakes found after this test was disabled.