### PR TITLE
[mce-2.4] Allow MachinePool autoscaler maxReplicas < #AZs

### DIFF
--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -782,7 +782,7 @@ func (r *ReconcileMachinePool) syncMachineAutoscalers(
 				}
 			}
 
-			if !found {
+			if !found && maxReplicas > 0 {
 				ma := &autoscalingv1beta1.MachineAutoscaler{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: ms.Namespace,

--- a/pkg/controller/machinepool/machinepool_controller_test.go
+++ b/pkg/controller/machinepool/machinepool_controller_test.go
@@ -1081,6 +1081,58 @@ func TestRemoteMachineSetReconcile(t *testing.T) {
 			},
 		},
 		{
+			name:              "Create machine autoscalers where maxReplicas < #AZs",
+			clusterDeployment: testClusterDeployment(),
+			machinePool:       testAutoscalingMachinePool(1, 2),
+			remoteExisting: []runtime.Object{
+				testMachine("master1", "master"),
+				testClusterAutoscaler("1"),
+			},
+			generatedMachineSets: []*machineapi.MachineSet{
+				testMachineSet("foo-12345-worker-us-east-1a", "worker", false, 0, 0),
+				testMachineSet("foo-12345-worker-us-east-1b", "worker", false, 0, 0),
+				testMachineSet("foo-12345-worker-us-east-1c", "worker", false, 0, 0),
+			},
+			expectedRemoteMachineSets: []*machineapi.MachineSet{
+				testMachineSet("foo-12345-worker-us-east-1a", "worker", false, 1, 0),
+				testMachineSet("foo-12345-worker-us-east-1b", "worker", false, 0, 0),
+				testMachineSet("foo-12345-worker-us-east-1c", "worker", false, 0, 0),
+			},
+			expectedRemoteMachineAutoscalers: []autoscalingv1beta1.MachineAutoscaler{
+				*testMachineAutoscaler("foo-12345-worker-us-east-1a", "1", 1, 1),
+				*testMachineAutoscaler("foo-12345-worker-us-east-1b", "1", 0, 1),
+			},
+			expectedRemoteClusterAutoscalers: []autoscalingv1.ClusterAutoscaler{
+				*testClusterAutoscaler("1"),
+			},
+		},
+		{
+			name:              "Create machine autoscalers where maxReplicas < #AZs and minReplicas==0",
+			clusterDeployment: testClusterDeployment(),
+			machinePool:       testAutoscalingMachinePool(0, 2),
+			remoteExisting: []runtime.Object{
+				testMachine("master1", "master"),
+				testClusterAutoscaler("1"),
+			},
+			generatedMachineSets: []*machineapi.MachineSet{
+				testMachineSet("foo-12345-worker-us-east-1a", "worker", false, 0, 0),
+				testMachineSet("foo-12345-worker-us-east-1b", "worker", false, 0, 0),
+				testMachineSet("foo-12345-worker-us-east-1c", "worker", false, 0, 0),
+			},
+			expectedRemoteMachineSets: []*machineapi.MachineSet{
+				testMachineSet("foo-12345-worker-us-east-1a", "worker", false, 0, 0),
+				testMachineSet("foo-12345-worker-us-east-1b", "worker", false, 0, 0),
+				testMachineSet("foo-12345-worker-us-east-1c", "worker", false, 0, 0),
+			},
+			expectedRemoteMachineAutoscalers: []autoscalingv1beta1.MachineAutoscaler{
+				*testMachineAutoscaler("foo-12345-worker-us-east-1a", "1", 0, 1),
+				*testMachineAutoscaler("foo-12345-worker-us-east-1b", "1", 0, 1),
+			},
+			expectedRemoteClusterAutoscalers: []autoscalingv1.ClusterAutoscaler{
+				*testClusterAutoscaler("1"),
+			},
+		},
+		{
 			name: "VSphere: generated without suffix, remate without suffix",
 			clusterDeployment: func() *hivev1.ClusterDeployment {
 				cd := testClusterDeployment()


### PR DESCRIPTION
Our algorithm to spread MachinePool.Spec.Autoscaling.MinReplicas and .MaxReplicas across spoke MachineAutoscalers previously assumed that it was sane to create one MachineAutoscaler per AZ and set maxReplicas to zero if that's what our computation came out with.

Not so.

MachineAutoscaler.Spec.MaxReplicas -- in contrast to MachineSet.Spec.Replicas -- is
[not allowed to be zero](https://github.com/openshift/cluster-autoscaler-operator/blob/67999a5e79d0200ee0a4aab3dcfbfd18e097b514/pkg/apis/autoscaling/v1beta1/machineautoscaler_types.go#L18).

The resulting behavior would manifest as a hive-controllers error similar to:

```
time="2024-02-21T16:33:56.802Z" level=error msg="unable to create machine autoscaler" controller=machinepool error="MachineAutoscaler.autoscaling.openshift.io \"efried-rg2wn-worker-test-us-east-1c\" is invalid: spec.maxReplicas: Invalid value: 0: spec.maxReplicas in body should be greater than or equal to 1" machinePool=efried/efried-worker-test reconcileID=nwpxskln
```

So instead we have to include a special case for this and delete such MachineAutoscalers instead.

(Further, since this error causes us to bail out of the machinepool controller's reconcile loop before updating the MachinePool status, the user doesn't have a great way to discover what went wrong. They just have to notice that MachineSets et al stop responding. We'll address this in a separate commit.)

[HIVE-2415](https://issues.redhat.com//browse/HIVE-2415)

(cherry picked from commit 80d9694e72e81bdd374d401931f034ab4b42fef4)