### PR TITLE
Add and use Reachable() in (remote client) Builder

### DIFF
--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -91,6 +91,8 @@ fi
 export CLUSTER_NAME="${CLUSTER_NAME:-hive-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
 
 echo "Creating cluster deployment"
+# Add a bogus API URL override to validate that our unreachable controller correctly
+# falls back to the default API URL when the override is unreachable.
 go run "${SRC_ROOT}/contrib/cmd/hiveutil/main.go" create-cluster "${CLUSTER_NAME}" \
 	--cloud="${CLOUD}" \
 	${CREDS_FILE_ARG} \
@@ -103,7 +105,8 @@ go run "${SRC_ROOT}/contrib/cmd/hiveutil/main.go" create-cluster "${CLUSTER_NAME
 	${REGION_ARG} \
 	${INSTANCE_TYPE_ARG} \
 	${MANAGED_DNS_ARG} \
-	${EXTRA_CREATE_CLUSTER_ARGS}
+	${EXTRA_CREATE_CLUSTER_ARGS} \
+  -o json | jq '.items[0].spec.controlPlaneConfig.apiURLOverride = "bogus-url.example.com"' | oc apply -f -
 
 # Sanity check the cluster deployment printer
 i=1

--- a/pkg/controller/unreachable/unreachable_controller.go
+++ b/pkg/controller/unreachable/unreachable_controller.go
@@ -198,7 +198,7 @@ func (r *ReconcileRemoteMachineSet) Reconcile(ctx context.Context, request recon
 	updateUnreachable := true
 	var primaryErr error
 	// Attempt to connect to the remote cluster using the preferred API URL.
-	_, primaryErr = remoteClientBuilder.UsePrimaryAPIURL().Build()
+	primaryErr = remoteClientBuilder.UsePrimaryAPIURL().Reachable()
 	if primaryErr != nil {
 		// If the remote cluster is not accessible via the preferred API URL, check if there is a fallback API URL to use.
 		if hasOverride(cd) {
@@ -209,7 +209,7 @@ func (r *ReconcileRemoteMachineSet) Reconcile(ctx context.Context, request recon
 			// become accessible, the controller should not recheck connectivity via the fallback API URL more often
 			// than once every 2 hours.
 			if connectivityRecheckNeeded || wasPrimaryActive {
-				if _, secondaryErr := remoteClientBuilder.UseSecondaryAPIURL().Build(); secondaryErr != nil {
+				if secondaryErr := remoteClientBuilder.UseSecondaryAPIURL().Reachable(); secondaryErr != nil {
 					cdLog.WithError(secondaryErr).Warn("unable to create remote API client with either the initial API URL or the API URL override, marking cluster unreachable")
 					unreachableError = utilerrors.NewAggregate([]error{primaryErr, secondaryErr})
 				}

--- a/pkg/controller/unreachable/unreachable_controller_test.go
+++ b/pkg/controller/unreachable/unreachable_controller_test.go
@@ -243,7 +243,7 @@ func TestReconcile(t *testing.T) {
 				if *test.errorConnecting {
 					buildError = errors.New("cluster not reachable")
 				}
-				mockRemoteClientBuilder.EXPECT().Build().Return(nil, buildError)
+				mockRemoteClientBuilder.EXPECT().Reachable().Return(buildError)
 			}
 			if test.errorConnectingSecondary != nil {
 				mockRemoteClientBuilder.EXPECT().UseSecondaryAPIURL().Return(mockRemoteClientBuilder)
@@ -251,7 +251,7 @@ func TestReconcile(t *testing.T) {
 				if *test.errorConnectingSecondary {
 					buildError = errors.New("cluster not reachable")
 				}
-				mockRemoteClientBuilder.EXPECT().Build().Return(nil, buildError)
+				mockRemoteClientBuilder.EXPECT().Reachable().Return(buildError)
 			}
 			rcd := &ReconcileRemoteMachineSet{
 				Client:                        fakeClient,

--- a/pkg/remoteclient/fake.go
+++ b/pkg/remoteclient/fake.go
@@ -115,3 +115,5 @@ func (b *fakeBuilder) UseSecondaryAPIURL() Builder {
 func (b *fakeBuilder) RESTConfig() (*rest.Config, error) {
 	return nil, errors.New("RESTConfig not implemented for fake cluster client builder")
 }
+
+func (b *fakeBuilder) Reachable() error { return nil }

--- a/pkg/remoteclient/kubeconfig.go
+++ b/pkg/remoteclient/kubeconfig.go
@@ -3,9 +3,11 @@ package remoteclient
 import (
 	"github.com/openshift/hive/pkg/util/scheme"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -70,4 +72,17 @@ func (b *kubeconfigBuilder) UseSecondaryAPIURL() Builder {
 
 func (b *kubeconfigBuilder) RESTConfig() (*rest.Config, error) {
 	return restConfigFromSecret(b.secret)
+}
+
+func (b *kubeconfigBuilder) Reachable() error {
+	cfg, err := b.RESTConfig()
+	if err != nil {
+		return err
+	}
+	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	_, err = restmapper.GetAPIGroupResources(dc)
+	return err
 }

--- a/pkg/remoteclient/mock/remoteclient_generated.go
+++ b/pkg/remoteclient/mock/remoteclient_generated.go
@@ -98,6 +98,20 @@ func (mr *MockBuilderMockRecorder) RESTConfig() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RESTConfig", reflect.TypeOf((*MockBuilder)(nil).RESTConfig))
 }
 
+// Reachable mocks base method.
+func (m *MockBuilder) Reachable() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Reachable")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Reachable indicates an expected call of Reachable.
+func (mr *MockBuilderMockRecorder) Reachable() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reachable", reflect.TypeOf((*MockBuilder)(nil).Reachable))
+}
+
 // UsePrimaryAPIURL mocks base method.
 func (m *MockBuilder) UsePrimaryAPIURL() remoteclient.Builder {
 	m.ctrl.T.Helper()

--- a/pkg/remoteclient/remoteclient.go
+++ b/pkg/remoteclient/remoteclient.go
@@ -13,9 +13,11 @@ import (
 	machnet "k8s.io/apimachinery/pkg/util/net"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -46,6 +48,9 @@ type Builder interface {
 	// UseSecondaryAPIURL will use the secondary API URL. If there is an API URL override, then the initial API URL
 	// is the secondary.
 	UseSecondaryAPIURL() Builder
+
+	// Reachable internally builds a client and runs a query to make sure it is healthy.
+	Reachable() error
 }
 
 // NewBuilder creates a new Builder for creating a client to connect to the remote cluster associated with the specified
@@ -203,6 +208,19 @@ func (b *builder) Build() (client.Client, error) {
 	return client.New(cfg, client.Options{
 		Scheme: scheme,
 	})
+}
+
+func (b *builder) Reachable() error {
+	cfg, err := b.RESTConfig()
+	if err != nil {
+		return err
+	}
+	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return err
+	}
+	_, err = restmapper.GetAPIGroupResources(dc)
+	return err
 }
 
 func (b *builder) BuildDynamic() (dynamic.Interface, error) {


### PR DESCRIPTION
With the controller-runtime upgrade from 8cfdccaec, our remote client `Builder` interface's `Build()` method got lazier. Before, if the remote client was unreachable, `Build()` itself would fail. Now it won't fail until the resulting client is actually used. This resulted in our "unreachable" controller incorrectly marking the ClusterDeployment's APIURLOverride as reachable when it wasn't, which had the ripple effect of making the clustersync controller fail early by trying to use that URL rather than falling back to the default.

This was exposed in situations where the DNS for the APIURLOverride was being configured via a syncset: the clustersync controller tried to use a URL that wouldn't resolve, so it couldn't sync the resource that would make that DNS work.

To fix, this commit adds a new `Reachable()` method to the `Builder` interface. This internally builds the client and then uses it to query the `/apis` of the remote client. We replace our used of `Build()` with this method in the "unreachable" controller to get back to the previous behavior.

[HIVE-2144](https://issues.redhat.com//browse/HIVE-2144)