### PR TITLE
Add labels to ClusterSyncFailing metric

### DIFF
--- a/pkg/controller/metrics/custom_collectors.go
+++ b/pkg/controller/metrics/custom_collectors.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -33,8 +34,8 @@ var (
 type provisioningUnderwayCollector struct {
 	client client.Client
 
-	// minDuration, when non-zero, is the minimum duration afer which clusters provisioning
-	// will start becomming part of this metric. When set to zero, all clusters provisioning
+	// minDuration, when non-zero, is the minimum duration after which clusters provisioning
+	// will start becoming part of this metric. When set to zero, all clusters provisioning
 	// will be included in the metric.
 	minDuration time.Duration
 
@@ -43,7 +44,7 @@ type provisioningUnderwayCollector struct {
 	metricClusterDeploymentProvisionUnderwaySeconds *prometheus.Desc
 }
 
-// collects the metrics for provisioningUnderwayCollector
+// Collect collects the metrics for provisioningUnderwayCollector
 func (cc provisioningUnderwayCollector) Collect(ch chan<- prometheus.Metric) {
 	ccLog := log.WithField("controller", "metrics")
 	ccLog.Info("calculating provisioning underway metrics across all ClusterDeployments")
@@ -132,7 +133,7 @@ type provisioningUnderwayInstallRestartsCollector struct {
 	metricClusterDeploymentProvisionUnderwayInstallRestarts *prometheus.Desc
 }
 
-// collects the metrics for provisioningUnderwayInstallRestartsCollector
+// Collect collects the metrics for provisioningUnderwayInstallRestartsCollector
 func (cc provisioningUnderwayInstallRestartsCollector) Collect(ch chan<- prometheus.Metric) {
 	ccLog := log.WithField("controller", "metrics")
 	ccLog.Info("calculating provisioning underway install restarts metrics across all ClusterDeployments")
@@ -249,7 +250,7 @@ type deprovisioningUnderwayCollector struct {
 	metricClusterDeploymentDeprovisionUnderwaySeconds *prometheus.Desc
 }
 
-// collects the metrics for deprovisioningUnderwayCollector
+// Collect collects the metrics for deprovisioningUnderwayCollector
 func (cc deprovisioningUnderwayCollector) Collect(ch chan<- prometheus.Metric) {
 	ccLog := log.WithField("controller", "metrics")
 	ccLog.Info("calculating deprovisioning underway metrics across all ClusterDeployments")
@@ -306,7 +307,7 @@ func newDeprovisioningUnderwaySecondsCollector(client client.Client) prometheus.
 type clusterSyncFailingCollector struct {
 	client client.Client
 
-	// minDuration, when non-zero, is the minimum duration afer which clustersync failure
+	// minDuration, when non-zero, is the minimum duration after which clustersync failure
 	// will start becoming part of this metric. When set to zero, all clustersync failures
 	// will be included in the metric.
 	minDuration time.Duration
@@ -314,9 +315,14 @@ type clusterSyncFailingCollector struct {
 	// metricClusterSyncFailingSeconds is a prometheus metric for the number of seconds
 	// between the start of a failing clustersync and now.
 	metricClusterSyncFailingSeconds *prometheus.Desc
+
+	// dynamicLabels is a collection of fixed (mandatory) and optional labels for the clusterSyncFailing metric.
+	// It also has labelList which stores the order of labels as defined in Desc. MustNewConstMetric doesn't
+	// accept a map of labels and values, so maintaining the order is needed while observing the metric.
+	dynamicLabels dynamicLabelsForCustomCollectors
 }
 
-// collects the metrics for custerSyncFailingCollector
+// Collect collects the metrics for custerSyncFailingCollector
 func (cc clusterSyncFailingCollector) Collect(ch chan<- prometheus.Metric) {
 	ccLog := log.WithField("controller", "metrics")
 	ccLog.Info("calculating cluster sync failing seconds metrics")
@@ -328,19 +334,40 @@ func (cc clusterSyncFailingCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
+	clusterDeployments := &hivev1.ClusterDeploymentList{}
+	err = cc.client.List(context.Background(), clusterDeployments)
+	if err != nil {
+		log.WithError(err).Error("error listing cluster deployments")
+		return
+	}
+
 	for _, cs := range clusterSyncList.Items {
 		// Failing cluster syncs
 		cond := controllerutils.FindCondition(cs.Status.Conditions, hiveintv1alpha1.ClusterSyncFailed)
 		if cond != nil && cond.Status == corev1.ConditionTrue {
-			seconds := time.Since(cond.LastTransitionTime.Time).Seconds()
-			// check if duration crosses the threshold
-			if cc.minDuration.Seconds() <= seconds {
-				ch <- prometheus.MustNewConstMetric(
-					cc.metricClusterSyncFailingSeconds,
-					prometheus.GaugeValue,
-					seconds,
-					cs.Namespace+"/"+cs.Name,
-				)
+			for _, cd := range clusterDeployments.Items {
+				// Expect to find the corresponding ClusterDeployment. In the rare case it got garbage collected by the time
+				// we fetched the list of ClusterSyncs, do not report the metric.
+				if cd.Namespace == cs.Namespace {
+					// Ignore uninstalled ClusterDeployments as it wouldn't have all conditions initialized.
+					if unreachableCondition := controllerutils.FindCondition(cd.Status.Conditions, hivev1.UnreachableCondition); unreachableCondition != nil {
+						fixedLabels := make(map[string]string, len(cc.dynamicLabels.fixedLabels))
+						fixedLabels["namespaced_name"] = cs.Namespace + "/" + cs.Name
+						fixedLabels["unreachable"] = string(unreachableCondition.Status)
+						labelValues := cc.dynamicLabels.buildLabelSlice(fixedLabels, &cd)
+						seconds := time.Since(cond.LastTransitionTime.Time).Seconds()
+						// check if duration crosses the threshold
+						if cc.minDuration.Seconds() <= seconds {
+							ch <- prometheus.MustNewConstMetric(
+								cc.metricClusterSyncFailingSeconds,
+								prometheus.GaugeValue,
+								seconds,
+								labelValues...,
+							)
+						}
+					}
+				}
+				continue
 			}
 		}
 	}
@@ -350,22 +377,30 @@ func (cc clusterSyncFailingCollector) Describe(ch chan<- *prometheus.Desc) {
 	prometheus.DescribeByCollect(cc, ch)
 }
 
-// MetricClusterSyncFailingSeconds is a prometheus metric that tracks the number of seconds for which a
-// clustersync has been in failing state
-var (
-	metricClusterSyncFailingSecondsDesc = prometheus.NewDesc(
-		"hive_clustersync_failing_seconds",
-		"Length of time a clustersync has been failing",
+func newClusterSyncFailingCollector(client client.Client, minimum time.Duration, optionalLabels map[string]string) prometheus.Collector {
+	metricName := "hive_clustersync_failing_seconds"
+	baseLabels := dynamicLabels{
 		// namespaced_name would be logged as $namespace/$name
-		[]string{"namespaced_name"},
-		nil,
-	)
-)
-
-func newClusterSyncFailingCollector(client client.Client, minimum time.Duration) prometheus.Collector {
+		// unreachable reports the status of unreachable condition of the corresponding cluster deployment
+		fixedLabels:    []string{"namespaced_name", "unreachable"},
+		optionalLabels: optionalLabels,
+	}
+	if repeatedLabels := baseLabels.getRepeatedLabels(); repeatedLabels != nil {
+		panic(fmt.Sprintf("Label(s) %v in HiveConfig.Spec.AdditionalClusterDeploymentLabels conflict with fixed label(s) for the metric %s. Please rename your label.", repeatedLabels, metricName))
+	}
+	labels := dynamicLabelsForCustomCollectors{
+		dynamicLabels: baseLabels,
+		labelList:     baseLabels.getLabelList(),
+	}
 	return clusterSyncFailingCollector{
-		client:                          client,
-		metricClusterSyncFailingSeconds: metricClusterSyncFailingSecondsDesc,
-		minDuration:                     minimum,
+		client: client,
+		metricClusterSyncFailingSeconds: prometheus.NewDesc(
+			metricName,
+			"Length of time a clustersync has been failing",
+			labels.labelList,
+			nil,
+		),
+		minDuration:   minimum,
+		dynamicLabels: labels,
 	}
 }

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -409,7 +409,7 @@ func (mc *Calculator) registerOptionalMetrics(mConfig *metricsconfig.MetricsConf
 			mapMetricToDurationHistograms[MetricClusterReadyTransitionSeconds] = metric.Duration.Duration
 		// Gauges
 		case metricsconfig.CurrentClusterSyncFailing:
-			metrics.Registry.MustRegister(newClusterSyncFailingCollector(mc.Client, metric.Duration.Duration))
+			metrics.Registry.MustRegister(newClusterSyncFailingCollector(mc.Client, metric.Duration.Duration, GetOptionalClusterTypeLabels(mConfig)))
 		}
 	}
 }

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -692,8 +692,10 @@ func (ca *clusterAccumulator) setMetrics(total, installed, uninstalled, deprovis
 
 // GetLabelValue returns the value of the label if set, otherwise a default value.
 func GetLabelValue(obj metav1.Object, label string) string {
-	if typeStr := obj.GetLabels()[label]; typeStr != "" {
-		return typeStr
+	if obj != nil {
+		if typeStr := obj.GetLabels()[label]; typeStr != "" {
+			return typeStr
+		}
 	}
 	return constants.MetricLabelDefaultValue
 }


### PR DESCRIPTION
- Add label that reports the status of unreachable condition for the corresponding ClusterDeployment
- Add optional label support
  - Use the existing implementation for dynamic labels wherever possible
  - MustNewConstMetric used to report this metric via custom collector does not accept a map of label-value pairs. So supply a slice of values for the corresponding labels instead. To achieve this, maintaining the order of labels used while defining the metric is important.
    - Add a wrapper struct around dynamic labels which, in addition to the fixed and optional labels, also stores the labelList
    - Add buildLabelSlice method which is logically similar to buildLabels, but instead of reporting a map of labels and values, uses the labelList and returns a slice of label values to be used while observing the metric.
  - Add some unit tests
- Some minor corrections to get rid of the yellow squiggly lines.

xref: https://issues.redhat.com/browse/HIVE-2286

/assign @2uasimojo 