### PR TITLE
Annotation to override installer image name

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -528,6 +528,10 @@ const (
 	// to avoid downloading the release and oc images at all -- only the (overridden) installer image will be pulled.
 	// Side effects include: a) You can't use a release image verifier; b) We won't try to must-gather on the spoke.
 	MinimalInstallModeAnnotation = "hive.openshift.io/minimal-install-mode"
+
+	// OverrideInstallerImageNameAnnotation specifies the name of the image within release metadata containing the
+	// `openshift-install` command. By default we look for the image named `installer`.
+	OverrideInstallerImageNameAnnotation = "hive.openshift.io/installer-image-name-override"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/pkg/imageset/updateinstaller.go
+++ b/pkg/imageset/updateinstaller.go
@@ -174,6 +174,12 @@ func (o *UpdateInstallerImageOptions) Run() (returnErr error) {
 		if cd.Spec.Platform.BareMetal != nil {
 			installerTagName = "baremetal-installer"
 		}
+		// Override annotation is allowed to override baremetal-installer too
+		if cd.Annotations != nil {
+			if override := cd.Annotations[constants.OverrideInstallerImageNameAnnotation]; override != "" {
+				installerTagName = override
+			}
+		}
 		installerImage, err = findImageSpec(is, installerTagName)
 		if err != nil {
 			return errors.Wrap(err, "could not get installer image")

--- a/pkg/imageset/updateinstaller_test.go
+++ b/pkg/imageset/updateinstaller_test.go
@@ -84,6 +84,37 @@ func TestUpdateInstallerImageCommand(t *testing.T) {
 			validateClusterDeployment: validateSuccessfulExecution(testInstallerImage, testCLIImage, ""),
 		},
 		{
+			name: "installer image name override",
+			existingClusterDeployment: func() *hivev1.ClusterDeployment {
+				cd := testClusterDeployment()
+				cd.Annotations = map[string]string{
+					constants.OverrideInstallerImageNameAnnotation: "some-other-installer",
+				}
+				return cd
+			}(),
+			images: map[string]string{
+				"some-other-installer": testInstallerImage,
+				"cli":                  testCLIImage,
+			},
+			validateClusterDeployment: validateSuccessfulExecution(testInstallerImage, testCLIImage, ""),
+		},
+		{
+			name: "installer image name override (baremetal)",
+			existingClusterDeployment: func() *hivev1.ClusterDeployment {
+				cd := testClusterDeployment()
+				cd.Spec.Platform.BareMetal = &baremetal.Platform{}
+				cd.Annotations = map[string]string{
+					constants.OverrideInstallerImageNameAnnotation: "some-other-installer",
+				}
+				return cd
+			}(),
+			images: map[string]string{
+				"some-other-installer": testInstallerImage,
+				"cli":                  testCLIImage,
+			},
+			validateClusterDeployment: validateSuccessfulExecution(testInstallerImage, testCLIImage, ""),
+		},
+		{
 			name:                      "successful execution with version in release metadata",
 			existingClusterDeployment: testClusterDeployment(),
 			images: map[string]string{


### PR DESCRIPTION
We find the image we use to obtain the `openshift-install` binary based on its name in release metadata.

```
        {
          "name": "installer",   <== THIS NAME
          "annotations": {
            "io.openshift.build.commit.id": "ead355d7836a8a24613d062bf06ab0a6eef2765c",
            "io.openshift.build.commit.ref": "",
            "io.openshift.build.source-location": "https://github.com/openshift/installer"
          },
          "from": {
            "kind": "DockerImage",
            "name": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b2942182a31a0591dcbf3a3eec10c363d9d1f05dd75b98e1f8ac7f486b0ce25e"
          },
          "generation": null,
          "importPolicy": {},
          "referencePolicy": {
            "type": ""
          }
        },
```
By default, we use the image identified as `"installer"`; or `"baremetal-installer"` for bare metal installations.

Alternative or experimental installer images may be included in certain release images alongside these well-known ones. This commit provides a mechanism for consuming such an image instead of the default: in your ClusterDeployment, set the annotation
`hive.openshift.io/installer-image-name-override` to the release metadata name of the alternative image you wish to use.

This is currently for internal use only, and will not be documented or officially supported.

[HIVE-2342](https://issues.redhat.com//browse/HIVE-2342)