### PR TITLE
e2e (AWS): Allow env var to override creds file

### DIFF
--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -210,7 +210,7 @@ POOL_SIZE=1
 go run "${SRC_ROOT}/contrib/cmd/hiveutil/main.go" clusterpool create-pool \
   -n "${CLUSTER_NAMESPACE}" \
   --cloud="${CLOUD}" \
-	--creds-file="${CREDS_FILE}" \
+	${CREDS_FILE_ARG} \
 	--pull-secret-file="${PULL_SECRET_FILE}" \
   --image-set "${IMAGESET_NAME}" \
   --region us-east-1 \

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -93,7 +93,7 @@ export CLUSTER_NAME="${CLUSTER_NAME:-hive-$(uuidgen | tr '[:upper:]' '[:lower:]'
 echo "Creating cluster deployment"
 go run "${SRC_ROOT}/contrib/cmd/hiveutil/main.go" create-cluster "${CLUSTER_NAME}" \
 	--cloud="${CLOUD}" \
-	--creds-file="${CREDS_FILE}" \
+	${CREDS_FILE_ARG} \
 	--ssh-public-key-file="${SSH_PUBLIC_KEY_FILE}" \
 	--pull-secret-file="${PULL_SECRET_FILE}" \
 	--base-domain="${CLUSTER_DOMAIN}" \


### PR DESCRIPTION
Resolve a long-standing TODO which allows AWS environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to be used when present, even if a credentials file exists, as the gods intended.

hiveutil already uses the appropriate logic such that, if a creds file is not supplied, it looks for the env vars. We just needed to fix it so we don't pass that arg in at all if the env vars are set.

(This was an incidental requirement of [HIVE-2234](https://issues.redhat.com//browse/HIVE-2234): the AWS credentials from the hypershift installation were taking precedence for managed DNS, which then bounced because the expected hosted zone is in a different account.)