### PR TITLE
Minimal install mode (don't pull release or oc images)

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -523,6 +523,11 @@ const (
 	// for forcing rollout of such changes on the target cluster -- e.g. by deleting the Machines -- as the machine
 	// config operator will not do so.
 	OverrideMachinePoolPlatformAnnotation = "hive.openshift.io/override-machinepool-platform"
+
+	// MinimalInstallModeAnnotation, if set to "true" on a ClusterDeployment along with InstallerImageOverride, asks hive
+	// to avoid downloading the release and oc images at all -- only the (overridden) installer image will be pulled.
+	// Side effects include: a) You can't use a release image verifier; b) We won't try to must-gather on the spoke.
+	MinimalInstallModeAnnotation = "hive.openshift.io/minimal-install-mode"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/pkg/controller/clusterprovision/clusterprovision_controller.go
+++ b/pkg/controller/clusterprovision/clusterprovision_controller.go
@@ -617,10 +617,15 @@ func (r *ReconcileClusterProvision) logProvisionSuccessFailureMetric(
 	if stage == hivev1.ClusterProvisionStageComplete {
 		timeMetric = metricInstallSuccessSeconds
 	}
+	installVersion := constants.MetricLabelDefaultValue
+	// InstallVersion is set by the imageset job. Can be nil if we never ran that (e.g. minimal install mode).
+	if cd.Status.InstallVersion != nil {
+		installVersion = *cd.Status.InstallVersion
+	}
 	fixedLabels := map[string]string{
 		"platform":        cd.Labels[hivev1.HiveClusterPlatformLabel],
 		"region":          cd.Labels[hivev1.HiveClusterRegionLabel],
-		"cluster_version": *cd.Status.InstallVersion,
+		"cluster_version": installVersion,
 		"workers":         r.getWorkers(*cd),
 		"install_attempt": strconv.Itoa(instance.Spec.Attempt),
 	}

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -333,7 +333,7 @@ func (m *InstallManager) Run() error {
 
 	m.ClusterName = cd.Spec.ClusterName
 
-	if err := m.copyInstallerBinaries(); err != nil {
+	if err := m.copyInstallerBinaries(cd); err != nil {
 		m.log.WithError(err).Error("error waiting for/copying binaries")
 		return err
 	}
@@ -615,10 +615,12 @@ func (m *InstallManager) waitForFiles(files []string) {
 	m.log.Infof("all files found, ready to proceed")
 }
 
-func (m *InstallManager) copyInstallerBinaries() error {
+func (m *InstallManager) copyInstallerBinaries(cd *hivev1.ClusterDeployment) error {
 	fileList := []string{
 		filepath.Join(m.WorkDir, "openshift-install"),
-		filepath.Join(m.WorkDir, "oc"),
+	}
+	if minimal, err := strconv.ParseBool(cd.Annotations[constants.MinimalInstallModeAnnotation]); err != nil || !minimal {
+		fileList = append(fileList, filepath.Join(m.WorkDir, "oc"))
 	}
 
 	// copy each binary to our container user's home dir to avoid situations
@@ -1243,6 +1245,10 @@ func (m *InstallManager) gatherLogs(cd *hivev1.ClusterDeployment, sshPrivKeyPath
 }
 
 func (m *InstallManager) gatherClusterLogs(cd *hivev1.ClusterDeployment) error {
+	if minimal, err := strconv.ParseBool(cd.Annotations[constants.MinimalInstallModeAnnotation]); err == nil && minimal {
+		m.log.Info("Minimal install mode: not attempting must-gather")
+		return nil
+	}
 	m.log.Info("attempting to gather logs with oc adm must-gather")
 	destDir := filepath.Join(m.LogsDir, fmt.Sprintf("%s-must-gather", time.Now().Format("20060102150405")))
 	cmd := exec.Command(filepath.Join(m.binaryDir, "oc"), "adm", "must-gather", "--dest-dir", destDir)


### PR DESCRIPTION
Certain environments, like ARO:
- Always use InstallerImageOverride
- Don't care to must-gather spokes on install failures

The latter is the only thing we use the `oc` command for. And the release image is only used to discover the URI for the installer image and the `oc` image.

To reduce burdens like ensuring those images are available and secure, this commit introduces a (back door, not-officially-supported) "minimal install mode". Activate it by doing two things:

1. Set ClusterDeployment annotation `hive.openshift.io/minimal-install-mode: True`
2. Set `ClusterDeployment.Spec.Provisioning.InstallerImageOverride`

This will cause hive to wend its way through the provisioning flow without pulling the release or `oc` images. It will use the InstallerImageOverride as the source of the `openshift-install` binary.

NOTE: This introduces a few limitations/oddities:
- You cannot use release image verification. (There's no release image to verify.)
- Failed installs will not attempt to must-gather the spoke, even if you have the rest of the install log capture stuff configured.
- `ClusterDeployment.Status.CLIImage` will be set to `"<NONE>"`.
- `ClusterDeployment.Status.InstallVersion` will not be set. Consequently...
- The `cluster_version` label on the `hive_cluster_deployment_install_failure_total` and `hive_cluster_deployment_install_success_total` metrics will be `"unspecified"` for these clusters.

[HIVE-2208](https://issues.redhat.com//browse/HIVE-2208)