### PR TITLE
Managed DNS is mutex with User-Configured DNS

### DIFF
--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -958,6 +958,8 @@ Hive can optionally create delegated DNS zones for each cluster.
 
 NOTE: This feature only works for provisioning to AWS, GCP, and Azure.
 
+NOTE: This feature is mutually exclusive with the `UserConfiguredDNS` install-config option.
+
 To use this feature:
 
   1. Manually create a DNS zone for your "root" domain (i.e. hive.example.com in the example below) and ensure your DNS is operational.


### PR DESCRIPTION
Add a note in the docs that hive's managed DNS is mutually exclusive with installer's user-configured DNS.

[HIVE-1812](https://issues.redhat.com//browse/HIVE-1812)