### PR TITLE
AWS deprovision: Plumb ClusterDomain

### DIFF
--- a/apis/hive/v1/clusterdeprovision_types.go
+++ b/apis/hive/v1/clusterdeprovision_types.go
@@ -20,6 +20,9 @@ type ClusterDeprovisionSpec struct {
 	// cluster is useful.
 	ClusterName string `json:"clusterName,omitempty"`
 
+	// BaseDomain is the DNS base domain.
+	BaseDomain string `json:"baseDomain,omitempty"`
+
 	// Platform contains platform-specific configuration for a ClusterDeprovision
 	Platform ClusterDeprovisionPlatform `json:"platform,omitempty"`
 }
@@ -59,7 +62,8 @@ type ClusterDeprovisionPlatform struct {
 type AlibabaCloudClusterDeprovision struct {
 	// Region is the Alibaba region for this deprovision
 	Region string `json:"region"`
-	// BaseDomain is the DNS base domain
+	// BaseDomain is the DNS base domain.
+	// TODO: Use the non-platform-specific BaseDomain field.
 	BaseDomain string `json:"baseDomain"`
 	// CredentialsSecretRef is the Alibaba account credentials to use for deprovisioning the cluster
 	CredentialsSecretRef corev1.LocalObjectReference `json:"credentialsSecretRef"`
@@ -150,7 +154,8 @@ type IBMClusterDeprovision struct {
 	CredentialsSecretRef corev1.LocalObjectReference `json:"credentialsSecretRef"`
 	// Region specifies the IBM Cloud region
 	Region string `json:"region"`
-	// BaseDomain is the DNS base domain
+	// BaseDomain is the DNS base domain.
+	// TODO: Use the non-platform-specific BaseDomain field.
 	BaseDomain string `json:"baseDomain"`
 }
 

--- a/config/crds/hive.openshift.io_clusterdeprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterdeprovisions.yaml
@@ -50,6 +50,9 @@ spec:
           spec:
             description: ClusterDeprovisionSpec defines the desired state of ClusterDeprovision
             properties:
+              baseDomain:
+                description: BaseDomain is the DNS base domain.
+                type: string
               clusterID:
                 description: ClusterID is a globally unique identifier for the cluster
                   to deprovision. It will be used if specified.
@@ -73,7 +76,8 @@ spec:
                       settings
                     properties:
                       baseDomain:
-                        description: BaseDomain is the DNS base domain
+                        description: 'BaseDomain is the DNS base domain. TODO: Use
+                          the non-platform-specific BaseDomain field.'
                         type: string
                       credentialsSecretRef:
                         description: CredentialsSecretRef is the Alibaba account credentials
@@ -185,7 +189,8 @@ spec:
                       settings
                     properties:
                       baseDomain:
-                        description: BaseDomain is the DNS base domain
+                        description: 'BaseDomain is the DNS base domain. TODO: Use
+                          the non-platform-specific BaseDomain field.'
                         type: string
                       credentialsSecretRef:
                         description: CredentialsSecretRef is the IBM Cloud credentials

--- a/contrib/pkg/deprovision/awstagdeprovision.go
+++ b/contrib/pkg/deprovision/awstagdeprovision.go
@@ -32,6 +32,7 @@ func NewDeprovisionAWSWithTagsCommand() *cobra.Command {
 				go terminateWhenFilesChange(credsDir)
 			}
 
+			log.Infof("Running destroyer with ClusterUninstall %#v", *opt)
 			// ClusterQuota stomped in return
 			if _, err := opt.Run(); err != nil {
 				log.WithError(err).Fatal("Runtime error")
@@ -43,6 +44,7 @@ func NewDeprovisionAWSWithTagsCommand() *cobra.Command {
 	flags.StringVar(&opt.Region, "region", "us-east-1", "AWS region to use")
 	flags.StringVar(&credsDir, "creds-dir", "", "directory of the creds. Changes in the creds will cause the program to terminate")
 	flags.StringVar(&opt.HostedZoneRole, "hosted-zone-role", "", "the role to assume when performing operations on a hosted zone owned by another account.")
+	flags.StringVar(&opt.ClusterDomain, "cluster-domain", "", "the parent DNS domain of the cluster (e.g. the thing after `api.`).")
 	return cmd
 }
 

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -1680,6 +1680,9 @@ objects:
             spec:
               description: ClusterDeprovisionSpec defines the desired state of ClusterDeprovision
               properties:
+                baseDomain:
+                  description: BaseDomain is the DNS base domain.
+                  type: string
                 clusterID:
                   description: ClusterID is a globally unique identifier for the cluster
                     to deprovision. It will be used if specified.
@@ -1703,7 +1706,8 @@ objects:
                         settings
                       properties:
                         baseDomain:
-                          description: BaseDomain is the DNS base domain
+                          description: 'BaseDomain is the DNS base domain. TODO: Use
+                            the non-platform-specific BaseDomain field.'
                           type: string
                         credentialsSecretRef:
                           description: CredentialsSecretRef is the Alibaba account
@@ -1816,7 +1820,8 @@ objects:
                         settings
                       properties:
                         baseDomain:
-                          description: BaseDomain is the DNS base domain
+                          description: 'BaseDomain is the DNS base domain. TODO: Use
+                            the non-platform-specific BaseDomain field.'
                           type: string
                         credentialsSecretRef:
                           description: CredentialsSecretRef is the IBM Cloud credentials

--- a/pkg/client/applyconfiguration/hive/v1/clusterdeprovisionspec.go
+++ b/pkg/client/applyconfiguration/hive/v1/clusterdeprovisionspec.go
@@ -8,6 +8,7 @@ type ClusterDeprovisionSpecApplyConfiguration struct {
 	InfraID     *string                                       `json:"infraID,omitempty"`
 	ClusterID   *string                                       `json:"clusterID,omitempty"`
 	ClusterName *string                                       `json:"clusterName,omitempty"`
+	BaseDomain  *string                                       `json:"baseDomain,omitempty"`
 	Platform    *ClusterDeprovisionPlatformApplyConfiguration `json:"platform,omitempty"`
 }
 
@@ -38,6 +39,14 @@ func (b *ClusterDeprovisionSpecApplyConfiguration) WithClusterID(value string) *
 // If called multiple times, the ClusterName field is set to the value of the last call.
 func (b *ClusterDeprovisionSpecApplyConfiguration) WithClusterName(value string) *ClusterDeprovisionSpecApplyConfiguration {
 	b.ClusterName = &value
+	return b
+}
+
+// WithBaseDomain sets the BaseDomain field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the BaseDomain field is set to the value of the last call.
+func (b *ClusterDeprovisionSpecApplyConfiguration) WithBaseDomain(value string) *ClusterDeprovisionSpecApplyConfiguration {
+	b.BaseDomain = &value
 	return b
 }
 

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -1795,6 +1795,7 @@ func generateDeprovision(cd *hivev1.ClusterDeployment) (*hivev1.ClusterDeprovisi
 			InfraID:     cd.Spec.ClusterMetadata.InfraID,
 			ClusterID:   cd.Spec.ClusterMetadata.ClusterID,
 			ClusterName: cd.Spec.ClusterName,
+			BaseDomain:  cd.Spec.BaseDomain,
 		},
 	}
 	controllerutils.CopyLogAnnotation(cd, req)

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeprovision_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeprovision_types.go
@@ -20,6 +20,9 @@ type ClusterDeprovisionSpec struct {
 	// cluster is useful.
 	ClusterName string `json:"clusterName,omitempty"`
 
+	// BaseDomain is the DNS base domain.
+	BaseDomain string `json:"baseDomain,omitempty"`
+
 	// Platform contains platform-specific configuration for a ClusterDeprovision
 	Platform ClusterDeprovisionPlatform `json:"platform,omitempty"`
 }
@@ -59,7 +62,8 @@ type ClusterDeprovisionPlatform struct {
 type AlibabaCloudClusterDeprovision struct {
 	// Region is the Alibaba region for this deprovision
 	Region string `json:"region"`
-	// BaseDomain is the DNS base domain
+	// BaseDomain is the DNS base domain.
+	// TODO: Use the non-platform-specific BaseDomain field.
 	BaseDomain string `json:"baseDomain"`
 	// CredentialsSecretRef is the Alibaba account credentials to use for deprovisioning the cluster
 	CredentialsSecretRef corev1.LocalObjectReference `json:"credentialsSecretRef"`
@@ -150,7 +154,8 @@ type IBMClusterDeprovision struct {
 	CredentialsSecretRef corev1.LocalObjectReference `json:"credentialsSecretRef"`
 	// Region specifies the IBM Cloud region
 	Region string `json:"region"`
-	// BaseDomain is the DNS base domain
+	// BaseDomain is the DNS base domain.
+	// TODO: Use the non-platform-specific BaseDomain field.
 	BaseDomain string `json:"baseDomain"`
 }
 


### PR DESCRIPTION
ClusterUninstaller.ClusterDomain has existed for a long time, but was never used before the advent of shared VPC. In this new flow, if it is absent, DNS entries in the private hosted zone are not cleaned up in the destroy flow. This commit adds a new CLI parameter, `--cluster-domain`, to `hiveutil aws-tag-deprovision`. It is plumbed through by adding `spec.BaseDomain` to the ClusterDeprovision CRD and constructing the value by joining that to the `spec.ClusterName`.

TODO: Our platform-specific ClusterDeprovision sub-structs for Alibaba and IBMCloud each have a `BaseDomain` field. We should transition those to using this new platform-agnostic field -- but later. See HIVE-2298.

HIVE-2297