### PR TITLE
Copy ClusterVersion.Status into ClusterDeployment

### DIFF
--- a/apis/hive/v1/clusterdeployment_types.go
+++ b/apis/hive/v1/clusterdeployment_types.go
@@ -381,6 +381,12 @@ type ClusterDeploymentStatus struct {
 	// perform the installation.
 	// +optional
 	Platform *PlatformStatus `json:"platformStatus,omitempty"`
+
+	// ClusterVersionStatus is a wholesale copy of the Status section of the spoke cluster's
+	// `clusterversion version` object. This is not officially supported, and is only populated
+	// on request.
+	// +optional
+	ClusterVersionStatus *configv1.ClusterVersionStatus `json:"clusterVersionStatus,omitempty"`
 }
 
 // ClusterDeploymentCondition contains details for the current condition of a cluster deployment

--- a/apis/hive/v1/zz_generated.deepcopy.go
+++ b/apis/hive/v1/zz_generated.deepcopy.go
@@ -947,6 +947,11 @@ func (in *ClusterDeploymentStatus) DeepCopyInto(out *ClusterDeploymentStatus) {
 		*out = new(PlatformStatus)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ClusterVersionStatus != nil {
+		in, out := &in.ClusterVersionStatus, &out.ClusterVersionStatus
+		*out = new(configv1.ClusterVersionStatus)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -1385,6 +1385,512 @@ spec:
                 cliImage:
                   description: CLIImage is the name of the oc cli image to use when installing the target cluster
                   type: string
+                clusterVersionStatus:
+                  description: |-
+                    ClusterVersionStatus is a wholesale copy of the Status section of the spoke cluster's
+                    `clusterversion version` object. This is not officially supported, and is only populated
+                    on request.
+                  properties:
+                    availableUpdates:
+                      description: |-
+                        availableUpdates contains updates recommended for this
+                        cluster. Updates which appear in conditionalUpdates but not in
+                        availableUpdates may expose this cluster to known issues. This list
+                        may be empty if no updates are recommended, if the update service
+                        is unavailable, or if an invalid channel has been specified.
+                      items:
+                        description: Release represents an OpenShift release image and associated metadata.
+                        properties:
+                          architecture:
+                            description: |-
+                              architecture is an optional field that indicates the
+                              value of the cluster architecture. In this context cluster
+                              architecture means either a single architecture or a multi
+                              architecture.
+                              Valid values are 'Multi' and empty.
+                            enum:
+                              - Multi
+                              - ""
+                            type: string
+                          channels:
+                            description: |-
+                              channels is the set of Cincinnati channels to which the release
+                              currently belongs.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          image:
+                            description: |-
+                              image is a container image location that contains the update. When this
+                              field is part of spec, image is optional if version is specified and the
+                              availableUpdates field contains a matching version.
+                            type: string
+                          url:
+                            description: |-
+                              url contains information about this release. This URL is set by
+                              the 'url' metadata property on a release or the metadata returned by
+                              the update API and should be displayed as a link in user
+                              interfaces. The URL field may not be set for test or nightly
+                              releases.
+                            type: string
+                          version:
+                            description: |-
+                              version is a semantic version identifying the update version. When this
+                              field is part of spec, version is optional if image is specified.
+                            type: string
+                        required:
+                          - image
+                          - version
+                        type: object
+                      nullable: true
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    capabilities:
+                      description: capabilities describes the state of optional, core cluster components.
+                      properties:
+                        enabledCapabilities:
+                          description: enabledCapabilities lists all the capabilities that are currently managed.
+                          items:
+                            description: ClusterVersionCapability enumerates optional, core cluster components.
+                            enum:
+                              - openshift-samples
+                              - baremetal
+                              - marketplace
+                              - Console
+                              - Insights
+                              - Storage
+                              - CSISnapshot
+                              - NodeTuning
+                              - MachineAPI
+                              - Build
+                              - DeploymentConfig
+                              - ImageRegistry
+                              - OperatorLifecycleManager
+                              - CloudCredential
+                              - Ingress
+                              - CloudControllerManager
+                              - OperatorLifecycleManagerV1
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        knownCapabilities:
+                          description: knownCapabilities lists all the capabilities known to the current cluster.
+                          items:
+                            description: ClusterVersionCapability enumerates optional, core cluster components.
+                            enum:
+                              - openshift-samples
+                              - baremetal
+                              - marketplace
+                              - Console
+                              - Insights
+                              - Storage
+                              - CSISnapshot
+                              - NodeTuning
+                              - MachineAPI
+                              - Build
+                              - DeploymentConfig
+                              - ImageRegistry
+                              - OperatorLifecycleManager
+                              - CloudCredential
+                              - Ingress
+                              - CloudControllerManager
+                              - OperatorLifecycleManagerV1
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    conditionalUpdates:
+                      description: |-
+                        conditionalUpdates contains the list of updates that may be
+                        recommended for this cluster if it meets specific required
+                        conditions. Consumers interested in the set of updates that are
+                        actually recommended for this cluster should use
+                        availableUpdates. This list may be empty if no updates are
+                        recommended, if the update service is unavailable, or if an empty
+                        or invalid channel has been specified.
+                      items:
+                        description: |-
+                          ConditionalUpdate represents an update which is recommended to some
+                          clusters on the version the current cluster is reconciling, but which
+                          may not be recommended for the current cluster.
+                        properties:
+                          conditions:
+                            description: |-
+                              conditions represents the observations of the conditional update's
+                              current status. Known types are:
+                              * Recommended, for whether the update is recommended for the current cluster.
+                            items:
+                              description: Condition contains details for one aspect of the current state of this API Resource.
+                              properties:
+                                lastTransitionTime:
+                                  description: |-
+                                    lastTransitionTime is the last time the condition transitioned from one status to another.
+                                    This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: |-
+                                    message is a human readable message indicating details about the transition.
+                                    This may be an empty string.
+                                  maxLength: 32768
+                                  type: string
+                                observedGeneration:
+                                  description: |-
+                                    observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                    For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                    with respect to the current state of the instance.
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                                reason:
+                                  description: |-
+                                    reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                    Producers of specific condition types may define expected values and meanings for this field,
+                                    and whether the values are considered a guaranteed API.
+                                    The value should be a CamelCase string.
+                                    This field may not be empty.
+                                  maxLength: 1024
+                                  minLength: 1
+                                  pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                  type: string
+                                status:
+                                  description: status of the condition, one of True, False, Unknown.
+                                  enum:
+                                    - "True"
+                                    - "False"
+                                    - Unknown
+                                  type: string
+                                type:
+                                  description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                  maxLength: 316
+                                  pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                  type: string
+                              required:
+                                - lastTransitionTime
+                                - message
+                                - reason
+                                - status
+                                - type
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - type
+                            x-kubernetes-list-type: map
+                          release:
+                            description: release is the target of the update.
+                            properties:
+                              architecture:
+                                description: |-
+                                  architecture is an optional field that indicates the
+                                  value of the cluster architecture. In this context cluster
+                                  architecture means either a single architecture or a multi
+                                  architecture.
+                                  Valid values are 'Multi' and empty.
+                                enum:
+                                  - Multi
+                                  - ""
+                                type: string
+                              channels:
+                                description: |-
+                                  channels is the set of Cincinnati channels to which the release
+                                  currently belongs.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              image:
+                                description: |-
+                                  image is a container image location that contains the update. When this
+                                  field is part of spec, image is optional if version is specified and the
+                                  availableUpdates field contains a matching version.
+                                type: string
+                              url:
+                                description: |-
+                                  url contains information about this release. This URL is set by
+                                  the 'url' metadata property on a release or the metadata returned by
+                                  the update API and should be displayed as a link in user
+                                  interfaces. The URL field may not be set for test or nightly
+                                  releases.
+                                type: string
+                              version:
+                                description: |-
+                                  version is a semantic version identifying the update version. When this
+                                  field is part of spec, version is optional if image is specified.
+                                type: string
+                            required:
+                              - image
+                              - version
+                            type: object
+                          risks:
+                            description: |-
+                              risks represents the range of issues associated with
+                              updating to the target release. The cluster-version
+                              operator will evaluate all entries, and only recommend the
+                              update if there is at least one entry and all entries
+                              recommend the update.
+                            items:
+                              description: |-
+                                ConditionalUpdateRisk represents a reason and cluster-state
+                                for not recommending a conditional update.
+                              properties:
+                                matchingRules:
+                                  description: |-
+                                    matchingRules is a slice of conditions for deciding which
+                                    clusters match the risk and which do not. The slice is
+                                    ordered by decreasing precedence. The cluster-version
+                                    operator will walk the slice in order, and stop after the
+                                    first it can successfully evaluate. If no condition can be
+                                    successfully evaluated, the update will not be recommended.
+                                  items:
+                                    description: |-
+                                      ClusterCondition is a union of typed cluster conditions.  The 'type'
+                                      property determines which of the type-specific properties are relevant.
+                                      When evaluated on a cluster, the condition may match, not match, or
+                                      fail to evaluate.
+                                    properties:
+                                      promql:
+                                        description: promql represents a cluster condition based on PromQL.
+                                        properties:
+                                          promql:
+                                            description: |-
+                                              promql is a PromQL query classifying clusters. This query
+                                              query should return a 1 in the match case and a 0 in the
+                                              does-not-match case. Queries which return no time
+                                              series, or which return values besides 0 or 1, are
+                                              evaluation failures.
+                                            type: string
+                                        required:
+                                          - promql
+                                        type: object
+                                      type:
+                                        description: |-
+                                          type represents the cluster-condition type. This defines
+                                          the members and semantics of any additional properties.
+                                        enum:
+                                          - Always
+                                          - PromQL
+                                        type: string
+                                    required:
+                                      - type
+                                    type: object
+                                  minItems: 1
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                message:
+                                  description: |-
+                                    message provides additional information about the risk of
+                                    updating, in the event that matchingRules match the cluster
+                                    state. This is only to be consumed by humans. It may
+                                    contain Line Feed characters (U+000A), which should be
+                                    rendered as new lines.
+                                  minLength: 1
+                                  type: string
+                                name:
+                                  description: |-
+                                    name is the CamelCase reason for not recommending a
+                                    conditional update, in the event that matchingRules match the
+                                    cluster state.
+                                  minLength: 1
+                                  type: string
+                                url:
+                                  description: url contains information about this risk.
+                                  format: uri
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - matchingRules
+                                - message
+                                - name
+                                - url
+                              type: object
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
+                        required:
+                          - release
+                          - risks
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    conditions:
+                      description: |-
+                        conditions provides information about the cluster version. The condition
+                        "Available" is set to true if the desiredUpdate has been reached. The
+                        condition "Progressing" is set to true if an update is being applied.
+                        The condition "Degraded" is set to true if an update is currently blocked
+                        by a temporary or permanent error. Conditions are only valid for the
+                        current desiredUpdate when metadata.generation is equal to
+                        status.generation.
+                      items:
+                        description: |-
+                          ClusterOperatorStatusCondition represents the state of the operator's
+                          managed and monitored components.
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the time of the last update to the current status property.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message provides additional information about the current condition.
+                              This is only to be consumed by humans.  It may contain Line Feed
+                              characters (U+000A), which should be rendered as new lines.
+                            type: string
+                          reason:
+                            description: reason is the CamelCase reason for the condition's current status.
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False, Unknown.
+                            type: string
+                          type:
+                            description: type specifies the aspect reported by this condition.
+                            type: string
+                        required:
+                          - lastTransitionTime
+                          - status
+                          - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - type
+                      x-kubernetes-list-type: map
+                    desired:
+                      description: |-
+                        desired is the version that the cluster is reconciling towards.
+                        If the cluster is not yet fully initialized desired will be set
+                        with the information available, which may be an image or a tag.
+                      properties:
+                        architecture:
+                          description: |-
+                            architecture is an optional field that indicates the
+                            value of the cluster architecture. In this context cluster
+                            architecture means either a single architecture or a multi
+                            architecture.
+                            Valid values are 'Multi' and empty.
+                          enum:
+                            - Multi
+                            - ""
+                          type: string
+                        channels:
+                          description: |-
+                            channels is the set of Cincinnati channels to which the release
+                            currently belongs.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        image:
+                          description: |-
+                            image is a container image location that contains the update. When this
+                            field is part of spec, image is optional if version is specified and the
+                            availableUpdates field contains a matching version.
+                          type: string
+                        url:
+                          description: |-
+                            url contains information about this release. This URL is set by
+                            the 'url' metadata property on a release or the metadata returned by
+                            the update API and should be displayed as a link in user
+                            interfaces. The URL field may not be set for test or nightly
+                            releases.
+                          type: string
+                        version:
+                          description: |-
+                            version is a semantic version identifying the update version. When this
+                            field is part of spec, version is optional if image is specified.
+                          type: string
+                      required:
+                        - image
+                        - version
+                      type: object
+                    history:
+                      description: |-
+                        history contains a list of the most recent versions applied to the cluster.
+                        This value may be empty during cluster startup, and then will be updated
+                        when a new update is being applied. The newest update is first in the
+                        list and it is ordered by recency. Updates in the history have state
+                        Completed if the rollout completed - if an update was failing or halfway
+                        applied the state will be Partial. Only a limited amount of update history
+                        is preserved.
+                      items:
+                        description: UpdateHistory is a single attempted update to the cluster.
+                        properties:
+                          acceptedRisks:
+                            description: |-
+                              acceptedRisks records risks which were accepted to initiate the update.
+                              For example, it may menition an Upgradeable=False or missing signature
+                              that was overriden via desiredUpdate.force, or an update that was
+                              initiated despite not being in the availableUpdates set of recommended
+                              update targets.
+                            type: string
+                          completionTime:
+                            description: |-
+                              completionTime, if set, is when the update was fully applied. The update
+                              that is currently being applied will have a null completion time.
+                              Completion time will always be set for entries that are not the current
+                              update (usually to the started time of the next update).
+                            format: date-time
+                            nullable: true
+                            type: string
+                          image:
+                            description: |-
+                              image is a container image location that contains the update. This value
+                              is always populated.
+                            type: string
+                          startedTime:
+                            description: startedTime is the time at which the update was started.
+                            format: date-time
+                            type: string
+                          state:
+                            description: |-
+                              state reflects whether the update was fully applied. The Partial state
+                              indicates the update is not fully applied, while the Completed state
+                              indicates the update was successfully rolled out at least once (all
+                              parts of the update successfully applied).
+                            type: string
+                          verified:
+                            description: |-
+                              verified indicates whether the provided update was properly verified
+                              before it was installed. If this is false the cluster may not be trusted.
+                              Verified does not cover upgradeable checks that depend on the cluster
+                              state at the time when the update target was accepted.
+                            type: boolean
+                          version:
+                            description: |-
+                              version is a semantic version identifying the update version. If the
+                              requested image does not define a version, or if a failure occurs
+                              retrieving the image, this value may be empty.
+                            type: string
+                        required:
+                          - completionTime
+                          - image
+                          - startedTime
+                          - state
+                          - verified
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    observedGeneration:
+                      description: |-
+                        observedGeneration reports which version of the spec is being synced.
+                        If this value is not equal to metadata.generation, then the desired
+                        and conditions fields may represent a previous version.
+                      format: int64
+                      type: integer
+                    versionHash:
+                      description: |-
+                        versionHash is a fingerprint of the content that the cluster will be
+                        updated with. It is used by the operator to avoid unnecessary work
+                        and is for internal use only.
+                      type: string
+                  required:
+                    - availableUpdates
+                    - desired
+                    - observedGeneration
+                    - versionHash
+                  type: object
                 conditions:
                   description: Conditions includes more detailed status for the cluster deployment
                   items:

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -2421,6 +2421,723 @@ objects:
                   description: CLIImage is the name of the oc cli image to use when
                     installing the target cluster
                   type: string
+                clusterVersionStatus:
+                  description: 'ClusterVersionStatus is a wholesale copy of the Status
+                    section of the spoke cluster''s
+
+                    `clusterversion version` object. This is not officially supported,
+                    and is only populated
+
+                    on request.'
+                  properties:
+                    availableUpdates:
+                      description: 'availableUpdates contains updates recommended
+                        for this
+
+                        cluster. Updates which appear in conditionalUpdates but not
+                        in
+
+                        availableUpdates may expose this cluster to known issues.
+                        This list
+
+                        may be empty if no updates are recommended, if the update
+                        service
+
+                        is unavailable, or if an invalid channel has been specified.'
+                      items:
+                        description: Release represents an OpenShift release image
+                          and associated metadata.
+                        properties:
+                          architecture:
+                            description: 'architecture is an optional field that indicates
+                              the
+
+                              value of the cluster architecture. In this context cluster
+
+                              architecture means either a single architecture or a
+                              multi
+
+                              architecture.
+
+                              Valid values are ''Multi'' and empty.'
+                            enum:
+                            - Multi
+                            - ''
+                            type: string
+                          channels:
+                            description: 'channels is the set of Cincinnati channels
+                              to which the release
+
+                              currently belongs.'
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: set
+                          image:
+                            description: 'image is a container image location that
+                              contains the update. When this
+
+                              field is part of spec, image is optional if version
+                              is specified and the
+
+                              availableUpdates field contains a matching version.'
+                            type: string
+                          url:
+                            description: 'url contains information about this release.
+                              This URL is set by
+
+                              the ''url'' metadata property on a release or the metadata
+                              returned by
+
+                              the update API and should be displayed as a link in
+                              user
+
+                              interfaces. The URL field may not be set for test or
+                              nightly
+
+                              releases.'
+                            type: string
+                          version:
+                            description: 'version is a semantic version identifying
+                              the update version. When this
+
+                              field is part of spec, version is optional if image
+                              is specified.'
+                            type: string
+                        required:
+                        - image
+                        - version
+                        type: object
+                      nullable: true
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    capabilities:
+                      description: capabilities describes the state of optional, core
+                        cluster components.
+                      properties:
+                        enabledCapabilities:
+                          description: enabledCapabilities lists all the capabilities
+                            that are currently managed.
+                          items:
+                            description: ClusterVersionCapability enumerates optional,
+                              core cluster components.
+                            enum:
+                            - openshift-samples
+                            - baremetal
+                            - marketplace
+                            - Console
+                            - Insights
+                            - Storage
+                            - CSISnapshot
+                            - NodeTuning
+                            - MachineAPI
+                            - Build
+                            - DeploymentConfig
+                            - ImageRegistry
+                            - OperatorLifecycleManager
+                            - CloudCredential
+                            - Ingress
+                            - CloudControllerManager
+                            - OperatorLifecycleManagerV1
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        knownCapabilities:
+                          description: knownCapabilities lists all the capabilities
+                            known to the current cluster.
+                          items:
+                            description: ClusterVersionCapability enumerates optional,
+                              core cluster components.
+                            enum:
+                            - openshift-samples
+                            - baremetal
+                            - marketplace
+                            - Console
+                            - Insights
+                            - Storage
+                            - CSISnapshot
+                            - NodeTuning
+                            - MachineAPI
+                            - Build
+                            - DeploymentConfig
+                            - ImageRegistry
+                            - OperatorLifecycleManager
+                            - CloudCredential
+                            - Ingress
+                            - CloudControllerManager
+                            - OperatorLifecycleManagerV1
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    conditionalUpdates:
+                      description: 'conditionalUpdates contains the list of updates
+                        that may be
+
+                        recommended for this cluster if it meets specific required
+
+                        conditions. Consumers interested in the set of updates that
+                        are
+
+                        actually recommended for this cluster should use
+
+                        availableUpdates. This list may be empty if no updates are
+
+                        recommended, if the update service is unavailable, or if an
+                        empty
+
+                        or invalid channel has been specified.'
+                      items:
+                        description: 'ConditionalUpdate represents an update which
+                          is recommended to some
+
+                          clusters on the version the current cluster is reconciling,
+                          but which
+
+                          may not be recommended for the current cluster.'
+                        properties:
+                          conditions:
+                            description: 'conditions represents the observations of
+                              the conditional update''s
+
+                              current status. Known types are:
+
+                              * Recommended, for whether the update is recommended
+                              for the current cluster.'
+                            items:
+                              description: Condition contains details for one aspect
+                                of the current state of this API Resource.
+                              properties:
+                                lastTransitionTime:
+                                  description: 'lastTransitionTime is the last time
+                                    the condition transitioned from one status to
+                                    another.
+
+                                    This should be when the underlying condition changed.  If
+                                    that is not known, then using the time when the
+                                    API field changed is acceptable.'
+                                  format: date-time
+                                  type: string
+                                message:
+                                  description: 'message is a human readable message
+                                    indicating details about the transition.
+
+                                    This may be an empty string.'
+                                  maxLength: 32768
+                                  type: string
+                                observedGeneration:
+                                  description: 'observedGeneration represents the
+                                    .metadata.generation that the condition was set
+                                    based upon.
+
+                                    For instance, if .metadata.generation is currently
+                                    12, but the .status.conditions[x].observedGeneration
+                                    is 9, the condition is out of date
+
+                                    with respect to the current state of the instance.'
+                                  format: int64
+                                  minimum: 0
+                                  type: integer
+                                reason:
+                                  description: 'reason contains a programmatic identifier
+                                    indicating the reason for the condition''s last
+                                    transition.
+
+                                    Producers of specific condition types may define
+                                    expected values and meanings for this field,
+
+                                    and whether the values are considered a guaranteed
+                                    API.
+
+                                    The value should be a CamelCase string.
+
+                                    This field may not be empty.'
+                                  maxLength: 1024
+                                  minLength: 1
+                                  pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                  type: string
+                                status:
+                                  description: status of the condition, one of True,
+                                    False, Unknown.
+                                  enum:
+                                  - 'True'
+                                  - 'False'
+                                  - Unknown
+                                  type: string
+                                type:
+                                  description: type of condition in CamelCase or in
+                                    foo.example.com/CamelCase.
+                                  maxLength: 316
+                                  pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                  type: string
+                              required:
+                              - lastTransitionTime
+                              - message
+                              - reason
+                              - status
+                              - type
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - type
+                            x-kubernetes-list-type: map
+                          release:
+                            description: release is the target of the update.
+                            properties:
+                              architecture:
+                                description: 'architecture is an optional field that
+                                  indicates the
+
+                                  value of the cluster architecture. In this context
+                                  cluster
+
+                                  architecture means either a single architecture
+                                  or a multi
+
+                                  architecture.
+
+                                  Valid values are ''Multi'' and empty.'
+                                enum:
+                                - Multi
+                                - ''
+                                type: string
+                              channels:
+                                description: 'channels is the set of Cincinnati channels
+                                  to which the release
+
+                                  currently belongs.'
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: set
+                              image:
+                                description: 'image is a container image location
+                                  that contains the update. When this
+
+                                  field is part of spec, image is optional if version
+                                  is specified and the
+
+                                  availableUpdates field contains a matching version.'
+                                type: string
+                              url:
+                                description: 'url contains information about this
+                                  release. This URL is set by
+
+                                  the ''url'' metadata property on a release or the
+                                  metadata returned by
+
+                                  the update API and should be displayed as a link
+                                  in user
+
+                                  interfaces. The URL field may not be set for test
+                                  or nightly
+
+                                  releases.'
+                                type: string
+                              version:
+                                description: 'version is a semantic version identifying
+                                  the update version. When this
+
+                                  field is part of spec, version is optional if image
+                                  is specified.'
+                                type: string
+                            required:
+                            - image
+                            - version
+                            type: object
+                          risks:
+                            description: 'risks represents the range of issues associated
+                              with
+
+                              updating to the target release. The cluster-version
+
+                              operator will evaluate all entries, and only recommend
+                              the
+
+                              update if there is at least one entry and all entries
+
+                              recommend the update.'
+                            items:
+                              description: 'ConditionalUpdateRisk represents a reason
+                                and cluster-state
+
+                                for not recommending a conditional update.'
+                              properties:
+                                matchingRules:
+                                  description: 'matchingRules is a slice of conditions
+                                    for deciding which
+
+                                    clusters match the risk and which do not. The
+                                    slice is
+
+                                    ordered by decreasing precedence. The cluster-version
+
+                                    operator will walk the slice in order, and stop
+                                    after the
+
+                                    first it can successfully evaluate. If no condition
+                                    can be
+
+                                    successfully evaluated, the update will not be
+                                    recommended.'
+                                  items:
+                                    description: 'ClusterCondition is a union of typed
+                                      cluster conditions.  The ''type''
+
+                                      property determines which of the type-specific
+                                      properties are relevant.
+
+                                      When evaluated on a cluster, the condition may
+                                      match, not match, or
+
+                                      fail to evaluate.'
+                                    properties:
+                                      promql:
+                                        description: promql represents a cluster condition
+                                          based on PromQL.
+                                        properties:
+                                          promql:
+                                            description: 'promql is a PromQL query
+                                              classifying clusters. This query
+
+                                              query should return a 1 in the match
+                                              case and a 0 in the
+
+                                              does-not-match case. Queries which return
+                                              no time
+
+                                              series, or which return values besides
+                                              0 or 1, are
+
+                                              evaluation failures.'
+                                            type: string
+                                        required:
+                                        - promql
+                                        type: object
+                                      type:
+                                        description: 'type represents the cluster-condition
+                                          type. This defines
+
+                                          the members and semantics of any additional
+                                          properties.'
+                                        enum:
+                                        - Always
+                                        - PromQL
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  minItems: 1
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                message:
+                                  description: 'message provides additional information
+                                    about the risk of
+
+                                    updating, in the event that matchingRules match
+                                    the cluster
+
+                                    state. This is only to be consumed by humans.
+                                    It may
+
+                                    contain Line Feed characters (U+000A), which should
+                                    be
+
+                                    rendered as new lines.'
+                                  minLength: 1
+                                  type: string
+                                name:
+                                  description: 'name is the CamelCase reason for not
+                                    recommending a
+
+                                    conditional update, in the event that matchingRules
+                                    match the
+
+                                    cluster state.'
+                                  minLength: 1
+                                  type: string
+                                url:
+                                  description: url contains information about this
+                                    risk.
+                                  format: uri
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - matchingRules
+                              - message
+                              - name
+                              - url
+                              type: object
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        required:
+                        - release
+                        - risks
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    conditions:
+                      description: 'conditions provides information about the cluster
+                        version. The condition
+
+                        "Available" is set to true if the desiredUpdate has been reached.
+                        The
+
+                        condition "Progressing" is set to true if an update is being
+                        applied.
+
+                        The condition "Degraded" is set to true if an update is currently
+                        blocked
+
+                        by a temporary or permanent error. Conditions are only valid
+                        for the
+
+                        current desiredUpdate when metadata.generation is equal to
+
+                        status.generation.'
+                      items:
+                        description: 'ClusterOperatorStatusCondition represents the
+                          state of the operator''s
+
+                          managed and monitored components.'
+                        properties:
+                          lastTransitionTime:
+                            description: lastTransitionTime is the time of the last
+                              update to the current status property.
+                            format: date-time
+                            type: string
+                          message:
+                            description: 'message provides additional information
+                              about the current condition.
+
+                              This is only to be consumed by humans.  It may contain
+                              Line Feed
+
+                              characters (U+000A), which should be rendered as new
+                              lines.'
+                            type: string
+                          reason:
+                            description: reason is the CamelCase reason for the condition's
+                              current status.
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            type: string
+                          type:
+                            description: type specifies the aspect reported by this
+                              condition.
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - status
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    desired:
+                      description: 'desired is the version that the cluster is reconciling
+                        towards.
+
+                        If the cluster is not yet fully initialized desired will be
+                        set
+
+                        with the information available, which may be an image or a
+                        tag.'
+                      properties:
+                        architecture:
+                          description: 'architecture is an optional field that indicates
+                            the
+
+                            value of the cluster architecture. In this context cluster
+
+                            architecture means either a single architecture or a multi
+
+                            architecture.
+
+                            Valid values are ''Multi'' and empty.'
+                          enum:
+                          - Multi
+                          - ''
+                          type: string
+                        channels:
+                          description: 'channels is the set of Cincinnati channels
+                            to which the release
+
+                            currently belongs.'
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: set
+                        image:
+                          description: 'image is a container image location that contains
+                            the update. When this
+
+                            field is part of spec, image is optional if version is
+                            specified and the
+
+                            availableUpdates field contains a matching version.'
+                          type: string
+                        url:
+                          description: 'url contains information about this release.
+                            This URL is set by
+
+                            the ''url'' metadata property on a release or the metadata
+                            returned by
+
+                            the update API and should be displayed as a link in user
+
+                            interfaces. The URL field may not be set for test or nightly
+
+                            releases.'
+                          type: string
+                        version:
+                          description: 'version is a semantic version identifying
+                            the update version. When this
+
+                            field is part of spec, version is optional if image is
+                            specified.'
+                          type: string
+                      required:
+                      - image
+                      - version
+                      type: object
+                    history:
+                      description: 'history contains a list of the most recent versions
+                        applied to the cluster.
+
+                        This value may be empty during cluster startup, and then will
+                        be updated
+
+                        when a new update is being applied. The newest update is first
+                        in the
+
+                        list and it is ordered by recency. Updates in the history
+                        have state
+
+                        Completed if the rollout completed - if an update was failing
+                        or halfway
+
+                        applied the state will be Partial. Only a limited amount of
+                        update history
+
+                        is preserved.'
+                      items:
+                        description: UpdateHistory is a single attempted update to
+                          the cluster.
+                        properties:
+                          acceptedRisks:
+                            description: 'acceptedRisks records risks which were accepted
+                              to initiate the update.
+
+                              For example, it may menition an Upgradeable=False or
+                              missing signature
+
+                              that was overriden via desiredUpdate.force, or an update
+                              that was
+
+                              initiated despite not being in the availableUpdates
+                              set of recommended
+
+                              update targets.'
+                            type: string
+                          completionTime:
+                            description: 'completionTime, if set, is when the update
+                              was fully applied. The update
+
+                              that is currently being applied will have a null completion
+                              time.
+
+                              Completion time will always be set for entries that
+                              are not the current
+
+                              update (usually to the started time of the next update).'
+                            format: date-time
+                            nullable: true
+                            type: string
+                          image:
+                            description: 'image is a container image location that
+                              contains the update. This value
+
+                              is always populated.'
+                            type: string
+                          startedTime:
+                            description: startedTime is the time at which the update
+                              was started.
+                            format: date-time
+                            type: string
+                          state:
+                            description: 'state reflects whether the update was fully
+                              applied. The Partial state
+
+                              indicates the update is not fully applied, while the
+                              Completed state
+
+                              indicates the update was successfully rolled out at
+                              least once (all
+
+                              parts of the update successfully applied).'
+                            type: string
+                          verified:
+                            description: 'verified indicates whether the provided
+                              update was properly verified
+
+                              before it was installed. If this is false the cluster
+                              may not be trusted.
+
+                              Verified does not cover upgradeable checks that depend
+                              on the cluster
+
+                              state at the time when the update target was accepted.'
+                            type: boolean
+                          version:
+                            description: 'version is a semantic version identifying
+                              the update version. If the
+
+                              requested image does not define a version, or if a failure
+                              occurs
+
+                              retrieving the image, this value may be empty.'
+                            type: string
+                        required:
+                        - completionTime
+                        - image
+                        - startedTime
+                        - state
+                        - verified
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    observedGeneration:
+                      description: 'observedGeneration reports which version of the
+                        spec is being synced.
+
+                        If this value is not equal to metadata.generation, then the
+                        desired
+
+                        and conditions fields may represent a previous version.'
+                      format: int64
+                      type: integer
+                    versionHash:
+                      description: 'versionHash is a fingerprint of the content that
+                        the cluster will be
+
+                        updated with. It is used by the operator to avoid unnecessary
+                        work
+
+                        and is for internal use only.'
+                      type: string
+                  required:
+                  - availableUpdates
+                  - desired
+                  - observedGeneration
+                  - versionHash
+                  type: object
                 conditions:
                   description: Conditions includes more detailed status for the cluster
                     deployment

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -560,6 +560,11 @@ const (
 	// of the clusterversion controller, which syncs hive.openshift.io/version* labels. It is how we plumb
 	// HiveConfig.Spec.ClusterVersionPollInterval from hive-operator through to the clusterversion controller.
 	ClusterVersionPollIntervalEnvVar = "CLUSTERVERSION_POLL_INTERVAL"
+
+	// SyncClusterVersionStatusAnnotation, if set to "true" on a ClusterDeployment, causes hive to copy the entire
+	// status section of the `clusterversion version` object from the spoke cluster into
+	// ClusterDeployment.Status.ClusterVersionStatus.
+	SyncClusterVersionStatusAnnotation = "hive.openshift.io/sync-clusterversion-status"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeployment_types.go
@@ -381,6 +381,12 @@ type ClusterDeploymentStatus struct {
 	// perform the installation.
 	// +optional
 	Platform *PlatformStatus `json:"platformStatus,omitempty"`
+
+	// ClusterVersionStatus is a wholesale copy of the Status section of the spoke cluster's
+	// `clusterversion version` object. This is not officially supported, and is only populated
+	// on request.
+	// +optional
+	ClusterVersionStatus *configv1.ClusterVersionStatus `json:"clusterVersionStatus,omitempty"`
 }
 
 // ClusterDeploymentCondition contains details for the current condition of a cluster deployment

--- a/vendor/github.com/openshift/hive/apis/hive/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/zz_generated.deepcopy.go
@@ -947,6 +947,11 @@ func (in *ClusterDeploymentStatus) DeepCopyInto(out *ClusterDeploymentStatus) {
 		*out = new(PlatformStatus)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ClusterVersionStatus != nil {
+		in, out := &in.ClusterVersionStatus, &out.ClusterVersionStatus
+		*out = new(configv1.ClusterVersionStatus)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 


### PR DESCRIPTION
Add a new field, ClusterDeployment.Status.ClusterVersionStatus.

At the behest of an (undocumented, unsupported) annotation, `hive.openshift.io/sync-clusterversion-status: "true"` (note: string `"true"` since it's an annotation) our clusterversion controller (the same one that updates the `hive.openshift.io/version*` labels) will populate it with a wholesale copy of the spoke's ClusterVersion.Status field.

NOTE: This requires that our vendor of openshift/api be kept up to date, as e.g. new enum values for `capabilities` will break us.

[HIVE-2366](https://issues.redhat.com//browse/HIVE-2366)