### PR TITLE
e2e: Save interim manifests

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -237,16 +237,17 @@ echo "Using cluster base domain: ${CLUSTER_DOMAIN}"
 oc get clusterdeployment > /dev/null
 
 function capture_manifests() {
-    oc get clusterdeployment -A -o yaml &> "${ARTIFACT_DIR}/hive_clusterdeployment.yaml" || true
-    oc get clusterimageset -o yaml &> "${ARTIFACT_DIR}/hive_clusterimagesets.yaml" || true
-    oc get clusterprovision -A -o yaml &> "${ARTIFACT_DIR}/hive_clusterprovision.yaml" || true
-    oc get clusterstate -A -o yaml &> "${ARTIFACT_DIR}/hive_clusterstate.yaml" || true
-    oc get dnszone -A -o yaml &> "${ARTIFACT_DIR}/hive_dnszones.yaml" || true
-    oc get machinepool -A -o yaml &> "${ARTIFACT_DIR}/hive_machinepools.yaml" || true
-    oc get clusterdeploymentcustomization -A -o yaml &> "${ARTIFACT_DIR}/hive_clusterdeploymentcustomization.yaml" || true
-    oc get clusterpool -A -o yaml &> "${ARTIFACT_DIR}/hive_clusterpool.yaml" || true
+    local prefix=$1
+    oc get clusterdeployment -A -o yaml &> "${ARTIFACT_DIR}/${prefix}_hive_clusterdeployment.yaml" || true
+    oc get clusterimageset -o yaml &> "${ARTIFACT_DIR}/${prefix}_hive_clusterimagesets.yaml" || true
+    oc get clusterprovision -A -o yaml &> "${ARTIFACT_DIR}/${prefix}_hive_clusterprovision.yaml" || true
+    oc get clusterstate -A -o yaml &> "${ARTIFACT_DIR}/${prefix}_hive_clusterstate.yaml" || true
+    oc get dnszone -A -o yaml &> "${ARTIFACT_DIR}/${prefix}_hive_dnszones.yaml" || true
+    oc get machinepool -A -o yaml &> "${ARTIFACT_DIR}/${prefix}_hive_machinepools.yaml" || true
+    oc get clusterdeploymentcustomization -A -o yaml &> "${ARTIFACT_DIR}/${prefix}_hive_clusterdeploymentcustomization.yaml" || true
+    oc get clusterpool -A -o yaml &> "${ARTIFACT_DIR}/${prefix}_hive_clusterpool.yaml" || true
     # Don't get the contents of the secrets, since they're sensitive; hopefully just listing them will be helpful.
-    oc get secrets -A &> "${ARTIFACT_DIR}/secret_list.txt" || true
+    oc get secrets -A &> "${ARTIFACT_DIR}/${prefix}_secret_list.txt" || true
 }
 
 function capture_cluster_logs() {

--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -96,7 +96,7 @@ REAL_POOL_NAME=$CLUSTER_NAME
 
 function cleanup() {
   echo "!EXIT TRAP!"
-  capture_manifests
+  capture_manifests EXIT
   # Let's save the logs now in case any of the following never finish
   echo "Saving hive logs before cleanup"
   save_hive_logs

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -8,7 +8,7 @@ source ${0%/*}/e2e-common.sh
 
 function teardown() {
   echo "!EXIT TRAP!"
-  capture_manifests
+  capture_manifests EXIT
   # Let's save the logs now in case any of the following never finish
   echo "Saving hive logs before cleanup"
   save_hive_logs
@@ -209,11 +209,11 @@ case "${INSTALL_RESULT}" in
         ;;
 esac
 
-capture_manifests
-capture_cluster_logs $CLUSTER_NAME $CLUSTER_NAMESPACE $INSTALL_RESULT
-
 echo "Running post-install tests"
 make test-e2e-postinstall
+
+capture_manifests 1
+capture_cluster_logs $CLUSTER_NAME $CLUSTER_NAMESPACE $INSTALL_RESULT
 
 echo "Running destroy test"
 make test-e2e-destroycluster


### PR DESCRIPTION
It was annoying to not be able to get things like clusterdeployment manifests for e2e runs that completed successfully. Now e2e will save those manifests twice: once right after the ClusterDeployment has been created and once on cleanup. (As today, the latter will only be interesting if the test fails.)