### PR TITLE
Spoof Sleep() for installmanager_test

### DIFF
--- a/pkg/installmanager/installmanager_test.go
+++ b/pkg/installmanager/installmanager_test.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -80,6 +81,10 @@ echo "echo Agent pid %s;"`
 
 func init() {
 	log.SetLevel(log.DebugLevel)
+}
+
+func dummySleep(d time.Duration) {
+	return
 }
 
 func TestInstallManager(t *testing.T) {
@@ -186,6 +191,7 @@ func TestInstallManager(t *testing.T) {
 
 			im := InstallManager{
 				LogLevel:               "debug",
+				sleep:                  dummySleep,
 				WorkDir:                tempDir,
 				ClusterProvisionName:   testProvisionName,
 				Namespace:              testNamespace,


### PR DESCRIPTION
installmanager_test takes an annoyingly, unnecessarily long time because there are several `time.Sleep()`s in the installmanager code.

This commit moves the sleep function to the InstallManager struct so we can fake it out with a no-op in the test suite.