### PR TITLE
Fix grafana dashboard

### DIFF
--- a/hack/grafana-dashboards/grafana-dashboard-hive-slo.configmap.yaml
+++ b/hack/grafana-dashboards/grafana-dashboard-hive-slo.configmap.yaml
@@ -2,57 +2,6 @@ apiVersion: v1
 data:
   Hive-SLO.json: |-
     {
-      "__inputs": [
-        {
-          "name": "DS_APPSREP05UE1-PROMETHEUS",
-          "label": "appsrep05ue1-prometheus",
-          "description": "",
-          "type": "datasource",
-          "pluginId": "prometheus",
-          "pluginName": "Prometheus"
-        },
-        {
-          "name": "DS_DEPLOY-EVENTS-DB",
-          "label": "deploy-events-db",
-          "description": "",
-          "type": "datasource",
-          "pluginId": "postgres",
-          "pluginName": "PostgreSQL"
-        }
-      ],
-      "__elements": {},
-      "__requires": [
-        {
-          "type": "panel",
-          "id": "gauge",
-          "name": "Gauge",
-          "version": ""
-        },
-        {
-          "type": "grafana",
-          "id": "grafana",
-          "name": "Grafana",
-          "version": "9.3.8"
-        },
-        {
-          "type": "datasource",
-          "id": "postgres",
-          "name": "PostgreSQL",
-          "version": "1.0.0"
-        },
-        {
-          "type": "datasource",
-          "id": "prometheus",
-          "name": "Prometheus",
-          "version": "1.0.0"
-        },
-        {
-          "type": "panel",
-          "id": "timeseries",
-          "name": "Time series",
-          "version": ""
-        }
-      ],
       "annotations": {
         "list": [
           {
@@ -76,7 +25,7 @@ data:
           {
             "datasource": {
               "type": "postgres",
-              "uid": "${DS_DEPLOY-EVENTS-DB}"
+              "uid": "P5108662370F9C14C"
             },
             "enable": false,
             "iconColor": "blue",
@@ -131,7 +80,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -210,7 +159,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "(sum (rate(hive_cluster_deployment_install_job_delay_seconds_bucket{appsre_env=\"$env\",le=\"$hive_le\",shard_status=\"$shard_status\"}[$bucket])))/(sum (rate(hive_cluster_deployment_install_job_delay_seconds_count{appsre_env=\"$env\",shard_status=\"$shard_status\"}[$bucket])))",
@@ -225,7 +174,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -280,7 +229,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "1-((1-((sum (rate(hive_cluster_deployment_install_job_delay_seconds_bucket{appsre_env=\"$env\",le=\"$hive_le\"}[$bucket])))/(sum (rate(hive_cluster_deployment_install_job_delay_seconds_count{appsre_env=\"$env\"}[$bucket])))))/(1-$hive_delay_slo))",
@@ -308,7 +257,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -387,7 +336,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "(sum (rate(hive_cluster_deployment_install_job_duration_seconds_bucket{appsre_env=\"$env\",le=\"$install_le\"}[$bucket])))/(sum (rate(hive_cluster_deployment_install_job_duration_seconds_count{appsre_env=\"$env\"}[$bucket])))",
@@ -402,7 +351,7 @@ data:
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+            "uid": "${datasource}"
           },
           "description": "",
           "fieldConfig": {
@@ -457,7 +406,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+                "uid": "${datasource}"
               },
               "editorMode": "code",
               "expr": "1-((1-((sum (rate(hive_cluster_deployment_install_job_duration_seconds_bucket{appsre_env=\"$env\",le=\"$install_le\"}[$bucket])))/(sum (rate(hive_cluster_deployment_install_job_duration_seconds_count{appsre_env=\"$env\"}[$bucket])))))/(1-$install_duration_slo))",
@@ -482,7 +431,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+                "uid": "${datasource}"
               },
               "description": "Detail of percentiles for a small bucket",
               "fieldConfig": {
@@ -576,7 +525,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+                    "uid": "${datasource}"
                   },
                   "editorMode": "code",
                   "expr": "histogram_quantile(0.99, (sum without(instance,pod,namespace,service,job)(rate(hive_cluster_deployment_install_job_delay_seconds_bucket{appsre_env=\"$env\",shard_status=\"$shard_status\"}[1d]))))",
@@ -587,7 +536,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+                    "uid": "${datasource}"
                   },
                   "editorMode": "code",
                   "expr": "histogram_quantile(0.95, (sum without(instance,pod,namespace,service,job)(rate(hive_cluster_deployment_install_job_delay_seconds_bucket{appsre_env=\"$env\",shard_status=\"$shard_status\"}[1d]))))",
@@ -599,7 +548,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+                    "uid": "${datasource}"
                   },
                   "editorMode": "code",
                   "expr": "histogram_quantile(0.90, (sum without(instance,pod,namespace,service,job)(rate(hive_cluster_deployment_install_job_delay_seconds_bucket{appsre_env=\"$env\",shard_status=\"$shard_status\"}[1d]))))",
@@ -611,7 +560,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+                    "uid": "${datasource}"
                   },
                   "editorMode": "code",
                   "expr": "histogram_quantile(0.85, (sum without(instance,pod,namespace,service,job)(rate(hive_cluster_deployment_install_job_delay_seconds_bucket{appsre_env=\"$env\",shard_status=\"$shard_status\"}[1d]))))",
@@ -623,7 +572,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+                    "uid": "${datasource}"
                   },
                   "editorMode": "code",
                   "expr": "histogram_quantile(0.5, (sum without(instance,pod,namespace,service,job)(rate(hive_cluster_deployment_install_job_delay_seconds_bucket{appsre_env=\"$env\",shard_status=\"$shard_status\"}[1d]))))",
@@ -653,7 +602,7 @@ data:
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+                "uid": "${datasource}"
               },
               "description": "Detail of percentiles for a small bucket",
               "fieldConfig": {
@@ -731,7 +680,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+                    "uid": "${datasource}"
                   },
                   "editorMode": "code",
                   "expr": "histogram_quantile(0.99, (sum without(instance,pod,namespace,service,job)(rate(hive_cluster_deployment_install_job_duration_seconds_bucket{appsre_env=\"$env\",shard_status=\"$shard_status\"}[1d]))))",
@@ -742,7 +691,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+                    "uid": "${datasource}"
                   },
                   "editorMode": "code",
                   "expr": "histogram_quantile(0.95, (sum without(instance,pod,namespace,service,job)(rate(hive_cluster_deployment_install_job_duration_seconds_bucket{appsre_env=\"$env\",shard_status=\"$shard_status\"}[1d]))))",
@@ -754,7 +703,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+                    "uid": "${datasource}"
                   },
                   "editorMode": "code",
                   "expr": "histogram_quantile(0.90, (sum without(instance,pod,namespace,service,job)(rate(hive_cluster_deployment_install_job_duration_seconds_bucket{appsre_env=\"$env\",shard_status=\"$shard_status\"}[1d]))))",
@@ -766,7 +715,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+                    "uid": "${datasource}"
                   },
                   "editorMode": "code",
                   "expr": "histogram_quantile(0.85, (sum without(instance,pod,namespace,service,job)(rate(hive_cluster_deployment_install_job_duration_seconds_bucket{appsre_env=\"$env\",shard_status=\"$shard_status\"}[1d]))))",
@@ -778,7 +727,7 @@ data:
                 {
                   "datasource": {
                     "type": "prometheus",
-                    "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+                    "uid": "${datasource}"
                   },
                   "editorMode": "code",
                   "expr": "histogram_quantile(0.5, (sum without(instance,pod,namespace,service,job)(rate(hive_cluster_deployment_install_job_duration_seconds_bucket{appsre_env=\"$env\",shard_status=\"$shard_status\"}[1d]))))",
@@ -820,10 +769,14 @@ data:
             "type": "datasource"
           },
           {
-            "current": {},
+            "current": {
+              "selected": false,
+               "text": "production",
+               "value": "production"
+            },
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+              "uid": "${datasource}"
             },
             "definition": "label_values(appsre_env)",
             "hide": 0,
@@ -911,10 +864,14 @@ data:
             "type": "interval"
           },
           {
-            "current": {},
+            "current": {
+              "selected": true,
+              "text": "300",
+              "value": "300"
+            },
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+              "uid": "${datasource}"
             },
             "definition": "label_values(le)",
             "hide": 0,
@@ -933,10 +890,14 @@ data:
             "type": "query"
           },
           {
-            "current": {},
+            "current": {
+              "selected": true,
+              "text": "3600",
+              "value": "3600"
+            },
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+              "uid": "${datasource}"
             },
             "definition": "label_values(le)",
             "description": "1800, 2400, 3000, 3600, 4500, 5400, 7200",
@@ -956,10 +917,14 @@ data:
             "type": "query"
           },
           {
-            "current": {},
+            "current": {
+              "selected": false,
+              "text": "active",
+              "value": "active"
+            },
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_APPSREP05UE1-PROMETHEUS}"
+              "uid": "${datasource}"
             },
             "definition": "label_values(shard_status)",
             "hide": 0,
@@ -1077,10 +1042,14 @@ data:
             "type": "custom"
           },
           {
-            "current": {},
+            "current": {
+              "selected": false,
+              "text": "production",
+              "value": "production"
+            },
             "datasource": {
               "type": "postgres",
-              "uid": "${DS_DEPLOY-EVENTS-DB}"
+              "uid": "P5108662370F9C14C"
             },
             "definition": "select env_name from deployments where env_name in ('osd-stage-01','osd-stage-hives02ue1','osd-integration-hivei01ue1',\n'osd-production-hivep01ue1','osd-production-hivep02ue1','osd-production-hivep03uw1','osd-production-hivep04ew2',\n'osd-production-hivep05ue1','osd-production-hivep06uw2','osd-production-hivep07ue2')",
             "hide": 2,
@@ -1106,7 +1075,7 @@ data:
       "timezone": "",
       "title": "Hive SLO",
       "uid": "r3dExJ24z",
-      "version": 30,
+      "version": 31,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
When exporting the JSON of an existing dashboard, it was chosen with an option `Export externally`, which has made it incompatible with the predefined variables that are define in the app-interface repo.