### PR TITLE
Enable Hive to delete the hive-additional-ca Secret

### DIFF
--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -372,7 +372,7 @@ func (r *ReconcileHiveConfig) includeAdditionalCAs(hLog log.FieldLogger, h resou
 	if additionalCA.Len() == 0 {
 		caSecret, err := r.hiveSecretLister.Secrets(hiveNS).Get(hiveAdditionalCASecret)
 		if err == nil {
-			err = h.Delete(caSecret.APIVersion, caSecret.Kind, caSecret.Namespace, caSecret.Name)
+			err = h.Delete("v1", "Secret", caSecret.Namespace, caSecret.Name)
 			if err != nil {
 				hLog.WithError(err).WithField("secret", fmt.Sprintf("%s/%s", hiveNS, hiveAdditionalCASecret)).
 					Error("cannot delete hive additional ca secret")


### PR DESCRIPTION
Hard-code the previously-unpopulated .apiVersion and .kind fields so that Secret/hive-additional-ca can be deleted by controller. 

See https://issues.redhat.com/browse/HIVE-2248