### PR TITLE
Merge Labels/Taints of MachineSets

### DIFF
--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -703,7 +703,7 @@ openstack:
 
 A MachinePool for the worker machinesets is not required. If the user creates a MachinePool for the worker MachineSets, then Hive will manage the worker MachineSets.
 
-MachinePool reconciliation is limited to updating MachineSet replicas to match the replicas configured for the MachinePool. Additionally, When `Labels` or `Taints` are configured for a MachinePool, Hive will completely override any existing `Label` or `Taints` configurations on the associated MachineSets, see [HIVE-2035](https://issues.redhat.com/browse/HIVE-2035).
+MachinePool reconciliation is limited to updating MachineSet replicas to match the replicas configured for the MachinePool. Additionally, any existing `Labels` or `Taints` on the MachineSets will be overridden if they clash with those on the MachinePool.
 
 MachinePool platform is immutable and any changes made to `MachinePool.spec.platform` are blocked by a validating webhook. The Machine Config Operator does not support updating existing machines when platform details are changed in a MachineSet and consequently Hive does not support making such changes to MachinePool platform, see [HIVE-2024](https://issues.redhat.com/browse/HIVE-2024).
 

--- a/pkg/controller/machinepool/machinepool_controller_test.go
+++ b/pkg/controller/machinepool/machinepool_controller_test.go
@@ -275,6 +275,145 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 			},
 		},
 		{
+			name:              "Merge labels and taints",
+			clusterDeployment: testClusterDeployment(),
+			machinePool: func() *hivev1.MachinePool {
+				mp := testMachinePool()
+				mp.Spec.Labels["test-label-2"] = "test-value-2"
+				mp.Spec.Taints = append(mp.Spec.Taints, corev1.Taint{
+					Key:   "test-taint-2",
+					Value: "test-value-2",
+				})
+				return mp
+			}(),
+			remoteExisting: []runtime.Object{
+				testMachine("master1", "master"),
+				func() *machineapi.MachineSet {
+					ms := testMachineSet("foo-12345-worker-us-east-1a", "worker", true, 1, 0)
+					ms.Spec.Template.Spec.Labels["test-label"] = "test-value"
+					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
+						Key:   "test-taint",
+						Value: "test-value",
+					})
+					return ms
+				}(),
+			},
+			generatedMachineSets: []*machineapi.MachineSet{
+				testMachineSet("foo-12345-worker-us-east-1a", "worker", false, 1, 0),
+			},
+			expectedRemoteMachineSets: []*machineapi.MachineSet{
+				func() *machineapi.MachineSet {
+					ms := testMachineSet("foo-12345-worker-us-east-1a", "worker", true, 1, 1)
+					ms.Spec.Template.Spec.Labels["test-label"] = "test-value"
+					ms.Spec.Template.Spec.Labels["test-label-2"] = "test-value-2"
+					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
+						Key:   "test-taint",
+						Value: "test-value",
+					})
+					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
+						Key:   "test-taint-2",
+						Value: "test-value-2",
+					})
+					return ms
+				}(),
+			},
+		},
+		{
+			name:              "Copy over labels and taints from MachinePool, label map nil on remote MachineSet",
+			clusterDeployment: testClusterDeployment(),
+			machinePool:       testMachinePool(),
+			remoteExisting: []runtime.Object{
+				testMachine("master1", "master"),
+				func() *machineapi.MachineSet {
+					//ms := testMachineSet("foo-12345-worker-us-east-1a", "worker", true, 1, 0)
+					msReplicas := int32(1)
+					rawAWSProviderSpec, err := encodeAWSMachineProviderSpec(testAWSProviderSpec(), scheme.Scheme)
+					if err != nil {
+						log.WithError(err).Fatal("error encoding AWS machine provider spec")
+					}
+					ms := machineapi.MachineSet{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: machineapi.SchemeGroupVersion.String(),
+							Kind:       "MachineSet",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:       "foo-12345-worker-us-east-1a",
+							Namespace:  machineAPINamespace,
+							Generation: int64(0),
+						},
+						Spec: machineapi.MachineSetSpec{
+							Replicas: &msReplicas,
+							Selector: metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"machine.openshift.io/cluster-api-machineset": "foo-12345-worker-us-east-1a",
+									"machine.openshift.io/cluster-api-cluster":    testInfraID,
+								},
+							},
+							Template: machineapi.MachineTemplateSpec{
+								Spec: machineapi.MachineSpec{
+									ProviderSpec: machineapi.ProviderSpec{
+										Value: rawAWSProviderSpec,
+									},
+								},
+							},
+						},
+					}
+					return &ms
+				}(),
+			},
+			generatedMachineSets: []*machineapi.MachineSet{
+				testMachineSet("foo-12345-worker-us-east-1a", "worker", false, 1, 0),
+			},
+			expectedRemoteMachineSets: []*machineapi.MachineSet{
+				func() *machineapi.MachineSet {
+					ms := testMachineSet("foo-12345-worker-us-east-1a", "worker", false, 1, 1)
+					return ms
+				}(),
+			},
+		},
+		{
+			name:              "Don't call update if labels or taints on remote MachineSet already exist",
+			clusterDeployment: testClusterDeployment(),
+			machinePool: func() *hivev1.MachinePool {
+				mp := testMachinePool()
+				mp.Spec.Labels["test-label-2"] = "test-value-2"
+				mp.Spec.Labels["test-label-1"] = "test-value-1"
+				mp.Spec.Taints = append(mp.Spec.Taints, corev1.Taint{
+					Key:   "test-taint",
+					Value: "test-value",
+				})
+				return mp
+			}(),
+			remoteExisting: []runtime.Object{
+				testMachine("master1", "master"),
+				func() *machineapi.MachineSet {
+					ms := testMachineSet("foo-12345-worker-us-east-1a", "worker", true, 1, 0)
+					ms.Spec.Template.Spec.Labels["test-label-1"] = "test-value-1"
+					ms.Spec.Template.Spec.Labels["test-label-2"] = "test-value-2"
+					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
+						Key:   "test-taint",
+						Value: "test-value",
+					})
+					return ms
+				}(),
+			},
+			generatedMachineSets: []*machineapi.MachineSet{
+				testMachineSet("foo-12345-worker-us-east-1a", "worker", false, 1, 0),
+			},
+			expectedRemoteMachineSets: []*machineapi.MachineSet{
+				func() *machineapi.MachineSet {
+					ms := testMachineSet("foo-12345-worker-us-east-1a", "worker", true, 1, 0)
+					ms.Spec.Template.Spec.Labels["test-label-1"] = "test-value-1"
+					ms.Spec.Template.Spec.Labels["test-label-2"] = "test-value-2"
+					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
+						Key:   "test-taint",
+						Value: "test-value",
+					})
+					return ms
+				}(),
+			},
+		},
+		{
 			name: "Skip create missing machine set when clusterDeployment has annotation hive.openshift.io/syncset-pause: true ",
 			clusterDeployment: func() *hivev1.ClusterDeployment {
 				cd := testClusterDeployment()


### PR DESCRIPTION
When MachineSets were generated, we overrode the existing labels and taints on the remoteMachineSet to reflect what was present on the MachinePool. This commit preserves the existing labels and taints on the MachineSet, and if they clash with those on MachinePool, they will be overwritten.

There was also a bug where labels and taints from generated MachineSets were not carried over to the remote MachineSet if the label map was empty - this commit also fixes that.

xref: https://issues.redhat.com/browse/HIVE-2035

/assign @abutcher 