### PR TITLE
MachinePool: Allow Platform edits via override

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -512,6 +512,12 @@ const (
 
 	// TrustedCABundleFile is the name of the file (and corresponding ConfigMap key) containing the merged CA bundle.
 	TrustedCABundleFile = "ca-bundle.crt"
+
+	// OverrideMachinePoolPlatformAnnotation can be set to "true" on a MachinePool to bypass the validating admission
+	// hook that normally forbids modifying its Spec.Platform. By setting this annotation, you are taking responsibility
+	// for forcing rollout of such changes on the target cluster -- e.g. by deleting the Machines -- as the machine
+	// config operator will not do so.
+	OverrideMachinePoolPlatformAnnotation = "hive.openshift.io/override-machinepool-platform"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/pkg/validating-webhooks/hive/v1/machinepool_validating_admission_hook.go
+++ b/pkg/validating-webhooks/hive/v1/machinepool_validating_admission_hook.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 
 	log "github.com/sirupsen/logrus"
 
@@ -26,6 +27,7 @@ import (
 	hivev1openstack "github.com/openshift/hive/apis/hive/v1/openstack"
 	hivev1ovirt "github.com/openshift/hive/apis/hive/v1/ovirt"
 	hivev1vsphere "github.com/openshift/hive/apis/hive/v1/vsphere"
+	"github.com/openshift/hive/pkg/constants"
 )
 
 const (
@@ -226,7 +228,9 @@ func validateMachinePoolUpdate(old, new *hivev1.MachinePool) field.ErrorList {
 	specPath := field.NewPath("spec")
 	allErrs = append(allErrs, validation.ValidateImmutableField(new.Spec.ClusterDeploymentRef, old.Spec.ClusterDeploymentRef, specPath.Child("clusterDeploymentRef"))...)
 	allErrs = append(allErrs, validation.ValidateImmutableField(new.Spec.Name, old.Spec.Name, specPath.Child("name"))...)
-	allErrs = append(allErrs, validation.ValidateImmutableField(new.Spec.Platform, old.Spec.Platform, specPath.Child("platform"))...)
+	if mutable, err := strconv.ParseBool(new.Annotations[constants.OverrideMachinePoolPlatformAnnotation]); err != nil || !mutable {
+		allErrs = append(allErrs, validation.ValidateImmutableField(new.Spec.Platform, old.Spec.Platform, specPath.Child("platform"))...)
+	}
 	return allErrs
 }
 

--- a/pkg/validating-webhooks/hive/v1/machinepool_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/machinepool_validating_admission_hook_test.go
@@ -18,6 +18,7 @@ import (
 	hivev1azure "github.com/openshift/hive/apis/hive/v1/azure"
 	hivev1gcp "github.com/openshift/hive/apis/hive/v1/gcp"
 	hivev1vsphere "github.com/openshift/hive/apis/hive/v1/vsphere"
+	"github.com/openshift/hive/pkg/constants"
 )
 
 func Test_MachinePoolAdmission_Validate_Kind(t *testing.T) {
@@ -170,7 +171,7 @@ func Test_MachinePoolAdmission_Validate_Create(t *testing.T) {
 			name: "zero replicas",
 			provision: func() *hivev1.MachinePool {
 				pool := testMachinePool()
-				pool.Spec.Replicas = pointer.Int64Ptr(0)
+				pool.Spec.Replicas = pointer.Int64(0)
 				return pool
 			}(),
 			expectAllowed: true,
@@ -179,7 +180,7 @@ func Test_MachinePoolAdmission_Validate_Create(t *testing.T) {
 			name: "positive replicas",
 			provision: func() *hivev1.MachinePool {
 				pool := testMachinePool()
-				pool.Spec.Replicas = pointer.Int64Ptr(1)
+				pool.Spec.Replicas = pointer.Int64(1)
 				return pool
 			}(),
 			expectAllowed: true,
@@ -188,7 +189,7 @@ func Test_MachinePoolAdmission_Validate_Create(t *testing.T) {
 			name: "negative replicas",
 			provision: func() *hivev1.MachinePool {
 				pool := testMachinePool()
-				pool.Spec.Replicas = pointer.Int64Ptr(-1)
+				pool.Spec.Replicas = pointer.Int64(-1)
 				return pool
 			}(),
 		},
@@ -196,7 +197,7 @@ func Test_MachinePoolAdmission_Validate_Create(t *testing.T) {
 			name: "replicas and autoscaling",
 			provision: func() *hivev1.MachinePool {
 				pool := testMachinePool()
-				pool.Spec.Replicas = pointer.Int64Ptr(1)
+				pool.Spec.Replicas = pointer.Int64(1)
 				pool.Spec.Autoscaling = &hivev1.MachinePoolAutoscaling{}
 				return pool
 			}(),
@@ -549,7 +550,7 @@ func Test_MachinePoolAdmission_Validate_Update(t *testing.T) {
 			old:  testMachinePool(),
 			new: func() *hivev1.MachinePool {
 				pool := testMachinePool()
-				pool.Spec.Replicas = pointer.Int64Ptr(5)
+				pool.Spec.Replicas = pointer.Int64(5)
 				return pool
 			}(),
 			expectAllowed: true,
@@ -582,6 +583,16 @@ func Test_MachinePoolAdmission_Validate_Update(t *testing.T) {
 			name: "platform changed",
 			old:  testMachinePool(),
 			new:  testGCPMachinePool(),
+		},
+		{
+			name: "platform changed with override",
+			old:  testMachinePool(),
+			new: func() *hivev1.MachinePool {
+				mp := testGCPMachinePool()
+				mp.Annotations = map[string]string{constants.OverrideMachinePoolPlatformAnnotation: "true"}
+				return mp
+			}(),
+			expectAllowed: true,
 		},
 		{
 			name: "instance type changed",


### PR DESCRIPTION
Normally we forbid updates to MachinePool.Spec.Platform via an admission hook because, while we would roll out the changes to the MachineSets on the target cluster, MCO ignores those changes.

With this commit, you can add an annotation to a MachinePool
```
hive.openshift.io/override-machinepool-platform: "true"
```
to bypass this check. By doing so, you are taking responsibility for forcing rollout of any changes, e.g. by deleting the Machines on the target cluster.

[HIVE-2024](https://issues.redhat.com//browse/HIVE-2024)