### PR TITLE
Fix field-tag of MachinePool TaintIndentifier

### DIFF
--- a/apis/hive/v1/machinepool_types.go
+++ b/apis/hive/v1/machinepool_types.go
@@ -120,9 +120,9 @@ type MachinePoolStatus struct {
 // key+effect, not simply by key.)
 type TaintIdentifier struct {
 	// Key matches corev1.Taint.Key.
-	Key string `json:"key:omitempty"`
+	Key string `json:"key,omitempty"`
 	// Effect matches corev1.Taint.Effect.
-	Effect corev1.TaintEffect `json:"effect:omitempty"`
+	Effect corev1.TaintEffect `json:"effect,omitempty"`
 }
 
 // MachineSetStatus is the status of a machineset in the remote cluster.

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -653,15 +653,12 @@ spec:
                     out taints are mutually exclusive by key+effect, not simply by
                     key.)
                   properties:
-                    effect:omitempty:
+                    effect:
                       description: Effect matches corev1.Taint.Effect.
                       type: string
-                    key:omitempty:
+                    key:
                       description: Key matches corev1.Taint.Key.
                       type: string
-                  required:
-                  - effect:omitempty
-                  - key:omitempty
                   type: object
                 type: array
               replicas:

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -5458,15 +5458,12 @@ objects:
                       turns out taints are mutually exclusive by key+effect, not simply
                       by key.)
                     properties:
-                      effect:omitempty:
+                      effect:
                         description: Effect matches corev1.Taint.Effect.
                         type: string
-                      key:omitempty:
+                      key:
                         description: Key matches corev1.Taint.Key.
                         type: string
-                    required:
-                    - effect:omitempty
-                    - key:omitempty
                     type: object
                   type: array
                 replicas:

--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -960,8 +960,9 @@ func (r *ReconcileMachinePool) updatePoolStatusForMachineSets(
 	}
 
 	// ...and taints
-	pool.Status.OwnedTaints = make([]hivev1.TaintIdentifier, len(pool.Spec.Taints))
-	for i, taint := range *controllerutils.GetUniqueTaints(&pool.Spec.Taints) {
+	uniqueTaints := *controllerutils.GetUniqueTaints(&pool.Spec.Taints)
+	pool.Status.OwnedTaints = make([]hivev1.TaintIdentifier, len(uniqueTaints))
+	for i, taint := range uniqueTaints {
 		pool.Status.OwnedTaints[i] = controllerutils.IdentifierForTaint(&taint)
 	}
 

--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -951,6 +951,18 @@ func (r *ReconcileMachinePool) updatePoolStatusForMachineSets(
 		}
 	}
 
+	pool.Status = updateOwnedLabelsAndTaints(pool)
+
+	if (len(origPool.Status.MachineSets) == 0 && len(pool.Status.MachineSets) == 0) ||
+		reflect.DeepEqual(origPool.Status, pool.Status) {
+		return reconcile.Result{RequeueAfter: requeueAfter}, nil
+	}
+
+	return reconcile.Result{RequeueAfter: requeueAfter}, errors.Wrap(r.Status().Update(context.Background(), pool), "failed to update pool status")
+}
+
+// updateOwnedLabelsAndTaints updates OwnedLabels and OwnedTaints in the MachinePool.Status, by fetching the relevant entries sans duplicates from MachinePool.Spec.
+func updateOwnedLabelsAndTaints(pool *hivev1.MachinePool) hivev1.MachinePoolStatus {
 	// Update our tracked labels...
 	pool.Status.OwnedLabels = make([]string, len(pool.Spec.Labels))
 	i := 0
@@ -965,13 +977,7 @@ func (r *ReconcileMachinePool) updatePoolStatusForMachineSets(
 	for i, taint := range uniqueTaints {
 		pool.Status.OwnedTaints[i] = controllerutils.IdentifierForTaint(&taint)
 	}
-
-	if (len(origPool.Status.MachineSets) == 0 && len(pool.Status.MachineSets) == 0) ||
-		reflect.DeepEqual(origPool.Status, pool.Status) {
-		return reconcile.Result{RequeueAfter: requeueAfter}, nil
-	}
-
-	return reconcile.Result{RequeueAfter: requeueAfter}, errors.Wrap(r.Status().Update(context.Background(), pool), "failed to update pool status")
+	return pool.Status
 }
 
 // summarizeMachinesError returns reason and message for error state of machineSets by

--- a/vendor/github.com/openshift/hive/apis/hive/v1/machinepool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/machinepool_types.go
@@ -120,9 +120,9 @@ type MachinePoolStatus struct {
 // key+effect, not simply by key.)
 type TaintIdentifier struct {
 	// Key matches corev1.Taint.Key.
-	Key string `json:"key:omitempty"`
+	Key string `json:"key,omitempty"`
 	// Effect matches corev1.Taint.Effect.
-	Effect corev1.TaintEffect `json:"effect:omitempty"`
+	Effect corev1.TaintEffect `json:"effect,omitempty"`
 }
 
 // MachineSetStatus is the status of a machineset in the remote cluster.


### PR DESCRIPTION
This commit fix 2 typos:
- Field-tags for MachinePool TaintIdentifier had a colon before omitempty instead of a comma
- When making a slice for OwnedTaints as a part of update, set it to the length of unique taints instead of MachinePool spec.taints, as Machinepool could have duplicate taints which will not be migrated to OwnedTaints

xref: https://issues.redhat.com/browse/HIVE-2268

/assign @2uasimojo 