### PR TITLE
Remove SyncSetInstance cleanup code

### DIFF
--- a/pkg/operator/hive/hive_controller.go
+++ b/pkg/operator/hive/hive_controller.go
@@ -564,13 +564,6 @@ func (r *ReconcileHiveConfig) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	if err := r.cleanupLegacySyncSetInstances(hLog); err != nil {
-		hLog.WithError(err).Error("error cleaning up legacy SyncSetInstances")
-		instance.Status.Conditions = util.SetHiveConfigCondition(instance.Status.Conditions, hivev1.HiveReadyCondition, corev1.ConditionFalse, "ErrorDeletingLegacySyncSetInstances", err.Error())
-		r.updateHiveConfigStatus(origHiveConfig, instance, hLog, false)
-		return reconcile.Result{}, err
-	}
-
 	// If we get here, we've successfully scrubbed all *our* resources out of previous target
 	// namespaces. Ideally, we would delete the namespace. Unfortunately, there's no good way to
 	// tell whether a) we were the one to create it, or b) it's empty. So settle for unlabeling it,


### PR DESCRIPTION
Remove the code to clean up legacy SyncSetInstance CRs and CRD, which were supplanted by ClusterSync via #1093 ~3y ago.

The consequence is that, if a customer upgrades from a pre-ClusterSync version of hive to a version at/after this commit, the SyncSetInstance CRs and CRD will be orphaned, unnecessarily cluttering etcd.

It has been long enough that we consider the probability of this to be quite low. If it does happen, there is a simple workaround: manually delete the CRs and CRD.

Why do this at all? I'm glad you asked. Since the SyncSetInstance CRD existed in the now-deprecated v1beta1 apiVersion of apiextensions.k8s.io, our API call to discover it was showing up on customers' radar and making them uncomfortable. At this point the risk of orphaning resources is the lesser evil.

[HIVE-2025](https://issues.redhat.com//browse/HIVE-2025)