### PR TITLE
e2e-pool: Plumb in BASE_DOMAIN

### DIFF
--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -218,6 +218,7 @@ go run "${SRC_ROOT}/contrib/cmd/hiveutil/main.go" clusterpool create-pool \
   ${REGION_ARG} \
 	${CREDS_FILE_ARG} \
 	--pull-secret-file="${PULL_SECRET_FILE}" \
+	--base-domain="${CLUSTER_DOMAIN}" \
   --image-set "${IMAGESET_NAME}" \
   --region us-east-1 \
   --size 0 \


### PR DESCRIPTION
hiveutil still defaults the base domain to new-installer.openshift.com, which is probably what we want since we (hive engineers) are the ones invoking it by hand, using the hive-team cluster as a hub, and will thus prefer less typing.

But now that we're switching to a new AWS account for CI, we want the AWS-based e2e suites to use the new base domain. We recognize and default a `$BASE_DOMAIN` variable for e2e itself, but weren't yet plumbing it through to e2e-pool. Fix.

[HIVE-2259](https://issues.redhat.com//browse/HIVE-2259)