### PR TITLE
Revert builder.Unreachable() and add reachable check to builder.Build()

### DIFF
--- a/pkg/controller/unreachable/unreachable_controller.go
+++ b/pkg/controller/unreachable/unreachable_controller.go
@@ -198,7 +198,7 @@ func (r *ReconcileRemoteMachineSet) Reconcile(ctx context.Context, request recon
 	updateUnreachable := true
 	var primaryErr error
 	// Attempt to connect to the remote cluster using the preferred API URL.
-	primaryErr = remoteClientBuilder.UsePrimaryAPIURL().Reachable()
+	_, primaryErr = remoteClientBuilder.UsePrimaryAPIURL().Build()
 	if primaryErr != nil {
 		// If the remote cluster is not accessible via the preferred API URL, check if there is a fallback API URL to use.
 		if hasOverride(cd) {
@@ -209,7 +209,7 @@ func (r *ReconcileRemoteMachineSet) Reconcile(ctx context.Context, request recon
 			// become accessible, the controller should not recheck connectivity via the fallback API URL more often
 			// than once every 2 hours.
 			if connectivityRecheckNeeded || wasPrimaryActive {
-				if secondaryErr := remoteClientBuilder.UseSecondaryAPIURL().Reachable(); secondaryErr != nil {
+				if _, secondaryErr := remoteClientBuilder.UseSecondaryAPIURL().Build(); secondaryErr != nil {
 					cdLog.WithError(secondaryErr).Warn("unable to create remote API client with either the initial API URL or the API URL override, marking cluster unreachable")
 					unreachableError = utilerrors.NewAggregate([]error{primaryErr, secondaryErr})
 				}

--- a/pkg/controller/unreachable/unreachable_controller_test.go
+++ b/pkg/controller/unreachable/unreachable_controller_test.go
@@ -243,7 +243,7 @@ func TestReconcile(t *testing.T) {
 				if *test.errorConnecting {
 					buildError = errors.New("cluster not reachable")
 				}
-				mockRemoteClientBuilder.EXPECT().Reachable().Return(buildError)
+				mockRemoteClientBuilder.EXPECT().Build().Return(nil, buildError)
 			}
 			if test.errorConnectingSecondary != nil {
 				mockRemoteClientBuilder.EXPECT().UseSecondaryAPIURL().Return(mockRemoteClientBuilder)
@@ -251,7 +251,7 @@ func TestReconcile(t *testing.T) {
 				if *test.errorConnectingSecondary {
 					buildError = errors.New("cluster not reachable")
 				}
-				mockRemoteClientBuilder.EXPECT().Reachable().Return(buildError)
+				mockRemoteClientBuilder.EXPECT().Build().Return(nil, buildError)
 			}
 			rcd := &ReconcileRemoteMachineSet{
 				Client:                        fakeClient,

--- a/pkg/remoteclient/fake.go
+++ b/pkg/remoteclient/fake.go
@@ -115,5 +115,3 @@ func (b *fakeBuilder) UseSecondaryAPIURL() Builder {
 func (b *fakeBuilder) RESTConfig() (*rest.Config, error) {
 	return nil, errors.New("RESTConfig not implemented for fake cluster client builder")
 }
-
-func (b *fakeBuilder) Reachable() error { return nil }

--- a/pkg/remoteclient/kubeconfig.go
+++ b/pkg/remoteclient/kubeconfig.go
@@ -3,11 +3,9 @@ package remoteclient
 import (
 	"github.com/openshift/hive/pkg/util/scheme"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/restmapper"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -72,17 +70,4 @@ func (b *kubeconfigBuilder) UseSecondaryAPIURL() Builder {
 
 func (b *kubeconfigBuilder) RESTConfig() (*rest.Config, error) {
 	return restConfigFromSecret(b.secret)
-}
-
-func (b *kubeconfigBuilder) Reachable() error {
-	cfg, err := b.RESTConfig()
-	if err != nil {
-		return err
-	}
-	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
-	if err != nil {
-		return err
-	}
-	_, err = restmapper.GetAPIGroupResources(dc)
-	return err
 }

--- a/pkg/remoteclient/mock/remoteclient_generated.go
+++ b/pkg/remoteclient/mock/remoteclient_generated.go
@@ -98,20 +98,6 @@ func (mr *MockBuilderMockRecorder) RESTConfig() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RESTConfig", reflect.TypeOf((*MockBuilder)(nil).RESTConfig))
 }
 
-// Reachable mocks base method.
-func (m *MockBuilder) Reachable() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Reachable")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Reachable indicates an expected call of Reachable.
-func (mr *MockBuilderMockRecorder) Reachable() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reachable", reflect.TypeOf((*MockBuilder)(nil).Reachable))
-}
-
 // UsePrimaryAPIURL mocks base method.
 func (m *MockBuilder) UsePrimaryAPIURL() remoteclient.Builder {
 	m.ctrl.T.Helper()

--- a/pkg/remoteclient/remoteclient.go
+++ b/pkg/remoteclient/remoteclient.go
@@ -13,11 +13,9 @@ import (
 	machnet "k8s.io/apimachinery/pkg/util/net"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -48,9 +46,6 @@ type Builder interface {
 	// UseSecondaryAPIURL will use the secondary API URL. If there is an API URL override, then the initial API URL
 	// is the secondary.
 	UseSecondaryAPIURL() Builder
-
-	// Reachable internally builds a client and runs a query to make sure it is healthy.
-	Reachable() error
 }
 
 // NewBuilder creates a new Builder for creating a client to connect to the remote cluster associated with the specified
@@ -208,19 +203,6 @@ func (b *builder) Build() (client.Client, error) {
 	return client.New(cfg, client.Options{
 		Scheme: scheme,
 	})
-}
-
-func (b *builder) Reachable() error {
-	cfg, err := b.RESTConfig()
-	if err != nil {
-		return err
-	}
-	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
-	if err != nil {
-		return err
-	}
-	_, err = restmapper.GetAPIGroupResources(dc)
-	return err
 }
 
 func (b *builder) BuildDynamic() (dynamic.Interface, error) {

--- a/pkg/remoteclient/remoteclient_test.go
+++ b/pkg/remoteclient/remoteclient_test.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
@@ -227,13 +226,9 @@ func Test_builder_Build(t *testing.T) {
 			builder := NewBuilder(c, cd, "test-controller-name")
 			var err error
 			if !tc.dynamic {
-				rc, buildErr := builder.Build()
-				assert.NoError(t, buildErr, "unexpected error building client")
-				namespaced_name := types.NamespacedName{
-					Name:      "bad-name",
-					Namespace: "bad-namespace",
-				}
-				err = rc.Get(context.Background(), namespaced_name, &hivev1.ClusterDeployment{})
+				// Build is expected to fail due to "no such host" error, as the Build() method
+				// is responsible for testing reachability.
+				_, err = builder.Build()
 			} else {
 				rc, buildErr := builder.BuildDynamic()
 				assert.NoError(t, buildErr, "unexpected error building dynamic client")


### PR DESCRIPTION
With the controller-runtime upgrade from 8cfdcca, our remote client
`Builder` interface's `Build()` method got lazier. Before, if the remote
client was unreachable, `Build()` itself would fail. Now it won't fail
until the resulting client is actually used. This resulted in our
"unreachable" controller incorrectly marking the ClusterDeployment's
APIURLOverride as reachable when it wasn't, which had the ripple effect
of making the clustersync controller fail early by trying to use that
URL rather than falling back to the default.

This was exposed in situations where the DNS for the APIURLOverride was
being configured via a syncset: the clustersync controller tried to use
a URL that wouldn't resolve, so it couldn't sync the resource that would
make that DNS work.

Initially, to fix this issue, a `Reachable()` method was added to the `Builder`,
but on further inspection, there are many cases where uses of the `Build()`
method result in a client being falsely marked as reachable.

To fix, this PR reverts the `Reachable()` commit 576401b8d
and moves the reachability check to the `Build()` method of the `Builder` interface.
This internally builds the client and then uses it to query the `/apis` of the remote client.

xref: [HIVE-2300](https://issues.redhat.com//browse/HIVE-2300)