### PR TITLE
Fix fake cluster version

### DIFF
--- a/pkg/remoteclient/fake.go
+++ b/pkg/remoteclient/fake.go
@@ -19,7 +19,8 @@ import (
 // fakeBuilder builds fake clients for fake clusters. Used to simulate communication with a cluster
 // that doesn't actually exist in scale testing.
 type fakeBuilder struct {
-	urlToUse int
+	urlToUse       int
+	clusterVersion string
 }
 
 // Build returns a fake controller-runtime test client populated with the resources we expect to query for a
@@ -43,7 +44,7 @@ func (b *fakeBuilder) Build() (client.Client, error) {
 			},
 			Status: configv1.ClusterVersionStatus{
 				Desired: configv1.Release{
-					Version: "4.6.8",
+					Version: b.clusterVersion,
 				},
 			},
 		},

--- a/pkg/remoteclient/remoteclient.go
+++ b/pkg/remoteclient/remoteclient.go
@@ -58,8 +58,13 @@ type Builder interface {
 // runtime.Objects we need to query for in all our controllers.
 func NewBuilder(c client.Client, cd *hivev1.ClusterDeployment, controllerName hivev1.ControllerName) Builder {
 	if utils.IsFakeCluster(cd) {
+		clusterVersion := ""
+		if cd.Status.InstallVersion != nil {
+			clusterVersion = *cd.Status.InstallVersion
+		}
 		return &fakeBuilder{
-			urlToUse: activeURL,
+			urlToUse:       activeURL,
+			clusterVersion: clusterVersion,
 		}
 	}
 	return &builder{


### PR DESCRIPTION
Fake clusters report their version based on a dummy CVO incorporated into their special remote client builder. Previously we were hardcoding that value to "4.6.8" in that builder. With this commit, we plumb in the value from cd.status.installVersion -- which gets set by the imageset/installer process even for fake clusters. So now if you watch the `VERSION` field for a fake cluster, it behaves the same as for a real cluster: empty until the cluster is `Provisioned` and the clusterversion controller kicks in again, whereupon it is set to the correct value based on the input release image.

[HIVE-2312](https://issues.redhat.com//browse/HIVE-2312)