### PR TITLE
Add manager field to ReconcileClusterDeployment object

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -135,6 +135,7 @@ func Add(mgr manager.Manager) error {
 // NewReconciler returns a new reconcile.Reconciler
 func NewReconciler(mgr manager.Manager, logger log.FieldLogger, rateLimiter flowcontrol.RateLimiter) reconcile.Reconciler {
 	r := &ReconcileClusterDeployment{
+		Manager:                                 mgr,
 		Client:                                  controllerutils.NewClientWithMetricsOrDie(mgr, ControllerName, &rateLimiter),
 		scheme:                                  mgr.GetScheme(),
 		logger:                                  logger,


### PR DESCRIPTION
Due to the controller-runtime update to v0.15.0, reconcile for cluster install now requires a Reconciler to have a Manager field in order to create a KindSource using it's cache.

Add Manager field to ReconcileClusterDeployment object.

[HIVE-2296](https://issues.redhat.com//browse/HIVE-2296)