### PR TITLE
e2e (AWS): Allow region override

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -187,7 +187,13 @@ case "${CLOUD}" in
   fi
 	BASE_DOMAIN="${BASE_DOMAIN:-hive-ci.openshift.com}"
 	EXTRA_CREATE_CLUSTER_ARGS="--aws-user-tags expirationDate=$(date -d '4 hours' --iso=minutes --utc)"
-	REGION_ARG="--region us-east-2"
+  if [ "$REGION" ]; then
+    REGION_ARG="--region $REGION"
+  else
+    # Default to us-east-2 for testing, because us-east-1 doesn't have all instance types in all AZs
+    # and this makes our autoscaling tests fail.
+    REGION_ARG="--region us-east-2"
+  fi
 	;;
 "azure")
 	CREDS_FILE_ARG="--creds-file=${CLUSTER_PROFILE_DIR}/osServicePrincipal.json"

--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -210,6 +210,7 @@ POOL_SIZE=1
 go run "${SRC_ROOT}/contrib/cmd/hiveutil/main.go" clusterpool create-pool \
   -n "${CLUSTER_NAMESPACE}" \
   --cloud="${CLOUD}" \
+  ${REGION_ARG} \
 	${CREDS_FILE_ARG} \
 	--pull-secret-file="${PULL_SECRET_FILE}" \
   --image-set "${IMAGESET_NAME}" \


### PR DESCRIPTION
- Allow the `REGION` environment variable to override the default region (`us-east-2`) used for the AWS path in e2e.
- Add the region arg to the clusterpool path in e2e-pool. This used to default to `us-east-1` when omitted. Now it will default to `us-east-2` via the same code path as above; but it can also be overridden by the `REGION` env var.