### PR TITLE
Provision: Copy CLI tools in InitContainers

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -191,6 +191,7 @@ case "${CLOUD}" in
         fi
 	BASE_DOMAIN="${BASE_DOMAIN:-hive-ci.openshift.com}"
 	EXTRA_CREATE_CLUSTER_ARGS="--aws-user-tags expirationDate=$(date -d '4 hours' --iso=minutes --utc)"
+	REGION_ARG="--region us-east-2"
 	;;
 "azure")
 	CREDS_FILE="${CLUSTER_PROFILE_DIR}/osServicePrincipal.json"

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -100,7 +100,7 @@ go run "${SRC_ROOT}/contrib/cmd/hiveutil/main.go" create-cluster "${CLUSTER_NAME
 	--release-image="${RELEASE_IMAGE}" \
 	--install-once=true \
 	--uninstall-once=true \
-	--region us-east-2 \
+	${REGION_ARG} \
 	${MANAGED_DNS_ARG} \
 	${EXTRA_CREATE_CLUSTER_ARGS}
 

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -308,7 +308,7 @@ func InstallerPodSpec(
 
 	// This container just needs to copy the required install binaries to the shared emptyDir volume,
 	// where our container will run them. This is effectively downloading the all-in-one installer.
-	containers := []corev1.Container{
+	initContainers := []corev1.Container{
 		{
 			Name:            "installer",
 			Image:           installerImage,
@@ -331,6 +331,8 @@ func InstallerPodSpec(
 			Args:         []string{"cp -v /usr/bin/oc /output/oc.tmp && mv -v /output/oc.tmp /output/oc && ls -la /output"},
 			VolumeMounts: volumeMounts,
 		},
+	}
+	containers := []corev1.Container{
 		{
 			Name:            "hive",
 			Image:           images.GetHiveImage(),
@@ -355,6 +357,7 @@ func InstallerPodSpec(
 	podSpec := &corev1.PodSpec{
 		DNSPolicy:          corev1.DNSClusterFirst,
 		RestartPolicy:      corev1.RestartPolicyNever,
+		InitContainers:     initContainers,
 		Containers:         containers,
 		Volumes:            volumes,
 		ServiceAccountName: serviceAccountName,

--- a/pkg/install/generate_test.go
+++ b/pkg/install/generate_test.go
@@ -93,11 +93,11 @@ func TestInstallerPodSpec(t *testing.T) {
 			},
 			validate: func(t *testing.T, actualPodSpec *corev1.PodSpec, actualError error) {
 				expectedPodMemoryRequest := resource.MustParse("800Mi")
-				actualPodMemoryRequest := actualPodSpec.Containers[2].Resources.Requests[corev1.ResourceMemory]
+				actualPodMemoryRequest := actualPodSpec.Containers[0].Resources.Requests[corev1.ResourceMemory]
 
 				assert.Equal(t, expectedPodMemoryRequest, actualPodMemoryRequest, "Incorrect pod memory request")
 
-				for _, container := range actualPodSpec.Containers {
+				for _, container := range append(actualPodSpec.Containers, actualPodSpec.InitContainers...) {
 					assert.Contains(t, container.Env, corev1.EnvVar{Name: "TESTVAR", Value: "TESTVAL"})
 				}
 				assert.NoError(t, actualError)

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -332,7 +332,7 @@ func (m *InstallManager) Run() error {
 
 	m.ClusterName = cd.Spec.ClusterName
 
-	if err := m.waitForAndCopyInstallerBinaries(); err != nil {
+	if err := m.copyInstallerBinaries(); err != nil {
 		m.log.WithError(err).Error("error waiting for/copying binaries")
 		return err
 	}
@@ -614,12 +614,11 @@ func (m *InstallManager) waitForFiles(files []string) {
 	m.log.Infof("all files found, ready to proceed")
 }
 
-func (m *InstallManager) waitForAndCopyInstallerBinaries() error {
+func (m *InstallManager) copyInstallerBinaries() error {
 	fileList := []string{
 		filepath.Join(m.WorkDir, "openshift-install"),
 		filepath.Join(m.WorkDir, "oc"),
 	}
-	m.waitForFiles(fileList)
 
 	// copy each binary to our container user's home dir to avoid situations
 	// where the /output workdir may be mounted with noexec. (surfaced when using kind


### PR DESCRIPTION
The pod that runs the installer first copies the `openshift-install` and `oc` binaries over from their respective images. It makes sense to run these copies in InitContainers rather than regular Containers:
- The real container no longer needs explicit logic to wait for those files to appear.
- Debugging is a bit simpler: you no longer need to gain the tribal knowledge that the `hive` container is the one doing the real work.
- You no longer need to specify a container when requesting logs.
- Previously if those copies failed, the `hive` container would sit around waiting for them until the pod deadline finally killed it. Now if they fail, the pod will fail right away.

Note that we may incur a slight wall-clock time penalty: InitContainers run synchronously and serially before Containers start, and while the actual copying time is negligible, container setup/teardown time may be enough to be noticeable.

[HIVE-2255](https://issues.redhat.com//browse/HIVE-2255)