### PR TITLE
Backport e2e fixes to mce-2.3

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -189,7 +189,7 @@ case "${CLOUD}" in
             # the whole CREDS_FILE_ARG="--creds-file=${CREDS_FILE}".
             printf '[default]\naws_access_key_id=%s\naws_secret_access_key=%s\n' "$AWS_ACCESS_KEY_ID" "$AWS_SECRET_ACCESS_KEY" > $CREDS_FILE
         fi
-	BASE_DOMAIN="${BASE_DOMAIN:-hive-ci.openshift.com}"
+	BASE_DOMAIN="${BASE_DOMAIN:-hive-ci.devcluster.openshift.com}"
 	EXTRA_CREATE_CLUSTER_ARGS="--aws-user-tags expirationDate=$(date -d '4 hours' --iso=minutes --utc)"
 	;;
 "azure")

--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -209,6 +209,11 @@ echo "Creating real cluster pool"
 # TODO: This can't be changed yet -- see other TODOs (search for 'variable POOL_SIZE')
 POOL_SIZE=1
 # TODO: This is aws-specific at the moment.
+# NOTE: We start with a zero-size pool and scale it up after we add the inventory.
+# Otherwise, adding the inventory immediately makes the already-provisioning cluster
+# stale, BUT it doesn't get purged until it's done provisioning. (Intentional
+# architectural decision to prefer presenting a stale claimable cluster early vs.
+# delaying until a non-stale one is available.)
 go run "${SRC_ROOT}/contrib/cmd/hiveutil/main.go" clusterpool create-pool \
   -n "${CLUSTER_NAMESPACE}" \
   --cloud="${CLOUD}" \
@@ -216,7 +221,7 @@ go run "${SRC_ROOT}/contrib/cmd/hiveutil/main.go" clusterpool create-pool \
 	--pull-secret-file="${PULL_SECRET_FILE}" \
   --image-set "${IMAGESET_NAME}" \
   --region us-east-1 \
-  --size "${POOL_SIZE}" \
+  --size 0 \
   ${REAL_POOL_NAME}
 
 ### INTERLUDE: FAKE POOL
@@ -235,7 +240,8 @@ oc get clusterpool ${REAL_POOL_NAME} -o json \
 NEW_CLUSTER_NAME=cdcci-${CLUSTER_NAME#*-}
 create_customization "cdc-test" "${CLUSTER_NAMESPACE}" "${NEW_CLUSTER_NAME}"
 oc patch cp -n $CLUSTER_NAMESPACE $REAL_POOL_NAME --type=merge -p '{"spec": {"inventory": [{"name": "cdc-test"}]}}'
-
+# Now we can scale up the pool so it starts creating clusters
+oc scale cp -n $CLUSTER_NAMESPACE $REAL_POOL_NAME --replicas=$POOL_SIZE
 
 wait_for_pool_to_be_ready $FAKE_POOL_NAME
 

--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -219,6 +219,7 @@ go run "${SRC_ROOT}/contrib/cmd/hiveutil/main.go" clusterpool create-pool \
   --cloud="${CLOUD}" \
 	--creds-file="${CREDS_FILE}" \
 	--pull-secret-file="${PULL_SECRET_FILE}" \
+	--base-domain="${CLUSTER_DOMAIN}" \
   --image-set "${IMAGESET_NAME}" \
   --region us-east-1 \
   --size 0 \


### PR DESCRIPTION
These are needed by https://github.com/openshift/release/pull/41519 to successfully switch our e2e to a new AWS account.