### PR TITLE
clustersync: fix pod security

### DIFF
--- a/config/clustersync/statefulset.yaml
+++ b/config/clustersync/statefulset.yaml
@@ -27,6 +27,10 @@ spec:
             controller-tools.k8s.io: "1.0"
       serviceAccount: hive-controllers
       serviceAccountName: hive-controllers
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: clustersync
         resources:
@@ -72,3 +76,7 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -150,6 +150,10 @@ spec:
             controller-tools.k8s.io: "1.0"
       serviceAccount: hive-controllers
       serviceAccountName: hive-controllers
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: clustersync
         resources:
@@ -195,6 +199,10 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
 `)
 
 func configClustersyncStatefulsetYamlBytes() ([]byte, error) {


### PR DESCRIPTION
Get rid of annoying log messages and potential future inability to stand up clustersync pods.