### PR TITLE
Revert "Require TLS cipher min version TLSv1.3"

### DIFF
--- a/config/hiveadmission/deployment.yaml
+++ b/config/hiveadmission/deployment.yaml
@@ -36,7 +36,6 @@ spec:
         - "--audit-log-path=-"
         - "--tls-cert-file=/var/serving-cert/tls.crt"
         - "--tls-private-key-file=/var/serving-cert/tls.key"
-        - "--tls-min-version=VersionTLS13"
         ports:
         - containerPort: 9443
           protocol: TCP

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -430,7 +430,6 @@ spec:
         - "--audit-log-path=-"
         - "--tls-cert-file=/var/serving-cert/tls.crt"
         - "--tls-private-key-file=/var/serving-cert/tls.key"
-        - "--tls-min-version=VersionTLS13"
         ports:
         - containerPort: 9443
           protocol: TCP


### PR DESCRIPTION
Reverts openshift/hive#2015

Turns out this is not The Way.

[HIVE-2243](https://issues.redhat.com//browse/HIVE-2243)