### PR TITLE
Use force when applying objects (for clustersync et al)

### DIFF
--- a/pkg/resource/apply.go
+++ b/pkg/resource/apply.go
@@ -223,6 +223,7 @@ func (r *helper) setupApplyCommand(f cmdutil.Factory, obj []byte, ioStreams gene
 		return nil, nil, err
 	}
 	o.DeleteOptions, err = delete.NewDeleteFlags("").ToOptions(dynamicClient, ioStreams)
+	o.DeleteOptions.ForceDeletion = true
 	if err != nil {
 		r.logger.WithError(err).Error("cannot create delete options")
 		return nil, nil, err


### PR DESCRIPTION
When hive applies objects -- notably for [Selector]SyncSets, but also as hive-operator lays down resources such as controller Deployments, webhook configurations, etc. -- we call into k8s library code used by `kubectl apply`. This has some quirks around the
`kubectl.kubernetes.io/last-applied-configuration` annotation which, under certain circumstances, could cause our apply-er to fail with this annoying error:

```
error when patching "object": <thing> is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update
```

There were several possible solutions (see linked card), but the one we're using in this commit is to use (the code equivalent of) the `--force` option, which disregards resourceVersion conflicts.

Note that this may result in race conditions under the covers if some other agent is updating the same object. This is considered acceptable as a) they shouldn't be doing that, and b) we are the source of truth for those objects anyway, so it is appropriate that we ultimately assert our version.

[HIVE-2321](https://issues.redhat.com//browse/HIVE-2321)