### PR TITLE
Automatically apply area/unit-tests label to PRs

### DIFF
--- a/pkg/OWNERS
+++ b/pkg/OWNERS
@@ -1,0 +1,4 @@
+filters:
+  "_test\\.go$":
+     labels:
+     - area/unit-tests


### PR DESCRIPTION
This change will have prow apply an area/unit-tests label to any PR that changes a unit test file inside the "pkg" dir.