### PR TITLE
Add awsprivatelink subcommand to hiveutil

### DIFF
--- a/contrib/cmd/hiveutil/main.go
+++ b/contrib/cmd/hiveutil/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/hive/contrib/pkg/adm"
+	"github.com/openshift/hive/contrib/pkg/awsprivatelink"
 	"github.com/openshift/hive/contrib/pkg/certificate"
 	"github.com/openshift/hive/contrib/pkg/clusterpool"
 	"github.com/openshift/hive/contrib/pkg/createcluster"
@@ -54,6 +55,7 @@ func newHiveutilCommand() *cobra.Command {
 	cmd.AddCommand(adm.NewAdmCommand())
 	cmd.AddCommand(version.NewVersionCommand())
 	cmd.AddCommand(clusterpool.NewClusterPoolCommand())
+	cmd.AddCommand(awsprivatelink.NewAWSPrivateLinkCommand())
 
 	return cmd
 }

--- a/contrib/pkg/awsprivatelink/awsprivatelink.go
+++ b/contrib/pkg/awsprivatelink/awsprivatelink.go
@@ -1,0 +1,39 @@
+package awsprivatelink
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var logLevelDebug bool
+
+func NewAWSPrivateLinkCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "awsprivatelink",
+		Short: "AWS PrivateLink setup and tear down",
+		Long: `AWS PrivateLink setup and tear down.
+All subcommands require an active cluster.
+`,
+		PersistentPreRun: setLogLevel,
+		Run: func(cmd *cobra.Command, args []string) {
+			_ = cmd.Usage()
+		},
+	}
+
+	cmd.AddCommand(NewEnableAWSPrivateLinkCommand())
+	cmd.AddCommand(NewDisableAWSPrivateLinkCommand())
+	cmd.AddCommand(NewEndpointVPCCommand())
+
+	cmd.PersistentFlags().BoolVarP(&logLevelDebug, "debug", "d", false, "Enable debug level logging")
+	return cmd
+}
+
+func setLogLevel(cmd *cobra.Command, args []string) {
+	switch logLevelDebug {
+	case true:
+		log.SetLevel(log.DebugLevel)
+		log.Debug("Setting log level to debug")
+	default:
+		log.SetLevel(log.InfoLevel)
+	}
+}

--- a/contrib/pkg/awsprivatelink/disable.go
+++ b/contrib/pkg/awsprivatelink/disable.go
@@ -1,0 +1,113 @@
+package awsprivatelink
+
+import (
+	"context"
+
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	hiveutils "github.com/openshift/hive/contrib/pkg/utils"
+	awsutils "github.com/openshift/hive/contrib/pkg/utils/aws"
+	operatorutils "github.com/openshift/hive/pkg/operator/hive"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type disableOptions struct {
+	dynamicClient client.Client
+}
+
+func NewDisableAWSPrivateLinkCommand() *cobra.Command {
+	opt := &disableOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "disable",
+		Short: "Disable AWS PrivateLink",
+		Long: `Disable AWS PrivateLink:
+1) Remove Secret(s) with AWS hub account credentials created when calling "hiveutil awsprivatelink enable ..."
+2) Empty HiveConfig.spec.awsPrivateLink`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := opt.Complete(cmd, args); err != nil {
+				return
+			}
+			if err := opt.Validate(cmd, args); err != nil {
+				return
+			}
+			if err := opt.Run(cmd, args); err != nil {
+				return
+			}
+		},
+	}
+	return cmd
+}
+
+func (o *disableOptions) Complete(cmd *cobra.Command, args []string) error {
+	// Get controller-runtime dynamic client
+	dynamicClient, err := hiveutils.GetClient()
+	if err != nil {
+		log.WithError(err).Fatal("Failed to create controller-runtime client")
+	}
+	o.dynamicClient = dynamicClient
+
+	return nil
+}
+
+func (o *disableOptions) Validate(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+func (o *disableOptions) Run(cmd *cobra.Command, args []string) error {
+	// Get HiveConfig
+	hiveConfig := &hivev1.HiveConfig{}
+	if err := o.dynamicClient.Get(context.Background(), types.NamespacedName{Name: "hive"}, hiveConfig); err != nil {
+		log.WithError(err).Fatal("Failed to get HiveConfig/hive")
+	}
+	if hiveConfig.Spec.AWSPrivateLink == nil {
+		log.Warn("AWS PrivateLink is already disabled in HiveConfig")
+	}
+	// It is assumed that no cloud resources for networking present
+	// if and only if there is either no endpoint VPC or no associated VPC.
+	if hiveConfig.Spec.AWSPrivateLink != nil &&
+		len(hiveConfig.Spec.AWSPrivateLink.EndpointVPCInventory) > 0 &&
+		len(hiveConfig.Spec.AWSPrivateLink.AssociatedVPCs) > 0 {
+		log.Fatal("HiveConfig has at least 1 associated VPC and 1 endpoint VPC specified. " +
+			"Please either remove all associated VPCs or all endpoint VPCs from it. " +
+			"Please remember to delete relevant cloud resources for networking " +
+			"(between the associated VPCs and endpoint VPCs) as you remove the VPCs." +
+			"You can remove the endpoint VPCs (and relevant cloud resources for networking) " +
+			"one by one via `hiveutil awsprivatelink endpointvpc remove ...`.")
+	}
+
+	// Delete Hub account secret(s) if present
+	hiveNS := operatorutils.GetHiveNamespace(hiveConfig)
+	hubAcctSecrets := &corev1.SecretList{}
+	if err := o.dynamicClient.List(
+		context.Background(),
+		hubAcctSecrets,
+		client.MatchingFields{"metadata.name": awsutils.PrivateLinkHubAcctCredsName},
+		client.MatchingLabels{awsutils.PrivateLinkHubAcctCredsLabel: "true"},
+		client.InNamespace(hiveNS),
+	); err != nil {
+		log.WithError(err).Error("Failed to list Hub account credentials Secrets")
+	}
+
+	for _, hubAcctSecret := range hubAcctSecrets.Items {
+		if err := o.dynamicClient.Delete(context.Background(), &hubAcctSecret); err != nil {
+			log.WithError(err).Errorf("Failed to delete Hub account credentials Secret %v", hubAcctSecret.Name)
+		} else {
+			log.Infof("Hub account credentials Secret %v deleted", hubAcctSecret.Name)
+		}
+	}
+
+	// Empty HiveConfig.spec.awsPrivateLink
+	hiveConfig.Spec.AWSPrivateLink = nil
+	if err := o.dynamicClient.Update(context.Background(), hiveConfig); err != nil {
+		log.WithError(err).Fatal("Failed to update HiveConfig")
+	}
+	log.Info("HiveConfig updated")
+
+	return nil
+}

--- a/contrib/pkg/awsprivatelink/enable.go
+++ b/contrib/pkg/awsprivatelink/enable.go
@@ -1,0 +1,221 @@
+package awsprivatelink
+
+import (
+	"context"
+	"errors"
+	"os/user"
+	"path/filepath"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+
+	configv1 "github.com/openshift/api/config/v1"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	hiveutils "github.com/openshift/hive/contrib/pkg/utils"
+	awsutils "github.com/openshift/hive/contrib/pkg/utils/aws"
+	"github.com/openshift/hive/pkg/awsclient"
+	operatorutils "github.com/openshift/hive/pkg/operator/hive"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type enableOptions struct {
+	homeDir string
+	// AWS region of the Hive cluster
+	region        string
+	infraId       string
+	dnsRecordType string
+
+	dynamicClient client.Client
+	// AWS clients in Hive cluster's region
+	awsClients awsclient.Client
+}
+
+func NewEnableAWSPrivateLinkCommand() *cobra.Command {
+	opt := &enableOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "enable",
+		Short: "Enable AWS PrivateLink",
+		Long: `Enable AWS PrivateLink:
+1) Extract AWS Hub account credentials from the environment where this command is called
+2) Create a Secret with the above credential.
+3) Add a reference to the Secret in HiveConfig.spec.awsPrivateLink.credentialsSecretRef.
+4) Add the active cluster's VPC to the list of HiveConfig.spec.awsPrivateLink.associatedVPCs`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := opt.Complete(cmd, args); err != nil {
+				return
+			}
+			if err := opt.Validate(cmd, args); err != nil {
+				return
+			}
+			if err := opt.Run(cmd, args); err != nil {
+				return
+			}
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&opt.dnsRecordType, "dns-record-type", "Alias", "HiveConfig.spec.awsPrivateLink.dnsRecordType")
+	return cmd
+}
+
+func (o *enableOptions) Complete(cmd *cobra.Command, args []string) error {
+	// Get controller-runtime dynamic client
+	if err := configv1.Install(scheme.Scheme); err != nil {
+		log.WithError(err).Fatal("Failed to add Openshift configv1 types to the default scheme")
+	}
+	dynamicClient, err := hiveutils.GetClient()
+	if err != nil {
+		log.WithError(err).Fatal("Failed to create controller-runtime client")
+	}
+	o.dynamicClient = dynamicClient
+
+	// Get current user's home directory
+	o.homeDir = "."
+	u, err := user.Current()
+	if err != nil {
+		log.WithError(err).Fatal("Failed to get the current user")
+	}
+	o.homeDir = u.HomeDir
+
+	// Get AWS clients
+	o.region, o.infraId, err = o.getRegionAndInfraId()
+	if err != nil {
+		log.WithError(err).Fatal("Failed to get region and infraID from Infrastructure/cluster")
+	}
+	log.Debugf("Found region = %v, infraId = %v", o.region, o.infraId)
+	awsClients, err := awsclient.NewClientFromSecret(nil, o.region)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to create AWS clients")
+	}
+	o.awsClients = awsClients
+
+	return nil
+}
+
+func (o *enableOptions) Validate(cmd *cobra.Command, args []string) error {
+	switch o.dnsRecordType {
+	case "Alias", "ARecord":
+	default:
+		log.Fatal(`--dns-record-type must be one of "Alias", "ARecord"`)
+	}
+
+	return nil
+}
+
+func (o *enableOptions) Run(cmd *cobra.Command, args []string) error {
+	// Get HiveConfig
+	hiveConfig := &hivev1.HiveConfig{}
+	if err := o.dynamicClient.Get(context.Background(), types.NamespacedName{Name: "hive"}, hiveConfig); err != nil {
+		log.WithError(err).Fatal("Failed to get HiveConfig/hive")
+	}
+	if hiveConfig.Spec.AWSPrivateLink != nil {
+		log.Fatal("AWS Private Link is already enabled. If a previous configuration attempt did not complete, " +
+			"you can clean up via `hiveutil awsprivatelink disable` and try again.")
+	}
+
+	// Get active cluster's VPC, filtering by infra-id
+	targetTagKey := "kubernetes.io/cluster/" + o.infraId
+	describeVPCsOutput, err := o.awsClients.DescribeVpcs(&ec2.DescribeVpcsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("tag-key"),
+				Values: []*string{aws.String(targetTagKey)},
+			},
+		},
+	})
+	if err != nil {
+		log.WithError(err).Fatal("Failed to get VPC of the active cluster")
+	}
+	if len(describeVPCsOutput.Vpcs) == 0 {
+		log.Fatal("VPC of the active cluster not found")
+	}
+	if len(describeVPCsOutput.Vpcs) > 1 {
+		log.Fatalf("Multiple VPCs found with tag key %s, cannot determine VPC of the active cluster", targetTagKey)
+	}
+	vpcID := *describeVPCsOutput.Vpcs[0].VpcId
+	log.Debugf("Found VPC ID = %v for the active cluster", vpcID)
+
+	// Create Hub account credentials Secret
+	hiveNS := operatorutils.GetHiveNamespace(hiveConfig)
+	hubCredentialsSecret, err := o.generateAWSCredentialsSecret(hiveNS)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to generate Secret with AWS credentials")
+	}
+	switch err = o.dynamicClient.Create(context.Background(), hubCredentialsSecret); {
+	case err == nil:
+		log.Infof("Secret/%s created in namespace %s", awsutils.PrivateLinkHubAcctCredsName, hiveNS)
+	case apierrors.IsAlreadyExists(err):
+		log.Warnf("Secret/%s already exists in namespace %s", awsutils.PrivateLinkHubAcctCredsName, hiveNS)
+	default:
+		log.WithError(err).Fatalf("Failed to create Secret/%s in namespace %s", awsutils.PrivateLinkHubAcctCredsName, hiveNS)
+	}
+
+	// Update HiveConfig
+	hiveConfig.Spec.AWSPrivateLink = &hivev1.AWSPrivateLinkConfig{
+		AssociatedVPCs: []hivev1.AWSAssociatedVPC{
+			{
+				AWSPrivateLinkVPC: hivev1.AWSPrivateLinkVPC{VPCID: vpcID, Region: o.region},
+			},
+		},
+		CredentialsSecretRef: corev1.LocalObjectReference{Name: hubCredentialsSecret.Name},
+		DNSRecordType:        hivev1.AWSPrivateLinkDNSRecordType(o.dnsRecordType),
+	}
+	if err = o.dynamicClient.Update(context.Background(), hiveConfig); err != nil {
+		log.WithError(err).Fatal("Failed to update HiveConfig")
+	}
+	log.Info("HiveConfig updated")
+
+	return nil
+}
+
+func (o *enableOptions) getRegionAndInfraId() (string, string, error) {
+	infrastructure := &configv1.Infrastructure{}
+	if err := o.dynamicClient.Get(context.Background(), types.NamespacedName{Name: "cluster"}, infrastructure); err != nil {
+		return "", "", err
+	}
+	if infrastructure.Status.PlatformStatus == nil {
+		return "", "", errors.New("Infrastructure.status.platformStatus is empty")
+	}
+	if infrastructure.Status.PlatformStatus.AWS == nil {
+		return "", "", errors.New("Infrastructure.status.platformStatus.aws is empty")
+	}
+
+	return infrastructure.Status.PlatformStatus.AWS.Region, infrastructure.Status.InfrastructureName, nil
+}
+
+// Adapted from contrib/pkg/adm/managedns/enable.go:generateAWSCredentialsSecret()
+func (o *enableOptions) generateAWSCredentialsSecret(namespace string) (*corev1.Secret, error) {
+	defaultCredsFilePath := filepath.Join(o.homeDir, ".aws", "credentials")
+	accessKeyID, secretAccessKey, err := awsutils.GetAWSCreds("", defaultCredsFilePath)
+	if err != nil {
+		return nil, err
+	}
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      awsutils.PrivateLinkHubAcctCredsName,
+			Namespace: namespace,
+			// Secrets without this label (e.g. the ones created and configured manually) won't be deleted
+			// when calling "hiveutil awsprivatelink disable".
+			Labels: map[string]string{awsutils.PrivateLinkHubAcctCredsLabel: "true"},
+		},
+		Type: corev1.SecretTypeOpaque,
+		StringData: map[string]string{
+			"aws_access_key_id":     accessKeyID,
+			"aws_secret_access_key": secretAccessKey,
+		},
+	}, nil
+}

--- a/contrib/pkg/awsprivatelink/endpointVPC.go
+++ b/contrib/pkg/awsprivatelink/endpointVPC.go
@@ -1,0 +1,21 @@
+package awsprivatelink
+
+import (
+	"github.com/openshift/hive/contrib/pkg/awsprivatelink/endpointvpc"
+	"github.com/spf13/cobra"
+)
+
+func NewEndpointVPCCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "endpointvpc",
+		Short: "Manage endpoint VPCs",
+		Long: `Manage endpoint VPCs. 
+Setup or tear down cloud resources needed for networking between endpoint VPCs and associated VPCs.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			_ = cmd.Usage()
+		},
+	}
+	cmd.AddCommand(endpointvpc.NewEndpointVPCAddCommand())
+	cmd.AddCommand(endpointvpc.NewEndpointVPCRemoveCommand())
+	return cmd
+}

--- a/contrib/pkg/awsprivatelink/endpointvpc/add.go
+++ b/contrib/pkg/awsprivatelink/endpointvpc/add.go
@@ -1,0 +1,418 @@
+package endpointvpc
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	hiveutils "github.com/openshift/hive/contrib/pkg/utils"
+	awsutils "github.com/openshift/hive/contrib/pkg/utils/aws"
+	"github.com/openshift/hive/pkg/awsclient"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type endpointVPCAddOptions struct {
+	hiveConfig        hivev1.HiveConfig
+	associatedVpcs    []hivev1.AWSAssociatedVPC
+	endpointVpcId     string
+	endpointVpcRegion string
+	endpointSubnetIds []string
+
+	dynamicClient      client.Client
+	endpointVpcClients awsclient.Client
+	awsClientsByRegion map[string]awsclient.Client
+}
+
+func NewEndpointVPCAddCommand() *cobra.Command {
+	opt := &endpointVPCAddOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "add vpc-id",
+		Short: "Networking setup between an endpoint VPC and each associated VPC",
+		Long: `Networking setup between an endpoint VPC and each associated VPC 
+specified in HiveConfig.spec.awsPrivateLink.associatedVPCs: 
+1) Establish VPC peering connection between the endpoint VPC and the associated VPC
+2) Add a route (to the peered VPC) in relevant route tables of the associated VPC and the endpoint VPC 
+3) Update relevant security groups of the associated VPC and the endpoint VPC to allow traffic between them
+4) Add the endpoint VPC to HiveConfig.spec.awsPrivateLink.endpointVPCInventory`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := opt.Complete(cmd, args); err != nil {
+				return
+			}
+			if err := opt.Validate(cmd, args); err != nil {
+				return
+			}
+			if err := opt.Run(cmd, args); err != nil {
+				return
+			}
+		},
+	}
+
+	regionFlag := "region"
+	subnetIdsFlag := "subnet-ids"
+
+	flags := cmd.Flags()
+	flags.StringVar(&opt.endpointVpcRegion, regionFlag, "", "AWS Region of the endpoint VPC to add")
+	flags.StringSliceVar(&opt.endpointSubnetIds, subnetIdsFlag, []string{}, "IDs of the endpoint subnets to use (as a comma-separated string)")
+
+	_ = cmd.MarkFlagRequired(regionFlag)
+	_ = cmd.MarkFlagRequired(subnetIdsFlag)
+	return cmd
+}
+
+func (o *endpointVPCAddOptions) Complete(cmd *cobra.Command, args []string) error {
+	o.endpointVpcId = args[0]
+
+	// Get controller-runtime dynamic client
+	dynamicClient, err := hiveutils.GetClient()
+	if err != nil {
+		log.WithError(err).Fatal("Failed to create controller-runtime client")
+	}
+	o.dynamicClient = dynamicClient
+
+	// Get HiveConfig
+	if err = o.dynamicClient.Get(context.Background(), types.NamespacedName{Name: "hive"}, &o.hiveConfig); err != nil {
+		log.WithError(err).Fatal("Failed to get HiveConfig/hive")
+	}
+	if o.hiveConfig.Spec.AWSPrivateLink == nil {
+		log.Fatal(`AWS PrivateLink is not enabled in HiveConfig. Please call "hiveutil awsprivatelink enable" first.`)
+	}
+	o.associatedVpcs = o.hiveConfig.Spec.AWSPrivateLink.AssociatedVPCs
+	if len(o.associatedVpcs) == 0 {
+		log.Warn("HiveConfig/hive does not specify any associated VPC. " +
+			"The endpoint VPC passed in as argument will still be added to HiveConfig, " +
+			"and yet no cloud resources will be set up for networking.")
+	}
+
+	// Get AWS clients by region
+	regions := sets.New(o.endpointVpcRegion)
+	for _, associatedVpc := range o.associatedVpcs {
+		regions.Insert(associatedVpc.AWSPrivateLinkVPC.Region)
+	}
+	o.awsClientsByRegion, err = awsutils.GetAWSClientsByRegion(regions)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to get AWS clients")
+	}
+	// A shortcut to AWS clients of the endpoint VPC
+	o.endpointVpcClients = o.awsClientsByRegion[o.endpointVpcRegion]
+
+	return nil
+}
+
+func (o *endpointVPCAddOptions) Validate(cmd *cobra.Command, args []string) error {
+	// Check if the endpoint VPC exists
+	if _, err := o.endpointVpcClients.DescribeVpcs(&ec2.DescribeVpcsInput{
+		VpcIds: []*string{aws.String(o.endpointVpcId)},
+	}); err != nil {
+		log.WithError(err).Fatal("Failed to describe endpoint VPC")
+	}
+
+	// Check if the endpoint subnets belong to the endpoint VPC
+	err := o.endpointVpcClients.DescribeSubnetsPages(
+		&ec2.DescribeSubnetsInput{
+			SubnetIds: aws.StringSlice(o.endpointSubnetIds),
+		},
+		func(page *ec2.DescribeSubnetsOutput, lastPage bool) bool {
+			for _, subnet := range page.Subnets {
+				if *subnet.VpcId != o.endpointVpcId {
+					log.Fatalf("Subnet %v does not belong to the endpoint VPC", *subnet.SubnetId)
+				}
+			}
+			return !lastPage
+		},
+	)
+	if err != nil {
+		log.WithError(err).Fatalf("Failed to describe the endpoint subnets")
+	}
+
+	return nil
+}
+
+func (o *endpointVPCAddOptions) Run(cmd *cobra.Command, args []string) error {
+	// Get default SG of the endpoint VPC
+	endpointVPCDefaultSG, err := awsutils.GetDefaultSGOfVpc(o.endpointVpcClients, aws.String(o.endpointVpcId))
+	if err != nil {
+		log.WithError(err).Fatal("Failed to get default SG of the endpoint VPC")
+	}
+	log.Debugf("Found default SG %v of the endpoint VPC", endpointVPCDefaultSG)
+
+	// Networking setup between the endpoint VPC and each associated VPC
+	for _, associatedVpc := range o.associatedVpcs {
+		associatedVpcRegion := associatedVpc.AWSPrivateLinkVPC.Region
+		associatedVpcClients := o.awsClientsByRegion[associatedVpcRegion]
+		associatedVpcId := associatedVpc.AWSPrivateLinkVPC.VPCID
+		log.Infof("Setting up networking between associated VPC %v and endpoint VPC %v", associatedVpcId, o.endpointVpcId)
+
+		// Setup peering connection
+		acceptVpcPeeringConnectionOutput, err := setupVpcPeeringConnection(
+			associatedVpcClients,
+			o.endpointVpcClients,
+			aws.String(associatedVpcId),
+			aws.String(o.endpointVpcId),
+			aws.String(o.endpointVpcRegion),
+		)
+		if err != nil {
+			log.WithError(err).Fatal("Failed to setup VPC peering connection")
+		}
+		vpcPeeringConnectionId := acceptVpcPeeringConnectionOutput.VpcPeeringConnection.VpcPeeringConnectionId
+		associatedVpcCIDR := acceptVpcPeeringConnectionOutput.VpcPeeringConnection.RequesterVpcInfo.CidrBlock
+		endpointVpcCIDR := acceptVpcPeeringConnectionOutput.VpcPeeringConnection.AccepterVpcInfo.CidrBlock
+		log.Debugf("Found associated VPC CIDR = %v, endpoint VPC CIDR = %v", *associatedVpcCIDR, *endpointVpcCIDR)
+
+		// Update route tables
+		log.Info("Adding route to private route tables of the associated VPC")
+		if err = addRouteToRouteTables(
+			associatedVpcClients,
+			aws.String(associatedVpcId),
+			endpointVpcCIDR,
+			vpcPeeringConnectionId,
+			&ec2.Filter{Name: aws.String("tag:Name"), Values: []*string{aws.String("*private*")}},
+		); err != nil {
+			log.WithError(err).Fatal("Failed to add route to private route tables of the associated VPC")
+		}
+
+		log.Info("Adding route to route tables of the endpoint subnets")
+		if err = addRouteToRouteTables(
+			o.endpointVpcClients,
+			aws.String(o.endpointVpcId),
+			associatedVpcCIDR,
+			vpcPeeringConnectionId,
+			&ec2.Filter{Name: aws.String("association.subnet-id"), Values: aws.StringSlice(o.endpointSubnetIds)},
+		); err != nil {
+			log.WithError(err).Fatal("Failed to add route to route tables of the endpoint subnets")
+		}
+
+		// Update SGs
+		associatedVpcWorkerSG, err := awsutils.GetWorkerSGFromVpcId(
+			associatedVpcClients,
+			aws.String(associatedVpcId),
+		)
+		if err != nil {
+			log.WithError(err).Fatal("Failed to get worker SG of the associated VPC")
+		}
+		log.Debugf("Found worker SG %v of the associated Hive cluster", associatedVpcWorkerSG)
+
+		switch {
+
+		// Associated VPC & endpoint VPC in the same region => allow ingress from SG of the peer
+		case associatedVpcRegion == o.endpointVpcRegion:
+			log.Info("Authorizing traffic from the associated VPC's worker SG to the endpoint VPC's default SG")
+			if _, err = awsutils.AuthorizeAllIngressFromSG(
+				o.endpointVpcClients,
+				aws.String(endpointVPCDefaultSG),
+				aws.String(associatedVpcWorkerSG),
+				aws.String(fmt.Sprintf("Access from worker SG of associated VPC %s", associatedVpcId)),
+			); err != nil {
+				// Proceed if ingress already authorized, fail otherwise
+				switch aerr, ok := err.(awserr.Error); {
+				case ok && aerr.Code() == "InvalidPermission.Duplicate":
+					log.Warnf("Traffic from the associated VPC's worker SG to the endpoint VPC's default SG is already authorized")
+				default:
+					log.WithError(err).Fatal("Failed to authorize traffic from the associated VPC's worker SG to the endpoint VPC's default SG")
+				}
+			}
+
+			log.Info("Authorizing traffic from the endpoint VPC's default SG to the associated VPC's worker SG")
+			if _, err = awsutils.AuthorizeAllIngressFromSG(
+				associatedVpcClients,
+				aws.String(associatedVpcWorkerSG),
+				aws.String(endpointVPCDefaultSG),
+				aws.String(fmt.Sprintf("Access from default SG of endpoint VPC %s", o.endpointVpcId)),
+			); err != nil {
+				// Proceed if ingress already authorized, fail otherwise
+				switch aerr, ok := err.(awserr.Error); {
+				case ok && aerr.Code() == "InvalidPermission.Duplicate":
+					log.Warnf("Traffic from the endpoint VPC's default SG to the associated VPC's worker SG is already authorized")
+				default:
+					log.WithError(err).Fatal("Failed to authorize traffic from the endpoint VPC's default SG to the associated VPC's worker SG")
+				}
+			}
+
+		// Associated VPC & endpoint VPC in different regions => allow ingress from CIDR of the peer
+		default:
+			log.Info("Authorizing traffic from the associated VPC's CIDR block to the endpoint VPC's default SG")
+			if _, err = awsutils.AuthorizeAllIngressFromCIDR(
+				o.endpointVpcClients,
+				aws.String(endpointVPCDefaultSG),
+				associatedVpcCIDR,
+				aws.String(fmt.Sprintf("Access from CIDR block of associated VPC %s", associatedVpcId)),
+			); err != nil {
+				// Proceed if ingress already authorized, fail otherwise
+				switch aerr, ok := err.(awserr.Error); {
+				case ok && aerr.Code() == "InvalidPermission.Duplicate":
+					log.Warnf("Traffic from the associated VPC's CIDR block to the endpoint VPC's default SG is already authorized")
+				default:
+					log.WithError(err).Fatal("Failed to authorize traffic from the associated VPC's CIDR block to the endpoint VPC's default SG")
+				}
+			}
+
+			log.Info("Authorizing traffic from the endpoint VPC's CIDR block to the associated VPC's worker SG")
+			if _, err = awsutils.AuthorizeAllIngressFromCIDR(
+				associatedVpcClients,
+				aws.String(associatedVpcWorkerSG),
+				endpointVpcCIDR,
+				aws.String(fmt.Sprintf("Access from CIDR block of endpoint VPC %s", o.endpointVpcId)),
+			); err != nil {
+				// Proceed if ingress already authorized, fail otherwise
+				switch aerr, ok := err.(awserr.Error); {
+				case ok && aerr.Code() == "InvalidPermission.Duplicate":
+					log.Warnf("Traffic from the endpoint VPC's CIDR block to the associated VPC's worker SG is already authorized")
+				default:
+					log.WithError(err).Fatal("Failed to authorize traffic from the endpoint VPC's CIDR block to the associated VPC's worker SG")
+				}
+			}
+		}
+	}
+
+	// Update HiveConfig
+	o.addEndpointVpcToHiveConfig()
+
+	return nil
+}
+
+func (o *endpointVPCAddOptions) addEndpointVpcToHiveConfig() {
+	log.Infof("Adding endpoint VPC %v to HiveConfig", o.endpointVpcId)
+
+	// Get AZ of each endpoint subnet
+	var endpointSubnets []hivev1.AWSPrivateLinkSubnet
+	if err := o.endpointVpcClients.DescribeSubnetsPages(
+		&ec2.DescribeSubnetsInput{
+			SubnetIds: aws.StringSlice(o.endpointSubnetIds),
+		},
+		func(page *ec2.DescribeSubnetsOutput, lastPage bool) bool {
+			for _, subnet := range page.Subnets {
+				endpointSubnet := hivev1.AWSPrivateLinkSubnet{
+					SubnetID:         *subnet.SubnetId,
+					AvailabilityZone: *subnet.AvailabilityZone,
+				}
+				endpointSubnets = append(endpointSubnets, endpointSubnet)
+			}
+			return !lastPage
+		},
+	); err != nil {
+		log.WithError(err).Fatal("Failed to describe endpoint subnets")
+	}
+	// Sort endpoint subnets by AZ first and then by subnet ID
+	sort.Slice(endpointSubnets, func(i, j int) bool {
+		return endpointSubnets[i].AvailabilityZone+endpointSubnets[i].SubnetID <
+			endpointSubnets[j].AvailabilityZone+endpointSubnets[j].SubnetID
+	})
+
+	// Make sure the endpoint VPC is specified in HiveConfig.
+	// Append/update HiveConfig.spec.awsPrivateLink.endpointVpcInventory depending on the situation.
+	endpointVpcToAdd := hivev1.AWSPrivateLinkInventory{
+		AWSPrivateLinkVPC: hivev1.AWSPrivateLinkVPC{
+			VPCID:  o.endpointVpcId,
+			Region: o.endpointVpcRegion,
+		},
+		Subnets: endpointSubnets,
+	}
+	if idx, ok := awsutils.FindVpcInInventory(o.endpointVpcId, o.hiveConfig.Spec.AWSPrivateLink.EndpointVPCInventory); ok {
+		if reflect.DeepEqual(o.hiveConfig.Spec.AWSPrivateLink.EndpointVPCInventory[idx], endpointVpcToAdd) {
+			log.Warn("Endpoint VPC found in HiveConfig. HiveConfig unchanged.")
+			return
+		}
+		log.Warn("Endpoint VPC found in HiveConfig but needs update.")
+		o.hiveConfig.Spec.AWSPrivateLink.EndpointVPCInventory[idx] = endpointVpcToAdd
+	} else {
+		o.hiveConfig.Spec.AWSPrivateLink.EndpointVPCInventory = append(
+			o.hiveConfig.Spec.AWSPrivateLink.EndpointVPCInventory,
+			endpointVpcToAdd,
+		)
+		log.Debugf("Endpoint VPC added to HiveConfig")
+	}
+
+	if err := o.dynamicClient.Update(context.Background(), &o.hiveConfig); err != nil {
+		log.WithError(err).Fatal("Failed to update HiveConfig/hive")
+	}
+}
+
+func addRouteToRouteTables(
+	vpcClients awsclient.Client,
+	vpcId, peerCIDR, VpcPeeringConnectionId *string,
+	additionalFiltersForRouteTables ...*ec2.Filter,
+) error {
+	filters := append([]*ec2.Filter{
+		{
+			Name:   aws.String("vpc-id"),
+			Values: []*string{vpcId},
+		},
+	}, additionalFiltersForRouteTables...)
+
+	return vpcClients.DescribeRouteTablesPages(
+		&ec2.DescribeRouteTablesInput{
+			Filters: filters,
+		},
+		func(page *ec2.DescribeRouteTablesOutput, lastPage bool) bool {
+			for _, routeTable := range page.RouteTables {
+				_, err := vpcClients.CreateRoute(&ec2.CreateRouteInput{
+					RouteTableId:           routeTable.RouteTableId,
+					DestinationCidrBlock:   peerCIDR,
+					VpcPeeringConnectionId: VpcPeeringConnectionId,
+				})
+				if err != nil {
+					// Proceed if route already exists, fail otherwise
+					switch aerr, ok := err.(awserr.Error); {
+					case ok && aerr.Code() == "RouteAlreadyExists":
+						log.Warnf("Route already exists in route table %v", *routeTable.RouteTableId)
+					default:
+						log.WithError(err).Fatalf("Failed to create route for route table %v", *routeTable.RouteTableId)
+					}
+				} else {
+					log.Debugf("Route added to route table %v", *routeTable.RouteTableId)
+				}
+			}
+
+			return !lastPage
+		},
+	)
+}
+
+// Does not error out even if the peering connection is already established between the two VPCs.
+func setupVpcPeeringConnection(
+	associatedVpcClients, endpointVpcClients awsclient.Client,
+	associatedVpcId, endpointVpcId, endpointVpcRegion *string,
+) (*ec2.AcceptVpcPeeringConnectionOutput, error) {
+	log.Info("Setting up VPC peering connection between the associated VPC and the endpoint VPC")
+
+	createVpcPeeringConnectionOutput, err := associatedVpcClients.CreateVpcPeeringConnection(&ec2.CreateVpcPeeringConnectionInput{
+		VpcId:      associatedVpcId,
+		PeerVpcId:  endpointVpcId,
+		PeerRegion: endpointVpcRegion,
+	})
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("VPC peering connection %v requested", *createVpcPeeringConnectionOutput.VpcPeeringConnection.VpcPeeringConnectionId)
+
+	err = endpointVpcClients.WaitUntilVpcPeeringConnectionExists(&ec2.DescribeVpcPeeringConnectionsInput{
+		VpcPeeringConnectionIds: []*string{createVpcPeeringConnectionOutput.VpcPeeringConnection.VpcPeeringConnectionId},
+	})
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("VPC peering connection %v exists", *createVpcPeeringConnectionOutput.VpcPeeringConnection.VpcPeeringConnectionId)
+
+	acceptVpcPeeringConnectionOutput, err := endpointVpcClients.AcceptVpcPeeringConnection(&ec2.AcceptVpcPeeringConnectionInput{
+		VpcPeeringConnectionId: createVpcPeeringConnectionOutput.VpcPeeringConnection.VpcPeeringConnectionId,
+	})
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("VPC peering connection %v accepted", *acceptVpcPeeringConnectionOutput.VpcPeeringConnection.VpcPeeringConnectionId)
+
+	return acceptVpcPeeringConnectionOutput, nil
+}

--- a/contrib/pkg/awsprivatelink/endpointvpc/remove.go
+++ b/contrib/pkg/awsprivatelink/endpointvpc/remove.go
@@ -1,0 +1,353 @@
+package endpointvpc
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	hiveutils "github.com/openshift/hive/contrib/pkg/utils"
+	awsutils "github.com/openshift/hive/contrib/pkg/utils/aws"
+	"github.com/openshift/hive/pkg/awsclient"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type endpointVPCRemoveOptions struct {
+	hiveConfig        hivev1.HiveConfig
+	associatedVpcs    []hivev1.AWSAssociatedVPC
+	endpointVpcId     string
+	endpointVpcRegion string
+	endpointVpcIdx    int
+	endpointSubnetIds []string
+
+	dynamicClient      client.Client
+	endpointVpcClients awsclient.Client
+	awsClientsByRegion map[string]awsclient.Client
+}
+
+func NewEndpointVPCRemoveCommand() *cobra.Command {
+	opt := &endpointVPCRemoveOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "remove vpc-id",
+		Short: "Tear down the networking elements between an endpoint VPC and each associated VPC",
+		Long: `Tear down the networking elements between an endpoint VPC and each associated VPC 
+specified in HiveConfig.spec.awsPrivateLink.associatedVPCs:
+1) Delete the VPC peering connection between the endpoint VPC and the associated VPC
+2) Delete the route (to the peered VPC) in relevant route tables of the associated VPC and the endpoint VPC 
+3) Remove the inbound rule from relevant SGs in the associated VPC and the endpoint VPC that permits traffic between them
+4) Remove the endpoint VPC from HiveConfig.spec.awsPrivateLink.endpointVPCInventory`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := opt.Complete(cmd, args); err != nil {
+				return
+			}
+			if err := opt.Validate(cmd, args); err != nil {
+				return
+			}
+			if err := opt.Run(cmd, args); err != nil {
+				return
+			}
+		},
+	}
+	return cmd
+}
+
+func (o *endpointVPCRemoveOptions) Complete(cmd *cobra.Command, args []string) error {
+	o.endpointVpcId = args[0]
+
+	// Get controller-runtime dynamic client
+	dynamicClient, err := hiveutils.GetClient()
+	if err != nil {
+		log.WithError(err).Fatal("Failed to create controller-runtime client")
+	}
+	o.dynamicClient = dynamicClient
+
+	// Get HiveConfig
+	if err = o.dynamicClient.Get(context.Background(), types.NamespacedName{Name: "hive"}, &o.hiveConfig); err != nil {
+		log.WithError(err).Fatal("Failed to get HiveConfig/hive")
+	}
+	if o.hiveConfig.Spec.AWSPrivateLink == nil {
+		log.Fatal(`AWS PrivateLink is not enabled in HiveConfig. Please call "hiveutil awsprivatelink enable" first`)
+	}
+	o.associatedVpcs = o.hiveConfig.Spec.AWSPrivateLink.AssociatedVPCs
+	if len(o.associatedVpcs) == 0 {
+		log.Warn("HiveConfig/hive does not specify any associated VPC. " +
+			"The endpoint VPC passed in as argument will still be removed from HiveConfig, " +
+			"and yet there will be no deletion of cloud resources.")
+	}
+
+	// Get endpoint VPC and AWS clients for it
+	endpointVpcIdx, ok := awsutils.FindVpcInInventory(o.endpointVpcId, o.hiveConfig.Spec.AWSPrivateLink.EndpointVPCInventory)
+	if !ok {
+		log.Fatalf("Endpoint VPC %v not found in HiveConfig.spec.awsPrivateLink.endpointVPCInventory. "+
+			"Please call `hiveutil privatelink endpointvpc add ...` to add it first", o.endpointVpcId)
+	}
+	o.endpointVpcIdx = endpointVpcIdx
+	o.endpointVpcRegion = o.hiveConfig.Spec.AWSPrivateLink.EndpointVPCInventory[endpointVpcIdx].AWSPrivateLinkVPC.Region
+	for _, subnet := range o.hiveConfig.Spec.AWSPrivateLink.EndpointVPCInventory[endpointVpcIdx].Subnets {
+		o.endpointSubnetIds = append(o.endpointSubnetIds, subnet.SubnetID)
+	}
+
+	// Get AWS clients by region
+	regions := sets.New(o.endpointVpcRegion)
+	for _, associatedVpc := range o.associatedVpcs {
+		regions.Insert(associatedVpc.AWSPrivateLinkVPC.Region)
+	}
+	o.awsClientsByRegion, err = awsutils.GetAWSClientsByRegion(regions)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to get AWS clients")
+	}
+	// A shortcut to AWS clients of the endpoint VPC
+	o.endpointVpcClients = o.awsClientsByRegion[o.endpointVpcRegion]
+
+	return nil
+}
+
+func (o *endpointVPCRemoveOptions) Validate(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+func (o *endpointVPCRemoveOptions) Run(cmd *cobra.Command, args []string) error {
+	// Get default SG of the endpoint VPC
+	endpointVPCDefaultSG, err := awsutils.GetDefaultSGOfVpc(o.endpointVpcClients, aws.String(o.endpointVpcId))
+	if err != nil {
+		log.WithError(err).Fatal("Failed to get default SG of the endpoint VPC")
+	}
+	log.Debugf("Found default SG %v of the endpoint VPC", endpointVPCDefaultSG)
+
+	// Remove the networking elements between the endpoint VPC and each associated VPC
+	for _, associatedVpc := range o.associatedVpcs {
+		associatedVpcRegion := associatedVpc.AWSPrivateLinkVPC.Region
+		associatedVpcClients := o.awsClientsByRegion[associatedVpcRegion]
+		associatedVpcId := associatedVpc.AWSPrivateLinkVPC.VPCID
+		log.Infof("Removing networking elements between associated VPC %v and endpoint VPC %v", associatedVpcId, o.endpointVpcId)
+
+		associatedVpcCIDR, err := awsutils.GetCIDRFromVpcId(associatedVpcClients, aws.String(associatedVpcId))
+		if err != nil {
+			log.Fatal("Failed to get CIDR of associated VPC")
+		}
+		log.Debugf("Found associated VPC CIDR = %v", associatedVpcCIDR)
+		endpointVpcCIDR, err := awsutils.GetCIDRFromVpcId(o.endpointVpcClients, aws.String(o.endpointVpcId))
+		if err != nil {
+			log.Fatal("Failed to get CIDR of endpoint VPC")
+		}
+		log.Debugf("Found endpoint VPC CIDR = %v", endpointVpcCIDR)
+
+		// Delete VPC peering connection
+		if err = deleteVpcPeeringConnection(
+			associatedVpcClients,
+			aws.String(associatedVpcId),
+			aws.String(o.endpointVpcId),
+		); err != nil {
+			log.WithError(err).Fatal("Failed to delete VPC peering connection")
+		}
+
+		// Update route tables
+		log.Info("Deleting route from private route tables of the associated VPC")
+		if err = deleteRouteFromRouteTables(
+			associatedVpcClients,
+			aws.String(associatedVpcId),
+			aws.String(endpointVpcCIDR),
+			&ec2.Filter{Name: aws.String("tag:Name"), Values: []*string{aws.String("*private*")}},
+		); err != nil {
+			log.WithError(err).Fatal("Failed to delete route from private route tables of the associated VPC")
+		}
+
+		log.Info("Deleting route from route tables of the endpoint subnets")
+		if err = deleteRouteFromRouteTables(
+			o.endpointVpcClients,
+			aws.String(o.endpointVpcId),
+			aws.String(associatedVpcCIDR),
+			&ec2.Filter{Name: aws.String("association.subnet-id"), Values: aws.StringSlice(o.endpointSubnetIds)},
+		); err != nil {
+			log.WithError(err).Fatal("Failed to delete route from route tables of the endpoint subnets")
+		}
+
+		// Update SGs
+		associatedVpcWorkerSG, err := awsutils.GetWorkerSGFromVpcId(associatedVpcClients, aws.String(associatedVpcId))
+		if err != nil {
+			log.WithError(err).Fatal("Failed to get worker SG of the associated Hive cluster")
+		}
+		log.Debugf("Found worker SG %v of the associated Hive cluster", associatedVpcWorkerSG)
+
+		switch {
+
+		// Associated VPC & endpoint VPC in the same region => revoke ingress from SG of the peer
+		case associatedVpcRegion == o.endpointVpcRegion:
+			log.Info("Revoking access from the endpoint VPC's default SG to the associated VPC's worker SG")
+			if _, err = awsutils.RevokeAllIngressFromSG(
+				associatedVpcClients,
+				aws.String(associatedVpcWorkerSG),
+				aws.String(endpointVPCDefaultSG),
+			); err != nil {
+				// Proceed if ingress not found, fail otherwise
+				switch aerr, ok := err.(awserr.Error); {
+				case ok && aerr.Code() == "InvalidPermission.NotFound":
+					log.Warnf("Access from the endpoint VPC's default SG to the associated VPC's worker SG is not enabled")
+				default:
+					log.WithError(err).Fatal("Failed to revoke access from the endpoint VPC's default SG to the associated VPC's worker SG")
+				}
+			}
+
+			log.Info("Revoking access from the associated VPC's worker SG to the endpoint VPC's default SG")
+			if _, err = awsutils.RevokeAllIngressFromSG(
+				o.endpointVpcClients,
+				aws.String(endpointVPCDefaultSG),
+				aws.String(associatedVpcWorkerSG),
+			); err != nil {
+				// Proceed if ingress not found, fail otherwise
+				switch aerr, ok := err.(awserr.Error); {
+				case ok && aerr.Code() == "InvalidPermission.NotFound":
+					log.Warnf("Access from the associated VPC's worker SG to the endpoint VPC's default SG is not enabled")
+				default:
+					log.WithError(err).Fatal("Failed to revoke access from the associated VPC's worker SG to the endpoint VPC's default SG")
+				}
+			}
+
+		// Associated VPC & endpoint VPC in different regions => revoke ingress from CIDR of the peer
+		default:
+			log.Info("Revoking access from the endpoint VPC's CIDR block to the associated VPC's worker SG")
+			if _, err = awsutils.RevokeAllIngressFromCIDR(
+				associatedVpcClients,
+				aws.String(associatedVpcWorkerSG),
+				aws.String(endpointVpcCIDR),
+			); err != nil {
+				// Proceed if ingress not found, fail otherwise
+				switch aerr, ok := err.(awserr.Error); {
+				case ok && aerr.Code() == "InvalidPermission.NotFound":
+					log.Warnf("Access from the endpoint VPC's CIDR block to the associated VPC's worker SG is not enabled")
+				default:
+					log.WithError(err).Fatal("Failed to revoke access from the endpoint VPC's CIDR block to the associated VPC's worker SG")
+				}
+			}
+
+			log.Info("Revoking access from the associated VPC's CIDR block to the endpoint VPC's default SG")
+			if _, err = awsutils.RevokeAllIngressFromCIDR(
+				o.endpointVpcClients,
+				aws.String(endpointVPCDefaultSG),
+				aws.String(associatedVpcCIDR),
+			); err != nil {
+				// Proceed if ingress not found, fail otherwise
+				switch aerr, ok := err.(awserr.Error); {
+				case ok && aerr.Code() == "InvalidPermission.NotFound":
+					log.Warnf("Access from the associated VPC's CIDR block to the endpoint VPC's default SG is not enabled")
+				default:
+					log.WithError(err).Fatal("Failed to revoke access from the associated VPC's CIDR block to the endpoint VPC's default SG")
+				}
+			}
+		}
+	}
+
+	// Update HiveConfig
+	o.removeEndpointVpcFromHiveConfig()
+
+	return nil
+}
+
+func (o *endpointVPCRemoveOptions) removeEndpointVpcFromHiveConfig() {
+	log.Infof("Removing endpoint VPC %v from HiveConfig", o.endpointVpcId)
+
+	// Remove endpoint VPC from HiveConfig if necessary
+	o.hiveConfig.Spec.AWSPrivateLink.EndpointVPCInventory[o.endpointVpcIdx] =
+		o.hiveConfig.Spec.AWSPrivateLink.EndpointVPCInventory[len(o.hiveConfig.Spec.AWSPrivateLink.EndpointVPCInventory)-1]
+	o.hiveConfig.Spec.AWSPrivateLink.EndpointVPCInventory =
+		o.hiveConfig.Spec.AWSPrivateLink.EndpointVPCInventory[:len(o.hiveConfig.Spec.AWSPrivateLink.EndpointVPCInventory)-1]
+	if err := o.dynamicClient.Update(context.Background(), &o.hiveConfig); err != nil {
+		log.WithError(err).Fatal("Failed to update HiveConfig")
+	}
+}
+
+func deleteVpcPeeringConnection(awsClients awsclient.Client, VpcId1, VpcId2 *string) error {
+	log.Info("Deleting VPC peering connection between the associated VPC and the endpoint VPC")
+
+	describeVpcPeeringConnectionsOutput, err := awsClients.DescribeVpcPeeringConnections(&ec2.DescribeVpcPeeringConnectionsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("requester-vpc-info.vpc-id"),
+				Values: []*string{VpcId1, VpcId2},
+			},
+			{
+				Name:   aws.String("accepter-vpc-info.vpc-id"),
+				Values: []*string{VpcId1, VpcId2},
+			},
+			// Only one peering connection can be active at any given time between a pair of VPCs
+			{
+				Name:   aws.String("status-code"),
+				Values: []*string{aws.String("active")},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if len(describeVpcPeeringConnectionsOutput.VpcPeeringConnections) == 0 {
+		log.Warn("No VPC peering connection found between the associated VPC and the endpoint VPC")
+		return nil
+	}
+
+	VpcPeeringConnectionId := describeVpcPeeringConnectionsOutput.VpcPeeringConnections[0].VpcPeeringConnectionId
+	if _, err = awsClients.DeleteVpcPeeringConnection(&ec2.DeleteVpcPeeringConnectionInput{
+		VpcPeeringConnectionId: VpcPeeringConnectionId,
+	}); err != nil {
+		return err
+	}
+	log.Debugf("The deletion of VPC peering connection %v has been initiated", *VpcPeeringConnectionId)
+
+	if err = awsClients.WaitUntilVpcPeeringConnectionDeleted(&ec2.DescribeVpcPeeringConnectionsInput{
+		VpcPeeringConnectionIds: []*string{VpcPeeringConnectionId},
+	}); err != nil {
+		return err
+	}
+	log.Debugf("VPC peering connection %v deleted", *VpcPeeringConnectionId)
+
+	return nil
+}
+
+func deleteRouteFromRouteTables(
+	vpcClients awsclient.Client,
+	vpcId, peerCIDR *string,
+	additionalFiltersForRouteTables ...*ec2.Filter,
+) error {
+	filters := append([]*ec2.Filter{
+		{
+			Name:   aws.String("vpc-id"),
+			Values: []*string{vpcId},
+		},
+	}, additionalFiltersForRouteTables...)
+
+	return vpcClients.DescribeRouteTablesPages(
+		&ec2.DescribeRouteTablesInput{
+			Filters: filters,
+		},
+		func(page *ec2.DescribeRouteTablesOutput, lastPage bool) bool {
+			for _, routeTable := range page.RouteTables {
+				_, err := vpcClients.DeleteRoute(&ec2.DeleteRouteInput{
+					RouteTableId:         routeTable.RouteTableId,
+					DestinationCidrBlock: peerCIDR,
+				})
+				if err != nil {
+					// Proceed if route not found, fail otherwise
+					switch aerr, ok := err.(awserr.Error); {
+					case ok && aerr.Code() == "InvalidRoute.NotFound":
+						log.Warnf("Route not found in route table %v", *routeTable.RouteTableId)
+					default:
+						log.WithError(err).Fatalf("Failed to delete route from route table %v", *routeTable.RouteTableId)
+					}
+				} else {
+					log.Debugf("Route deleted from route table %v", *routeTable.RouteTableId)
+				}
+			}
+
+			return !lastPage
+		},
+	)
+}

--- a/contrib/pkg/utils/aws/aws.go
+++ b/contrib/pkg/utils/aws/aws.go
@@ -1,15 +1,211 @@
 package aws
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/contrib/pkg/utils"
+	"github.com/openshift/hive/pkg/awsclient"
 	"github.com/openshift/hive/pkg/constants"
+
 	log "github.com/sirupsen/logrus"
 	ini "gopkg.in/ini.v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const (
+	// PrivateLinkHubAcctCredsName is the name of the AWS PrivateLink Hub account credentials Secret
+	// created by the "hiveutil awsprivatelink enable" command
+	PrivateLinkHubAcctCredsName = "awsprivatelink-hub-acct-creds"
+
+	// PrivateLinkHubAcctCredsLabel is added to the AWS PrivateLink Hub account credentials Secret
+	// created by the "hiveutil awsprivatelink enable" command and
+	// referenced by HiveConfig.spec.awsPrivateLink.credentialsSecretRef.
+	PrivateLinkHubAcctCredsLabel = "hive.openshift.io/awsprivatelink-hub-acct-credentials"
+)
+
+func GetAWSClientsByRegion(regions sets.Set[string]) (map[string]awsclient.Client, error) {
+	awsClientsByRegion := make(map[string]awsclient.Client)
+	for region := range regions {
+		awsClients, err := awsclient.NewClientFromSecret(nil, region)
+		if err != nil {
+			return awsClientsByRegion, err
+		}
+		awsClientsByRegion[region] = awsClients
+	}
+
+	return awsClientsByRegion, nil
+}
+
+func FindVpcInInventory(vpcId string, inventory []hivev1.AWSPrivateLinkInventory) (int, bool) {
+	for i, endpointVpc := range inventory {
+		if vpcId == endpointVpc.AWSPrivateLinkVPC.VPCID {
+			return i, true
+		}
+	}
+
+	return -1, false
+}
+
+// GetDefaultSGOfVpc gets the default SG of a VPC.
+func GetDefaultSGOfVpc(awsClients awsclient.Client, vpcId *string) (string, error) {
+	describeSecurityGroupsOutput, err := awsClients.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("vpc-id"),
+				Values: []*string{vpcId},
+			},
+			{
+				Name:   aws.String("group-name"),
+				Values: []*string{aws.String("default")},
+			},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(describeSecurityGroupsOutput.SecurityGroups) == 0 {
+		return "", fmt.Errorf("default SG not found for VPC %v", vpcId)
+	}
+
+	return *describeSecurityGroupsOutput.SecurityGroups[0].GroupId, nil
+}
+
+// RevokeAllIngressFromCIDR removes an SG inbound rule which allows all ingress originating from a CIDR block.
+func RevokeAllIngressFromCIDR(awsClients awsclient.Client, SG, cidr *string) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+	return awsClients.RevokeSecurityGroupIngress(&ec2.RevokeSecurityGroupIngressInput{
+		GroupId: SG,
+		IpPermissions: []*ec2.IpPermission{
+			{
+				IpRanges: []*ec2.IpRange{
+					{
+						CidrIp: cidr,
+					},
+				},
+				IpProtocol: aws.String("-1"),
+			},
+		},
+	})
+}
+
+// RevokeAllIngressFromSG removes an SG inbound rule which allows all ingress originating from another SG.
+func RevokeAllIngressFromSG(awsClients awsclient.Client, SG, sourceSG *string) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+	return awsClients.RevokeSecurityGroupIngress(&ec2.RevokeSecurityGroupIngressInput{
+		GroupId: SG,
+		IpPermissions: []*ec2.IpPermission{
+			{
+				IpProtocol: aws.String("-1"),
+				UserIdGroupPairs: []*ec2.UserIdGroupPair{
+					{
+						GroupId: sourceSG,
+					},
+				},
+			},
+		},
+	})
+}
+
+// AuthorizeAllIngressFromCIDR adds an SG inbound rule which allows all ingress originating from a CIDR block.
+func AuthorizeAllIngressFromCIDR(awsClients awsclient.Client, SG, cidr, description *string) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
+	return awsClients.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: SG,
+		IpPermissions: []*ec2.IpPermission{
+			{
+				IpRanges: []*ec2.IpRange{
+					{
+						CidrIp:      cidr,
+						Description: description,
+					},
+				},
+				IpProtocol: aws.String("-1"),
+			},
+		},
+	})
+}
+
+// AuthorizeAllIngressFromSG adds an SG inbound rule which allows all ingress originating from another SG.
+func AuthorizeAllIngressFromSG(awsClients awsclient.Client, SG, sourceSG, description *string) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
+	return awsClients.AuthorizeSecurityGroupIngress(&ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: SG,
+		IpPermissions: []*ec2.IpPermission{
+			{
+				IpProtocol: aws.String("-1"),
+				UserIdGroupPairs: []*ec2.UserIdGroupPair{
+					{
+						Description: description,
+						GroupId:     sourceSG,
+					},
+				},
+			},
+		},
+	})
+}
+
+// GetInfraIdFromVpcId gets the infraID of an OCP cluster using the ID of the VPC it resides.
+func GetInfraIdFromVpcId(awsClients awsclient.Client, vpcId *string) (string, error) {
+	// When we specify the resource IDs explicitly instead of using filtering,
+	// AWS functions will return a non-nil error if nothing is found.
+	describeVpcsOutput, err := awsClients.DescribeVpcs(&ec2.DescribeVpcsInput{
+		VpcIds: []*string{vpcId},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	targetPrefix := "kubernetes.io/cluster/"
+	for _, tag := range describeVpcsOutput.Vpcs[0].Tags {
+		if strings.HasPrefix(*tag.Key, targetPrefix) {
+			return strings.Replace(*tag.Key, targetPrefix, "", 1), nil
+		}
+	}
+	return "", fmt.Errorf("no tag with prefix %v found on VPC %v", targetPrefix, vpcId)
+}
+
+// GetWorkerSGFromVpcId gets the worker SG ID of an OCP cluster using the ID of the VPC it resides.
+func GetWorkerSGFromVpcId(awsClients awsclient.Client, vpcId *string) (string, error) {
+	infraID, err := GetInfraIdFromVpcId(awsClients, vpcId)
+	if err != nil {
+		return "", err
+	}
+
+	describeSecurityGroupsOutput, err := awsClients.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("tag:Name"),
+				Values: []*string{aws.String(infraID + "-worker-sg")},
+			},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(describeSecurityGroupsOutput.SecurityGroups) == 0 {
+		return "", fmt.Errorf("default SG not found for VPC %v", vpcId)
+	}
+
+	return *describeSecurityGroupsOutput.SecurityGroups[0].GroupId, err
+}
+
+// GetCIDRFromVpcId gets the CIDR block of a VPC using the ID of it.
+func GetCIDRFromVpcId(awsClients awsclient.Client, vpcId *string) (string, error) {
+	// When we specify the resource IDs explicitly instead of using filtering,
+	// AWS functions will return a non-nil error if nothing is found.
+	describeVpcOutput, err := awsClients.DescribeVpcs(&ec2.DescribeVpcsInput{
+		VpcIds: []*string{vpcId},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return *describeVpcOutput.Vpcs[0].CidrBlock, nil
+}
 
 // GetAWSCreds reads AWS credentials either from either the specified credentials file,
 // the standard environment variables, or a default credentials file. (~/.aws/credentials)

--- a/docs/awsprivatelink.md
+++ b/docs/awsprivatelink.md
@@ -30,6 +30,17 @@ pair to create an Private Link to cluster's internal NLB for k8s API server,
 allowing Hive to access the API without forcing the cluster to publish it on
 the Internet.
 
+## Setting up AWS Private Link with hiveutil
+
+The `hiveutil awsprivatelink` command provides multiple subcommands for managing AWS PrivateLink configuration. 
+It automates tasks such as managing `HiveConfig.spec.awsPrivateLink` and setting up
+or tearing down networking between associated VPCs and endpoint VPCs.
+For detailed information about these subcommands and their usage,
+please refer to the [hiveutil documentation](./hiveutil.md#aws-privatelink).
+
+Disclaimer: `hiveutil` is an internal utility for use by hive developers and
+hive itself. It is not supported for general use.
+
 ## Configuring Hive to enable AWS Private Link
 
 To configure Hive to support Private Link in a specific region,

--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -61,11 +61,25 @@ type Client interface {
 	// EC2
 	DescribeAvailabilityZones(*ec2.DescribeAvailabilityZonesInput) (*ec2.DescribeAvailabilityZonesOutput, error)
 	DescribeSubnets(*ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
+	DescribeSubnetsPages(*ec2.DescribeSubnetsInput, func(*ec2.DescribeSubnetsOutput, bool) bool) error
 	DescribeRouteTables(*ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error)
+	DescribeRouteTablesPages(*ec2.DescribeRouteTablesInput, func(*ec2.DescribeRouteTablesOutput, bool) bool) error
+	CreateRoute(*ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error)
+	DeleteRoute(*ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error)
 	DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error)
 	StopInstances(*ec2.StopInstancesInput) (*ec2.StopInstancesOutput, error)
 	TerminateInstances(*ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error)
 	StartInstances(*ec2.StartInstancesInput) (*ec2.StartInstancesOutput, error)
+	DescribeSecurityGroups(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error)
+	AuthorizeSecurityGroupIngress(*ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error)
+	RevokeSecurityGroupIngress(*ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error)
+	DescribeVpcs(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
+	CreateVpcPeeringConnection(*ec2.CreateVpcPeeringConnectionInput) (*ec2.CreateVpcPeeringConnectionOutput, error)
+	DescribeVpcPeeringConnections(*ec2.DescribeVpcPeeringConnectionsInput) (*ec2.DescribeVpcPeeringConnectionsOutput, error)
+	AcceptVpcPeeringConnection(*ec2.AcceptVpcPeeringConnectionInput) (*ec2.AcceptVpcPeeringConnectionOutput, error)
+	DeleteVpcPeeringConnection(*ec2.DeleteVpcPeeringConnectionInput) (*ec2.DeleteVpcPeeringConnectionOutput, error)
+	WaitUntilVpcPeeringConnectionExists(*ec2.DescribeVpcPeeringConnectionsInput) error
+	WaitUntilVpcPeeringConnectionDeleted(*ec2.DescribeVpcPeeringConnectionsInput) error
 	CreateVpcEndpointServiceConfiguration(*ec2.CreateVpcEndpointServiceConfigurationInput) (*ec2.CreateVpcEndpointServiceConfigurationOutput, error)
 	DescribeVpcEndpointServiceConfigurations(*ec2.DescribeVpcEndpointServiceConfigurationsInput) (*ec2.DescribeVpcEndpointServiceConfigurationsOutput, error)
 	ModifyVpcEndpointServiceConfiguration(*ec2.ModifyVpcEndpointServiceConfigurationInput) (*ec2.ModifyVpcEndpointServiceConfigurationOutput, error)
@@ -131,9 +145,29 @@ func (c *awsClient) DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.Descr
 	return c.ec2Client.DescribeSubnets(input)
 }
 
+func (c *awsClient) DescribeSubnetsPages(input *ec2.DescribeSubnetsInput, fn func(*ec2.DescribeSubnetsOutput, bool) bool) error {
+	metricAWSAPICalls.WithLabelValues("DescribeSubnetsPages").Inc()
+	return c.ec2Client.DescribeSubnetsPages(input, fn)
+}
+
 func (c *awsClient) DescribeRouteTables(input *ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error) {
 	metricAWSAPICalls.WithLabelValues("DescribeRouteTables").Inc()
 	return c.ec2Client.DescribeRouteTables(input)
+}
+
+func (c *awsClient) DescribeRouteTablesPages(input *ec2.DescribeRouteTablesInput, fn func(*ec2.DescribeRouteTablesOutput, bool) bool) error {
+	metricAWSAPICalls.WithLabelValues("DescribeRouteTablesPages").Inc()
+	return c.ec2Client.DescribeRouteTablesPages(input, fn)
+}
+
+func (c *awsClient) CreateRoute(input *ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error) {
+	metricAWSAPICalls.WithLabelValues("CreateRoute").Inc()
+	return c.ec2Client.CreateRoute(input)
+}
+
+func (c *awsClient) DeleteRoute(input *ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error) {
+	metricAWSAPICalls.WithLabelValues("DeleteRoute").Inc()
+	return c.ec2Client.DeleteRoute(input)
 }
 
 func (c *awsClient) DescribeInstances(input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
@@ -154,6 +188,51 @@ func (c *awsClient) TerminateInstances(input *ec2.TerminateInstancesInput) (*ec2
 func (c *awsClient) StartInstances(input *ec2.StartInstancesInput) (*ec2.StartInstancesOutput, error) {
 	metricAWSAPICalls.WithLabelValues("StartInstances").Inc()
 	return c.ec2Client.StartInstances(input)
+}
+
+func (c *awsClient) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+	metricAWSAPICalls.WithLabelValues("DescribeSecurityGroups").Inc()
+	return c.ec2Client.DescribeSecurityGroups(input)
+}
+
+func (c *awsClient) AuthorizeSecurityGroupIngress(input *ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
+	metricAWSAPICalls.WithLabelValues("AuthorizeSecurityGroupIngress").Inc()
+	return c.ec2Client.AuthorizeSecurityGroupIngress(input)
+}
+
+func (c *awsClient) RevokeSecurityGroupIngress(input *ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+	metricAWSAPICalls.WithLabelValues("RevokeSecurityGroupIngress").Inc()
+	return c.ec2Client.RevokeSecurityGroupIngress(input)
+}
+
+func (c *awsClient) CreateVpcPeeringConnection(input *ec2.CreateVpcPeeringConnectionInput) (*ec2.CreateVpcPeeringConnectionOutput, error) {
+	metricAWSAPICalls.WithLabelValues("CreateVpcPeeringConnection").Inc()
+	return c.ec2Client.CreateVpcPeeringConnection(input)
+}
+
+func (c *awsClient) DescribeVpcPeeringConnections(input *ec2.DescribeVpcPeeringConnectionsInput) (*ec2.DescribeVpcPeeringConnectionsOutput, error) {
+	metricAWSAPICalls.WithLabelValues("DescribeVpcPeeringConnections").Inc()
+	return c.ec2Client.DescribeVpcPeeringConnections(input)
+}
+
+func (c *awsClient) AcceptVpcPeeringConnection(input *ec2.AcceptVpcPeeringConnectionInput) (*ec2.AcceptVpcPeeringConnectionOutput, error) {
+	metricAWSAPICalls.WithLabelValues("AcceptVpcPeeringConnection").Inc()
+	return c.ec2Client.AcceptVpcPeeringConnection(input)
+}
+
+func (c *awsClient) DeleteVpcPeeringConnection(input *ec2.DeleteVpcPeeringConnectionInput) (*ec2.DeleteVpcPeeringConnectionOutput, error) {
+	metricAWSAPICalls.WithLabelValues("DeleteVpcPeeringConnection").Inc()
+	return c.ec2Client.DeleteVpcPeeringConnection(input)
+}
+
+func (c *awsClient) WaitUntilVpcPeeringConnectionExists(input *ec2.DescribeVpcPeeringConnectionsInput) error {
+	metricAWSAPICalls.WithLabelValues("WaitUntilVpcPeeringConnectionExists").Inc()
+	return c.ec2Client.WaitUntilVpcPeeringConnectionExists(input)
+}
+
+func (c *awsClient) WaitUntilVpcPeeringConnectionDeleted(input *ec2.DescribeVpcPeeringConnectionsInput) error {
+	metricAWSAPICalls.WithLabelValues("WaitUntilVpcPeeringConnectionDeleted").Inc()
+	return c.ec2Client.WaitUntilVpcPeeringConnectionDeleted(input)
 }
 
 func (c *awsClient) CreateVpcEndpointServiceConfiguration(input *ec2.CreateVpcEndpointServiceConfigurationInput) (*ec2.CreateVpcEndpointServiceConfigurationOutput, error) {
@@ -214,6 +293,11 @@ func (c *awsClient) CreateVpcEndpoint(input *ec2.CreateVpcEndpointInput) (*ec2.C
 func (c *awsClient) DeleteVpcEndpoints(input *ec2.DeleteVpcEndpointsInput) (*ec2.DeleteVpcEndpointsOutput, error) {
 	metricAWSAPICalls.WithLabelValues("DeleteVpcEndpoints").Inc()
 	return c.ec2Client.DeleteVpcEndpoints(input)
+}
+
+func (c *awsClient) DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+	metricAWSAPICalls.WithLabelValues("DescribeVpcs").Inc()
+	return c.ec2Client.DescribeVpcs(input)
 }
 
 func (c *awsClient) DescribeLoadBalancers(input *elbv2.DescribeLoadBalancersInput) (*elbv2.DescribeLoadBalancersOutput, error) {

--- a/pkg/awsclient/mock/client_generated.go
+++ b/pkg/awsclient/mock/client_generated.go
@@ -40,6 +40,21 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// AcceptVpcPeeringConnection mocks base method.
+func (m *MockClient) AcceptVpcPeeringConnection(arg0 *ec2.AcceptVpcPeeringConnectionInput) (*ec2.AcceptVpcPeeringConnectionOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AcceptVpcPeeringConnection", arg0)
+	ret0, _ := ret[0].(*ec2.AcceptVpcPeeringConnectionOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AcceptVpcPeeringConnection indicates an expected call of AcceptVpcPeeringConnection.
+func (mr *MockClientMockRecorder) AcceptVpcPeeringConnection(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptVpcPeeringConnection", reflect.TypeOf((*MockClient)(nil).AcceptVpcPeeringConnection), arg0)
+}
+
 // AssociateVPCWithHostedZone mocks base method.
 func (m *MockClient) AssociateVPCWithHostedZone(arg0 *route53.AssociateVPCWithHostedZoneInput) (*route53.AssociateVPCWithHostedZoneOutput, error) {
 	m.ctrl.T.Helper()
@@ -53,6 +68,21 @@ func (m *MockClient) AssociateVPCWithHostedZone(arg0 *route53.AssociateVPCWithHo
 func (mr *MockClientMockRecorder) AssociateVPCWithHostedZone(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateVPCWithHostedZone", reflect.TypeOf((*MockClient)(nil).AssociateVPCWithHostedZone), arg0)
+}
+
+// AuthorizeSecurityGroupIngress mocks base method.
+func (m *MockClient) AuthorizeSecurityGroupIngress(arg0 *ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthorizeSecurityGroupIngress", arg0)
+	ret0, _ := ret[0].(*ec2.AuthorizeSecurityGroupIngressOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AuthorizeSecurityGroupIngress indicates an expected call of AuthorizeSecurityGroupIngress.
+func (mr *MockClientMockRecorder) AuthorizeSecurityGroupIngress(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorizeSecurityGroupIngress", reflect.TypeOf((*MockClient)(nil).AuthorizeSecurityGroupIngress), arg0)
 }
 
 // ChangeResourceRecordSets mocks base method.
@@ -100,6 +130,21 @@ func (mr *MockClientMockRecorder) CreateHostedZone(input interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateHostedZone", reflect.TypeOf((*MockClient)(nil).CreateHostedZone), input)
 }
 
+// CreateRoute mocks base method.
+func (m *MockClient) CreateRoute(arg0 *ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateRoute", arg0)
+	ret0, _ := ret[0].(*ec2.CreateRouteOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateRoute indicates an expected call of CreateRoute.
+func (mr *MockClientMockRecorder) CreateRoute(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRoute", reflect.TypeOf((*MockClient)(nil).CreateRoute), arg0)
+}
+
 // CreateVPCAssociationAuthorization mocks base method.
 func (m *MockClient) CreateVPCAssociationAuthorization(arg0 *route53.CreateVPCAssociationAuthorizationInput) (*route53.CreateVPCAssociationAuthorizationOutput, error) {
 	m.ctrl.T.Helper()
@@ -145,6 +190,21 @@ func (mr *MockClientMockRecorder) CreateVpcEndpointServiceConfiguration(arg0 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcEndpointServiceConfiguration", reflect.TypeOf((*MockClient)(nil).CreateVpcEndpointServiceConfiguration), arg0)
 }
 
+// CreateVpcPeeringConnection mocks base method.
+func (m *MockClient) CreateVpcPeeringConnection(arg0 *ec2.CreateVpcPeeringConnectionInput) (*ec2.CreateVpcPeeringConnectionOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateVpcPeeringConnection", arg0)
+	ret0, _ := ret[0].(*ec2.CreateVpcPeeringConnectionOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateVpcPeeringConnection indicates an expected call of CreateVpcPeeringConnection.
+func (mr *MockClientMockRecorder) CreateVpcPeeringConnection(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateVpcPeeringConnection", reflect.TypeOf((*MockClient)(nil).CreateVpcPeeringConnection), arg0)
+}
+
 // DeleteHostedZone mocks base method.
 func (m *MockClient) DeleteHostedZone(input *route53.DeleteHostedZoneInput) (*route53.DeleteHostedZoneOutput, error) {
 	m.ctrl.T.Helper()
@@ -158,6 +218,21 @@ func (m *MockClient) DeleteHostedZone(input *route53.DeleteHostedZoneInput) (*ro
 func (mr *MockClientMockRecorder) DeleteHostedZone(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteHostedZone", reflect.TypeOf((*MockClient)(nil).DeleteHostedZone), input)
+}
+
+// DeleteRoute mocks base method.
+func (m *MockClient) DeleteRoute(arg0 *ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRoute", arg0)
+	ret0, _ := ret[0].(*ec2.DeleteRouteOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteRoute indicates an expected call of DeleteRoute.
+func (mr *MockClientMockRecorder) DeleteRoute(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRoute", reflect.TypeOf((*MockClient)(nil).DeleteRoute), arg0)
 }
 
 // DeleteVPCAssociationAuthorization mocks base method.
@@ -203,6 +278,21 @@ func (m *MockClient) DeleteVpcEndpoints(arg0 *ec2.DeleteVpcEndpointsInput) (*ec2
 func (mr *MockClientMockRecorder) DeleteVpcEndpoints(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcEndpoints", reflect.TypeOf((*MockClient)(nil).DeleteVpcEndpoints), arg0)
+}
+
+// DeleteVpcPeeringConnection mocks base method.
+func (m *MockClient) DeleteVpcPeeringConnection(arg0 *ec2.DeleteVpcPeeringConnectionInput) (*ec2.DeleteVpcPeeringConnectionOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteVpcPeeringConnection", arg0)
+	ret0, _ := ret[0].(*ec2.DeleteVpcPeeringConnectionOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteVpcPeeringConnection indicates an expected call of DeleteVpcPeeringConnection.
+func (mr *MockClientMockRecorder) DeleteVpcPeeringConnection(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVpcPeeringConnection", reflect.TypeOf((*MockClient)(nil).DeleteVpcPeeringConnection), arg0)
 }
 
 // DescribeAvailabilityZones mocks base method.
@@ -280,6 +370,35 @@ func (mr *MockClientMockRecorder) DescribeRouteTables(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRouteTables", reflect.TypeOf((*MockClient)(nil).DescribeRouteTables), arg0)
 }
 
+// DescribeRouteTablesPages mocks base method.
+func (m *MockClient) DescribeRouteTablesPages(arg0 *ec2.DescribeRouteTablesInput, arg1 func(*ec2.DescribeRouteTablesOutput, bool) bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeRouteTablesPages", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeRouteTablesPages indicates an expected call of DescribeRouteTablesPages.
+func (mr *MockClientMockRecorder) DescribeRouteTablesPages(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeRouteTablesPages", reflect.TypeOf((*MockClient)(nil).DescribeRouteTablesPages), arg0, arg1)
+}
+
+// DescribeSecurityGroups mocks base method.
+func (m *MockClient) DescribeSecurityGroups(arg0 *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeSecurityGroups", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeSecurityGroupsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeSecurityGroups indicates an expected call of DescribeSecurityGroups.
+func (mr *MockClientMockRecorder) DescribeSecurityGroups(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSecurityGroups", reflect.TypeOf((*MockClient)(nil).DescribeSecurityGroups), arg0)
+}
+
 // DescribeSubnets mocks base method.
 func (m *MockClient) DescribeSubnets(arg0 *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
 	m.ctrl.T.Helper()
@@ -293,6 +412,20 @@ func (m *MockClient) DescribeSubnets(arg0 *ec2.DescribeSubnetsInput) (*ec2.Descr
 func (mr *MockClientMockRecorder) DescribeSubnets(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubnets", reflect.TypeOf((*MockClient)(nil).DescribeSubnets), arg0)
+}
+
+// DescribeSubnetsPages mocks base method.
+func (m *MockClient) DescribeSubnetsPages(arg0 *ec2.DescribeSubnetsInput, arg1 func(*ec2.DescribeSubnetsOutput, bool) bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeSubnetsPages", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeSubnetsPages indicates an expected call of DescribeSubnetsPages.
+func (mr *MockClientMockRecorder) DescribeSubnetsPages(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeSubnetsPages", reflect.TypeOf((*MockClient)(nil).DescribeSubnetsPages), arg0, arg1)
 }
 
 // DescribeVpcEndpointServiceConfigurations mocks base method.
@@ -367,6 +500,36 @@ func (m *MockClient) DescribeVpcEndpointsPages(arg0 *ec2.DescribeVpcEndpointsInp
 func (mr *MockClientMockRecorder) DescribeVpcEndpointsPages(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcEndpointsPages", reflect.TypeOf((*MockClient)(nil).DescribeVpcEndpointsPages), arg0, arg1)
+}
+
+// DescribeVpcPeeringConnections mocks base method.
+func (m *MockClient) DescribeVpcPeeringConnections(arg0 *ec2.DescribeVpcPeeringConnectionsInput) (*ec2.DescribeVpcPeeringConnectionsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeVpcPeeringConnections", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeVpcPeeringConnectionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeVpcPeeringConnections indicates an expected call of DescribeVpcPeeringConnections.
+func (mr *MockClientMockRecorder) DescribeVpcPeeringConnections(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcPeeringConnections", reflect.TypeOf((*MockClient)(nil).DescribeVpcPeeringConnections), arg0)
+}
+
+// DescribeVpcs mocks base method.
+func (m *MockClient) DescribeVpcs(arg0 *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeVpcs", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeVpcsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeVpcs indicates an expected call of DescribeVpcs.
+func (mr *MockClientMockRecorder) DescribeVpcs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeVpcs", reflect.TypeOf((*MockClient)(nil).DescribeVpcs), arg0)
 }
 
 // DisassociateVPCFromHostedZone mocks base method.
@@ -532,6 +695,21 @@ func (mr *MockClientMockRecorder) ModifyVpcEndpointServicePermissions(arg0 inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModifyVpcEndpointServicePermissions", reflect.TypeOf((*MockClient)(nil).ModifyVpcEndpointServicePermissions), arg0)
 }
 
+// RevokeSecurityGroupIngress mocks base method.
+func (m *MockClient) RevokeSecurityGroupIngress(arg0 *ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RevokeSecurityGroupIngress", arg0)
+	ret0, _ := ret[0].(*ec2.RevokeSecurityGroupIngressOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RevokeSecurityGroupIngress indicates an expected call of RevokeSecurityGroupIngress.
+func (mr *MockClientMockRecorder) RevokeSecurityGroupIngress(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RevokeSecurityGroupIngress", reflect.TypeOf((*MockClient)(nil).RevokeSecurityGroupIngress), arg0)
+}
+
 // StartInstances mocks base method.
 func (m *MockClient) StartInstances(arg0 *ec2.StartInstancesInput) (*ec2.StartInstancesOutput, error) {
 	m.ctrl.T.Helper()
@@ -590,4 +768,32 @@ func (m *MockClient) Upload(arg0 *s3manager.UploadInput) (*s3manager.UploadOutpu
 func (mr *MockClientMockRecorder) Upload(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*MockClient)(nil).Upload), arg0)
+}
+
+// WaitUntilVpcPeeringConnectionDeleted mocks base method.
+func (m *MockClient) WaitUntilVpcPeeringConnectionDeleted(arg0 *ec2.DescribeVpcPeeringConnectionsInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitUntilVpcPeeringConnectionDeleted", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUntilVpcPeeringConnectionDeleted indicates an expected call of WaitUntilVpcPeeringConnectionDeleted.
+func (mr *MockClientMockRecorder) WaitUntilVpcPeeringConnectionDeleted(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVpcPeeringConnectionDeleted", reflect.TypeOf((*MockClient)(nil).WaitUntilVpcPeeringConnectionDeleted), arg0)
+}
+
+// WaitUntilVpcPeeringConnectionExists mocks base method.
+func (m *MockClient) WaitUntilVpcPeeringConnectionExists(arg0 *ec2.DescribeVpcPeeringConnectionsInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitUntilVpcPeeringConnectionExists", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUntilVpcPeeringConnectionExists indicates an expected call of WaitUntilVpcPeeringConnectionExists.
+func (mr *MockClientMockRecorder) WaitUntilVpcPeeringConnectionExists(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilVpcPeeringConnectionExists", reflect.TypeOf((*MockClient)(nil).WaitUntilVpcPeeringConnectionExists), arg0)
 }

--- a/pkg/operator/hive/clustersync.go
+++ b/pkg/operator/hive/clustersync.go
@@ -85,7 +85,7 @@ func (r *ReconcileHiveConfig) deployClusterSync(hLog log.FieldLogger, h resource
 		hiveContainer.Env = append(hiveContainer.Env, syncsetReapplyIntervalEnvVar)
 	}
 
-	hiveNSName := getHiveNamespace(hiveconfig)
+	hiveNSName := GetHiveNamespace(hiveconfig)
 
 	// Load namespaced assets, decode them, set to our target namespace, and apply:
 	for _, assetPath := range namespacedAssets {

--- a/pkg/operator/hive/configmap.go
+++ b/pkg/operator/hive/configmap.go
@@ -268,7 +268,7 @@ func (r *ReconcileHiveConfig) deployConfigMap(hLog log.FieldLogger, h resource.H
 
 	cm := &corev1.ConfigMap{}
 	cm.Name = cmInfo.name
-	cm.Namespace = getHiveNamespace(instance)
+	cm.Namespace = GetHiveNamespace(instance)
 	cm.Data = make(map[string]string)
 
 	if cmInfo.setData != nil {

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -153,7 +153,7 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 		})
 	}
 
-	hiveNSName := getHiveNamespace(instance)
+	hiveNSName := GetHiveNamespace(instance)
 
 	if awssp := instance.Spec.ServiceProviderCredentialsConfig.AWS; awssp != nil && awssp.CredentialsSecretRef.Name != "" {
 		hiveContainer.Env = append(hiveContainer.Env, corev1.EnvVar{
@@ -354,7 +354,7 @@ func (r *ReconcileHiveConfig) includeAdditionalCAs(hLog log.FieldLogger, h resou
 		}
 	}
 
-	hiveNS := getHiveNamespace(instance)
+	hiveNS := GetHiveNamespace(instance)
 	additionalCA := &bytes.Buffer{}
 	for _, clientCARef := range instance.Spec.AdditionalCertificateAuthoritiesSecretRef {
 		caSecret, err := r.hiveSecretLister.Secrets(hiveNS).Get(clientCARef.Name)
@@ -384,7 +384,7 @@ func (r *ReconcileHiveConfig) includeAdditionalCAs(hLog log.FieldLogger, h resou
 
 	caSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: getHiveNamespace(instance),
+			Namespace: GetHiveNamespace(instance),
 			Name:      hiveAdditionalCASecret,
 		},
 		Data: map[string][]byte{

--- a/pkg/operator/hive/hive_controller.go
+++ b/pkg/operator/hive/hive_controller.go
@@ -384,7 +384,7 @@ func (r *ReconcileHiveConfig) Reconcile(ctx context.Context, request reconcile.R
 	}
 
 	origHiveConfig := instance.DeepCopy()
-	hiveNSName := getHiveNamespace(instance)
+	hiveNSName := GetHiveNamespace(instance)
 
 	// Initialize HiveConfig conditions if not present
 	newConditions, changed := util.InitializeHiveConfigConditions(instance.Status.Conditions, HiveConfigConditions)

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -72,7 +72,7 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h resour
 		}
 	}
 
-	hiveNSName := getHiveNamespace(instance)
+	hiveNSName := GetHiveNamespace(instance)
 
 	// Load namespaced assets, decode them, set to our target namespace, and apply:
 	for _, assetPath := range namespacedAssets {

--- a/pkg/operator/hive/operatorutils.go
+++ b/pkg/operator/hive/operatorutils.go
@@ -19,7 +19,7 @@ import (
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 )
 
-func getHiveNamespace(config *hivev1.HiveConfig) string {
+func GetHiveNamespace(config *hivev1.HiveConfig) string {
 	if config.Spec.TargetNamespace == "" {
 		return constants.DefaultHiveNamespace
 	}


### PR DESCRIPTION
Automate the networking setup & teardown between associate VPCs & endpoint VPCs, as well as the update of HiveConfig. 

With the new subcommand, e2e tests on PrivateLink clusters can be automated as follows:
1. Create a CloudFormation stack (not necessarily in Hive cluster's region) for an endpoint VPC and get the returned stackID. Here we can use "./hack/awsprivatelink/vpc.cf.yaml" for example. 
2. Wait until the stack is successfully created. 
3. Get VPC ID and private subnet IDs from the above stack.
4. Enable PrivateLink with "hiveutil awsprivatelink enable ..." 
5. Set up networking between the new endpoint VPC & each associate VPC with "hiveutil awsprivatelink endpointvpc add ..."
6. Create a PrivateLink cluster in the region of the endpoint VPC with "hiveutil create-cluster fxie-hive-1 --base-domain qe.devcluster.openshift.com --region endpoint-vpc-region --aws-private-link --internal"
7. Run e2e tests on the PrivateLink cluster
8. Delete the PrivateLink CD, wait for the deletion to complete
9. Tear down networking elements between the new endpoint VPC & each associate VPC with "hiveutil awsprivatelink endpointvpc remove ..."
10. Disable PrivateLink with "hiveutil awsprivatelink disable ..."
11. Delete the CloudFormation stack

Checkout https://issues.redhat.com/browse/OCPQE-14714 for details. 
