### PR TITLE
Annotation to hold uninstall pod

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -523,6 +523,11 @@ const (
 	// for forcing rollout of such changes on the target cluster -- e.g. by deleting the Machines -- as the machine
 	// config operator will not do so.
 	OverrideMachinePoolPlatformAnnotation = "hive.openshift.io/override-machinepool-platform"
+
+	// HoldUninstallPodAnnotation, if set to "true" on a ClusterDeployment, will cause hive to add the key as a finalizer
+	// to the uninstall pod when the ClusterDeployment is deleted. The user will need to explicitly delete the finalizer
+	// to allow the pod to be garbage collected. This can be useful e.g. for gathering uninstall logs.
+	HoldUninstallPodAnnotation = "hive.openshift.io/hold-uninstall-pod"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -1537,7 +1537,7 @@ func (r *ReconcileClusterDeployment) ensureDNSZonePreserveOnDeleteAndLogAnnotati
 		return false, nil
 	}
 
-	changed := controllerutils.CopyLogAnnotation(cd, dnsZone)
+	changed := controllerutils.CopyLogAnnotation(cd, dnsZone, constants.AdditionalLogFieldsAnnotation)
 
 	if dnsZone.Spec.PreserveOnDelete != cd.Spec.PreserveOnDelete {
 		changed = true
@@ -1715,7 +1715,7 @@ func (r *ReconcileClusterDeployment) createManagedDNSZone(cd *hivev1.ClusterDepl
 			LinkToParentDomain: true,
 		},
 	}
-	controllerutils.CopyLogAnnotation(cd, dnsZone)
+	controllerutils.CopyLogAnnotation(cd, dnsZone, constants.AdditionalLogFieldsAnnotation)
 
 	switch {
 	case cd.Spec.Platform.AWS != nil:
@@ -1798,7 +1798,8 @@ func generateDeprovision(cd *hivev1.ClusterDeployment) (*hivev1.ClusterDeprovisi
 			BaseDomain:  cd.Spec.BaseDomain,
 		},
 	}
-	controllerutils.CopyLogAnnotation(cd, req)
+	controllerutils.CopyLogAnnotation(cd, req, constants.AdditionalLogFieldsAnnotation)
+	controllerutils.CopyLogAnnotation(cd, req, constants.HoldUninstallPodAnnotation)
 
 	switch {
 	case cd.Spec.Platform.AWS != nil:

--- a/pkg/controller/clusterdeployment/clusterprovisions.go
+++ b/pkg/controller/clusterdeployment/clusterprovisions.go
@@ -183,7 +183,7 @@ func (r *ReconcileClusterDeployment) startNewProvision(
 			Stage:   hivev1.ClusterProvisionStageInitializing,
 		},
 	}
-	controllerutils.CopyLogAnnotation(cd, provision)
+	controllerutils.CopyLogAnnotation(cd, provision, constants.AdditionalLogFieldsAnnotation)
 
 	// Copy over the name, cluster ID and infra ID from previous provision so that a failed install can be removed.
 	if lastFailedProvision != nil {

--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -250,7 +250,7 @@ func (r *ReconcileMachinePool) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, err
 	}
 	// Sync log annotations from the CD to the pool, if necessary.
-	if controllerutils.CopyLogAnnotation(cd, pool) {
+	if controllerutils.CopyLogAnnotation(cd, pool, constants.AdditionalLogFieldsAnnotation) {
 		return reconcile.Result{}, r.Update(context.Background(), pool)
 	}
 

--- a/pkg/controller/utils/logtagger.go
+++ b/pkg/controller/utils/logtagger.go
@@ -106,7 +106,7 @@ func AddLogFieldsEnvVar(from metav1.Object, to *batchv1.Job) {
 	}
 }
 
-func CopyLogAnnotation(from, to metav1.Object) bool {
+func CopyLogAnnotation(from, to metav1.Object, key string) bool {
 	froma := from.GetAnnotations()
 	if froma == nil {
 		// Spoof empty so we can delete the annotation if it exists on `to`
@@ -119,7 +119,6 @@ func CopyLogAnnotation(from, to metav1.Object) bool {
 	}
 
 	changed := false
-	key := constants.AdditionalLogFieldsAnnotation
 	fromv, fromexists := froma[key]
 	tov, toexists := toa[key]
 	if fromexists && fromv != tov {

--- a/pkg/controller/utils/logtagger_test.go
+++ b/pkg/controller/utils/logtagger_test.go
@@ -335,7 +335,7 @@ func TestCopyLogAnnotation(t *testing.T) {
 			if tt.toa != nil {
 				to.Annotations = tt.toa
 			}
-			if got := CopyLogAnnotation(from, to); got != tt.expectChanged {
+			if got := CopyLogAnnotation(from, to, constants.AdditionalLogFieldsAnnotation); got != tt.expectChanged {
 				t.Errorf("CopyLogAnnotations() = %v, want %v", got, tt.expectChanged)
 			}
 			if tt.expectTargetAnnotation != nil {


### PR DESCRIPTION
To destroy a cluster, you delete the ClusterDeployment. Hive responds as follows:
- Create a ClusterDeprovision
- Create a Job
- ...which creates a Pod
- ...which has a Container
- ...which runs the installer's destroy code

Under normal circumstances, when the destroy process finishes, the Pod gets garbage collected very quickly -- often before logs can even finish streaming, if they're being watched. This can make debugging uninstall issues difficult.

With this commit, we add support for an annotation on ClusterDeployment:

`hive.openshift.io/hold-uninstall-pod: true`

This annotation is copied to the ClusterDeprovision, and when hive sees it there, it will add that key (`hive.openshift.io/hold-uninstall-pod`) as a finalizer to the uninstall pod. This will cause it to remain in `Terminating` state until the finalizer is removed, *which must be done "manually" by the consumer*.

[HIVE-2309](https://issues.redhat.com//browse/HIVE-2309)