### PR TITLE
Refactor MachinePool unit tests to use Builder/Options

### DIFF
--- a/pkg/controller/machinepool/openstackactuator_test.go
+++ b/pkg/controller/machinepool/openstackactuator_test.go
@@ -19,6 +19,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	hivev1osp "github.com/openshift/hive/apis/hive/v1/openstack"
 	testfake "github.com/openshift/hive/pkg/test/fake"
+	testmp "github.com/openshift/hive/pkg/test/machinepool"
 
 	clientconfig "github.com/gophercloud/utils/openstack/clientconfig"
 )
@@ -246,8 +247,8 @@ func validateOSPMachineSets(t *testing.T, mSets []*machinev1beta1.MachineSet, ex
 	}
 }
 
-func testOSPPool() *hivev1.MachinePool {
-	p := testMachinePool()
+func testOSPPool(opts ...testmp.Option) *hivev1.MachinePool {
+	p := testMachinePool(opts...)
 	p.Spec.Platform = hivev1.MachinePoolPlatform{
 		OpenStack: &hivev1osp.MachinePool{
 			Flavor: "Flav",

--- a/pkg/test/machinepool/machinepool.go
+++ b/pkg/test/machinepool/machinepool.go
@@ -5,8 +5,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/openshift/hive/apis/hive/v1/aws"
 	"github.com/openshift/hive/pkg/test/generic"
 )
 
@@ -68,26 +70,20 @@ func (b *builder) GenericOptions(opts ...generic.Option) Builder {
 	return b.Options(options...)
 }
 
-// BuildFull builds a MachinePool with the specified pool name for the ClusterDeployment, namespace, and supplied options.
-// This will also fill out the type meta and resource version for the MachinePool.
-func BuildFull(namespace, poolName, cdName string, options ...Option) *hivev1.MachinePool {
-	options = append(
-		[]Option{
-			Generic(generic.WithTypeMeta()),
-			Generic(generic.WithResourceVersion("1")),
-			Generic(generic.WithNamespace(namespace)),
-			WithPoolNameForClusterDeployment(poolName, cdName),
-		},
-		options...,
-	)
-	return Build(options...)
-}
-
 // Generic allows common functions applicable to all objects to be used as Options to Build
 func Generic(opt generic.Option) Option {
 	return func(machinePool *hivev1.MachinePool) {
 		opt(machinePool)
 	}
+}
+
+func Deleted() Option {
+	return Generic(generic.Deleted())
+}
+
+// WithNamespace sets the object.Namespace field when building an object with Build.
+func WithNamespace(namespace string) Option {
+	return Generic(generic.WithNamespace(namespace))
 }
 
 // WithName sets the object.Name field when building an object with Build.
@@ -100,7 +96,127 @@ func WithPoolNameForClusterDeployment(poolName, clusterDeploymentName string) Op
 	}
 }
 
-// WithNamespace sets the object.Namespace field when building an object with Build.
-func WithNamespace(namespace string) Option {
-	return Generic(generic.WithNamespace(namespace))
+// WithInitializedStatusConditions returns an Option that *replaces* status conditions
+// with the set of initialized ("Unknown") conditions.
+func WithInitializedStatusConditions() Option {
+	return func(mp *hivev1.MachinePool) {
+		mp.Status.Conditions = []hivev1.MachinePoolCondition{
+			{
+				Status: corev1.ConditionUnknown,
+				Type:   hivev1.NotEnoughReplicasMachinePoolCondition,
+			},
+			{
+				Status: corev1.ConditionUnknown,
+				Type:   hivev1.NoMachinePoolNameLeasesAvailable,
+			},
+			{
+				Status: corev1.ConditionUnknown,
+				Type:   hivev1.InvalidSubnetsMachinePoolCondition,
+			},
+			{
+				Status: corev1.ConditionUnknown,
+				Type:   hivev1.UnsupportedConfigurationMachinePoolCondition,
+			},
+		}
+	}
+}
+
+func WithFinalizer(finalizer string) Option {
+	return Generic(generic.WithFinalizer(finalizer))
+}
+
+func WithAnnotations(annotations map[string]string) Option {
+	return func(mp *hivev1.MachinePool) {
+		for k, v := range annotations {
+			generic.WithAnnotation(k, v)(mp)
+		}
+	}
+}
+
+func WithReplicas(replicas int64) Option {
+	return func(mp *hivev1.MachinePool) {
+		mp.Spec.Replicas = pointer.Int64(replicas)
+	}
+}
+
+func WithAWSInstanceType(instanceType string) Option {
+	return func(mp *hivev1.MachinePool) {
+		if mp.Spec.Platform.AWS == nil {
+			mp.Spec.Platform.AWS = &aws.MachinePoolPlatform{}
+		}
+		mp.Spec.Platform.AWS.InstanceType = instanceType
+	}
+}
+
+// WithLabels returns an Option that *adds* labels on the target MachinePool's
+// *Spec* (not its metadata!)
+// Existing labels are not removed. When keys conflict, those given in the most
+// recent WithLabels will win.
+func WithLabels(labels map[string]string) Option {
+	return func(mp *hivev1.MachinePool) {
+		if mp.Spec.Labels == nil {
+			mp.Spec.Labels = labels
+		} else {
+			for k, v := range labels {
+				mp.Spec.Labels[k] = v
+			}
+		}
+	}
+}
+
+// WithOwnedLabels returns an Option that *appends* labelKeys to the target's
+// Status.OwnedLabels. Existing keys are not removed. You are responsible for
+// avoiding duplicates.
+func WithOwnedLabels(labelKeys ...string) Option {
+	return func(mp *hivev1.MachinePool) {
+		if mp.Status.OwnedLabels == nil {
+			mp.Status.OwnedLabels = labelKeys
+		} else {
+			mp.Status.OwnedLabels = append(mp.Status.OwnedLabels, labelKeys...)
+		}
+	}
+}
+
+// WithTaints returns an Option that *appends* taints on the target MachinePool's
+// *Spec* (not its metadata!)
+// Existing taints are not removed. You are responsible for avoiding duplicates.
+func WithTaints(taints ...corev1.Taint) Option {
+	return func(mp *hivev1.MachinePool) {
+		if mp.Spec.Taints == nil {
+			mp.Spec.Taints = taints
+		} else {
+			mp.Spec.Taints = append(mp.Spec.Taints, taints...)
+		}
+	}
+}
+
+// WithOwnedTaints returns an Option that *appends* taint identifiers on the
+// target MachinePool's Status.OwnedTaints. Existing taint identifiers are not
+// removed. You are responsible for avoiding duplicates.
+func WithOwnedTaints(taintIDs ...hivev1.TaintIdentifier) Option {
+	return func(mp *hivev1.MachinePool) {
+		if mp.Status.OwnedTaints == nil {
+			mp.Status.OwnedTaints = taintIDs
+		} else {
+			mp.Status.OwnedTaints = append(mp.Status.OwnedTaints, taintIDs...)
+		}
+	}
+}
+
+func WithAutoscaling(min, max int32) Option {
+	return func(mp *hivev1.MachinePool) {
+		mp.Spec.Replicas = nil
+		mp.Spec.Autoscaling = &hivev1.MachinePoolAutoscaling{
+			MinReplicas: min,
+			MaxReplicas: max,
+		}
+		for i, cond := range mp.Status.Conditions {
+			// Condition will always be present because it is initialized in testMachinePool
+			if cond.Type == hivev1.NotEnoughReplicasMachinePoolCondition {
+				cond.Status = corev1.ConditionFalse
+				cond.Reason = "EnoughReplicas"
+				mp.Status.Conditions[i] = cond
+			}
+		}
+	}
 }


### PR DESCRIPTION
In preparation for expanding OpenStack-specific MachinePool unit tests, refactor the helper funcs in the existing suite to use the MachinePool "Builder" pattern with "Options". For example, we change this:

```go
machinePool: func() *hivev1.MachinePool {
        mp := testMachinePoolWithoutLabelsTaints()
        mp.Spec.Labels = make(map[string]string)
        mp.Spec.Labels["test-label"] = "test-value"
        return mp
}(),
```

to:

```go
machinePool: testMachinePoolWithoutLabelsTaints(
        testmp.WithLabels(map[string]string{
                "test-label": "test-value",
        }),
),
```

This makes the test code slightly tighter and more readable, and brings the suite more in line with our usual (or at least, best practice) patterns.

Facilitates [HIVE-2476](https://issues.redhat.com//browse/HIVE-2476)