### PR TITLE
Unstructured OpenstackProviderSpec

### DIFF
--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -1105,7 +1105,7 @@ func (r *ReconcileMachinePool) createActuator(
 		}
 		return NewAzureActuator(creds, cd.Spec.Platform.Azure.CloudName.Name(), logger)
 	case cd.Spec.Platform.OpenStack != nil:
-		return NewOpenStackActuator(masterMachine, r.scheme, r.Client, logger)
+		return NewOpenStackActuator(masterMachine, r.Client, logger)
 	case cd.Spec.Platform.VSphere != nil:
 		return NewVSphereActuator(masterMachine, r.scheme, logger)
 	case cd.Spec.Platform.Ovirt != nil:

--- a/pkg/controller/machinepool/openstackactuator_test.go
+++ b/pkg/controller/machinepool/openstackactuator_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
 
 	machinev1alpha1 "github.com/openshift/api/machine/v1alpha1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
@@ -49,6 +51,153 @@ func BROKEN__TestOpenStackActuator(t *testing.T) {
 			} else {
 				require.NoError(t, err, "unexpected error for test cast")
 				validateOSPMachineSets(t, generatedMachineSets, test.expectedMachineSetReplicas)
+			}
+		})
+	}
+}
+
+func Test_getOpenStackOSImage(t *testing.T) {
+	logger := log.WithField("actuator", "openstackactuator_test")
+	tests := []struct {
+		name             string
+		providerSpecYaml string
+		wantOSImage      string
+		wantErr          bool
+	}{
+		{
+			name:             "Un-unmarshalable providerSpec",
+			providerSpecYaml: "this is not valid yaml",
+			wantErr:          true,
+		},
+		{
+			name: "Old apiVersion, OSImage in image",
+			// This is a real providerSpec from a real live test. We won't bother with
+			// complete ones after this.
+			providerSpecYaml: `apiVersion: openstackproviderconfig.openshift.io/v1alpha1
+cloudName: openstack
+cloudsSecret:
+  name: openstack-cloud-credentials
+  namespace: openshift-machine-api
+flavor: m1.xlarge
+image: clc-auto-psi-fh6rg-rhcos
+kind: OpenstackProviderSpec
+metadata:
+  creationTimestamp: null
+networks:
+- filter: {}
+  subnets:
+  - filter:
+    name: clc-auto-psi-fh6rg-nodes
+    tags: openshiftClusterID=clc-auto-psi-fh6rg
+securityGroups:
+- filter: {}
+  name: clc-auto-psi-fh6rg-worker
+serverGroupName: clc-auto-psi-fh6rg-worker
+serverMetadata:
+  Name: clc-auto-psi-fh6rg-worker
+  openshiftClusterID: clc-auto-psi-fh6rg
+tags:
+- openshiftClusterID=clc-auto-psi-fh6rg
+trunk: true
+userDataSecret:
+  name: worker-user-data
+`,
+			wantOSImage: "clc-auto-psi-fh6rg-rhcos",
+		},
+		{
+			name: "Future apiVersion, OSImage in rootVolume",
+			providerSpecYaml: `apiVersion: something.we.do.not.know.yet/v1theta1
+kind: OpenstackProviderSpec
+rootVolume:
+  sourceUUID: the-image
+`,
+			wantOSImage: "the-image",
+		},
+		{
+			name: "sourceUUID takes precedence over image",
+			providerSpecYaml: `apiVersion: whatever/v1
+image: not-the-image
+kind: OpenstackProviderSpec
+rootVolume:
+  sourceUUID: the-image
+`,
+			wantOSImage: "the-image",
+		},
+		{
+			name: "empty rootVolume ignored",
+			providerSpecYaml: `apiVersion: whatever/v1
+image: the-image
+kind: OpenstackProviderSpec
+rootVolume: {}
+`,
+			wantOSImage: "the-image",
+		},
+		{
+			name: "empty sourceUUID ignored",
+			providerSpecYaml: `apiVersion: whatever/v1
+image: the-image
+kind: OpenstackProviderSpec
+rootVolume:
+  sourceUUID: ""
+`,
+			wantOSImage: "the-image",
+		},
+		{
+			name: "rootVolume not castable to map",
+			providerSpecYaml: `apiVersion: whatever/v1
+kind: OpenstackProviderSpec
+rootVolume: 42
+`,
+			wantErr: true,
+		},
+		{
+			name: "sourceUUID not castable to string",
+			providerSpecYaml: `apiVersion: whatever/v1
+kind: OpenstackProviderSpec
+rootVolume:
+  sourceUUID: 42
+`,
+			wantErr: true,
+		},
+		{
+			name: "image not castable to string",
+			providerSpecYaml: `apiVersion: whatever/v1
+image: 42
+kind: OpenstackProviderSpec
+`,
+			wantErr: true,
+		},
+		{
+			name: "no osImage found",
+			providerSpecYaml: `apiVersion: whatever/v1
+image: ""
+kind: OpenstackProviderSpec
+rootVolume:
+  sourceUUID: ""
+`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			providerSpecJSON, err := yaml.YAMLToJSON([]byte(tt.providerSpecYaml))
+			assert.NoError(t, err, "Couldn't convert yaml providerSpec test input to JSON")
+			masterMachine := &machinev1beta1.Machine{
+				Spec: machinev1beta1.MachineSpec{
+					ProviderSpec: machinev1beta1.ProviderSpec{
+						Value: &runtime.RawExtension{
+							Raw: providerSpecJSON,
+						},
+					},
+				},
+			}
+			gotOSImage, err := getOpenStackOSImage(masterMachine, logger)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getOpenStackOSImage() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotOSImage != tt.wantOSImage {
+				t.Errorf("getOpenStackOSImage() = %v, want %v", gotOSImage, tt.wantOSImage)
 			}
 		})
 	}


### PR DESCRIPTION
Another attempt to address the move of OpenstackProviderSpec from cluster-api-provider-openstack to openstack/api/machine. See #2117 for background. In that PR, we simply replaced our imports. The result is that we could only decode the _new_ thing. The problem is that we may still get the _old_ thing if we're talking to an old cluster.

We only need the decoding to steal the osImage from the master machines so we can use that value for new workers. Rather than importing both schemata, trying to figure out which version we're talking to, and decoding against the correct one, this commit unmarshals the providerSpec as raw JSON into an Unstructured object and explicitly paths into it map-wise.

On the creation side, we're told that the spoke cluster itself will understand the new thing even if it's an old version (MAPI also unmarshals the JSON raw). So it should be fine to continue using recent vendored installer code to generate MachineSets (which will contain new-apiVersion OpenstackProviderSpec).

[HIVE-2308](https://issues.redhat.com//browse/HIVE-2308)

(cherry picked from commit 28dac77cfc2d836956972ea9f2254de962ce63af)