### PR TITLE
Add install log regexes for cert-related network failures

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -315,6 +315,16 @@ data:
       - "failed to initialize the cluster: Some cluster operators are still updating:"
       installFailingReason: GeneralClusterOperatorsStillUpdating
       installFailingMessage: Timeout waiting for all cluster operators to become ready
+    - name: InstallConfigNetworkAuthFail
+      searchRegexStrings:
+      - "failed to create install config: failed to create a network client: Authentication failed"
+      installFailingReason: InstallConfigNetworkAuthFail
+      installFailingMessage: Authentication failure attempting to create a network client - check credentials and certificates
+    - name: InstallConfigNetworkBadCACert
+      searchRegexStrings:
+      - "failed to create install config: failed to create a network client: Error parsing CA Cert from"
+      installFailingReason: InstallConfigNetworkBadCACert
+      installFailingMessage: Failure attempting to create a network client - invalid CA certificate
 
     # Keep these at the bottom so that they're only hit if nothing above matches.
     # We don't want to show these to users unless it's a last resort. It's barely better than "unknown error".

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -64,6 +64,8 @@ const (
 	noWorkerNodesReady                      = "ReadyIngressNodesAvailable: Authentication requires functional ingress which requires at least one schedulable and ready node. Got 0 worker nodes, 3 master nodes, 0 custom target nodes (none are schedulable or ready for ingress pods)."
 	s3AccessControlListNotSupported         = "time=\"2023-04-11T08:22:52Z\" level=error msg=\"Error: error creating S3 bucket ACL for rosa-6lr7x-flcmj-bootstrap: AccessControlListNotSupported: The bucket does not allow ACLs\""
 	awsAccountBlocked                       = "Error: creating EC2 Instance: Blocked: This account is currently blocked and not recognized as a valid account. Please contact aws-verification@amazon.com if you have questions."
+	installConfigAuthFail                   = `failed to fetch Master Machines: failed to load asset "Install Config": failed to create install config: failed to create a network client: Authentication failed`
+	installConfigBadCACert                  = `failed to fetch Master Machines: failed to load asset "Install Config": failed to create install config: failed to create a network client: Error parsing CA Cert from /etc/pki/ca-trust/extracted/pem/tls-ca-bundle1111.pem`
 )
 
 func TestParseInstallLog(t *testing.T) {
@@ -434,6 +436,16 @@ func TestParseInstallLog(t *testing.T) {
 			name:           "AWSAccountBlocked",
 			log:            pointer.String(awsAccountBlocked),
 			expectedReason: "AWSAccountIsBlocked",
+		},
+		{
+			name:           "InstallConfigAuthFail",
+			log:            pointer.String(installConfigAuthFail),
+			expectedReason: "InstallConfigNetworkAuthFail",
+		},
+		{
+			name:           "InstallConfigCACert",
+			log:            pointer.String(installConfigBadCACert),
+			expectedReason: "InstallConfigNetworkBadCACert",
 		},
 	}
 

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1939,6 +1939,16 @@ data:
       - "failed to initialize the cluster: Some cluster operators are still updating:"
       installFailingReason: GeneralClusterOperatorsStillUpdating
       installFailingMessage: Timeout waiting for all cluster operators to become ready
+    - name: InstallConfigNetworkAuthFail
+      searchRegexStrings:
+      - "failed to create install config: failed to create a network client: Authentication failed"
+      installFailingReason: InstallConfigNetworkAuthFail
+      installFailingMessage: Authentication failure attempting to create a network client - check credentials and certificates
+    - name: InstallConfigNetworkBadCACert
+      searchRegexStrings:
+      - "failed to create install config: failed to create a network client: Error parsing CA Cert from"
+      installFailingReason: InstallConfigNetworkBadCACert
+      installFailingMessage: Failure attempting to create a network client - invalid CA certificate
 
     # Keep these at the bottom so that they're only hit if nothing above matches.
     # We don't want to show these to users unless it's a last resort. It's barely better than "unknown error".


### PR DESCRIPTION
These were showing up as `FallbackInsvalidInstallConfig` with a generic message. Make them more specific/scrutable/actionable.

[HIVE-2360](https://issues.redhat.com//browse/HIVE-2360)

(cherry picked from commit 49c009b0acbabeef83e138f0116c22a7ba3cdb8b)