### PR TITLE
Properly handle MachinePool Labels and Taints

### DIFF
--- a/apis/hive/v1/machinepool_types.go
+++ b/apis/hive/v1/machinepool_types.go
@@ -100,6 +100,26 @@ type MachinePoolStatus struct {
 	// Conditions includes more detailed status for the cluster deployment
 	// +optional
 	Conditions []MachinePoolCondition `json:"conditions,omitempty"`
+
+	// OwnedLabels lists the keys of labels this MachinePool created on the remote MachineSet.
+	// Used to identify labels to remove from the remote MachineSet when they are absent from
+	// the MachinePool's spec.labels.
+	// +optional
+	OwnedLabels []string `json:"ownedLabels,omitempty"`
+	// OwnedTaints lists identifiers of taints this MachinePool created on the remote MachineSet.
+	// Used to identify taints to remove from the remote MachineSet when they are absent from
+	// the MachinePool's spec.taints.
+	// +optional
+	OwnedTaints []TaintIdentifier `json:"ownedTaints,omitempty"`
+}
+
+// TaintIdentifier uniquely identifies a Taint. (It turns out taints are mutually exclusive by
+// key+effect, not simply by key.)
+type TaintIdentifier struct {
+	// Key matches corev1.Taint.Key.
+	Key string `json:"key:omitempty"`
+	// Effect matches corev1.Taint.Effect.
+	Effect corev1.TaintEffect `json:"effect:omitempty"`
 }
 
 // MachineSetStatus is the status of a machineset in the remote cluster.

--- a/apis/hive/v1/machinepool_types.go
+++ b/apis/hive/v1/machinepool_types.go
@@ -54,6 +54,9 @@ type MachinePoolSpec struct {
 
 	// List of taints that will be applied to the created MachineSet's MachineSpec.
 	// This list will overwrite any modifications made to Node taints on an ongoing basis.
+	// In case of duplicate entries, first encountered taint Value will be preserved,
+	// and the rest collapsed on the corresponding MachineSets.
+	// Note that taints are uniquely identified based on key+effect, not just key.
 	// +optional
 	Taints []corev1.Taint `json:"taints,omitempty"`
 }

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -632,6 +632,35 @@ spec:
                   - replicas
                   type: object
                 type: array
+              ownedLabels:
+                description: OwnedLabels lists the keys of labels this MachinePool
+                  created on the remote MachineSet. Used to identify labels to remove
+                  from the remote MachineSet when they are absent from the MachinePool's
+                  spec.labels.
+                items:
+                  type: string
+                type: array
+              ownedTaints:
+                description: OwnedTaints lists identifiers of taints this MachinePool
+                  created on the remote MachineSet. Used to identify taints to remove
+                  from the remote MachineSet when they are absent from the MachinePool's
+                  spec.taints.
+                items:
+                  description: TaintIdentifier uniquely identifies a Taint. (It turns
+                    out taints are mutually exclusive by key+effect, not simply by
+                    key.)
+                  properties:
+                    effect:omitempty:
+                      description: Effect matches corev1.Taint.Effect.
+                      type: string
+                    key:omitempty:
+                      description: Key matches corev1.Taint.Key.
+                      type: string
+                  required:
+                  - effect:omitempty
+                  - key:omitempty
+                  type: object
+                type: array
               replicas:
                 description: Replicas is the current number of replicas for the machine
                   pool.

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -515,7 +515,10 @@ spec:
               taints:
                 description: List of taints that will be applied to the created MachineSet's
                   MachineSpec. This list will overwrite any modifications made to
-                  Node taints on an ongoing basis.
+                  Node taints on an ongoing basis. In case of duplicate entries, first
+                  encountered taint Value will be preserved, and the rest collapsed
+                  on the corresponding MachineSets. Note that taints are uniquely
+                  identified based on key+effect, not just key.
                 items:
                   description: The node this Taint is attached to has the "effect"
                     on any pod that does not tolerate the Taint.

--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -703,7 +703,7 @@ openstack:
 
 A MachinePool for the worker machinesets is not required. If the user creates a MachinePool for the worker MachineSets, then Hive will manage the worker MachineSets.
 
-MachinePool reconciliation is limited to updating MachineSet replicas to match the replicas configured for the MachinePool. Additionally, any existing `Labels` or `Taints` on the MachineSets will be overridden if they clash with those on the MachinePool.
+MachinePool reconciliation is limited to updating MachineSet replicas to match the replicas configured for the MachinePool. Additionally, any existing `Labels` or `Taints` on the MachineSets will be overridden if they clash with those on the MachinePool. In case of duplicate taints, the taint encountered first will be preserved and the rest collapsed on the MachineSets.
 
 MachinePool platform is immutable and any changes made to `MachinePool.spec.platform` are blocked by a validating webhook. The Machine Config Operator does not support updating existing machines when platform details are changed in a MachineSet and consequently Hive does not support making such changes to MachinePool platform, see [HIVE-2024](https://issues.redhat.com/browse/HIVE-2024).
 

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -5291,7 +5291,10 @@ objects:
                 taints:
                   description: List of taints that will be applied to the created
                     MachineSet's MachineSpec. This list will overwrite any modifications
-                    made to Node taints on an ongoing basis.
+                    made to Node taints on an ongoing basis. In case of duplicate
+                    entries, first encountered taint Value will be preserved, and
+                    the rest collapsed on the corresponding MachineSets. Note that
+                    taints are uniquely identified based on key+effect, not just key.
                   items:
                     description: The node this Taint is attached to has the "effect"
                       on any pod that does not tolerate the Taint.

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -5410,6 +5410,35 @@ objects:
                     - replicas
                     type: object
                   type: array
+                ownedLabels:
+                  description: OwnedLabels lists the keys of labels this MachinePool
+                    created on the remote MachineSet. Used to identify labels to remove
+                    from the remote MachineSet when they are absent from the MachinePool's
+                    spec.labels.
+                  items:
+                    type: string
+                  type: array
+                ownedTaints:
+                  description: OwnedTaints lists identifiers of taints this MachinePool
+                    created on the remote MachineSet. Used to identify taints to remove
+                    from the remote MachineSet when they are absent from the MachinePool's
+                    spec.taints.
+                  items:
+                    description: TaintIdentifier uniquely identifies a Taint. (It
+                      turns out taints are mutually exclusive by key+effect, not simply
+                      by key.)
+                    properties:
+                      effect:omitempty:
+                        description: Effect matches corev1.Taint.Effect.
+                        type: string
+                      key:omitempty:
+                        description: Key matches corev1.Taint.Key.
+                        type: string
+                    required:
+                    - effect:omitempty
+                    - key:omitempty
+                    type: object
+                  type: array
                 replicas:
                   description: Replicas is the current number of replicas for the
                     machine pool.

--- a/pkg/controller/machinepool/machinepool_controller_test.go
+++ b/pkg/controller/machinepool/machinepool_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
@@ -279,8 +280,9 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 				mp := testMachinePool()
 				mp.Spec.Labels["test-label-2"] = "test-value-2"
 				mp.Spec.Taints = append(mp.Spec.Taints, corev1.Taint{
-					Key:   "test-taint-2",
-					Value: "test-value-2",
+					Key:    "test-taint-2",
+					Value:  "test-value-2",
+					Effect: "NoSchedule",
 				})
 				return mp
 			}(),
@@ -290,8 +292,9 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 					ms := testMachineSet("foo-12345-worker-us-east-1a", "worker", true, 1, 0)
 					ms.Spec.Template.Spec.Labels["test-label"] = "test-value"
 					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
-						Key:   "test-taint",
-						Value: "test-value",
+						Key:    "test-taint",
+						Value:  "test-value",
+						Effect: "NoSchedule",
 					})
 					return ms
 				}(),
@@ -305,12 +308,14 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 					ms.Spec.Template.Spec.Labels["test-label"] = "test-value"
 					ms.Spec.Template.Spec.Labels["test-label-2"] = "test-value-2"
 					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
-						Key:   "test-taint",
-						Value: "test-value",
+						Key:    "test-taint",
+						Value:  "test-value",
+						Effect: "NoSchedule",
 					})
 					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
-						Key:   "test-taint-2",
-						Value: "test-value-2",
+						Key:    "test-taint-2",
+						Value:  "test-value-2",
+						Effect: "NoSchedule",
 					})
 					return ms
 				}(),
@@ -321,18 +326,20 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 			clusterDeployment: testClusterDeployment(),
 			machinePool: func() *hivev1.MachinePool {
 				mp := testMachinePool()
+				// Allow empty string as value for labels
 				mp.Spec.Labels["test-label-2"] = ""
 				mp.Spec.Labels["test-label-1"] = "test-value-1"
 				mp.Spec.Taints = append(mp.Spec.Taints, corev1.Taint{
-					Key:   "test-taint",
-					Value: "test-value",
+					Key:    "test-taint",
+					Value:  "test-value",
+					Effect: "NoSchedule",
 				})
 				return mp
 			}(),
 			remoteExisting: []runtime.Object{
 				testMachine("master1", "master"),
 				func() *machineapi.MachineSet {
-					//ms := testMachineSet("foo-12345-worker-us-east-1a", "worker", true, 1, 0)
+					// remote MachineSet with empty Spec.Template.Spec.Labels
 					msReplicas := int32(1)
 					rawAWSProviderSpec, err := encodeAWSMachineProviderSpec(testAWSProviderSpec(), scheme.GetScheme())
 					if err != nil {
@@ -377,8 +384,122 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 					ms.Spec.Template.Spec.ObjectMeta.Labels["test-label-1"] = "test-value-1"
 					ms.Spec.Template.Spec.ObjectMeta.Labels["test-label-2"] = ""
 					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
-						Key:   "test-taint",
-						Value: "test-value",
+						Key:    "test-taint",
+						Value:  "test-value",
+						Effect: "NoSchedule",
+					})
+					return ms
+				}(),
+			},
+		},
+		{
+			name:              "Update all entries of taints (account for duplicate entries)",
+			clusterDeployment: testClusterDeployment(),
+			machinePool: func() *hivev1.MachinePool {
+				mp := testMachinePool()
+				mp.Spec.Taints = append(mp.Spec.Taints, corev1.Taint{
+					Key:    "test-taint",
+					Value:  "new-value",
+					Effect: "NoSchedule",
+				})
+				return mp
+			}(),
+			remoteExisting: []runtime.Object{
+				testMachine("master1", "master"),
+				func() *machineapi.MachineSet {
+					ms := testMachineSet("foo-12345-worker-us-east-1a", "worker", true, 1, 0)
+					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
+						Key:    "test-taint",
+						Value:  "test-value",
+						Effect: "NoSchedule",
+					})
+					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
+						Key:    "test-taint",
+						Value:  "test-value",
+						Effect: "NoSchedule",
+					})
+					return ms
+				}(),
+			},
+			generatedMachineSets: []*machineapi.MachineSet{
+				testMachineSet("foo-12345-worker-us-east-1a", "worker", false, 1, 0),
+			},
+			expectedRemoteMachineSets: []*machineapi.MachineSet{
+				func() *machineapi.MachineSet {
+					ms := testMachineSet("foo-12345-worker-us-east-1a", "worker", true, 1, 1)
+					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
+						Key:    "test-taint",
+						Value:  "new-value",
+						Effect: "NoSchedule",
+					})
+					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
+						Key:    "test-taint",
+						Value:  "new-value",
+						Effect: "NoSchedule",
+					})
+					return ms
+				}(),
+			},
+		},
+		{
+			name:              "Delete labels and taints if relevant entries in MachinePool Spec modified",
+			clusterDeployment: testClusterDeployment(),
+			machinePool: func() *hivev1.MachinePool {
+				mp := testMachinePool()
+				mp.Spec.Labels["test-label"] = "keep-me"
+				mp.Spec.Taints = append(mp.Spec.Taints, corev1.Taint{
+					Key:    "test-taint",
+					Value:  "keep-me",
+					Effect: "NoSchedule",
+				})
+				mp.Status.OwnedLabels = []string{"test-label-2"}
+				mp.Status.OwnedTaints = []hivev1.TaintIdentifier{
+					{Key: "test-taint-2", Effect: "NoSchedule"},
+				}
+				return mp
+			}(),
+			remoteExisting: []runtime.Object{
+				testMachine("master1", "master"),
+				func() *machineapi.MachineSet {
+					ms := testMachineSet("foo-12345-worker-us-east-1a", "worker", true, 1, 0)
+					ms.Spec.Template.Spec.Labels["test-label"] = "keep-me"
+					ms.Spec.Template.Spec.Labels["test-label-2"] = "remove-me"
+					ms.Spec.Template.Spec.Labels["test-label-3"] = "preserve-me"
+					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
+						Key:    "test-taint",
+						Value:  "keep-me",
+						Effect: "NoSchedule",
+					})
+					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
+						Key:    "test-taint-2",
+						Value:  "remove-me",
+						Effect: "NoSchedule",
+					})
+					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
+						Key:    "test-taint-3",
+						Value:  "preserve-me",
+						Effect: "NoSchedule",
+					})
+					return ms
+				}(),
+			},
+			generatedMachineSets: []*machineapi.MachineSet{
+				testMachineSet("foo-12345-worker-us-east-1a", "worker", false, 1, 0),
+			},
+			expectedRemoteMachineSets: []*machineapi.MachineSet{
+				func() *machineapi.MachineSet {
+					ms := testMachineSet("foo-12345-worker-us-east-1a", "worker", true, 1, 1)
+					ms.Spec.Template.Spec.Labels["test-label"] = "keep-me"
+					ms.Spec.Template.Spec.Labels["test-label-3"] = "preserve-me"
+					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
+						Key:    "test-taint",
+						Value:  "keep-me",
+						Effect: "NoSchedule",
+					})
+					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
+						Key:    "test-taint-3",
+						Value:  "preserve-me",
+						Effect: "NoSchedule",
 					})
 					return ms
 				}(),
@@ -392,8 +513,9 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 				mp.Spec.Labels["test-label-2"] = "test-value-2"
 				mp.Spec.Labels["test-label-1"] = "test-value-1"
 				mp.Spec.Taints = append(mp.Spec.Taints, corev1.Taint{
-					Key:   "test-taint",
-					Value: "test-value",
+					Key:    "test-taint",
+					Value:  "test-value",
+					Effect: "NoSchedule",
 				})
 				return mp
 			}(),
@@ -404,8 +526,9 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 					ms.Spec.Template.Spec.Labels["test-label-1"] = "test-value-1"
 					ms.Spec.Template.Spec.Labels["test-label-2"] = "test-value-2"
 					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
-						Key:   "test-taint",
-						Value: "test-value",
+						Key:    "test-taint",
+						Value:  "test-value",
+						Effect: "NoSchedule",
 					})
 					return ms
 				}(),
@@ -419,8 +542,9 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 					ms.Spec.Template.Spec.Labels["test-label-1"] = "test-value-1"
 					ms.Spec.Template.Spec.Labels["test-label-2"] = "test-value-2"
 					ms.Spec.Template.Spec.Taints = append(ms.Spec.Template.Spec.Taints, corev1.Taint{
-						Key:   "test-taint",
-						Value: "test-value",
+						Key:    "test-taint",
+						Value:  "test-value",
+						Effect: "NoSchedule",
 					})
 					return ms
 				}(),
@@ -1071,7 +1195,8 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 							if !reflect.DeepEqual(eMS.Spec.Template.Spec.Labels, rMS.Spec.Template.Spec.Labels) {
 								t.Errorf("machineset %v machinespec has unexpected labels:\nexpected: %v\nactual: %v", eMS.Name, eMS.Spec.Template.Spec.Labels, rMS.Spec.Template.Spec.Labels)
 							}
-							if !reflect.DeepEqual(eMS.Spec.Template.Spec.Taints, rMS.Spec.Template.Spec.Taints) {
+							// Taints are stored as a list, so sort them before comparing.
+							if !reflect.DeepEqual(sortedTaints(eMS.Spec.Template.Spec.Taints), sortedTaints(rMS.Spec.Template.Spec.Taints)) {
 								t.Errorf("machineset %v has unexpected taints:\nexpected: %v\nactual: %v", eMS.Name, eMS.Spec.Template.Spec.Taints, rMS.Spec.Template.Spec.Taints)
 							}
 
@@ -1112,6 +1237,20 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 			}
 		})
 	}
+}
+
+// sortedTaints sorts and returns the provided list of taints based on the ascending order of taint key, effect and value - in that order.
+func sortedTaints(taints []corev1.Taint) []corev1.Taint {
+	sort.SliceStable(taints, func(i, j int) bool {
+		if taints[i].Key != taints[j].Key {
+			return taints[i].Key < taints[j].Key
+		}
+		if taints[i].Effect != taints[j].Effect {
+			return taints[i].Effect < taints[j].Effect
+		}
+		return taints[i].Value < taints[j].Value
+	})
+	return taints
 }
 
 func Test_summarizeMachinesError(t *testing.T) {

--- a/pkg/controller/utils/taints.go
+++ b/pkg/controller/utils/taints.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func IdentifierForTaint(taint *corev1.Taint) hivev1.TaintIdentifier {
+	// Let a nil `taint` panic
+	return hivev1.TaintIdentifier{
+		Key:    taint.Key,
+		Effect: taint.Effect,
+	}
+}
+
+// GetUniqueTaints collapses the duplicates from the list of taints provided before returning them.
+// Key+Effect are unique identifiers, and the first Value of the taint entry encountered will be preserved.
+func GetUniqueTaints(taints *[]corev1.Taint) *[]corev1.Taint {
+	// uniqueTaints would be a map of key + effect to taint
+	uniqueTaints := make(map[hivev1.TaintIdentifier]corev1.Taint)
+	for _, taint := range *taints {
+		// If value is already present (we have encountered a duplicate), skip.
+		// This means that when we encounter duplicates, the value of the first entry encountered will be preserved.
+		if !TaintExists(uniqueTaints, &taint) {
+			uniqueTaints[IdentifierForTaint(&taint)] = taint
+		}
+	}
+	return ListFromTaintMap(&uniqueTaints)
+}
+
+// ListFromTaintMap simply compiles a list of taints from the corresponding map
+func ListFromTaintMap(taintMap *map[hivev1.TaintIdentifier]corev1.Taint) *[]corev1.Taint {
+	returnTaints := make([]corev1.Taint, 0, len(*taintMap))
+	for _, taint := range *taintMap {
+		returnTaints = append(returnTaints, taint)
+	}
+	return &returnTaints
+}
+
+// TaintExists checks if the TaintIdentifier for given taint is present in the provided taintMap
+func TaintExists(taintMap map[hivev1.TaintIdentifier]corev1.Taint, taint *corev1.Taint) bool {
+	if _, ok := taintMap[IdentifierForTaint(taint)]; ok {
+		return true
+	}
+	return false
+}

--- a/vendor/github.com/openshift/hive/apis/hive/v1/machinepool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/machinepool_types.go
@@ -100,6 +100,26 @@ type MachinePoolStatus struct {
 	// Conditions includes more detailed status for the cluster deployment
 	// +optional
 	Conditions []MachinePoolCondition `json:"conditions,omitempty"`
+
+	// OwnedLabels lists the keys of labels this MachinePool created on the remote MachineSet.
+	// Used to identify labels to remove from the remote MachineSet when they are absent from
+	// the MachinePool's spec.labels.
+	// +optional
+	OwnedLabels []string `json:"ownedLabels,omitempty"`
+	// OwnedTaints lists identifiers of taints this MachinePool created on the remote MachineSet.
+	// Used to identify taints to remove from the remote MachineSet when they are absent from
+	// the MachinePool's spec.taints.
+	// +optional
+	OwnedTaints []TaintIdentifier `json:"ownedTaints,omitempty"`
+}
+
+// TaintIdentifier uniquely identifies a Taint. (It turns out taints are mutually exclusive by
+// key+effect, not simply by key.)
+type TaintIdentifier struct {
+	// Key matches corev1.Taint.Key.
+	Key string `json:"key:omitempty"`
+	// Effect matches corev1.Taint.Effect.
+	Effect corev1.TaintEffect `json:"effect:omitempty"`
 }
 
 // MachineSetStatus is the status of a machineset in the remote cluster.

--- a/vendor/github.com/openshift/hive/apis/hive/v1/machinepool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/machinepool_types.go
@@ -54,6 +54,9 @@ type MachinePoolSpec struct {
 
 	// List of taints that will be applied to the created MachineSet's MachineSpec.
 	// This list will overwrite any modifications made to Node taints on an ongoing basis.
+	// In case of duplicate entries, first encountered taint Value will be preserved,
+	// and the rest collapsed on the corresponding MachineSets.
+	// Note that taints are uniquely identified based on key+effect, not just key.
 	// +optional
 	Taints []corev1.Taint `json:"taints,omitempty"`
 }


### PR DESCRIPTION
With implementing the merging of MachinePool Labels and Taints, we lost the ability to sync and update based on MachinePool.Spec. To fix this, we add two new statusfields to MachinePool: OwnedLabels and OwnedTaints. These keep track of the labels and taints that were added to the remote MachineSets at the behest of this MachinePool. Conversely, this allows us to identify which ones were added on the remote side, and thus shouldn't be touched by our controller.

We also fix the logic for matching taints, which are "keyed" by the combination of the Key and Effect fields.

To summarize the behavior with this commit in play:
- Labels and taints listed in MachinePool.Spec are synced to the remote MachineSets.
- Labels and taints that are *not* in MachinePool.Spec are removed from the remote MachineSets *iff* they are present in
MachinePool.Status.Owned{Labels|Taints}.
- Upon successful syncing, we update MachinePool.Status.Owned{Labels|Taints} to match the spec.

The effect is that editing MachinePool.Spec to remove a label or taint should cause that label/taint to be removed from the remote MachineSets, BUT labels/taints that only exist on the remote MachineSets remain untouched.

[HIVE-2035](https://issues.redhat.com//browse/HIVE-2035)
[HIVE-2276](https://issues.redhat.com//browse/HIVE-2276)
[HIVE-2279](https://issues.redhat.com//browse/HIVE-2279)
[HIVE-2268](https://issues.redhat.com//browse/HIVE-2268)

/assign @2uasimojo 