### PR TITLE
HIVE-2232: Update AWS default instance configuration to match openshift-install values.

### DIFF
--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -398,9 +398,9 @@ compute:
     aws:
       rootVolume:
         iops: 100
-        size: 22
-        type: gp2
-      type: m4.xlarge
+        size: 120
+        type: gp3
+      type: m5.xlarge
   replicas: 3
 controlPlane:
   name: master
@@ -408,9 +408,9 @@ controlPlane:
     aws:
       rootVolume:
         iops: 100
-        size: 22
-        type: gp2
-      type: m4.xlarge
+        size: 120
+        type: gp3
+      type: m5.xlarge
 metadata:
   name: mycluster
 networking:
@@ -727,9 +727,9 @@ spec:
     aws:
       rootVolume:
         iops: 100
-        size: 22
-        type: gp2
-      type: m4.xlarge
+        size: 120
+        type: gp3
+      type: m5.xlarge
   replicas: 3
 ```
 
@@ -813,9 +813,9 @@ spec:
     aws:
       rootVolume:
         iops: 100
-        size: 22
-        type: gp2
-      type: m4.xlarge
+        size: 120
+        type: gp3
+      type: m5.xlarge
       zones:
         - us-east-1a
         - us-east-1b
@@ -842,9 +842,9 @@ spec:
     aws:
       rootVolume:
         iops: 100
-        size: 22
-        type: gp2
-      type: m4.xlarge
+        size: 120
+        type: gp3
+      type: m5.xlarge
   autoscaling:
     minReplicas: 3
     maxReplicas: 6

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -100,6 +100,7 @@ go run "${SRC_ROOT}/contrib/cmd/hiveutil/main.go" create-cluster "${CLUSTER_NAME
 	--release-image="${RELEASE_IMAGE}" \
 	--install-once=true \
 	--uninstall-once=true \
+	--region us-east-2 \
 	${MANAGED_DNS_ARG} \
 	${EXTRA_CREATE_CLUSTER_ARGS}
 

--- a/pkg/clusterresource/aws.go
+++ b/pkg/clusterresource/aws.go
@@ -16,9 +16,9 @@ import (
 )
 
 const (
-	awsInstanceType = "m4.xlarge"
-	volumeSize      = 22
-	volumeType      = "gp2"
+	awsInstanceType = "m5.xlarge"
+	volumeSize      = 120
+	volumeType      = "gp3"
 )
 
 var _ CloudBuilder = (*AWSCloudBuilder)(nil)

--- a/pkg/controller/clusterdeployment/installconfigvalidation_test.go
+++ b/pkg/controller/clusterdeployment/installconfigvalidation_test.go
@@ -28,9 +28,9 @@ compute:
     aws:
       rootVolume:
         iops: 100
-        size: 22
-        type: gp2
-      type: m4.xlarge
+        size: 120
+        type: gp3
+      type: m5.xlarge
   replicas: 3
 controlPlane:
   name: master
@@ -38,9 +38,9 @@ controlPlane:
     aws:
       rootVolume:
         iops: 100
-        size: 22
-        type: gp2
-      type: m4.xlarge
+        size: 120
+        type: gp3
+      type: m5.xlarge
   replicas: 3
 networking:
   clusterNetwork:

--- a/pkg/installmanager/installmanager_test.go
+++ b/pkg/installmanager/installmanager_test.go
@@ -747,7 +747,7 @@ spec:
           - ebs:
               encrypted: true
               volumeSize: 120
-              volumeType: gp2
+              volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials
           iamInstanceProfile:

--- a/pkg/installmanager/testdata/install-config-with-existing-pull-secret.yaml
+++ b/pkg/installmanager/testdata/install-config-with-existing-pull-secret.yaml
@@ -6,9 +6,9 @@ compute:
     aws:
       rootVolume:
         iops: 100
-        size: 22
-        type: gp2
-      type: m4.xlarge
+        size: 120
+        type: gp3
+      type: m5.xlarge
   replicas: 3
 controlPlane:
   name: master
@@ -16,9 +16,9 @@ controlPlane:
     aws:
       rootVolume:
         iops: 100
-        size: 22
-        type: gp2
-      type: m4.xlarge
+        size: 120
+        type: gp3
+      type: m5.xlarge
   replicas: 3
 metadata:
   name: hive-cluster

--- a/pkg/installmanager/testdata/install-config-with-pull-secret.yaml
+++ b/pkg/installmanager/testdata/install-config-with-pull-secret.yaml
@@ -6,9 +6,9 @@ compute:
     aws:
       rootVolume:
         iops: 100
-        size: 22
-        type: gp2
-      type: m4.xlarge
+        size: 120
+        type: gp3
+      type: m5.xlarge
   replicas: 3
 controlPlane:
   name: master
@@ -16,9 +16,9 @@ controlPlane:
     aws:
       rootVolume:
         iops: 100
-        size: 22
-        type: gp2
-      type: m4.xlarge
+        size: 120
+        type: gp3
+      type: m5.xlarge
   replicas: 3
 metadata:
   name: hive-cluster

--- a/pkg/installmanager/testdata/install-config.yaml
+++ b/pkg/installmanager/testdata/install-config.yaml
@@ -6,9 +6,9 @@ compute:
     aws:
       rootVolume:
         iops: 100
-        size: 22
-        type: gp2
-      type: m4.xlarge
+        size: 120
+        type: gp3
+      type: m5.xlarge
   replicas: 3
 controlPlane:
   name: master
@@ -16,9 +16,9 @@ controlPlane:
     aws:
       rootVolume:
         iops: 100
-        size: 22
-        type: gp2
-      type: m4.xlarge
+        size: 120
+        type: gp3
+      type: m5.xlarge
   replicas: 3
 metadata:
   name: hive-cluster


### PR DESCRIPTION
Update AWS default instance settings to match current openshift-install values.

https://issues.redhat.com/browse/HIVE-2232