### PR TITLE
MachinePool: Add GCP OnHostMaintenance

### DIFF
--- a/apis/hive/v1/gcp/machinepools.go
+++ b/apis/hive/v1/gcp/machinepools.go
@@ -25,6 +25,14 @@ type MachinePool struct {
 	// +kubebuilder:validation:Enum=Enabled;Disabled
 	// +optional
 	SecureBoot string `json:"secureBoot,omitempty"`
+
+	// OnHostMaintenance determines the behavior when a maintenance event occurs that might cause the instance to reboot.
+	// This is required to be set to "Terminate" if you want to provision machine with attached GPUs.
+	// Otherwise, allowed values are "Migrate" and "Terminate".
+	// If omitted, the platform chooses a default, which is subject to change over time, currently that default is "Migrate".
+	// +kubebuilder:validation:Enum=Migrate;Terminate;
+	// +optional
+	OnHostMaintenance string `json:"onHostMaintenance,omitempty"`
 }
 
 // OSDisk defines the disk for machines on GCP.

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -268,6 +268,18 @@ spec:
                           network and subnets exist in when they are not in the main
                           ProjectID.
                         type: string
+                      onHostMaintenance:
+                        description: OnHostMaintenance determines the behavior when
+                          a maintenance event occurs that might cause the instance
+                          to reboot. This is required to be set to "Terminate" if
+                          you want to provision machine with attached GPUs. Otherwise,
+                          allowed values are "Migrate" and "Terminate". If omitted,
+                          the platform chooses a default, which is subject to change
+                          over time, currently that default is "Migrate".
+                        enum:
+                        - Migrate
+                        - Terminate
+                        type: string
                       osDisk:
                         description: OSDisk defines the storage for instances.
                         properties:

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -5126,6 +5126,18 @@ objects:
                             network and subnets exist in when they are not in the
                             main ProjectID.
                           type: string
+                        onHostMaintenance:
+                          description: OnHostMaintenance determines the behavior when
+                            a maintenance event occurs that might cause the instance
+                            to reboot. This is required to be set to "Terminate" if
+                            you want to provision machine with attached GPUs. Otherwise,
+                            allowed values are "Migrate" and "Terminate". If omitted,
+                            the platform chooses a default, which is subject to change
+                            over time, currently that default is "Migrate".
+                          enum:
+                          - Migrate
+                          - Terminate
+                          type: string
                         osDisk:
                           description: OSDisk defines the storage for instances.
                           properties:

--- a/pkg/controller/machinepool/gcpactuator.go
+++ b/pkg/controller/machinepool/gcpactuator.go
@@ -194,6 +194,10 @@ func (a *GCPActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *hi
 		computePool.Platform.GCP.SecureBoot = secureBoot
 	}
 
+	if ohm := poolGCP.OnHostMaintenance; ohm != "" {
+		computePool.Platform.GCP.OnHostMaintenance = ohm
+	}
+
 	if poolGCP.OSDisk.DiskType != "" {
 		computePool.Platform.GCP.OSDisk.DiskType = poolGCP.OSDisk.DiskType
 	}

--- a/pkg/controller/machinepool/gcpactuator_test.go
+++ b/pkg/controller/machinepool/gcpactuator_test.go
@@ -211,6 +211,34 @@ func TestGCPActuator(t *testing.T) {
 				generateGCPMachineSetName("worker", "zone1"): 3,
 			},
 		},
+		{
+			name: "generate machinesets with OnHostMaintenance=Terminate",
+			pool: func() *hivev1.MachinePool {
+				pool := testGCPPool(testPoolName)
+				pool.Spec.Platform.GCP.OnHostMaintenance = "Terminate"
+				return pool
+			}(),
+			mockGCPClient: func(client *mockgcp.MockClient) {
+				mockListComputeZones(client, []string{"zone1"}, testRegion)
+			},
+			expectedMachineSetReplicas: map[string]int64{
+				generateGCPMachineSetName("worker", "zone1"): 3,
+			},
+		},
+		{
+			name: "generate machinesets with OnHostMaintenance=Migrate",
+			pool: func() *hivev1.MachinePool {
+				pool := testGCPPool(testPoolName)
+				pool.Spec.Platform.GCP.OnHostMaintenance = "Migrate"
+				return pool
+			}(),
+			mockGCPClient: func(client *mockgcp.MockClient) {
+				mockListComputeZones(client, []string{"zone1"}, testRegion)
+			},
+			expectedMachineSetReplicas: map[string]int64{
+				generateGCPMachineSetName("worker", "zone1"): 3,
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -307,6 +335,11 @@ func TestGCPActuator(t *testing.T) {
 						assert.Equal(t, sb, string(gcpProvider.ShieldedInstanceConfig.SecureBoot))
 					} else {
 						assert.Equal(t, "", string(gcpProvider.ShieldedInstanceConfig.SecureBoot))
+					}
+
+					// OnHostMaintenance
+					if ohm := platform.OnHostMaintenance; ohm != "" {
+						assert.Equal(t, ohm, string(gcpProvider.OnHostMaintenance))
 					}
 				}
 			}

--- a/vendor/github.com/openshift/hive/apis/hive/v1/gcp/machinepools.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/gcp/machinepools.go
@@ -25,6 +25,14 @@ type MachinePool struct {
 	// +kubebuilder:validation:Enum=Enabled;Disabled
 	// +optional
 	SecureBoot string `json:"secureBoot,omitempty"`
+
+	// OnHostMaintenance determines the behavior when a maintenance event occurs that might cause the instance to reboot.
+	// This is required to be set to "Terminate" if you want to provision machine with attached GPUs.
+	// Otherwise, allowed values are "Migrate" and "Terminate".
+	// If omitted, the platform chooses a default, which is subject to change over time, currently that default is "Migrate".
+	// +kubebuilder:validation:Enum=Migrate;Terminate;
+	// +optional
+	OnHostMaintenance string `json:"onHostMaintenance,omitempty"`
 }
 
 // OSDisk defines the disk for machines on GCP.


### PR DESCRIPTION
To facilitate machine types with GPUs, MachinePool consumers need to be able to tell those machines to terminate on reboot. Add `MachinePool.Spec.Platform.GCP.OnHostMaintenance` to populate the field of the same name on the GCP providerSpec.

[HIVE-2483](https://issues.redhat.com//browse/HIVE-2483)