### PR TITLE
Fix hiveutil awsprivatelink bug caused by unknown user

### DIFF
--- a/contrib/pkg/awsprivatelink/enable.go
+++ b/contrib/pkg/awsprivatelink/enable.go
@@ -75,9 +75,10 @@ func (o *enableOptions) Complete(cmd *cobra.Command, args []string) error {
 	o.homeDir = "."
 	u, err := user.Current()
 	if err != nil {
-		log.WithError(err).Fatal("Failed to get the current user")
+		log.WithError(err).Warn("Failed to get the current user, is hiveutil running in Openshift ?")
+	} else {
+		o.homeDir = u.HomeDir
 	}
-	o.homeDir = u.HomeDir
 
 	// Get AWS clients
 	o.region, o.infraId, err = o.getRegionAndInfraId()


### PR DESCRIPTION
user.Current() errors out when the binary runs as an unknown user (no entry in /etc/passwd), which is the case when running in Openshift. 

https://github.com/golang/go/issues/38599
