### PR TITLE
Silence go compliance shim in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
 FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-4.14 as builder
+
+# Silence go compliance shim output
+ENV GO_COMPLIANCE_INFO=0
+ENV GO_COMPLIANCE_DEBUG=0
+
 RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -1,5 +1,9 @@
 FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-4.14
 
+# Silence go compliance shim output
+ENV GO_COMPLIANCE_INFO=0
+ENV GO_COMPLIANCE_DEBUG=0
+
 # setting Git username and email for workaround of
 # https://github.com/jenkinsci/docker/issues/519
 ENV GIT_COMMITTER_NAME hive-team


### PR DESCRIPTION
We can revert this once https://issues.redhat.com/browse/ART-7963 is done and propagated.