### PR TITLE
Refresh vendor, temporarily "fix" webhook CI

### DIFF
--- a/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook_test.go
@@ -398,8 +398,10 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
-			expectedAllowed: false,
+			operation: admissionv1beta1.Update,
+			// TODO: REVERT!
+			// expectedAllowed: false,
+			expectedAllowed: true,
 		},
 		{
 			name:      "Test Update PreserveOnDelete",
@@ -823,8 +825,10 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
-			expectedAllowed: false,
+			operation: admissionv1beta1.Update,
+			// TODO: REVERT!
+			// expectedAllowed: false,
+			expectedAllowed: true,
 		},
 		// TODO: ensure Azure clusterDeployments have necessary info for
 		// machine sets

--- a/vendor/github.com/openshift/installer/pkg/destroy/aws/aws.go
+++ b/vendor/github.com/openshift/installer/pkg/destroy/aws/aws.go
@@ -114,7 +114,6 @@ func (o *ClusterUninstaller) RunWithContext(ctx context.Context) ([]string, erro
 	if err != nil {
 		return nil, err
 	}
-	o.Logger.Infof("BUGGIN ClusterUninstaller: %#v", *o)
 
 	awsSession := o.Session
 	if awsSession == nil {
@@ -133,14 +132,12 @@ func (o *ClusterUninstaller) RunWithContext(ctx context.Context) ([]string, erro
 		resourcegroupstaggingapi.New(awsSession),
 	}
 
-	o.Logger.Infof("BUGGIN Checking if o.HostedZoneRole is set, o.HostedZoneRole: %s", o.HostedZoneRole)
 	if o.HostedZoneRole != "" {
 		cfg := awssession.GetR53ClientCfg(awsSession, o.HostedZoneRole)
 		// This client is specifically for finding route53 zones,
 		// so it needs to use the global us-east-1 region.
 		cfg.Region = aws.String(endpoints.UsEast1RegionID)
 		tagClients = append(tagClients, resourcegroupstaggingapi.New(awsSession, cfg))
-		o.Logger.Infof("BUGGIN Tag Client for Shared VPC Account Added")
 	}
 
 	switch o.Region {

--- a/vendor/github.com/openshift/installer/pkg/destroy/aws/shared.go
+++ b/vendor/github.com/openshift/installer/pkg/destroy/aws/shared.go
@@ -180,7 +180,6 @@ func (o *ClusterUninstaller) removeSharedTag(ctx context.Context, session *sessi
 }
 
 func (o *ClusterUninstaller) cleanSharedARN(ctx context.Context, session *session.Session, arn arn.ARN, logger logrus.FieldLogger) error {
-	logger.Debugf("BUGGIN found shared resource: %s", arn.String())
 	switch service := arn.Service; service {
 	case "route53":
 		return o.cleanSharedRoute53(ctx, session, arn, logger)
@@ -211,8 +210,6 @@ func (o *ClusterUninstaller) cleanSharedHostedZone(ctx context.Context, session 
 	// in which case we need a separate client.
 	publicZoneClient := route53.New(session)
 	privateZoneClient := route53.New(session)
-	o.Logger.Infof("BUGGIN Checking if o.HostedZoneRole is set to create privateZoneClient, o.HostedZoneRole: %s", o.HostedZoneRole)
-
 	if o.HostedZoneRole != "" {
 		creds := stscreds.NewCredentials(session, o.HostedZoneRole)
 		privateZoneClient = route53.New(session, &aws.Config{Credentials: creds})


### PR DESCRIPTION
This partially reverts #2102 / 8b12180d.

We are finished debugging vendored installer code, so restore the vendor directory to its pristine state. This should fix `verify`.

To lockstep with Clusters Service, who needs to refresh their hive/apis version, we are **leaving the immutable clusterMetadata webhook check disabled** and toggling the unit tests so `unit` and `coverage` will pass.

This should allow merges to master to resume in the normal fashion.

TODO: Revert the webhook bypass and corresponding test changes once CS has been updated.

[HIVE-2297](https://issues.redhat.com//browse/HIVE-2297)