### PR TITLE
Add additional regex for DefaultEbsKmsKeyInsufficientPermissions

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -95,6 +95,7 @@ data:
     - name: DefaultEbsKmsKeyInsufficientPermissions
       searchRegexStrings:
         - "Client.InternalError: Client error on launch"
+        - "Client.InvalidKMSKey.InvalidState: The KMS key provided is in an incorrect state"
       installFailingReason: DefaultEbsKmsKeyInsufficientPermissions
       installFailingMessage: Default KMS key for EBS encryption has insufficient permissions to launch EC2 instances
     - name: SimulatorThrottling

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1719,6 +1719,7 @@ data:
     - name: DefaultEbsKmsKeyInsufficientPermissions
       searchRegexStrings:
         - "Client.InternalError: Client error on launch"
+        - "Client.InvalidKMSKey.InvalidState: The KMS key provided is in an incorrect state"
       installFailingReason: DefaultEbsKmsKeyInsufficientPermissions
       installFailingMessage: Default KMS key for EBS encryption has insufficient permissions to launch EC2 instances
     - name: SimulatorThrottling


### PR DESCRIPTION
We found another way an AWS cluster's default EBS KMS Key can be misconfigured in [OSD-19693](https://issues.redhat.com//browse/OSD-19693)

```
time="2023-11-15T13:06:50Z" level=error msg="Error: waiting for EC2 Instance (i-0e4febdf8a337aa30) create: unexpected state 'shutting-down', wanted target 'running'. last error: Client.InvalidKMSKey.InvalidState: The KMS key provided is in an incorrect state"
```