### PR TITLE
WIP: MachinePool honors CD.spec.preserveOnDelete

### DIFF
--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -263,6 +263,11 @@ func (r *ReconcileMachinePool) Reconcile(ctx context.Context, request reconcile.
 		return r.removeFinalizer(pool, logger)
 	}
 
+	if pool.DeletionTimestamp != nil && cd.Spec.PreserveOnDelete {
+		logger.Warn("skipping reconcile for MachinePool due to PreserveOnDelete=true, removing finalizer")
+		return r.removeFinalizer(pool, logger)
+	}
+
 	if controllerutils.IsFakeCluster(cd) {
 		logger.Info("skipping reconcile for fake cluster")
 		if pool.DeletionTimestamp != nil {


### PR DESCRIPTION
Possible design option where we use the existing *ClusterDeployment* preserveOnDelete field as the indicator to orphan spoke MachineSets when their MachinePool is deleted.

TODO:
- design buy-in -- see card
- test
- docs, incl adoption

[HIVE-2043](https://issues.redhat.com//browse/HIVE-2043)