### PR TITLE
MachinePool/GCP: support image override annotation

### DIFF
--- a/apis/hive/v1/machinepool_types.go
+++ b/apis/hive/v1/machinepool_types.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// MachinePoolImageIDOverrideAnnotation can be applied to MachinePools to control the precise image ID to be used
-	// for the MachineSets we reconcile for this pool. This feature is presently only implemented for AWS, and
+	// for the MachineSets we reconcile for this pool. This feature is presently only implemented for AWS and GCP, and
 	// is intended for very limited use cases we do not recommend pursuing regularly. As such it is not currently
 	// part of our official API.
 	MachinePoolImageIDOverrideAnnotation = "hive.openshift.io/image-id-override"

--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -1039,7 +1039,7 @@ func (r *ReconcileMachinePool) createActuator(
 		if err != nil {
 			return nil, err
 		}
-		return NewGCPActuator(r.Client, creds, clusterVersion, masterMachine, remoteMachineSets, r.scheme, r.expectations, logger)
+		return NewGCPActuator(r.Client, creds, pool, clusterVersion, masterMachine, remoteMachineSets, r.scheme, r.expectations, logger)
 	case cd.Spec.Platform.Azure != nil:
 		creds := &corev1.Secret{}
 		if err := r.Get(

--- a/vendor/github.com/openshift/hive/apis/hive/v1/machinepool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/machinepool_types.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// MachinePoolImageIDOverrideAnnotation can be applied to MachinePools to control the precise image ID to be used
-	// for the MachineSets we reconcile for this pool. This feature is presently only implemented for AWS, and
+	// for the MachineSets we reconcile for this pool. This feature is presently only implemented for AWS and GCP, and
 	// is intended for very limited use cases we do not recommend pursuing regularly. As such it is not currently
 	// part of our official API.
 	MachinePoolImageIDOverrideAnnotation = "hive.openshift.io/image-id-override"


### PR DESCRIPTION
Add support for overriding the VM image used for GCP MachinePools via the `hive.openshift.io/image-id-override` annotation, which was previously only available for AWS.

This is (still) not part of the official API.

[HIVE-2275](https://issues.redhat.com//browse/HIVE-2275)