### PR TITLE
Use default network type

### DIFF
--- a/pkg/clusterresource/builder.go
+++ b/pkg/clusterresource/builder.go
@@ -377,7 +377,6 @@ func (o *Builder) generateInstallConfigSecret() (*corev1.Secret, error) {
 		SSHKey:     o.SSHPublicKey,
 		BaseDomain: o.BaseDomain,
 		Networking: &installertypes.Networking{
-			NetworkType:    "OpenShiftSDN",
 			ServiceNetwork: []ipnet.IPNet{*ipnet.MustParseCIDR("172.30.0.0/16")},
 			ClusterNetwork: []installertypes.ClusterNetworkEntry{
 				{

--- a/pkg/controller/clusterdeployment/installconfigvalidation_test.go
+++ b/pkg/controller/clusterdeployment/installconfigvalidation_test.go
@@ -48,7 +48,6 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
-  networkType: OpenShiftSDN
   serviceNetwork:
   - 172.30.0.0/16
 platform:
@@ -87,7 +86,6 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
-  networkType: OpenShiftSDN
   serviceNetwork:
   - 172.30.0.0/16
 platform:
@@ -127,7 +125,6 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
-  networkType: OpenShiftSDN
   serviceNetwork:
   - 172.30.0.0/16
 platform:


### PR DESCRIPTION
Installer will default the network type to OVNKubernetes if not specified. We have been overriding it to OpenShiftSDN in the clusterresource builder used for hiveutil and thus e2e. This commit removes that override, letting the installer default it for resources provisioned through those code paths.