### PR TITLE
hiveutil create-cluster: cheaper AWS instances

### DIFF
--- a/contrib/pkg/createcluster/create.go
+++ b/contrib/pkg/createcluster/create.go
@@ -169,9 +169,10 @@ type Options struct {
 	FeatureSet                        string
 
 	// AWS
-	AWSUserTags     []string
-	AWSPrivateLink  bool
-	AWSInstanceType string
+	AWSUserTags           []string
+	AWSPrivateLink        bool
+	AWSInstanceType       string
+	AWSWorkerInstanceType string
 
 	// Azure
 	AzureBaseDomainResourceGroupName string
@@ -325,7 +326,8 @@ OpenShift Installer publishes all the services of the cluster like API server an
 	// AWS flags
 	flags.StringSliceVar(&opt.AWSUserTags, "aws-user-tags", nil, "Additional tags to add to resources. Must be in the form \"key=value\"")
 	flags.BoolVar(&opt.AWSPrivateLink, "aws-private-link", false, "Enables access to cluster using AWS PrivateLink")
-	flags.StringVar(&opt.AWSInstanceType, "aws-instance-type", clusterresource.AWSInstanceTypeDefault, "AWS cloud instance type")
+	flags.StringVar(&opt.AWSInstanceType, "aws-instance-type", clusterresource.AWSInstanceTypeDefault, "AWS cloud instance type for masters and workers (unless the latter is overridden by --aws-worker-instance-type)")
+	flags.StringVar(&opt.AWSWorkerInstanceType, "aws-worker-instance-type", "", "AWS cloud instance type for workers only. If unset, --aws-instance-type is used.")
 
 	// Azure flags
 	flags.StringVar(&opt.AzureBaseDomainResourceGroupName, "azure-base-domain-resource-group-name", "os4-common", "Resource group where the azure DNS zone for the base domain is found")
@@ -641,7 +643,9 @@ func (o *Options) GenerateObjects() ([]runtime.Object, error) {
 			UserTags:        userTags,
 			Region:          o.Region,
 			InstanceType:    o.AWSInstanceType,
-			PrivateLink:     o.AWSPrivateLink,
+			// Will default to above if unset
+			WorkerInstanceType: o.AWSWorkerInstanceType,
+			PrivateLink:        o.AWSPrivateLink,
 		}
 		builder.CloudBuilder = awsProvider
 	case cloudAzure:

--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -198,6 +198,10 @@ case "${CLOUD}" in
     # NOTE: Only observed by hiveutil create-cluster, not clusterpool at this time.
     INSTANCE_TYPE_ARG="--aws-instance-type $AWS_INSTANCE_TYPE"
   fi
+  # Default workers to the smaller m6a.large
+  AWS_WORKER_INSTANCE_TYPE=${AWS_WORKER_INSTANCE_TYPE:-m6a.large}
+  # NOTE: Only observed by hiveutil create-cluster, not clusterpool at this time.
+  WORKER_INSTANCE_TYPE_ARG="--aws-worker-instance-type $AWS_WORKER_INSTANCE_TYPE"
 	;;
 "azure")
 	CREDS_FILE_ARG="--creds-file=${CLUSTER_PROFILE_DIR}/osServicePrincipal.json"

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -106,6 +106,7 @@ go run "${SRC_ROOT}/contrib/cmd/hiveutil/main.go" create-cluster "${CLUSTER_NAME
 	--workers=2 \
 	${REGION_ARG} \
 	${INSTANCE_TYPE_ARG} \
+	${WORKER_INSTANCE_TYPE_ARG} \
 	${MANAGED_DNS_ARG} \
 	${EXTRA_CREATE_CLUSTER_ARGS} \
   -o json \

--- a/test/e2e/postinstall/machinesets/infra_test.go
+++ b/test/e2e/postinstall/machinesets/infra_test.go
@@ -308,9 +308,9 @@ func TestAutoscalingMachinePool(t *testing.T) {
 
 	// busyboxDeployment creates a large number of pods to place CPU pressure
 	// on the machine pool. With 100 replicas and a CPU request for each pod of
-	// 1, the total CPU request from the deployment is 100. For AWS using m6i.xlarge,
-	// each machine has a CPU limit of 6. For the max replicas of 12, the total
-	// CPU limit is 72.
+	// 1, the total CPU request from the deployment is 100. For AWS using m6a.xlarge,
+	// each machine has a CPU limit of 4. For the max replicas of 12, the total
+	// CPU limit is 48.
 	busyboxDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",


### PR DESCRIPTION
For cost savings:
- Change the default AWS instance type we use for `hiveutil create-cluster` and clusterpools from m6i.xlarge to m6a.xlarge. These have the same specs, but we're told `i`(ntel) is more expensive than `a`(md).
- Plumb a new `--aws-worker-instance-type` flag into `hiveutil create-cluster` to allow customizing _just_ the worker instance type in the generated install-config and machine pool. If unset, the previous behavior will hold: we'll use `--aws-instance-type` for (masters and) workers.
- Use the above to shrink the default worker instance type for e2e to m6a.large, which has half the CPU and memory of m6a.xlarge.

[HIVE-2426](https://issues.redhat.com//browse/HIVE-2426)