### PR TITLE
SyncSet: Parameterized CD labels in resources

### DIFF
--- a/apis/hive/v1/syncset_types.go
+++ b/apis/hive/v1/syncset_types.go
@@ -243,6 +243,15 @@ type SyncSetCommonSpec struct {
 	// labels, and other map entries in general.
 	// +optional
 	ApplyBehavior SyncSetApplyBehavior `json:"applyBehavior,omitempty"`
+
+	// EnableResourceTemplates, if True, causes hive to honor golang text/templates in Resources.
+	// While the standard syntax is supported, it won't do you a whole lot of good as the parser
+	// does not pass a data object (i.e. there is no "dot" for you to use). This currently exists
+	// to expose a single function: {{ fromCDLabel "some.label/key" }} will
+	// be substituted with the string value of ClusterDeployment.Labels["some.label/key"]. The
+	// empty string is interpolated if there are no labels, or if the indicated key does not exist.
+	// Note that this only works in values (not e.g. map keys) that are of type string.
+	EnableResourceTemplates bool `json:"enableResourceTemplates,omitempty"`
 }
 
 // SelectorSyncSetSpec defines the SyncSetCommonSpec resources and patches to sync along

--- a/config/crds/hive.openshift.io_selectorsyncsets.yaml
+++ b/config/crds/hive.openshift.io_selectorsyncsets.yaml
@@ -102,6 +102,18 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              enableResourceTemplates:
+                description: 'EnableResourceTemplates, if True, causes hive to honor
+                  golang text/templates in Resources. While the standard syntax is
+                  supported, it won''t do you a whole lot of good as the parser does
+                  not pass a data object (i.e. there is no "dot" for you to use).
+                  This currently exists to expose a single function: {{ fromCDLabel
+                  "some.label/key" }} will be substituted with the string value of
+                  ClusterDeployment.Labels["some.label/key"]. The empty string is
+                  interpolated if there are no labels, or if the indicated key does
+                  not exist. Note that this only works in values (not e.g. map keys)
+                  that are of type string.'
+                type: boolean
               patches:
                 description: Patches is the list of patches to apply.
                 items:

--- a/config/crds/hive.openshift.io_syncsets.yaml
+++ b/config/crds/hive.openshift.io_syncsets.yaml
@@ -71,6 +71,18 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              enableResourceTemplates:
+                description: 'EnableResourceTemplates, if True, causes hive to honor
+                  golang text/templates in Resources. While the standard syntax is
+                  supported, it won''t do you a whole lot of good as the parser does
+                  not pass a data object (i.e. there is no "dot" for you to use).
+                  This currently exists to expose a single function: {{ fromCDLabel
+                  "some.label/key" }} will be substituted with the string value of
+                  ClusterDeployment.Labels["some.label/key"]. The empty string is
+                  interpolated if there are no labels, or if the indicated key does
+                  not exist. Note that this only works in values (not e.g. map keys)
+                  that are of type string.'
+                type: boolean
               patches:
                 description: Patches is the list of patches to apply.
                 items:

--- a/docs/syncset.md
+++ b/docs/syncset.md
@@ -2,6 +2,8 @@
 
 - [Overview](#overview)
 - [SyncSet Object Definition](#syncset-object-definition)
+  - [Resource Parameters](#resource-parameters)
+    - [`fromCDLabel` Custom Function](#fromcdlabel-custom-function)
   - [Example of SyncSet use](#example-of-syncset-use)
 - [SelectorSyncSet Object Definition](#selectorsyncset-object-definition)
 - [Ordering](#ordering)
@@ -34,6 +36,8 @@ spec:
 
   resourceApplyMode: Upsert
 
+  enableResourceTemplates  : false
+
   resources:
   - apiVersion: user.openshift.io/v1
     kind: Group
@@ -64,9 +68,64 @@ spec:
 |-------|-------|
 | `clusterDeploymentRefs` | List of `ClusterDeployment` names in the current namespace which the `SyncSet` will apply to. |
 | `resourceApplyMode` | Defaults to `"Upsert"`, which indicates that objects will be created and updated to match the `SyncSet`. Existing `SyncSet` resources that are not listed in the `SyncSet` are not deleted. Specify `"Sync"` to allow deleting existing objects that were previously in the resources list. This includes deleting _all_ resources when the entire SyncSet is deleted. |
+| `enableResourceTemplates  ` | If true, special use of golang's `text/templates` is allowed in `resources`. More details [below](#resource-parameters). |
 | `resources` | A list of resource object definitions. Resources will be created in the referenced clusters. |
 | `patches` | A list of patches to apply to existing resources in the referenced clusters. You can include any valid cluster object type in the list. By default, the `patch` `applyMode` value is `"AlwaysApply"`, which applies the patch every 2 hours. |
 | `secretMappings` | A list of secret mappings. The secrets will be copied from the existing sources to the target resources in the referenced clusters |
+
+### Resource Parameters
+By setting `spec.enableResourceTemplates  : true`, it is possible to use golang
+[text/template](https://pkg.go.dev/text/template)-isms in
+`spec.resources[]` values. Note, however, that there is no
+"dot" (data object) so the out-of-the-box functionality won't convey a
+lot of power.
+This feature exists to expose custom functions, described below.
+
+Note:
+- Templates are only honored on resource _values_. They are ignored for keys.
+- Templates are only honored on values whose schema type is `string`.
+  (This is because the embedded resource must be valid JSON _before_ it is parsed; and templates can't be recognized as any other valid JSON type.)
+- Errors parsing or processing the template will cause the SyncSet to fail
+and will be bubbled up in the ClusterSync status as usual.
+- Templates are only supported on `spec.resources[]`, not on `patches` or `secretMappings`.
+
+#### `fromCDLabel` Custom Function
+With `enableResourceTemplates` on, including a string like
+
+`{{ fromCDLabel "any.clusterdeployment/label-key" }}`
+
+in a resource will cause hive to substitute it with the value of that label from
+the ClusterDeployment owning the [Selector]SyncSet being processed. For
+example:
+
+```yaml
+---
+  enableResourceTemplates  : true
+
+  resources:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: mycm
+      namespace: myns
+    data:
+      platform: the platform is {{ fromCDLabel "hive.openshift.io/cluster-platform" }}
+```
+
+...might result in the following ConfigMap on the spoke cluster:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mycm
+  namespace: myns
+data:
+  platform: the platform is gcp
+```
+
+If the ClusterDeployment has no labels, or if there is no label with the specified key,
+the empty string is substituted.
 
 ### Example of SyncSet use
 

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -6402,6 +6402,18 @@ objects:
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
+                enableResourceTemplates:
+                  description: 'EnableResourceTemplates, if True, causes hive to honor
+                    golang text/templates in Resources. While the standard syntax
+                    is supported, it won''t do you a whole lot of good as the parser
+                    does not pass a data object (i.e. there is no "dot" for you to
+                    use). This currently exists to expose a single function: {{ fromCDLabel
+                    "some.label/key" }} will be substituted with the string value
+                    of ClusterDeployment.Labels["some.label/key"]. The empty string
+                    is interpolated if there are no labels, or if the indicated key
+                    does not exist. Note that this only works in values (not e.g.
+                    map keys) that are of type string.'
+                  type: boolean
                 patches:
                   description: Patches is the list of patches to apply.
                   items:
@@ -7209,6 +7221,18 @@ objects:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
+                enableResourceTemplates:
+                  description: 'EnableResourceTemplates, if True, causes hive to honor
+                    golang text/templates in Resources. While the standard syntax
+                    is supported, it won''t do you a whole lot of good as the parser
+                    does not pass a data object (i.e. there is no "dot" for you to
+                    use). This currently exists to expose a single function: {{ fromCDLabel
+                    "some.label/key" }} will be substituted with the string value
+                    of ClusterDeployment.Labels["some.label/key"]. The empty string
+                    is interpolated if there are no labels, or if the indicated key
+                    does not exist. Note that this only works in values (not e.g.
+                    map keys) that are of type string.'
+                  type: boolean
                 patches:
                   description: Patches is the list of patches to apply.
                   items:

--- a/pkg/client/applyconfiguration/hive/v1/selectorsyncsetspec.go
+++ b/pkg/client/applyconfiguration/hive/v1/selectorsyncsetspec.go
@@ -73,6 +73,14 @@ func (b *SelectorSyncSetSpecApplyConfiguration) WithApplyBehavior(value hivev1.S
 	return b
 }
 
+// WithEnableResourceTemplates sets the EnableResourceTemplates field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EnableResourceTemplates field is set to the value of the last call.
+func (b *SelectorSyncSetSpecApplyConfiguration) WithEnableResourceTemplates(value bool) *SelectorSyncSetSpecApplyConfiguration {
+	b.EnableResourceTemplates = &value
+	return b
+}
+
 // WithClusterDeploymentSelector sets the ClusterDeploymentSelector field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the ClusterDeploymentSelector field is set to the value of the last call.

--- a/pkg/client/applyconfiguration/hive/v1/syncsetcommonspec.go
+++ b/pkg/client/applyconfiguration/hive/v1/syncsetcommonspec.go
@@ -10,11 +10,12 @@ import (
 // SyncSetCommonSpecApplyConfiguration represents an declarative configuration of the SyncSetCommonSpec type for use
 // with apply.
 type SyncSetCommonSpecApplyConfiguration struct {
-	Resources         []runtime.RawExtension              `json:"resources,omitempty"`
-	ResourceApplyMode *v1.SyncSetResourceApplyMode        `json:"resourceApplyMode,omitempty"`
-	Patches           []SyncObjectPatchApplyConfiguration `json:"patches,omitempty"`
-	Secrets           []SecretMappingApplyConfiguration   `json:"secretMappings,omitempty"`
-	ApplyBehavior     *v1.SyncSetApplyBehavior            `json:"applyBehavior,omitempty"`
+	Resources               []runtime.RawExtension              `json:"resources,omitempty"`
+	ResourceApplyMode       *v1.SyncSetResourceApplyMode        `json:"resourceApplyMode,omitempty"`
+	Patches                 []SyncObjectPatchApplyConfiguration `json:"patches,omitempty"`
+	Secrets                 []SecretMappingApplyConfiguration   `json:"secretMappings,omitempty"`
+	ApplyBehavior           *v1.SyncSetApplyBehavior            `json:"applyBehavior,omitempty"`
+	EnableResourceTemplates *bool                               `json:"enableResourceTemplates,omitempty"`
 }
 
 // SyncSetCommonSpecApplyConfiguration constructs an declarative configuration of the SyncSetCommonSpec type for use with
@@ -72,5 +73,13 @@ func (b *SyncSetCommonSpecApplyConfiguration) WithSecrets(values ...*SecretMappi
 // If called multiple times, the ApplyBehavior field is set to the value of the last call.
 func (b *SyncSetCommonSpecApplyConfiguration) WithApplyBehavior(value v1.SyncSetApplyBehavior) *SyncSetCommonSpecApplyConfiguration {
 	b.ApplyBehavior = &value
+	return b
+}
+
+// WithEnableResourceTemplates sets the EnableResourceTemplates field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EnableResourceTemplates field is set to the value of the last call.
+func (b *SyncSetCommonSpecApplyConfiguration) WithEnableResourceTemplates(value bool) *SyncSetCommonSpecApplyConfiguration {
+	b.EnableResourceTemplates = &value
 	return b
 }

--- a/pkg/client/applyconfiguration/hive/v1/syncsetspec.go
+++ b/pkg/client/applyconfiguration/hive/v1/syncsetspec.go
@@ -73,6 +73,14 @@ func (b *SyncSetSpecApplyConfiguration) WithApplyBehavior(value hivev1.SyncSetAp
 	return b
 }
 
+// WithEnableResourceTemplates sets the EnableResourceTemplates field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the EnableResourceTemplates field is set to the value of the last call.
+func (b *SyncSetSpecApplyConfiguration) WithEnableResourceTemplates(value bool) *SyncSetSpecApplyConfiguration {
+	b.EnableResourceTemplates = &value
+	return b
+}
+
 // WithClusterDeploymentRefs adds the given value to the ClusterDeploymentRefs field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the ClusterDeploymentRefs field.

--- a/pkg/controller/clustersync/templates.go
+++ b/pkg/controller/clustersync/templates.go
@@ -1,0 +1,93 @@
+package clustersync
+
+import (
+	"bytes"
+	"reflect"
+	"text/template"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+)
+
+// processParameters modifies `u`, appling text/template parameters found in string values therein.
+func processParameters(u *unstructured.Unstructured, cd *hivev1.ClusterDeployment, logger log.FieldLogger) error {
+	resourceParamTemplate := template.New("resourceParams").Funcs(
+		template.FuncMap{
+			"fromCDLabel": fromCDLabel(cd),
+		},
+	)
+	for k, v := range u.Object {
+		newVal, err := applyTemplate(resourceParamTemplate, v)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to apply template to value %#v", v)
+		}
+		u.Object[k] = newVal
+	}
+	return nil
+}
+
+// fromCDLabel produces a text/template-suitable func accepting a single parameter which will be
+// interpreted as a key for a label on `cd`. If the label exists, its value is returned by the
+// func. If `cd` has no labels, or if no label with the specified key exists, the empty string is
+// returned.
+func fromCDLabel(cd *hivev1.ClusterDeployment) func(string) string {
+	return func(labelKey string) string {
+		if cd.Labels == nil {
+			return ""
+		}
+		return cd.Labels[labelKey]
+	}
+}
+
+// applyTemplate recursively parses and executes `t` against the string values found within `v`.
+// The template is executed with a `nil` data object -- i.e. templates referring to `.` ("dot")
+// will not work. This really exists only to support invoking functions in the template's FuncMap.
+// We expect `v` to be a descendant of an Unstructured.Object, and thus limited to types
+// string, float, int, bool, []interface{}, or map[string]interface{} (where the list/map
+// interface{} values are similarly limited, recursively).
+func applyTemplate(t *template.Template, v interface{}) (interface{}, error) {
+	ival := reflect.ValueOf(v)
+	switch ival.Kind() {
+	case reflect.String:
+		sval := ival.String()
+		// Special case: Parse ignores the empty string so hard that it keeps whatever was
+		// previously in the template, resulting in reusing the string from the most recent
+		// "successful" iteration. We could rebuild the parser every time, but this is more
+		// efficient (and correct because the empty string can't contain any parameters).
+		if sval == "" {
+			return "", nil
+		}
+		parsed, err := t.Parse(sval)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse template string %q", sval)
+		}
+		buf := new(bytes.Buffer)
+		err = parsed.Execute(buf, nil)
+		return buf.String(), errors.Wrapf(err, "failed to execute template on string %q", sval)
+	case reflect.Array, reflect.Slice:
+		for i := 0; i < ival.Len(); i++ {
+			newVal, err := applyTemplate(t, ival.Index(i).Interface())
+			if err != nil {
+				return nil, err
+			}
+			ival.Index(i).Set(reflect.ValueOf(newVal))
+		}
+	case reflect.Map:
+		for _, k := range ival.MapKeys() {
+			newVal, err := applyTemplate(t, ival.MapIndex(k).Interface())
+			if err != nil {
+				return nil, err
+			}
+			// Special case: If the elem is nil, SetMapIndex deletes the key (why??)
+			// We know the template won't mutate `nil` anyway, so skip "setting" it.
+			if newVal != nil {
+				ival.SetMapIndex(k, reflect.ValueOf(newVal))
+			}
+		}
+	}
+	return v, nil
+}

--- a/vendor/github.com/openshift/hive/apis/hive/v1/syncset_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/syncset_types.go
@@ -243,6 +243,15 @@ type SyncSetCommonSpec struct {
 	// labels, and other map entries in general.
 	// +optional
 	ApplyBehavior SyncSetApplyBehavior `json:"applyBehavior,omitempty"`
+
+	// EnableResourceTemplates, if True, causes hive to honor golang text/templates in Resources.
+	// While the standard syntax is supported, it won't do you a whole lot of good as the parser
+	// does not pass a data object (i.e. there is no "dot" for you to use). This currently exists
+	// to expose a single function: {{ fromCDLabel "some.label/key" }} will
+	// be substituted with the string value of ClusterDeployment.Labels["some.label/key"]. The
+	// empty string is interpolated if there are no labels, or if the indicated key does not exist.
+	// Note that this only works in values (not e.g. map keys) that are of type string.
+	EnableResourceTemplates bool `json:"enableResourceTemplates,omitempty"`
 }
 
 // SelectorSyncSetSpec defines the SyncSetCommonSpec resources and patches to sync along


### PR DESCRIPTION
Via a new knob, `[Selector]SyncSet.Spec.EnableResourceTemplates: True`
(that's a bool), it is now possible to use golang
[text/template](https://pkg.go.dev/text/template)-isms in `[Selector]SyncSet.Spec.Resources[]` string values (not keys! do you need that?). Note, however, that there is no "dot" (data object) so the out-of-the-box functionality won't convey a lot of power.

However, this commit introduces one custom function: `fromCDLabel`. If you include a string like

`{{ fromCDLabel "any.clusterdeployment/label-key" }}`

in a resource, hive will substitute it with the value of that label from the ClusterDeployment owning the [Selector]SyncSet being processed. For example:

```yaml
---
apiVersion: hive.openshift.io/v1
kind: SyncSet
metadata:
  name: mygroup
spec:
  clusterDeploymentRefs:
  - name: ClusterName

  resourceApplyMode: Upsert

  enableResourceTemplates: true

  resources:
  - apiVersion: v1
    kind: ConfigMap
    metadata:
      name: mycm
      namespace: myns
    data:
      platform: the platform is {{ fromCDLabel "hive.openshift.io/cluster-platform" }}
```

...might result in the following ConfigMap on the spoke cluster:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: mycm
  namespace: myns
data:
  platform: the platform is gcp
```

If the CD has no labels, or if there is no label with the specified key, the empty string is substituted.

Errors parsing or processing the template will cause the SyncSet to fail and will be bubbled up in the ClusterSync status as usual.

[HIVE-1748](https://issues.redhat.com//browse/HIVE-1748)