### PR TITLE
MachinePool (GCP): Add NetworkProjectID 

### DIFF
--- a/apis/hive/v1/gcp/machinepools.go
+++ b/apis/hive/v1/gcp/machinepools.go
@@ -13,6 +13,11 @@ type MachinePool struct {
 	//
 	// +optional
 	OSDisk OSDisk `json:"osDisk"`
+
+	// NetworkProjectID specifies which project the network and subnets exist in when
+	// they are not in the main ProjectID.
+	// +optional
+	NetworkProjectID string `json:"networkProjectID,omitempty"`
 }
 
 // OSDisk defines the disk for machines on GCP.

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -281,6 +281,11 @@ spec:
                     description: GCP is the configuration used when installing on
                       GCP.
                     properties:
+                      networkProjectID:
+                        description: NetworkProjectID specifies which project the
+                          network and subnets exist in when they are not in the main
+                          ProjectID.
+                        type: string
                       osDisk:
                         description: OSDisk defines the storage for instances.
                         properties:

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -5082,6 +5082,11 @@ objects:
                       description: GCP is the configuration used when installing on
                         GCP.
                       properties:
+                        networkProjectID:
+                          description: NetworkProjectID specifies which project the
+                            network and subnets exist in when they are not in the
+                            main ProjectID.
+                          type: string
                         osDisk:
                           description: OSDisk defines the storage for instances.
                           properties:

--- a/pkg/controller/machinepool/gcpactuator.go
+++ b/pkg/controller/machinepool/gcpactuator.go
@@ -168,10 +168,11 @@ func (a *GCPActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *hi
 	ic := &installertypes.InstallConfig{
 		Platform: installertypes.Platform{
 			GCP: &installertypesgcp.Platform{
-				Region:        cd.Spec.Platform.GCP.Region,
-				ProjectID:     a.projectID,
-				ComputeSubnet: a.subnet,
-				Network:       a.network,
+				Region:           cd.Spec.Platform.GCP.Region,
+				ProjectID:        a.projectID,
+				ComputeSubnet:    a.subnet,
+				Network:          a.network,
+				NetworkProjectID: pool.Spec.Platform.GCP.NetworkProjectID,
 			},
 		},
 	}

--- a/vendor/github.com/openshift/hive/apis/hive/v1/gcp/machinepools.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/gcp/machinepools.go
@@ -13,6 +13,11 @@ type MachinePool struct {
 	//
 	// +optional
 	OSDisk OSDisk `json:"osDisk"`
+
+	// NetworkProjectID specifies which project the network and subnets exist in when
+	// they are not in the main ProjectID.
+	// +optional
+	NetworkProjectID string `json:"networkProjectID,omitempty"`
 }
 
 // OSDisk defines the disk for machines on GCP.


### PR DESCRIPTION
Add NetworkProjectID to the GCP Platform section of MachinePool and plumb it through to the generated MachineSets. This is in support of XPN (shared VPC).

[HIVE-2310](https://issues.redhat.com//browse/HIVE-2310)