### PR TITLE
e2e-pool: Better wait for controllers to be ready

### DIFF
--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -7,6 +7,8 @@ source ${0%/*}/e2e-common.sh
 
 echo "Waiting for the operator deployment to settle"
 oc wait --for=condition=Available --timeout=2m deploy/hive-operator -n $HIVE_OPERATOR_NS
+echo "Waiting for operator to deploy controllers"
+oc wait --for=condition=Ready --timeout=2m hiveconfig/hive
 echo "Waiting for the controllers and admission deployments to settle"
 for deployment in hive-controllers hiveadmission; do
   oc wait --for=condition=Available --timeout=2m deploy/$deployment -n $HIVE_NS


### PR DESCRIPTION
It turns out we weren't actually disabling managed DNS for e2e-pool -- see https://github.com/openshift/release/pull/42172. However, attempting to do so revealed a timing problem which was being papered over: We were using `oc wait` to wait for the controllers to become ready, but hive-operator hadn't yet gotten a chance to create those deployments. (When we were enabling managed DNS, that process took some time *and* waited for those deployments, so we never noticed.)

With this commit, after waiting for the hive-operator deployment itself to become Available, we then wait for HiveConfig to report Ready, indicating that the operator has created the deployments.