### PR TITLE
OCM-6713 | feat: allow user defined tags on machinepool creation

### DIFF
--- a/apis/hive/v1/aws/machinepool.go
+++ b/apis/hive/v1/aws/machinepool.go
@@ -36,6 +36,12 @@ type MachinePoolPlatform struct {
 	//
 	// +optional
 	AdditionalSecurityGroupIDs []string `json:"additionalSecurityGroupIDs,omitempty"`
+
+	// UserTags contains the user defined tags to be supplied for the ec2 instance.
+	// Note that these will be merged with ClusterDeployment.Spec.Platform.AWS.UserTags, with
+	// this field taking precedence when keys collide.
+	// +optional
+	UserTags map[string]string `json:"userTags,omitempty"`
 }
 
 // SpotMarketOptions defines the options available to a user when configuring

--- a/apis/hive/v1/aws/zz_generated.deepcopy.go
+++ b/apis/hive/v1/aws/zz_generated.deepcopy.go
@@ -82,6 +82,13 @@ func (in *MachinePoolPlatform) DeepCopyInto(out *MachinePoolPlatform) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.UserTags != nil {
+		in, out := &in.UserTags, &out.UserTags
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -162,6 +162,14 @@ spec:
                         description: InstanceType defines the ec2 instance type. eg.
                           m4-large
                         type: string
+                      userTags:
+                        additionalProperties:
+                          type: string
+                        description: UserTags contains the user defined tags to be
+                          supplied for the ec2 instance. Note that these will be merged
+                          with ClusterDeployment.Spec.Platform.AWS.UserTags, with
+                          this field taking precedence when keys collide.
+                        type: object
                       zones:
                         description: Zones is list of availability zones that can
                           be used.

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -5019,6 +5019,14 @@ objects:
                           description: InstanceType defines the ec2 instance type.
                             eg. m4-large
                           type: string
+                        userTags:
+                          additionalProperties:
+                            type: string
+                          description: UserTags contains the user defined tags to
+                            be supplied for the ec2 instance. Note that these will
+                            be merged with ClusterDeployment.Spec.Platform.AWS.UserTags,
+                            with this field taking precedence when keys collide.
+                          type: object
                         zones:
                           description: Zones is list of availability zones that can
                             be used.

--- a/pkg/clusterresource/aws.go
+++ b/pkg/clusterresource/aws.go
@@ -114,15 +114,16 @@ func (p *AWSCloudBuilder) addMachinePoolPlatform(o *Builder, mp *hivev1.MachineP
 			Size: volumeSize,
 			Type: volumeType,
 		},
+		UserTags: p.UserTags,
 	}
-
 }
 
 func (p *AWSCloudBuilder) addInstallConfigPlatform(o *Builder, ic *installertypes.InstallConfig) {
 	// Inject platform details into InstallConfig:
 	ic.Platform = installertypes.Platform{
 		AWS: &awsinstallertypes.Platform{
-			Region: p.Region,
+			Region:   p.Region,
+			UserTags: p.UserTags,
 		},
 	}
 

--- a/pkg/clusterresource/builder.go
+++ b/pkg/clusterresource/builder.go
@@ -201,7 +201,7 @@ func (o *Builder) Build() ([]runtime.Object, error) {
 	allObjects = append(allObjects, o.generateClusterDeployment())
 
 	if mp := o.generateMachinePool(); mp != nil && !o.SkipMachinePools {
-		allObjects = append(allObjects, o.generateMachinePool())
+		allObjects = append(allObjects, mp)
 	}
 
 	if o.InstallConfigTemplate != "" {

--- a/pkg/controller/machinepool/awsactuator.go
+++ b/pkg/controller/machinepool/awsactuator.go
@@ -177,10 +177,18 @@ func (a *AWSActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *hi
 	if err != nil {
 		return nil, false, errors.Wrap(err, "processing subnets")
 	}
-	// userTags are settings available in the installconfig that we are choosing
-	// to ignore for the timebeing. These empty settings should be updated to feed
-	// from the machinepool / installconfig in the future.
+
 	userTags := map[string]string{}
+	// Pull both CD and pool user tags
+	// pool takes precedence if both contain the same tag
+	if len(cd.Spec.Platform.AWS.UserTags) > 0 {
+		userTags = cd.Spec.Platform.AWS.UserTags
+	}
+	if len(pool.Spec.Platform.AWS.UserTags) > 0 {
+		for key, value := range pool.Spec.Platform.AWS.UserTags {
+			userTags[key] = value
+		}
+	}
 
 	installerMachineSets, err := installaws.MachineSets(
 		&installaws.MachineSetInput{

--- a/pkg/controller/machinepool/machinepool_controller_test.go
+++ b/pkg/controller/machinepool/machinepool_controller_test.go
@@ -1825,6 +1825,10 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 						Name: "aws-credentials",
 					},
 					Region: testRegion,
+					UserTags: map[string]string{
+						"cd-label":              "cd-value",
+						"cd-label-sync-from-mp": "cd-value-2",
+					},
 				},
 			},
 			ClusterMetadata: &hivev1.ClusterMetadata{

--- a/vendor/github.com/openshift/hive/apis/hive/v1/aws/machinepool.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/aws/machinepool.go
@@ -36,6 +36,12 @@ type MachinePoolPlatform struct {
 	//
 	// +optional
 	AdditionalSecurityGroupIDs []string `json:"additionalSecurityGroupIDs,omitempty"`
+
+	// UserTags contains the user defined tags to be supplied for the ec2 instance.
+	// Note that these will be merged with ClusterDeployment.Spec.Platform.AWS.UserTags, with
+	// this field taking precedence when keys collide.
+	// +optional
+	UserTags map[string]string `json:"userTags,omitempty"`
 }
 
 // SpotMarketOptions defines the options available to a user when configuring

--- a/vendor/github.com/openshift/hive/apis/hive/v1/aws/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/aws/zz_generated.deepcopy.go
@@ -82,6 +82,13 @@ func (in *MachinePoolPlatform) DeepCopyInto(out *MachinePoolPlatform) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.UserTags != nil {
+		in, out := &in.UserTags, &out.UserTags
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
[OCM-6713](https://issues.redhat.com//browse/OCM-6713)

Create AWS tags for machine pool on cluster creation time (day 1) and post-cluster creation time (day 2) on ROSA Classic.  Modification of AWS tags are out-of-scope.

Hive to support additional map of AWS tags on MachinePools
These are AWS user-defined / custom tags, not to be confused with node labels

## Implementation Strategy
The strategy opted for this PR is to merge the user tags with ClusterDeployment.Spec.Platform.AWS.UserTags, where the machine pool level field takes precedence when keys collide.