### PR TITLE
Hibernation: No more pause, hack ClusterOperators

### DIFF
--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -74,6 +74,10 @@ const (
 	// ClusterPowerStateFailedToStartMachines
 	ClusterPowerStateFailedToStartMachines ClusterPowerState = "FailedToStartMachines"
 
+	// ClusterPowerStatePreppingClusterOperators indicates we are updating ClusterOperator
+	// statuses so we can tell when they have been refreshed on resume.
+	ClusterPowerStatePreppingClusterOperators ClusterPowerState = "PreparingClusterOperators"
+
 	// ClusterPowerStateStopping indicates the cluster is transitioning
 	// from a Running state to a Hibernating state.
 	ClusterPowerStateStopping ClusterPowerState = "Stopping"
@@ -90,9 +94,6 @@ const (
 
 	// ClusterPowerStateWaitingForNodes is used when waiting for nodes to become Ready.
 	ClusterPowerStateWaitingForNodes ClusterPowerState = "WaitingForNodes"
-
-	// ClusterPowerStatePausingForClusterOperatorsToSettle is used when pausing to let ClusterOperators start and post new status before we check it.
-	ClusterPowerStatePausingForClusterOperatorsToSettle ClusterPowerState = "PausingForClusterOperatorsToSettle"
 
 	// ClusterPowerStateWaitingForClusterOperators is used when waiting for ClusterOperators to
 	// get to a good state. (Available=True, Processing=False, Degraded=False)
@@ -507,6 +508,9 @@ const (
 	// HibernatingReasonResumingOrRunning is used as the reason for the Hibernating condition when the cluster
 	// is resuming or running. Precise details are available in the Ready condition.
 	HibernatingReasonResumingOrRunning = "ResumingOrRunning"
+	// HibernatingReasonPreppingClusterOperators indicates we are about to update CO statuses to help us determine
+	// when they have been checked on resume.
+	HibernatingReasonPreppingClusterOperators = "PreparingClusterOperators"
 	// HibernatingReasonStopping is used as the reason when the cluster is transitioning
 	// from a Running state to a Hibernating state.
 	HibernatingReasonStopping = string(ClusterPowerStateStopping)
@@ -548,8 +552,6 @@ const (
 	ReadyReasonWaitingForMachines = string(ClusterPowerStateWaitingForMachines)
 	// ReadyReasonWaitingForNodes is used on the Ready condition when waiting for nodes to become Ready.
 	ReadyReasonWaitingForNodes = string(ClusterPowerStateWaitingForNodes)
-	// ReadyReasonPausingForClusterOperatorsToSettle is used on the Ready condition when pausing to let ClusterOperators start and post new status before we check it.
-	ReadyReasonPausingForClusterOperatorsToSettle = string(ClusterPowerStatePausingForClusterOperatorsToSettle)
 	// ReadyReasonWaitingForClusterOperators is used on the Ready condition when waiting for ClusterOperators to
 	// get to a good state. (Available=True, Processing=False, Degraded=False)
 	ReadyReasonWaitingForClusterOperators = string(ClusterPowerStateWaitingForClusterOperators)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,8 +1,6 @@
 package constants
 
 import (
-	"time"
-
 	apihelpers "github.com/openshift/hive/apis/helpers"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 )
@@ -472,11 +470,6 @@ const (
 
 	// AlibabaCloudAccessKeySecretSecretKey is the key we use in a Kubernetes Secret containing Alibaba Cloud credentials for the access key secret.
 	AlibabaCloudAccessKeySecretSecretKey = "alibaba_cloud_access_key_secret"
-
-	// ClusterOperatorSettlePause is the time interval we wait after Nodes are reporting ready, before
-	// actually checking if ClusterOperators are in a good state. This is to allow them time to start
-	// their pods and report accurate status so we avoid reading good state from before hibernation.
-	ClusterOperatorSettlePause = 2 * time.Minute
 
 	// AdditionalLogFieldsAnnotation keys an annotation containing a JSON-encoded map of key/value pairs. If specified,
 	// nonempty, and parseable into such a map, the key/value pairs are blindly included in log lines for any controller

--- a/pkg/controller/hibernation/hibernation_controller_test.go
+++ b/pkg/controller/hibernation/hibernation_controller_test.go
@@ -380,12 +380,12 @@ func TestReconcile(t *testing.T) {
 				builder.EXPECT().Build().Times(1).Return(c, nil)
 			},
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
-				assert.Equal(t, hivev1.ClusterPowerStatePausingForClusterOperatorsToSettle, cd.Status.PowerState)
+				assert.Equal(t, hivev1.ClusterPowerStateWaitingForClusterOperators, cd.Status.PowerState)
 			},
 			expectRequeueAfter: time.Minute * 2,
 		},
 		{
-			name: "proceed to pausing for cluster operators from starting machines",
+			name: "proceed to waiting for cluster operators from starting machines",
 			cd: cdBuilder.Options(o.shouldRun).Build(
 				testcd.WithCondition(hibernatingCondition(corev1.ConditionFalse,
 					hivev1.HibernatingReasonResumingOrRunning, 6*time.Hour)),
@@ -402,12 +402,12 @@ func TestReconcile(t *testing.T) {
 				builder.EXPECT().Build().Times(1).Return(c, nil)
 			},
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
-				assert.Equal(t, hivev1.ClusterPowerStatePausingForClusterOperatorsToSettle, cd.Status.PowerState)
+				assert.Equal(t, hivev1.ClusterPowerStateWaitingForClusterOperators, cd.Status.PowerState)
 			},
 			expectRequeueAfter: time.Minute * 2,
 		},
 		{
-			name: "proceed to pausing for cluster operators from waiting for machines",
+			name: "proceed to waiting for cluster operators from waiting for machines",
 			cd: cdBuilder.Options(o.shouldRun).Build(
 				testcd.WithCondition(hibernatingCondition(corev1.ConditionFalse,
 					hivev1.HibernatingReasonResumingOrRunning, 6*time.Hour)),
@@ -424,12 +424,12 @@ func TestReconcile(t *testing.T) {
 				builder.EXPECT().Build().Times(1).Return(c, nil)
 			},
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
-				assert.Equal(t, hivev1.ClusterPowerStatePausingForClusterOperatorsToSettle, cd.Status.PowerState)
+				assert.Equal(t, hivev1.ClusterPowerStateWaitingForClusterOperators, cd.Status.PowerState)
 			},
 			expectRequeueAfter: time.Minute * 2,
 		},
 		{
-			name: "proceed to pausing for cluster operators from waiting for nodes",
+			name: "proceed to waiting for cluster operators from waiting for nodes",
 			cd: cdBuilder.Options(o.shouldRun).Build(
 				testcd.WithCondition(hibernatingCondition(corev1.ConditionFalse,
 					hivev1.HibernatingReasonResumingOrRunning, 6*time.Hour)),
@@ -446,7 +446,7 @@ func TestReconcile(t *testing.T) {
 				builder.EXPECT().Build().Times(1).Return(c, nil)
 			},
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
-				assert.Equal(t, hivev1.ClusterPowerStatePausingForClusterOperatorsToSettle, cd.Status.PowerState)
+				assert.Equal(t, hivev1.ClusterPowerStateWaitingForClusterOperators, cd.Status.PowerState)
 			},
 			expectRequeueAfter: time.Minute * 2,
 		},

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -152,9 +152,6 @@ var (
 	// mapMetricToDurationHistograms is a map of optional durationMetrics of type Histogram to their specific duration,
 	// if mentioned
 	mapMetricToDurationHistograms map[*prometheus.HistogramVec]time.Duration
-	// mapMetricToDurationGauges is a map of optional durationMetrics of type Gauge to their specific duration, if
-	// mentioned
-	mapMetricToDurationGauges map[*prometheus.GaugeVec]time.Duration
 )
 
 // ReconcileOutcome is used in controller "reconcile complete" log entries, and the metricControllerReconcileTime
@@ -282,12 +279,9 @@ func (mc *Calculator) Start(ctx context.Context) error {
 						logHistogramDurationMetric(MetricResumingClustersSeconds, &cd,
 							time.Since(hibernatingCond.LastTransitionTime.Time).Seconds())
 					}
-					// While logging for WaitingForClusterOperators, account for the hard coded pause while waiting
-					// after nodes are ready, before we could query status of cluster operators
 					if readyCond.Reason == hivev1.ReadyReasonWaitingForClusterOperators {
 						logHistogramDurationMetric(MetricWaitingForCOClustersSeconds, &cd,
-							(time.Since(hibernatingCond.LastTransitionTime.Time).Seconds())+
-								constants.ClusterOperatorSettlePause.Seconds())
+							time.Since(hibernatingCond.LastTransitionTime.Time).Seconds())
 					}
 				}
 			}
@@ -386,7 +380,6 @@ func (mc *Calculator) Start(ctx context.Context) error {
 // registerOptionalMetrics registers the metrics, and stores their configs in the corresponding maps
 func (mc *Calculator) registerOptionalMetrics(mConfig *metricsconfig.MetricsConfig) {
 	mapMetricToDurationHistograms = make(map[*prometheus.HistogramVec]time.Duration)
-	mapMetricToDurationGauges = make(map[*prometheus.GaugeVec]time.Duration)
 	for _, metric := range mConfig.MetricsWithDuration {
 		switch metric.Name {
 		// Histograms

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -74,6 +74,10 @@ const (
 	// ClusterPowerStateFailedToStartMachines
 	ClusterPowerStateFailedToStartMachines ClusterPowerState = "FailedToStartMachines"
 
+	// ClusterPowerStatePreppingClusterOperators indicates we are updating ClusterOperator
+	// statuses so we can tell when they have been refreshed on resume.
+	ClusterPowerStatePreppingClusterOperators ClusterPowerState = "PreparingClusterOperators"
+
 	// ClusterPowerStateStopping indicates the cluster is transitioning
 	// from a Running state to a Hibernating state.
 	ClusterPowerStateStopping ClusterPowerState = "Stopping"
@@ -90,9 +94,6 @@ const (
 
 	// ClusterPowerStateWaitingForNodes is used when waiting for nodes to become Ready.
 	ClusterPowerStateWaitingForNodes ClusterPowerState = "WaitingForNodes"
-
-	// ClusterPowerStatePausingForClusterOperatorsToSettle is used when pausing to let ClusterOperators start and post new status before we check it.
-	ClusterPowerStatePausingForClusterOperatorsToSettle ClusterPowerState = "PausingForClusterOperatorsToSettle"
 
 	// ClusterPowerStateWaitingForClusterOperators is used when waiting for ClusterOperators to
 	// get to a good state. (Available=True, Processing=False, Degraded=False)
@@ -507,6 +508,9 @@ const (
 	// HibernatingReasonResumingOrRunning is used as the reason for the Hibernating condition when the cluster
 	// is resuming or running. Precise details are available in the Ready condition.
 	HibernatingReasonResumingOrRunning = "ResumingOrRunning"
+	// HibernatingReasonPreppingClusterOperators indicates we are about to update CO statuses to help us determine
+	// when they have been checked on resume.
+	HibernatingReasonPreppingClusterOperators = "PreparingClusterOperators"
 	// HibernatingReasonStopping is used as the reason when the cluster is transitioning
 	// from a Running state to a Hibernating state.
 	HibernatingReasonStopping = string(ClusterPowerStateStopping)
@@ -548,8 +552,6 @@ const (
 	ReadyReasonWaitingForMachines = string(ClusterPowerStateWaitingForMachines)
 	// ReadyReasonWaitingForNodes is used on the Ready condition when waiting for nodes to become Ready.
 	ReadyReasonWaitingForNodes = string(ClusterPowerStateWaitingForNodes)
-	// ReadyReasonPausingForClusterOperatorsToSettle is used on the Ready condition when pausing to let ClusterOperators start and post new status before we check it.
-	ReadyReasonPausingForClusterOperatorsToSettle = string(ClusterPowerStatePausingForClusterOperatorsToSettle)
 	// ReadyReasonWaitingForClusterOperators is used on the Ready condition when waiting for ClusterOperators to
 	// get to a good state. (Available=True, Processing=False, Degraded=False)
 	ReadyReasonWaitingForClusterOperators = string(ClusterPowerStateWaitingForClusterOperators)


### PR DESCRIPTION
This commit changes how we check the health of ClusterOperators when resuming from hibernation.

The problem is that we can't immediately tell by looking at a ClusterOperator whether it has been checked yet since the cluster was resumed. This is because the status conditions' `lastTransitionTime`s are only updated if/when the condition's `status` changes -- and it may not change if the CO is already healthy by the time it is inspected. Thus even if the CO's status conditions indicate it is healthy, we can't be sure that that state is not stale, from before we hibernated.

Previously, we had a hardcoded 2m wait after nodes became ready, on the assumption that this was enough time to ensure all COs had been checked.

With this commit, we get rid of that 2m wait time. Instead, we update the CO's `Available` condition to have `status="Unknown"`. This forces its owning controller to update the status and the `lastTransitionTime`, allowing us to ascertain definitively that that has happened since we started resuming (i.e. the `lastTransitionTime` of the ClusterDeployment's `Hibernating` condition).

WIP: Just editing status on restart doesn't work: some operators do not pay attention to their CO CR, so they don't revert that status (unless their pods are restarted -- maybe?). Current incarnation of this commit is experimenting with hacking the status *before hibernation* as well as on resume. But we still have some timing issues to work out: In order to not hot loop the before-hibernation bit, we would only want to hack the COs whose `lastTransitionTime` is earlier than when we started hibernating (i.e. the Ready condition's `lastTransitionTime`). But that means we would have to transition that status before hacking operators, which means adding a new state to the flow. This commit is partway there, but doesn't have it right yet. (I'm becoming more and more concerned that the hibernation controller is too brittle to handle how this change is turning out -- we may just want to punt and try to work it into the ever-forthcoming PowerState controller.)

[HIVE-2226](https://issues.redhat.com//browse/HIVE-2226)