### PR TITLE
Copy conditions while cluster install is provisioning

### DIFF
--- a/pkg/controller/clusterdeployment/clusterinstalls.go
+++ b/pkg/controller/clusterdeployment/clusterinstalls.go
@@ -161,13 +161,17 @@ func (r *ReconcileClusterDeployment) reconcileExistingInstallingClusterInstall(c
 	// if we are still provisioning...
 	if clusterInstallStopped.Status != corev1.ConditionTrue && clusterInstallCompleted.Status != corev1.ConditionTrue && clusterInstallFailed.Status != corev1.ConditionTrue {
 		// let the end user know
-		conditions, statusModified = controllerutils.SetClusterDeploymentConditionWithChangeCheck(conditions,
+		changedProvisionedCondition := false
+		conditions, changedProvisionedCondition = controllerutils.SetClusterDeploymentConditionWithChangeCheck(conditions,
 			hivev1.ProvisionedCondition,
 			corev1.ConditionFalse,
 			hivev1.ProvisionedReasonProvisioning,
 			"Provisioning in progress",
 			controllerutils.UpdateConditionIfReasonOrMessageChange,
 		)
+		if changedProvisionedCondition {
+			statusModified = true
+		}
 	}
 
 	// if the cluster install has very recently become stopped...


### PR DESCRIPTION
Before this commit if the Provisioned condition was not updated none of the other cluster install conditions would get copied to the cluster deployment.

This updates the logic so that other status updates are still saved even when the provisioning state does not also change.