### PR TITLE
bundle-gen: Fix channel discovery for get_previous_version

### DIFF
--- a/hack/bundle-gen.py
+++ b/hack/bundle-gen.py
@@ -165,8 +165,8 @@ def get_previous_version(work_dir, channel_name):
             try:
                 with open(annotation_yaml_path, "r") as stream:
                     annotation_yaml = yaml.load(stream, Loader=yaml.SafeLoader)
-                    version_channel = annotation_yaml["annotations"]["operators.operatorframework.io.bundle.channel.default.v1"]
-                    if version_channel == channel_name:
+                    version_channels = annotation_yaml["annotations"]["operators.operatorframework.io.bundle.channels.v1"]
+                    if channel_name in version_channels.split(","):
                         if semver.compare(version, highest_version) > 0:
                             highest_version = version
             except (NotADirectoryError, FileNotFoundError):


### PR DESCRIPTION
We were using the wrong annotation to discover the channel of a given bundle. This resulted in `replaces` pointing to an incorrect version, and the bundles wouldn't pass CI. Fix.

[HIVE-1658](https://issues.redhat.com//browse/HIVE-1658)