### PR TITLE
MachinePool (AWS): AdditionalSecurityGroupIDs

### DIFF
--- a/apis/hive/v1/aws/machinepool.go
+++ b/apis/hive/v1/aws/machinepool.go
@@ -30,6 +30,12 @@ type MachinePoolPlatform struct {
 	// EC2MetadataOptions defines metadata service interaction options for EC2 instances in the machine pool.
 	// +optional
 	EC2Metadata *EC2Metadata `json:"metadataService,omitempty"`
+
+	// AdditionalSecurityGroupIDs contains IDs of additional security groups for machines, where each ID
+	// is presented in the format sg-xxxx.
+	//
+	// +optional
+	AdditionalSecurityGroupIDs []string `json:"additionalSecurityGroupIDs,omitempty"`
 }
 
 // SpotMarketOptions defines the options available to a user when configuring

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -123,6 +123,13 @@ spec:
                     description: AWS is the configuration used when installing on
                       AWS.
                     properties:
+                      additionalSecurityGroupIDs:
+                        description: AdditionalSecurityGroupIDs contains IDs of additional
+                          security groups for machines, where each ID is presented
+                          in the format sg-xxxx.
+                        items:
+                          type: string
+                        type: array
                       metadataService:
                         description: EC2MetadataOptions defines metadata service interaction
                           options for EC2 instances in the machine pool.

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -4922,6 +4922,13 @@ objects:
                       description: AWS is the configuration used when installing on
                         AWS.
                       properties:
+                        additionalSecurityGroupIDs:
+                          description: AdditionalSecurityGroupIDs contains IDs of
+                            additional security groups for machines, where each ID
+                            is presented in the format sg-xxxx.
+                          items:
+                            type: string
+                          type: array
                         metadataService:
                           description: EC2MetadataOptions defines metadata service
                             interaction options for EC2 instances in the machine pool.

--- a/vendor/github.com/openshift/hive/apis/hive/v1/aws/machinepool.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/aws/machinepool.go
@@ -30,6 +30,12 @@ type MachinePoolPlatform struct {
 	// EC2MetadataOptions defines metadata service interaction options for EC2 instances in the machine pool.
 	// +optional
 	EC2Metadata *EC2Metadata `json:"metadataService,omitempty"`
+
+	// AdditionalSecurityGroupIDs contains IDs of additional security groups for machines, where each ID
+	// is presented in the format sg-xxxx.
+	//
+	// +optional
+	AdditionalSecurityGroupIDs []string `json:"additionalSecurityGroupIDs,omitempty"`
 }
 
 // SpotMarketOptions defines the options available to a user when configuring


### PR DESCRIPTION
Mirror the installer's new AdditionalSecurityGroupIDs field (see openshift/installer#7151) into hive's MachinePool CRD. Plumb it into the installer's provider code so the additional SGIDs are included in generated MachineSets.

Note:
There's a back door, added via #1743 / a028ecd0 and refined via #1767 / cdf36016, whereby a (single) additional security group can be added by name. It is mutually exclusive with this feature: if you try to use both, your MachinePool will get the UnsupportedConfiguration condition. (We probably didn't *need* to make the two things mutually exclusive, but we did anyway.)

[HIVE-2306](https://issues.redhat.com//browse/HIVE-2306)