### PR TITLE
Allow labels with empty value to carry over

### DIFF
--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -587,7 +587,7 @@ func (r *ReconcileMachinePool) syncMachineSets(
 					rMS.Spec.Template.Spec.Labels = make(map[string]string)
 				}
 				for key, value := range ms.Spec.Template.Spec.Labels {
-					if rMS.Spec.Template.Spec.Labels[key] != value {
+					if val, ok := rMS.Spec.Template.Spec.Labels[key]; !ok || val != value {
 						rMS.Spec.Template.Spec.Labels[key] = value
 						objectModified = true
 					}

--- a/pkg/controller/machinepool/machinepool_controller_test.go
+++ b/pkg/controller/machinepool/machinepool_controller_test.go
@@ -321,7 +321,16 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 		{
 			name:              "Copy over labels and taints from MachinePool, label map nil on remote MachineSet",
 			clusterDeployment: testClusterDeployment(),
-			machinePool:       testMachinePool(),
+			machinePool: func() *hivev1.MachinePool {
+				mp := testMachinePool()
+				mp.Spec.Labels["test-label-2"] = ""
+				mp.Spec.Labels["test-label-1"] = "test-value-1"
+				mp.Spec.Taints = append(mp.Spec.Taints, corev1.Taint{
+					Key:   "test-taint",
+					Value: "test-value",
+				})
+				return mp
+			}(),
 			remoteExisting: []runtime.Object{
 				testMachine("master1", "master"),
 				func() *machineapi.MachineSet {
@@ -367,6 +376,12 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 			expectedRemoteMachineSets: []*machineapi.MachineSet{
 				func() *machineapi.MachineSet {
 					ms := testMachineSet("foo-12345-worker-us-east-1a", "worker", false, 1, 1)
+					ms.Spec.Template.Spec.ObjectMeta.Labels["test-label-1"] = "test-value-1"
+					ms.Spec.Template.Spec.ObjectMeta.Labels["test-label-2"] = ""
+					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
+						Key:   "test-taint",
+						Value: "test-value",
+					})
 					return ms
 				}(),
 			},


### PR DESCRIPTION
Current implementation didn't account for labels that could have empty string as a value. Allow for such labels from MachinePool and remote MachineSet to be carried over to the generated MachineSet.

xref: https://issues.redhat.com/browse/HIVE-2268

/assign @abutcher 