### PR TITLE
e2e: Use the default region for non-AWS

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -191,6 +191,7 @@ case "${CLOUD}" in
         fi
 	BASE_DOMAIN="${BASE_DOMAIN:-hive-ci.openshift.com}"
 	EXTRA_CREATE_CLUSTER_ARGS="--aws-user-tags expirationDate=$(date -d '4 hours' --iso=minutes --utc)"
+	REGION_ARG="--region us-east-2"
 	;;
 "azure")
 	CREDS_FILE="${CLUSTER_PROFILE_DIR}/osServicePrincipal.json"

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -100,7 +100,7 @@ go run "${SRC_ROOT}/contrib/cmd/hiveutil/main.go" create-cluster "${CLUSTER_NAME
 	--release-image="${RELEASE_IMAGE}" \
 	--install-once=true \
 	--uninstall-once=true \
-	--region us-east-2 \
+	${REGION_ARG} \
 	${MANAGED_DNS_ARG} \
 	${EXTRA_CREATE_CLUSTER_ARGS}
 


### PR DESCRIPTION
In b3c1262 / #2042 we changed e2e to use region us-east-2... across the board. That region doesn't exist in clouds that aren't AWS. Fix so we only specify that region for AWS, and otherwise let hiveutil pick the default.