### PR TITLE
Pass networkProjectID to destroyer

### DIFF
--- a/contrib/pkg/deprovision/gcp.go
+++ b/contrib/pkg/deprovision/gcp.go
@@ -95,8 +95,9 @@ func (o *gcpOptions) Run() error {
 		InfraID: o.infraID,
 		ClusterPlatformMetadata: types.ClusterPlatformMetadata{
 			GCP: &typesgcp.Metadata{
-				Region:    o.region,
-				ProjectID: o.projectID,
+				Region:           o.region,
+				ProjectID:        o.projectID,
+				NetworkProjectID: o.networkProjectID,
 			},
 		},
 	}


### PR DESCRIPTION
This was missed in #2151.

[HIVE-2334](https://issues.redhat.com//browse/HIVE-2334)