### PR TITLE
HIVE-2399: Reuse restConfigClientGetter when creating cmdutil.Factory

### DIFF
--- a/apis/hiveinternal/v1alpha1/clustersync_types.go
+++ b/apis/hiveinternal/v1alpha1/clustersync_types.go
@@ -9,6 +9,12 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+const (
+	// FinalizerCachePurge is used on ClusterDeployments to ensure we remove cluster sync related
+	// entries from a cache before cleaning up the CD object.
+	FinalizerCachePurge string = "hive.openshift.io/clustersync-cache"
+)
+
 // ClusterSync is the status of all of the SelectorSyncSets and SyncSets that apply to a ClusterDeployment.
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status

--- a/contrib/pkg/adm/managedns/enable.go
+++ b/contrib/pkg/adm/managedns/enable.go
@@ -379,7 +379,7 @@ func (o *Options) getResourceHelper() (resource.Helper, error) {
 		log.WithError(err).Error("Cannot get client config")
 		return nil, err
 	}
-	return resource.NewHelperFromRESTConfig(cfg, log.WithField("command", "adm manage-dns enable"))
+	return resource.NewHelper(log.WithField("command", "adm manage-dns enable"), resource.WithRESTConfig(cfg))
 }
 
 func (o *Options) setupLocalClients() error {

--- a/contrib/pkg/testresource/command.go
+++ b/contrib/pkg/testresource/command.go
@@ -55,7 +55,7 @@ func newApplyCommand() *cobra.Command {
 			}
 			content := mustRead(args[0])
 			kubeconfig := mustRead(kubeconfigPath)
-			helper, err := resource.NewHelper(kubeconfig, log.WithField("cmd", "apply"))
+			helper, err := resource.NewHelper(log.WithField("cmd", "apply"), resource.WithKubeconfig(kubeconfig))
 			if err != nil {
 				fmt.Printf("Error creating resource helper: %v\n", err)
 				return
@@ -127,7 +127,7 @@ func newPatchCommand() *cobra.Command {
 			}
 			content := mustRead(args[0])
 			kubeconfig := mustRead(kubeconfigPath)
-			helper, err := resource.NewHelper(kubeconfig, log.WithField("cmd", "patch"))
+			helper, err := resource.NewHelper(log.WithField("cmd", "patch"), resource.WithKubeconfig(kubeconfig))
 			if err != nil {
 				fmt.Printf("Error creating resource helper: %v\n", err)
 				return

--- a/contrib/pkg/utils/generic.go
+++ b/contrib/pkg/utils/generic.go
@@ -56,7 +56,7 @@ func GetResourceHelper(logger log.FieldLogger) (resource.Helper, error) {
 		logger.WithError(err).Error("Cannot get client config")
 		return nil, err
 	}
-	return resource.NewHelperFromRESTConfig(cfg, logger)
+	return resource.NewHelper(logger, resource.WithRESTConfig(cfg))
 }
 
 func DefaultNamespace() (string, error) {

--- a/pkg/controller/clustersync/clustersync_controller_test.go
+++ b/pkg/controller/clustersync/clustersync_controller_test.go
@@ -293,6 +293,7 @@ func TestReconcileClusterSync_NoWorkToDo(t *testing.T) {
 			cd: testcd.FullBuilder(testNamespace, testCDName, scheme).
 				GenericOptions(
 					testgeneric.WithUID(testCDUID),
+					testgeneric.WithFinalizer(hiveintv1alpha1.FinalizerCachePurge),
 				).
 				Options(
 					testcd.WithCondition(hivev1.ClusterDeploymentCondition{
@@ -2555,6 +2556,7 @@ func cdBuilder(scheme *runtime.Scheme) testcd.Builder {
 	return testcd.FullBuilder(testNamespace, testCDName, scheme).
 		GenericOptions(
 			testgeneric.WithUID(testCDUID),
+			testgeneric.WithFinalizer(hiveintv1alpha1.FinalizerCachePurge),
 		).
 		Options(
 			testcd.Installed(),

--- a/pkg/controller/controlplanecerts/controlplanecerts_controller.go
+++ b/pkg/controller/controlplanecerts/controlplanecerts_controller.go
@@ -82,7 +82,7 @@ func Add(mgr manager.Manager) error {
 // NewReconciler returns a new reconcile.Reconciler
 func NewReconciler(mgr manager.Manager, rateLimiter flowcontrol.RateLimiter) reconcile.Reconciler {
 	logger := log.WithField("controller", ControllerName)
-	helper, err := resource.NewHelperWithMetricsFromRESTConfig(mgr.GetConfig(), ControllerName, logger)
+	helper, err := resource.NewHelper(logger, resource.WithRESTConfig(mgr.GetConfig()), resource.WithMetrics(ControllerName))
 	if err != nil {
 		// Hard exit if we can't create this controller
 		logger.WithError(err).Fatal("unable to create resource helper")

--- a/pkg/controller/remoteingress/remoteingress_controller.go
+++ b/pkg/controller/remoteingress/remoteingress_controller.go
@@ -83,7 +83,7 @@ func Add(mgr manager.Manager) error {
 // NewReconciler returns a new reconcile.Reconciler
 func NewReconciler(mgr manager.Manager, rateLimiter flowcontrol.RateLimiter) reconcile.Reconciler {
 	logger := log.WithField("controller", ControllerName)
-	helper, err := resource.NewHelperWithMetricsFromRESTConfig(mgr.GetConfig(), ControllerName, logger)
+	helper, err := resource.NewHelper(logger, resource.WithRESTConfig(mgr.GetConfig()), resource.WithMetrics(ControllerName))
 	if err != nil {
 		// Hard exit if we can't create this controller
 		logger.WithError(err).Fatal("unable to create resource helper")

--- a/pkg/operator/hive/hive_controller.go
+++ b/pkg/operator/hive/hive_controller.go
@@ -393,7 +393,7 @@ func (r *ReconcileHiveConfig) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	h, err := resource.NewHelperFromRESTConfig(r.restConfig, hLog)
+	h, err := resource.NewHelper(hLog, resource.WithRESTConfig(r.restConfig))
 	if err != nil {
 		hLog.WithError(err).Error("error creating resource helper")
 		instance.Status.Conditions = util.SetHiveConfigCondition(instance.Status.Conditions, hivev1.HiveReadyCondition, corev1.ConditionFalse, "ErrorCreatingResourceHelper", err.Error())

--- a/pkg/remoteclient/fake.go
+++ b/pkg/remoteclient/fake.go
@@ -116,3 +116,7 @@ func (b *fakeBuilder) UseSecondaryAPIURL() Builder {
 func (b *fakeBuilder) RESTConfig() (*rest.Config, error) {
 	return nil, errors.New("RESTConfig not implemented for fake cluster client builder")
 }
+
+func (b *fakeBuilder) RESTConfigAndSecretVersion() (*rest.Config, string, error) {
+	return nil, "", errors.New("RESTConfigAndSecretVersion not implemented for fake cluster client builder")
+}

--- a/pkg/remoteclient/kubeconfig.go
+++ b/pkg/remoteclient/kubeconfig.go
@@ -83,3 +83,8 @@ func (b *kubeconfigBuilder) UseSecondaryAPIURL() Builder {
 func (b *kubeconfigBuilder) RESTConfig() (*rest.Config, error) {
 	return restConfigFromSecret(b.secret)
 }
+
+func (b *kubeconfigBuilder) RESTConfigAndSecretVersion() (*rest.Config, string, error) {
+	config, err := restConfigFromSecret(b.secret)
+	return config, b.secret.ObjectMeta.GetResourceVersion(), err
+}

--- a/pkg/remoteclient/mock/remoteclient_generated.go
+++ b/pkg/remoteclient/mock/remoteclient_generated.go
@@ -98,6 +98,22 @@ func (mr *MockBuilderMockRecorder) RESTConfig() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RESTConfig", reflect.TypeOf((*MockBuilder)(nil).RESTConfig))
 }
 
+// RESTConfigAndSecretVersion mocks base method.
+func (m *MockBuilder) RESTConfigAndSecretVersion() (*rest.Config, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RESTConfigAndSecretVersion")
+	ret0, _ := ret[0].(*rest.Config)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// RESTConfigAndSecretVersion indicates an expected call of RESTConfigAndSecretVersion.
+func (mr *MockBuilderMockRecorder) RESTConfigAndSecretVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RESTConfigAndSecretVersion", reflect.TypeOf((*MockBuilder)(nil).RESTConfigAndSecretVersion))
+}
+
 // UsePrimaryAPIURL mocks base method.
 func (m *MockBuilder) UsePrimaryAPIURL() remoteclient.Builder {
 	m.ctrl.T.Helper()

--- a/pkg/resource/helper.go
+++ b/pkg/resource/helper.go
@@ -48,6 +48,13 @@ type helper struct {
 	restConfig     *rest.Config
 	getFactory     func(namespace string) (cmdutil.Factory, error)
 	openAPISchema  openapi.Resources
+
+	// restConfigClientGetterKey is an optional field, and iff set will be used as a cache key
+	// for reusing restConfigClientGetters (see restconfig_factory.go)
+	restConfigClientGetterKey string
+	// restConfigClientGetterVersion is an optional field, and iff set will be used as a cache version
+	// for invalidating restConfigClientGetters (see restconfig_factory.go)
+	restConfigClientGetterVersion string
 }
 
 // cacheOpenAPISchema builds the very expensive OpenAPISchema (>3s commonly) once, and stores
@@ -65,40 +72,47 @@ func (r *helper) cacheOpenAPISchema() error {
 	return nil
 }
 
-// NewHelperFromRESTConfig returns a new object that allows apply and patch operations
-func NewHelperFromRESTConfig(restConfig *rest.Config, logger log.FieldLogger) (Helper, error) {
-	r := &helper{
-		logger:     logger,
-		cacheDir:   getCacheDir(logger),
-		restConfig: restConfig,
+type HelperOption func(*helper)
+
+func WithKubeconfig(kubeconfig []byte) HelperOption {
+	return func(r *helper) {
+		r.kubeconfig = kubeconfig
+		r.getFactory = r.getKubeconfigFactory
 	}
-	r.getFactory = r.getRESTConfigFactory
-	err := r.cacheOpenAPISchema()
-	return r, err
 }
 
-// NewHelperWithMetricsFromRESTConfig returns a new object that allows apply and patch operations, with metrics tracking enabled.
-func NewHelperWithMetricsFromRESTConfig(restConfig *rest.Config, controllerName hivev1.ControllerName, logger log.FieldLogger) (Helper, error) {
-	r := &helper{
-		logger:         logger,
-		metricsEnabled: true,
-		controllerName: controllerName,
-		cacheDir:       getCacheDir(logger),
-		restConfig:     restConfig,
+func WithRESTConfig(restConfig *rest.Config) HelperOption {
+	return func(r *helper) {
+		r.restConfig = restConfig
+		r.getFactory = r.getRESTConfigFactory
 	}
-	r.getFactory = r.getRESTConfigFactory
-	err := r.cacheOpenAPISchema()
-	return r, err
+}
+
+func WithMetrics(controllerName hivev1.ControllerName) HelperOption {
+	return func(r *helper) {
+		r.metricsEnabled = true
+		r.controllerName = controllerName
+	}
+}
+
+func WithCacheKeyAndVersion(restConfigClientGetterKey string, restConfigClientGetterVersion string) HelperOption {
+	return func(r *helper) {
+		r.restConfigClientGetterKey = restConfigClientGetterKey
+		r.restConfigClientGetterVersion = restConfigClientGetterVersion
+	}
 }
 
 // NewHelper returns a new object that allows apply and patch operations
-func NewHelper(kubeconfig []byte, logger log.FieldLogger) (Helper, error) {
+func NewHelper(logger log.FieldLogger, options ...HelperOption) (Helper, error) {
 	r := &helper{
-		logger:     logger,
-		cacheDir:   getCacheDir(logger),
-		kubeconfig: kubeconfig,
+		logger:   logger,
+		cacheDir: getCacheDir(logger),
 	}
-	r.getFactory = r.getKubeconfigFactory
+
+	for _, f := range options {
+		f(r)
+	}
+
 	err := r.cacheOpenAPISchema()
 	return r, err
 }

--- a/pkg/resource/restconfig_factory.go
+++ b/pkg/resource/restconfig_factory.go
@@ -2,13 +2,42 @@ package resource
 
 import (
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sync"
 )
+
+// HIVE-2399: In the cluster sync controller, getRESTConfigFactory is called once per
+// reconcile loop. Previously, a restConfigClientGetter was created for every reconcile,
+// used to apply (or rather, attempt to apply) various synced objects, and then thrown
+// away at the end of the reconcile pass.
+//
+// The restConfigClientGetter (or more accurately, the  cmdutil.Factory that wraps it) is
+// used by the cluster sync controller (via this helper) to apply the various objects to
+// the target cluster during the syncing process. During the application process (see apply.go),
+// the apply command is set up (aptly named setupApplyCommand()) using the factory returned
+// by the getRESTConfigFactory() below. Within this setup, the ToRESTMapper() function of the
+// restConfigClientGetter is invoked. While the mapper returned is a deferred variant (restmapper.DeferredDiscoveryRESTMapper),
+// eventually the inner NewDiscoveryRESTMapper() function is invoked, which is very expensive
+// and allocates a huge amount of memory over time if repeatedly called in a hot loop. A graphic
+// demonstrating these allocations is attached the HIVE-2399 card.
+//
+// The solution is twofold:
+// 1) store the deferred mapper on the restConfigClientGetter so that it can be reused
+// 2) cache the restConfigClientGetter for each rest config and reuse it for future reconciles
+// The type of this map is effectively map[string]*restConfigClientGetter
+var restConfigClientGetterCache sync.Map
+
+func RemoveRestConfigClientGetterCacheEntry(logger log.FieldLogger, key string) {
+	logger.WithField("getter-cache-key", key).Debug("removing client config cache entry")
+
+	restConfigClientGetterCache.Delete(key)
+}
 
 func (r *helper) getRESTConfigFactory(namespace string) (cmdutil.Factory, error) {
 	if r.metricsEnabled {
@@ -17,8 +46,47 @@ func (r *helper) getRESTConfigFactory(namespace string) (cmdutil.Factory, error)
 		controllerutils.AddControllerMetricsTransportWrapper(cfg, r.controllerName, false)
 		r.restConfig = cfg
 	}
-	r.logger.WithField("cache-dir", r.cacheDir).Debug("creating cmdutil.Factory from REST client config and cache directory")
-	f := cmdutil.NewFactory(&restConfigClientGetter{restConfig: r.restConfig, cacheDir: r.cacheDir, namespace: namespace})
+
+	// If we're not using the cache, this will be the getter used. If we are using the cache,
+	// this value will be stored if the cache misses.
+	freshRestClientGetter := &restConfigClientGetter{
+		restConfig: r.restConfig,
+		cacheDir:   r.cacheDir,
+		namespace:  namespace,
+		logger:     r.logger,
+		version:    r.restConfigClientGetterVersion,
+	}
+	restClientGetter := freshRestClientGetter
+	reused := false
+
+	// HIVE-2399: reuse the same restConfigClientGetter if a cache key is provided
+	if len(r.restConfigClientGetterKey) != 0 {
+		// retrieve a cached getter, or store one if none exists for the given cache key
+		cachedRestClientGetterAny, loaded := restConfigClientGetterCache.LoadOrStore(r.restConfigClientGetterKey, freshRestClientGetter)
+
+		// if we didn't store a new getter, we check to see if we can reuse it:
+		if loaded {
+			cachedRestClientGetter := cachedRestClientGetterAny.(*restConfigClientGetter)
+
+			if cachedRestClientGetter.version == r.restConfigClientGetterVersion {
+				// if the getter has the same version, we reuse it
+				restClientGetter = cachedRestClientGetter
+				reused = true
+			} else {
+				// otherwise, update it with the fresh one
+				restConfigClientGetterCache.Store(r.restConfigClientGetterKey, freshRestClientGetter)
+			}
+		}
+	}
+
+	r.logger.
+		WithField("cache-dir", r.cacheDir).
+		WithField("getter-cache-key", r.restConfigClientGetterKey).
+		WithField("reused-getter", reused).
+		WithField("getter-version", restClientGetter.version).
+		Debug("creating cmdutil.Factory from REST client config and cache directory")
+
+	f := cmdutil.NewFactory(restClientGetter)
 	return f, nil
 }
 
@@ -26,6 +94,13 @@ type restConfigClientGetter struct {
 	restConfig *rest.Config
 	cacheDir   string
 	namespace  string
+	logger     log.FieldLogger
+
+	// HIVE-2399: since we are reusing the restConfigClientGetter, it may be accessed concurrently
+	mu              sync.Mutex
+	mapper          *restmapper.DeferredDiscoveryRESTMapper
+	discoveryClient discovery.CachedDiscoveryInterface
+	version         string
 }
 
 // ToRESTConfig returns restconfig
@@ -39,18 +114,37 @@ func (r *restConfigClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryI
 	return getDiscoveryClient(config, r.cacheDir)
 }
 
-// ToRESTMapper returns a restmapper
+// HIVE-2399: store the meta.RESTMapper and its associated discovery client for future use
+func (r *restConfigClientGetter) ensureCachedMapper() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.mapper == nil {
+		r.logger.Debugf("creating discovery client and mapper for ToRESTMapper()")
+		discoveryClient, err := r.ToDiscoveryClient()
+		if err != nil {
+			return err
+		}
+		r.mapper = restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
+		r.discoveryClient = discoveryClient
+	} else {
+		r.logger.Debugf("reusing discovery client and mapper for ToRESTMapper()")
+	}
+
+	return nil
+}
+
+// ToRESTMapper returns a meta.RESTMapper
 func (r *restConfigClientGetter) ToRESTMapper() (meta.RESTMapper, error) {
-	discoveryClient, err := r.ToDiscoveryClient()
-	if err != nil {
+	if err := r.ensureCachedMapper(); err != nil {
 		return nil, err
 	}
 
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
 	expander := restmapper.NewShortcutExpander(
-		mapper, discoveryClient,
-		// TODO: Plumb logger through restconfigClientGetter and log warnings here
-		func(string) {})
+		r.mapper, r.discoveryClient,
+		func(warning string) {
+			r.logger.Warnln(warning)
+		})
 	return expander, nil
 }
 

--- a/vendor/github.com/openshift/hive/apis/hiveinternal/v1alpha1/clustersync_types.go
+++ b/vendor/github.com/openshift/hive/apis/hiveinternal/v1alpha1/clustersync_types.go
@@ -9,6 +9,12 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+const (
+	// FinalizerCachePurge is used on ClusterDeployments to ensure we remove cluster sync related
+	// entries from a cache before cleaning up the CD object.
+	FinalizerCachePurge string = "hive.openshift.io/clustersync-cache"
+)
+
 // ClusterSync is the status of all of the SelectorSyncSets and SyncSets that apply to a ClusterDeployment.
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status


### PR DESCRIPTION
xref: [HIVE-2399](https://issues.redhat.com//browse/HIVE-2399)

(copied and formatted explanation from the comments in the code)

[HIVE-2399](https://issues.redhat.com//browse/HIVE-2399): In the cluster sync controller, `getRESTConfigFactory` is called once per reconcile loop. Previously, a `restConfigClientGetter` was created for every reconcile, used to apply (or rather, attempt to apply) various synced objects, and then thrown away at the end of the reconcile pass.

The `restConfigClientGetter` (or more accurately, the  `cmdutil.Factory` that wraps it) is used by the cluster sync controller (via the resource `helper`) to apply the various objects to the target cluster during the syncing process. During the application process (see `apply.go`), the apply command is set up (aptly named `setupApplyCommand()`) using the factory returned by the `getRESTConfigFactory()` function. Within this setup, the `ToRESTMapper()` function of the `restConfigClientGetter` is invoked. While the mapper returned is a deferred variant, eventually the inner `NewDiscoveryRESTMapper()` function is invoked, which is **very expensive** and allocates a **_huge_** amount of memory over time if repeatedly called in a hot loop. A graphic demonstrating these allocations is attached the the [HIVE-2399](https://issues.redhat.com//browse/HIVE-2399) card.

The solution is twofold:
1) store the deferred mapper on the `restConfigClientGetter` so that it can be reused
2) cache the `restConfigClientGetter` for each rest config and reuse it for future reconciles

/assign @2uasimojo 
/hold
