### PR TITLE
e2e (AWS): Default BASE_DOMAIN for new CI account

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -185,7 +185,7 @@ case "${CLOUD}" in
   if [ -s $CREDS_FILE ] && ! [ "${AWS_ACCESS_KEY_ID}" ] && ! [ "${AWS_SECRET_ACCESS_KEY}" ]; then
     CREDS_FILE_ARG="--creds-file=${CREDS_FILE}"
   fi
-	BASE_DOMAIN="${BASE_DOMAIN:-hive-ci.openshift.com}"
+	BASE_DOMAIN="${BASE_DOMAIN:-hive-ci.devcluster.openshift.com}"
 	EXTRA_CREATE_CLUSTER_ARGS="--aws-user-tags expirationDate=$(date -d '4 hours' --iso=minutes --utc)"
   if [ "$REGION" ]; then
     REGION_ARG="--region $REGION"


### PR DESCRIPTION
Our e2e suite for AWS was setting a default base domain that (AFAIK) we don't have control over, so we were overriding it in the test config. We've recently switched to a new AWS account for these tests. Change the default base domain accordingly so we don't need to override it in the test config.

[HIVE-2259](https://issues.redhat.com//browse/HIVE-2259)