### PR TITLE
DNM: Test e2e-gcp required-ness

### DIFF
--- a/pkg/controller/machinepool/gcpactuator.go
+++ b/pkg/controller/machinepool/gcpactuator.go
@@ -222,7 +222,7 @@ func (a *GCPActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *hi
 			return nil, false, errors.Wrap(err, "compute pool not providing list of zones and failed to fetch list of zones")
 		}
 		if len(zones) == 0 {
-			return nil, false, fmt.Errorf("zero zones returned for region %s", cd.Spec.Platform.GCP.Region)
+			return nil, false, fmt.Errorf("TRIGGER e2e-gcp // zero zones returned for region %s", cd.Spec.Platform.GCP.Region)
 		}
 		computePool.Platform.GCP.Zones = zones
 	}

--- a/test/e2e/postinstall/machinesets/infra_test.go
+++ b/test/e2e/postinstall/machinesets/infra_test.go
@@ -43,7 +43,9 @@ func TestScaleMachinePool(t *testing.T) {
 	switch p := cd.Spec.Platform; {
 	case p.AWS != nil:
 	case p.Azure != nil:
+	// Make e2e-gcp fail!
 	case p.GCP != nil:
+		panic("FAIL!")
 	default:
 		t.Log("Scaling the machine pool is only implemented for AWS, Azure, and GCP")
 		return


### PR DESCRIPTION
We're trying to make e2e-gcp (and -azure) mandatory iff they are triggered: https://github.com/openshift/release/pull/44171

This commit does two things:
- No-op change to a GCP-specific source file to cause e2e-gcp to be triggered.
- Change to postinstall that should make e2e-gcp fail

The idea will be to `lgtm` this PR to demonstrate that it doesn't merge!

(Then we'll want to watch a normal PR that we _do_ want to merge and make sure that not running e2e-gcp at all doesn't block it.)