### PR TITLE
Fix TaintIdentifier fields in applyconfiguration

### DIFF
--- a/pkg/client/applyconfiguration/hive/v1/taintidentifier.go
+++ b/pkg/client/applyconfiguration/hive/v1/taintidentifier.go
@@ -9,8 +9,8 @@ import (
 // TaintIdentifierApplyConfiguration represents an declarative configuration of the TaintIdentifier type for use
 // with apply.
 type TaintIdentifierApplyConfiguration struct {
-	Key    *string         `json:"key:omitempty,omitempty"`
-	Effect *v1.TaintEffect `json:"effect:omitempty,omitempty"`
+	Key    *string         `json:"key,omitempty"`
+	Effect *v1.TaintEffect `json:"effect,omitempty"`
 }
 
 // TaintIdentifierApplyConfiguration constructs an declarative configuration of the TaintIdentifier type for use with


### PR DESCRIPTION
Still don't know what applyconfiguration is or does, but `make update` made this change that looks like it should have been swept up in #2112.

[HIVE-2268](https://issues.redhat.com//browse/HIVE-2268)