### PR TITLE
Read-only root file system

### DIFF
--- a/config/clustersync/statefulset.yaml
+++ b/config/clustersync/statefulset.yaml
@@ -54,6 +54,14 @@ spec:
               fieldPath: metadata.name
         - name: HIVE_SKIP_LEADER_ELECTION
           value: "true"
+        - name: TMPDIR
+          value: /tmp
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: true
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -72,3 +80,6 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
+      volumes:
+      - name: tmp
+        emptyDir: {}

--- a/config/controllers/deployment.yaml
+++ b/config/controllers/deployment.yaml
@@ -25,6 +25,8 @@ spec:
       volumes:
       - name: kubectl-cache
         emptyDir: {}
+      - name: tmp
+        emptyDir: {}
       containers:
       # By default we will use the latest CI images published from hive master:
       - image: registry.ci.openshift.org/openshift/hive-v4.0:hive
@@ -42,6 +44,8 @@ spec:
         volumeMounts:
         - name: kubectl-cache
           mountPath: /var/cache/kubectl
+        - name: tmp
+          mountPath: /tmp
         env:
         - name: CLI_CACHE_DIR
           value: /var/cache/kubectl
@@ -49,6 +53,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: TMPDIR
+          value: /tmp
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: true
         readinessProbe:
           httpGet:
             path: /readyz

--- a/config/hiveadmission/deployment.yaml
+++ b/config/hiveadmission/deployment.yaml
@@ -42,9 +42,17 @@ spec:
         envFrom:
         - configMapRef:
             name: hive-feature-gates
+        env:
+        - name: TMPDIR
+          value: /tmp
         volumeMounts:
         - mountPath: /var/serving-cert
           name: serving-cert
+        - name: tmp
+          mountPath: /tmp
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: true
         readinessProbe:
           httpGet:
             path: /healthz
@@ -55,3 +63,5 @@ spec:
         secret:
           defaultMode: 420
           secretName: hiveadmission-serving-cert
+      - name: tmp
+        emptyDir: {}

--- a/config/operator/operator_deployment.yaml
+++ b/config/operator/operator_deployment.yaml
@@ -30,6 +30,8 @@ spec:
       volumes:
       - name: kubectl-cache
         emptyDir: {}
+      - name: tmp
+        emptyDir: {}
       containers:
       # By default we will use the latest CI images published from hive master:
       - image: registry.ci.openshift.org/openshift/hive-v4.0:hive
@@ -50,6 +52,8 @@ spec:
         volumeMounts:
         - name: kubectl-cache
           mountPath: /var/cache/kubectl
+        - name: tmp
+          mountPath: /tmp
         env:
         - name: CLI_CACHE_DIR
           value: /var/cache/kubectl
@@ -57,6 +61,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: TMPDIR
+          value: /tmp
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: true
         readinessProbe:
           httpGet:
             path: /readyz

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -7488,6 +7488,8 @@ objects:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: TMPDIR
+            value: /tmp
           image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
           imagePullPolicy: Always
           livenessProbe:
@@ -7507,14 +7509,21 @@ objects:
             requests:
               cpu: 100m
               memory: 256Mi
+          securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true
           volumeMounts:
           - mountPath: /var/cache/kubectl
             name: kubectl-cache
+          - mountPath: /tmp
+            name: tmp
         serviceAccountName: hive-operator
         terminationGracePeriodSeconds: 10
         volumes:
         - emptyDir: {}
           name: kubectl-cache
+        - emptyDir: {}
+          name: tmp
 parameters:
 - name: REGISTRY_IMG
   required: true

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -177,6 +177,14 @@ spec:
               fieldPath: metadata.name
         - name: HIVE_SKIP_LEADER_ELECTION
           value: "true"
+        - name: TMPDIR
+          value: /tmp
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: true
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -195,6 +203,9 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
+      volumes:
+      - name: tmp
+        emptyDir: {}
 `)
 
 func configClustersyncStatefulsetYamlBytes() ([]byte, error) {
@@ -436,9 +447,17 @@ spec:
         envFrom:
         - configMapRef:
             name: hive-feature-gates
+        env:
+        - name: TMPDIR
+          value: /tmp
         volumeMounts:
         - mountPath: /var/serving-cert
           name: serving-cert
+        - name: tmp
+          mountPath: /tmp
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: true
         readinessProbe:
           httpGet:
             path: /healthz
@@ -449,6 +468,8 @@ spec:
         secret:
           defaultMode: 420
           secretName: hiveadmission-serving-cert
+      - name: tmp
+        emptyDir: {}
 `)
 
 func configHiveadmissionDeploymentYamlBytes() ([]byte, error) {
@@ -858,6 +879,8 @@ spec:
       volumes:
       - name: kubectl-cache
         emptyDir: {}
+      - name: tmp
+        emptyDir: {}
       containers:
       # By default we will use the latest CI images published from hive master:
       - image: registry.ci.openshift.org/openshift/hive-v4.0:hive
@@ -875,6 +898,8 @@ spec:
         volumeMounts:
         - name: kubectl-cache
           mountPath: /var/cache/kubectl
+        - name: tmp
+          mountPath: /tmp
         env:
         - name: CLI_CACHE_DIR
           value: /var/cache/kubectl
@@ -882,6 +907,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: TMPDIR
+          value: /tmp
+        securityContext:
+          privileged: false
+          readOnlyRootFilesystem: true
         readinessProbe:
           httpGet:
             path: /readyz


### PR DESCRIPTION
Add `readOnlyRootFilesystem` to our Deployments and StatefulSets. Why? Cause it's more securer.

One thing I needed to do to make this work was to add a volume for `/tmp`, which I guess is by default part of `/`. This resulted in an actual problem in hive-controllers creating a Session for AWS... but I did it for all the things just in case.

This scares me a little bit. For one thing, any time we mess with `securityContext`s we seem to break our friends running hive under vanilla k8s. But also, who knows what corner cases are expecting to be able to write somewhere in the root file system? We won't find out if, like, trying to use additional certs under OpenStack is a problem until some customer tries it.

[HIVE-2350](https://issues.redhat.com//browse/HIVE-2350)