### PR TITLE
e2e: unset exit-on-error during cleanup

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -161,7 +161,7 @@ function save_hive_logs() {
 }
 # The consumer of this lib can set up its own exit trap, but this basic one will at least help
 # debug e.g. problems from `make deploy` and managed DNS setup.
-trap 'kill %1; save_hive_logs' EXIT
+trap 'set +e; kill %1; save_hive_logs' EXIT
 
 # Install Hive
 IMG="${HIVE_IMAGE}" make deploy

--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -123,7 +123,7 @@ function cleanup() {
   done
   echo "Cleanup complete"
 }
-trap 'kill %1; cleanup' EXIT
+trap 'set +e; kill %1; cleanup' EXIT
 
 function wait_for_pool_to_be_ready() {
   local poolname=$1

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -42,7 +42,7 @@ function teardown() {
   echo "Saving hive logs after cleanup"
   save_hive_logs
 }
-trap 'kill %1; teardown' EXIT
+trap 'set +e; kill %1; teardown' EXIT
 
 echo "Running post-deploy tests in original namespace $HIVE_NS"
 make test-e2e-postdeploy


### PR DESCRIPTION
We want cleanup to be best-effort, and we don't want failures therein to blow the whole test up if it already succeeded otherwise. `set +e` in all exit traps.