### PR TITLE
Include linux/amd64 nodeSelector by default

### DIFF
--- a/config/operator/operator_deployment.yaml
+++ b/config/operator/operator_deployment.yaml
@@ -26,6 +26,9 @@ spec:
         control-plane: hive-operator
         controller-tools.k8s.io: "1.0"
     spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
       serviceAccountName: hive-operator
       volumes:
       - name: kubectl-cache

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -7554,6 +7554,9 @@ objects:
             name: kubectl-cache
           - mountPath: /tmp
             name: tmp
+        nodeSelector:
+          kubernetes.io/arch: amd64
+          kubernetes.io/os: linux
         serviceAccountName: hive-operator
         terminationGracePeriodSeconds: 10
         volumes:


### PR DESCRIPTION
Today we only build the hive image for linux/amd64. Attempting to run it in a multi-arch cluster without adding a nodeSelector can result in "exec format error" if any component (hive-operator, hive-controllers, hive-clustersync, hiveadmission) lands on e.g. an ARM node.

We provide a sample hive-operator Deployment which gets built into the operatorhub CSV and the OSD SaaS template, and may also be used as a starting point by other consumers. Absent this PR:
- For OLM-based installations, it can be provided via Subscription.config.nodeSelector.
- Bespoke consumers can add nodeSelector manually if desired.
- OSD would need to do... something else; but this is not currently a problem we've been asked to fix.

This PR adds a linux/amd64 nodeSelector to the sample hive-operator Deployment manifest, which will result in that nodeSelector being included in the OperatorHub bundle and the OSD SaaS deployment by default.

[HIVE-2487](https://issues.redhat.com//browse/HIVE-2487)