### PR TITLE
MachinePool: Properly handle labels & taints

### DIFF
--- a/apis/hive/v1/machinepool_types.go
+++ b/apis/hive/v1/machinepool_types.go
@@ -100,6 +100,26 @@ type MachinePoolStatus struct {
 	// Conditions includes more detailed status for the cluster deployment
 	// +optional
 	Conditions []MachinePoolCondition `json:"conditions,omitempty"`
+
+	// OwnedLabels lists the keys of labels this MachinePool created on the remote MachineSet.
+	// Used to identify labels to remove from the remote MachineSet when they are absent from
+	// the MachinePool's spec.labels.
+	// +optional
+	OwnedLabels []string `json:"ownedLabels,omitempty"`
+	// OwnedTaints lists identifiers of taints this MachinePool created on the remote MachineSet.
+	// Used to identify taints to remove from the remote MachineSet when they are absent from
+	// the MachinePool's spec.taints.
+	// +optional
+	OwnedTaints []TaintIdentifier `json:"ownedTaints,omitempty"`
+}
+
+// TaintIdentifier uniquely identifies a Taint. (It turns out taints are mutually exclusive by
+// key+effect, not simply by key.)
+type TaintIdentifier struct {
+	// Key matches corev1.Taint.Key.
+	Key string `json:"key:omitempty"`
+	// Effect matches corev1.Taint.Effect.
+	Effect corev1.TaintEffect `json:"effect:omitempty"`
 }
 
 // MachineSetStatus is the status of a machineset in the remote cluster.

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -632,6 +632,35 @@ spec:
                   - replicas
                   type: object
                 type: array
+              ownedLabels:
+                description: OwnedLabels lists the keys of labels this MachinePool
+                  created on the remote MachineSet. Used to identify labels to remove
+                  from the remote MachineSet when they are absent from the MachinePool's
+                  spec.labels.
+                items:
+                  type: string
+                type: array
+              ownedTaints:
+                description: OwnedTaints lists identifiers of taints this MachinePool
+                  created on the remote MachineSet. Used to identify taints to remove
+                  from the remote MachineSet when they are absent from the MachinePool's
+                  spec.taints.
+                items:
+                  description: TaintIdentifier uniquely identifies a Taint. (It turns
+                    out taints are mutually exclusive by key+effect, not simply by
+                    key.)
+                  properties:
+                    effect:omitempty:
+                      description: Effect matches corev1.Taint.Effect.
+                      type: string
+                    key:omitempty:
+                      description: Key matches corev1.Taint.Key.
+                      type: string
+                  required:
+                  - effect:omitempty
+                  - key:omitempty
+                  type: object
+                type: array
               replicas:
                 description: Replicas is the current number of replicas for the machine
                   pool.

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -5410,6 +5410,35 @@ objects:
                     - replicas
                     type: object
                   type: array
+                ownedLabels:
+                  description: OwnedLabels lists the keys of labels this MachinePool
+                    created on the remote MachineSet. Used to identify labels to remove
+                    from the remote MachineSet when they are absent from the MachinePool's
+                    spec.labels.
+                  items:
+                    type: string
+                  type: array
+                ownedTaints:
+                  description: OwnedTaints lists identifiers of taints this MachinePool
+                    created on the remote MachineSet. Used to identify taints to remove
+                    from the remote MachineSet when they are absent from the MachinePool's
+                    spec.taints.
+                  items:
+                    description: TaintIdentifier uniquely identifies a Taint. (It
+                      turns out taints are mutually exclusive by key+effect, not simply
+                      by key.)
+                    properties:
+                      effect:omitempty:
+                        description: Effect matches corev1.Taint.Effect.
+                        type: string
+                      key:omitempty:
+                        description: Key matches corev1.Taint.Key.
+                        type: string
+                    required:
+                    - effect:omitempty
+                    - key:omitempty
+                    type: object
+                  type: array
                 replicas:
                   description: Replicas is the current number of replicas for the
                     machine pool.

--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -19,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/pointer"
@@ -558,6 +560,17 @@ func (r *ReconcileMachinePool) syncMachineSets(
 	machineSetsToCreate := []*machineapi.MachineSet{}
 	machineSetsToUpdate := []*machineapi.MachineSet{}
 
+	labelsToDelete := sets.Set[string]{}
+	labelsToDelete.Insert(pool.Status.OwnedLabels...)
+	for labelKey := range pool.Spec.Labels {
+		labelsToDelete.Delete(labelKey)
+	}
+	taintsToDelete := sets.Set[hivev1.TaintIdentifier]{}
+	taintsToDelete.Insert(pool.Status.OwnedTaints...)
+	for _, taint := range pool.Spec.Taints {
+		taintsToDelete.Delete(identifierForTaint(&taint))
+	}
+
 	// Find MachineSets that need updating/creating
 	for i, ms := range generatedMachineSets {
 		found := false
@@ -606,6 +619,13 @@ func (r *ReconcileMachinePool) syncMachineSets(
 				if rMS.Spec.Template.Spec.Labels == nil {
 					rMS.Spec.Template.Spec.Labels = make(map[string]string)
 				}
+				for key := range rMS.Spec.Template.Spec.Labels {
+					if labelsToDelete.Has(key) {
+						// Safe to delete while iterating as long as we're deleting the key for this iteration.
+						delete(rMS.Spec.Template.Spec.Labels, key)
+						objectMetaModified = true
+					}
+				}
 				for key, value := range ms.Spec.Template.Spec.Labels {
 					if val, ok := rMS.Spec.Template.Spec.Labels[key]; !ok || val != value {
 						rMS.Spec.Template.Spec.Labels[key] = value
@@ -618,25 +638,51 @@ func (r *ReconcileMachinePool) syncMachineSets(
 					rMS.Spec.Template.Spec.Taints = []corev1.Taint{}
 				}
 				// Make a temporary map of generated MachineSet's taints for easy lookup
-				gTaintsByKey := make(map[string]*corev1.Taint)
+				gTaintsByID := make(map[hivev1.TaintIdentifier]*corev1.Taint)
 				for gIndex, gTaint := range ms.Spec.Template.Spec.Taints {
-					gTaintsByKey[gTaint.Key] = &ms.Spec.Template.Spec.Taints[gIndex]
+					gTaintsByID[identifierForTaint(&gTaint)] = &ms.Spec.Template.Spec.Taints[gIndex]
 				}
-				// Go through the remote MachineSet's taints, replacing overlaps with the generated MachineSet
-				for rIndex, rTaint := range rMS.Spec.Template.Spec.Taints {
-					if gTaint, foundTaint := gTaintsByKey[rTaint.Key]; foundTaint {
-						if gTaint.Value != rTaint.Value || gTaint.Effect != rTaint.Effect {
-							rMS.Spec.Template.Spec.Taints[rIndex] = *gTaint
-							objectModified = true
-						}
-						delete(gTaintsByKey, rTaint.Key)
+				// Build the list of taints for the remote MachineSet from scratch
+				taints := make([]corev1.Taint, 0)
+				// Go through the remote MachineSet's taints, adding/replacing matches from the generated MachineSet
+				for _, rTaint := range rMS.Spec.Template.Spec.Taints {
+					tid := identifierForTaint(&rTaint)
+
+					// If we need to "delete" this one, skip it, but mark modified
+					if taintsToDelete.Has(tid) {
+						objectModified = true
+						continue
 					}
+
+					if gTaint, foundTaint := gTaintsByID[tid]; foundTaint && gTaint.Value != rTaint.Value {
+						// Existing taint is modified
+						rTaint = *gTaint
+						objectModified = true
+					}
+
+					// If we get here, one of the following is true:
+					// - The taint was in the generated MachineSet. Whether it was modified or not, it must be included.
+					// - The taint was in the remote MachineSet but not the generated one. However, it wasn't in our
+					//   "owned" list, i.e. it is "remote only". Preserve it.
+					taints = append(taints, rTaint)
+					// We'll want to include any "extras" from the generated MachineSet
+					delete(gTaintsByID, tid)
 				}
-				// Any remaining taints from the temporary map are new and need to be added
-				for _, gTaint := range gTaintsByKey {
-					rMS.Spec.Template.Spec.Taints = append(rMS.Spec.Template.Spec.Taints, *gTaint)
-					objectModified = true
+				// Anything remaining from the generated MachineSet is new
+				for _, taint := range gTaintsByID {
+					taints = append(taints, *taint)
 				}
+				sort.SliceStable(taints, func(i, j int) bool {
+					if taints[i].Key != taints[j].Key {
+						return taints[i].Key < taints[j].Key
+					}
+					if taints[i].Effect != taints[j].Effect {
+						return taints[i].Effect < taints[j].Effect
+					}
+					// We should never get here, as taints with the same key+effect should be replaced
+					return taints[i].Value < taints[j].Value
+				})
+				rMS.Spec.Template.Spec.Taints = taints
 
 				// Platform updates will be blocked by webhook, unless they're not.
 				if !reflect.DeepEqual(rMS.Spec.Template.Spec.ProviderSpec.Value, ms.Spec.Template.Spec.ProviderSpec.Value) {
@@ -940,6 +986,27 @@ func (r *ReconcileMachinePool) updatePoolStatusForMachineSets(
 			break
 		}
 	}
+
+	// Update our tracked labels...
+	pool.Status.OwnedLabels = make([]string, len(pool.Spec.Labels))
+	i := 0
+	for labelKey := range pool.Spec.Labels {
+		pool.Status.OwnedLabels[i] = labelKey
+		i++
+	}
+	sort.Strings(pool.Status.OwnedLabels)
+
+	// ...and taints
+	pool.Status.OwnedTaints = make([]hivev1.TaintIdentifier, len(pool.Spec.Taints))
+	for i, taint := range pool.Spec.Taints {
+		pool.Status.OwnedTaints[i] = identifierForTaint(&taint)
+	}
+	sort.SliceStable(pool.Status.OwnedTaints, func(i, j int) bool {
+		if pool.Status.OwnedTaints[i].Key != pool.Status.OwnedTaints[j].Key {
+			return pool.Status.OwnedTaints[i].Key < pool.Status.OwnedTaints[j].Key
+		}
+		return pool.Status.OwnedTaints[i].Effect < pool.Status.OwnedTaints[j].Effect
+	})
 
 	if (len(origPool.Status.MachineSets) == 0 && len(pool.Status.MachineSets) == 0) ||
 		reflect.DeepEqual(origPool.Status, pool.Status) {
@@ -1285,4 +1352,12 @@ func IsErrorUpdateEvent(evt event.UpdateEvent) bool {
 	}
 
 	return false
+}
+
+func identifierForTaint(taint *corev1.Taint) hivev1.TaintIdentifier {
+	// Let a nil `taint` panic
+	return hivev1.TaintIdentifier{
+		Key:    taint.Key,
+		Effect: taint.Effect,
+	}
 }

--- a/vendor/github.com/openshift/hive/apis/hive/v1/machinepool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/machinepool_types.go
@@ -100,6 +100,26 @@ type MachinePoolStatus struct {
 	// Conditions includes more detailed status for the cluster deployment
 	// +optional
 	Conditions []MachinePoolCondition `json:"conditions,omitempty"`
+
+	// OwnedLabels lists the keys of labels this MachinePool created on the remote MachineSet.
+	// Used to identify labels to remove from the remote MachineSet when they are absent from
+	// the MachinePool's spec.labels.
+	// +optional
+	OwnedLabels []string `json:"ownedLabels,omitempty"`
+	// OwnedTaints lists identifiers of taints this MachinePool created on the remote MachineSet.
+	// Used to identify taints to remove from the remote MachineSet when they are absent from
+	// the MachinePool's spec.taints.
+	// +optional
+	OwnedTaints []TaintIdentifier `json:"ownedTaints,omitempty"`
+}
+
+// TaintIdentifier uniquely identifies a Taint. (It turns out taints are mutually exclusive by
+// key+effect, not simply by key.)
+type TaintIdentifier struct {
+	// Key matches corev1.Taint.Key.
+	Key string `json:"key:omitempty"`
+	// Effect matches corev1.Taint.Effect.
+	Effect corev1.TaintEffect `json:"effect:omitempty"`
 }
 
 // MachineSetStatus is the status of a machineset in the remote cluster.


### PR DESCRIPTION
With this commit, MachinePool grows two new statusfields: `OwnedLabels` and `OwnedTaints`. These keep track of the labels and taints that were added to the remote MachineSets at the behest of this MachinePool. Conversely, this allows us to identify which ones were added on the remote side, and thus shouldn't be touched by our controller.

We also fix the logic for matching taints, which are "keyed" by the combination of the `Key` and `Effect` fields.

To summarize the behavior with this commit in play:
- Labels and taints listed in MachinePool.Spec are synced to the remote MachineSets.
- Labels and taints that are *not* in MachinePool.Spec are removed from the remote MachineSets *iff* they are present in
MachinePool.Status.Owned{Labels|Taints}.
- Upon successful syncing, we update MachinePool.Status.Owned{Labels|Taints} to match the spec.

The effect is that editing MachinePool.Spec to remove a label or taint should cause that label/taint to be removed from the remote MachineSets, BUT labels/taints that only exist on the remote MachineSets remain untouched.

[HIVE-2035](https://issues.redhat.com//browse/HIVE-2035)
[HIVE-2276](https://issues.redhat.com//browse/HIVE-2276)
[HIVE-2279](https://issues.redhat.com//browse/HIVE-2279)
[HIVE-2268](https://issues.redhat.com//browse/HIVE-2268)