### PR TITLE
Consolidate and bump default AWS instance type (m6i.xlarge)

### DIFF
--- a/contrib/pkg/clusterpool/clusterpool.go
+++ b/contrib/pkg/clusterpool/clusterpool.go
@@ -271,6 +271,16 @@ func (o *ClusterPoolOptions) generateObjects() ([]runtime.Object, error) {
 		BaseDomain: o.BaseDomain,
 	}
 
+	var awsBuilder *clusterresource.AWSCloudBuilder
+	if o.Cloud == cloudAWS {
+		awsBuilder = &clusterresource.AWSCloudBuilder{
+			Region: o.Region,
+			// TODO: CLI option for this
+			InstanceType: clusterresource.AWSInstanceTypeDefault,
+		}
+		builder.CloudBuilder = awsBuilder
+	}
+
 	if o.createCloudSecret {
 		switch o.Cloud {
 		case cloudAWS:
@@ -280,11 +290,9 @@ func (o *ClusterPoolOptions) generateObjects() ([]runtime.Object, error) {
 				o.log.WithError(err).Error("Failed to get AWS credentials")
 				return nil, err
 			}
-			builder.CloudBuilder = &clusterresource.AWSCloudBuilder{
-				AccessKeyID:     accessKeyID,
-				SecretAccessKey: secretAccessKey,
-				Region:          o.Region,
-			}
+			// Update AWS cloud builder with creds
+			awsBuilder.AccessKeyID = accessKeyID
+			awsBuilder.SecretAccessKey = secretAccessKey
 		case cloudAzure:
 			creds, err := azureutils.GetCreds(o.CredsFile)
 			if err != nil {

--- a/contrib/pkg/createcluster/create.go
+++ b/contrib/pkg/createcluster/create.go
@@ -174,8 +174,9 @@ type Options struct {
 	FeatureSet                        string
 
 	// AWS
-	AWSUserTags    []string
-	AWSPrivateLink bool
+	AWSUserTags     []string
+	AWSPrivateLink  bool
+	AWSInstanceType string
 
 	// Azure
 	AzureBaseDomainResourceGroupName string
@@ -330,6 +331,7 @@ OpenShift Installer publishes all the services of the cluster like API server an
 	// AWS flags
 	flags.StringSliceVar(&opt.AWSUserTags, "aws-user-tags", nil, "Additional tags to add to resources. Must be in the form \"key=value\"")
 	flags.BoolVar(&opt.AWSPrivateLink, "aws-private-link", false, "Enables access to cluster using AWS PrivateLink")
+	flags.StringVar(&opt.AWSInstanceType, "aws-instance-type", clusterresource.AWSInstanceTypeDefault, "AWS cloud instance type")
 
 	// Azure flags
 	flags.StringVar(&opt.AzureBaseDomainResourceGroupName, "azure-base-domain-resource-group-name", "os4-common", "Resource group where the azure DNS zone for the base domain is found")
@@ -660,6 +662,7 @@ func (o *Options) GenerateObjects() ([]runtime.Object, error) {
 			SecretAccessKey: secretAccessKey,
 			UserTags:        userTags,
 			Region:          o.Region,
+			InstanceType:    o.AWSInstanceType,
 			PrivateLink:     o.AWSPrivateLink,
 		}
 		builder.CloudBuilder = awsProvider

--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -194,6 +194,10 @@ case "${CLOUD}" in
     # and this makes our autoscaling tests fail.
     REGION_ARG="--region us-east-2"
   fi
+  if [ "$AWS_INSTANCE_TYPE" ]; then
+    # NOTE: Only observed by hiveutil create-cluster, not clusterpool at this time.
+    INSTANCE_TYPE_ARG="--aws-instance-type $AWS_INSTANCE_TYPE"
+  fi
 	;;
 "azure")
 	CREDS_FILE_ARG="--creds-file=${CLUSTER_PROFILE_DIR}/osServicePrincipal.json"

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -101,6 +101,7 @@ go run "${SRC_ROOT}/contrib/cmd/hiveutil/main.go" create-cluster "${CLUSTER_NAME
 	--install-once=true \
 	--uninstall-once=true \
 	${REGION_ARG} \
+	${INSTANCE_TYPE_ARG} \
 	${MANAGED_DNS_ARG} \
 	${EXTRA_CREATE_CLUSTER_ARGS}
 

--- a/pkg/clusterresource/aws.go
+++ b/pkg/clusterresource/aws.go
@@ -16,9 +16,9 @@ import (
 )
 
 const (
-	awsInstanceType = "m5.xlarge"
-	volumeSize      = 120
-	volumeType      = "gp3"
+	AWSInstanceTypeDefault = "m6i.xlarge"
+	volumeSize             = 120
+	volumeType             = "gp3"
 )
 
 var _ CloudBuilder = (*AWSCloudBuilder)(nil)
@@ -36,6 +36,8 @@ type AWSCloudBuilder struct {
 	UserTags map[string]string
 	// Region is the AWS region to which to install the cluster
 	Region string
+
+	InstanceType string
 
 	PrivateLink bool
 }
@@ -96,7 +98,7 @@ func (p *AWSCloudBuilder) GenerateCloudObjects(o *Builder) []runtime.Object {
 
 func (p *AWSCloudBuilder) addMachinePoolPlatform(o *Builder, mp *hivev1.MachinePool) {
 	mp.Spec.Platform.AWS = &hivev1aws.MachinePoolPlatform{
-		InstanceType: awsInstanceType,
+		InstanceType: p.InstanceType,
 		EC2RootVolume: hivev1aws.EC2RootVolume{
 			Size: volumeSize,
 			Type: volumeType,
@@ -115,7 +117,7 @@ func (p *AWSCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installertype
 
 	// Used for both control plane and workers.
 	mpp := &awsinstallertypes.MachinePool{
-		InstanceType: awsInstanceType,
+		InstanceType: p.InstanceType,
 		EC2RootVolume: awsinstallertypes.EC2RootVolume{
 			Size: volumeSize,
 			Type: volumeType,

--- a/pkg/clusterresource/builder_test.go
+++ b/pkg/clusterresource/builder_test.go
@@ -108,6 +108,7 @@ func createAWSClusterBuilder() *Builder {
 	b.CloudBuilder = &AWSCloudBuilder{
 		AccessKeyID:     fakeAWSAccessKeyID,
 		SecretAccessKey: fakeAWSSecretAccessKey,
+		InstanceType:    AWSInstanceTypeDefault,
 	}
 	return b
 }
@@ -174,7 +175,7 @@ func TestBuildClusterResources(t *testing.T) {
 				require.NotNil(t, credsSecret)
 				assert.Equal(t, credsSecret.Name, cd.Spec.Platform.AWS.CredentialsSecretRef.Name)
 
-				assert.Equal(t, awsInstanceType, workerPool.Spec.Platform.AWS.InstanceType)
+				assert.Equal(t, AWSInstanceTypeDefault, workerPool.Spec.Platform.AWS.InstanceType)
 			},
 		},
 		{

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -1229,6 +1229,8 @@ func (r *ReconcileClusterPool) createCloudBuilder(pool *hivev1.ClusterPool, logg
 		}
 
 		cloudBuilder.Region = platform.AWS.Region
+		// TODO: Plumb in an option for this
+		cloudBuilder.InstanceType = clusterresource.AWSInstanceTypeDefault
 		return cloudBuilder, nil
 	case platform.GCP != nil:
 		credsSecret, err := r.getCredentialsSecret(pool, platform.GCP.CredentialsSecretRef.Name, logger)

--- a/test/e2e/postinstall/machinesets/infra_test.go
+++ b/test/e2e/postinstall/machinesets/infra_test.go
@@ -26,6 +26,7 @@ import (
 	hivev1aws "github.com/openshift/hive/apis/hive/v1/aws"
 	hivev1azure "github.com/openshift/hive/apis/hive/v1/azure"
 	hivev1gcp "github.com/openshift/hive/apis/hive/v1/gcp"
+	"github.com/openshift/hive/pkg/clusterresource"
 	"github.com/openshift/hive/test/e2e/common"
 )
 
@@ -122,7 +123,7 @@ func TestNewMachinePool(t *testing.T) {
 	case p.AWS != nil:
 		infraMachinePool.Spec.Platform = hivev1.MachinePoolPlatform{
 			AWS: &hivev1aws.MachinePoolPlatform{
-				InstanceType: "m4.large",
+				InstanceType: clusterresource.AWSInstanceTypeDefault,
 				EC2RootVolume: hivev1aws.EC2RootVolume{
 					IOPS: 100,
 					Size: 22,
@@ -295,9 +296,9 @@ func TestAutoscalingMachinePool(t *testing.T) {
 
 	// busyboxDeployment creates a large number of pods to place CPU pressure
 	// on the machine pool. With 100 replicas and a CPU request for each pod of
-	// 1, the total CPU request from the deployment is 100. For AWS using m4.xlarge,
-	// each machine has a CPU limit of 4. For the max replicas of 12, the total
-	// CPU limit is 48.
+	// 1, the total CPU request from the deployment is 100. For AWS using m6i.xlarge,
+	// each machine has a CPU limit of 6. For the max replicas of 12, the total
+	// CPU limit is 72.
 	busyboxDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",


### PR DESCRIPTION
This commit cleans up how we handle instance types in hiveutil and e2e CI.
- `hiveutil create-cluster` now accepts an `--aws-instance-type` option.
- The default instance type is now `m6i.xlarge`. It was previously `m5.xlarge` for hiveutil and `m4.large` for the MachinePool scaling tests in our e2e CI.
- This default now lives in one place, so it's easier to change later without missing things.
- To allow easier noodling via CI rehearsals, `e2e` will feed a new `$AWS_INSTANCE_TYPE` environment variable through to the new `--aws-instance-type` param for `create-cluster`.

[HIVE-2235](https://issues.redhat.com//browse/HIVE-2235)