### PR TITLE
bundle-gen.py: Set the url of the origin remote unconditionally

### DIFF
--- a/hack/bundle-gen.py
+++ b/hack/bundle-gen.py
@@ -410,6 +410,13 @@ def open_pr(
     os.chdir(repo_full_path)
 
     repo = git.Repo(repo_full_path)
+
+    try:
+        repo.remotes.origin.set_url(fork_repo)
+    except:
+        print("Failed to set origin remote")
+        raise
+
     try:
         repo.create_remote("upstream", upstream_repo)
     except:


### PR DESCRIPTION
When opening PRs, bundle-gen will re-use one of the repositories cloned earlier to save a clone.  However, the origin of this repository points to the upstream reposistory instead of the fork repository.

/cc @lleshchi @2uasimojo 
/assign @lleshchi 