### PR TITLE
Deployment patch example misses the spec part

### DIFF
--- a/docs/syncset.md
+++ b/docs/syncset.md
@@ -75,6 +75,7 @@ metadata:
     app: sise
   name: sise-deploy
   namespace: default
+spec:
   replicas: 2
   xxxxxxx
 ```


### PR DESCRIPTION
Just making the example in the documentation a bit more clear, adding ``replicas`` under the ``spec`` section.