### PR TITLE
Copy nodeSelector, tolerations into Jobs

### DIFF
--- a/config/controllers/deployment.yaml
+++ b/config/controllers/deployment.yaml
@@ -47,6 +47,14 @@ spec:
         - name: tmp
           mountPath: /tmp
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: CLI_CACHE_DIR
           value: /var/cache/kubectl
         - name: HIVE_NS

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -3428,6 +3428,8 @@ platform:
 					(schema.GroupVersionKind{Group: "hive.openshift.io", Version: "v1", Kind: "FakeClusterInstall"}).String(): {},
 				},
 				releaseImageVerifier: test.riVerifier,
+				nodeSelector:         &map[string]string{},
+				tolerations:          &[]corev1.Toleration{},
 			}
 
 			if test.reconcilerSetup != nil {
@@ -3504,6 +3506,8 @@ func TestClusterDeploymentReconcileResults(t *testing.T) {
 				logger:                        logger,
 				expectations:                  controllerExpectations,
 				remoteClusterAPIClientBuilder: func(*hivev1.ClusterDeployment) remoteclient.Builder { return mockRemoteClientBuilder },
+				nodeSelector:                  &map[string]string{},
+				tolerations:                   &[]corev1.Toleration{},
 			}
 
 			reconcileResult, err := rcd.Reconcile(context.TODO(), reconcile.Request{
@@ -3621,8 +3625,10 @@ func TestDeleteStaleProvisions(t *testing.T) {
 			}
 			fakeClient := testfake.NewFakeClientBuilder().WithRuntimeObjects(provisions...).Build()
 			rcd := &ReconcileClusterDeployment{
-				Client: fakeClient,
-				scheme: scheme.GetScheme(),
+				Client:       fakeClient,
+				scheme:       scheme.GetScheme(),
+				nodeSelector: &map[string]string{},
+				tolerations:  &[]corev1.Toleration{},
 			}
 			rcd.deleteStaleProvisions(getProvisions(fakeClient), log.WithField("test", "TestDeleteStaleProvisions"))
 			actualAttempts := []int{}
@@ -3673,8 +3679,10 @@ func TestDeleteOldFailedProvisions(t *testing.T) {
 			scheme := scheme.GetScheme()
 			fakeClient := testfake.NewFakeClientBuilder().WithRuntimeObjects(provisions...).Build()
 			rcd := &ReconcileClusterDeployment{
-				Client: fakeClient,
-				scheme: scheme,
+				Client:       fakeClient,
+				scheme:       scheme,
+				nodeSelector: &map[string]string{},
+				tolerations:  &[]corev1.Toleration{},
 			}
 			rcd.deleteOldFailedProvisions(getProvisions(fakeClient), log.WithField("test", "TestDeleteOldFailedProvisions"))
 			assert.Len(t, getProvisions(fakeClient), tc.expectedNumberOfProvisionsAfterDeletion, "unexpected provisions kept")
@@ -4196,6 +4204,8 @@ func TestUpdatePullSecretInfo(t *testing.T) {
 				validateCredentialsForClusterDeployment: func(client.Client, *hivev1.ClusterDeployment, log.FieldLogger) (bool, error) {
 					return true, nil
 				},
+				nodeSelector: &map[string]string{},
+				tolerations:  &[]corev1.Toleration{},
 			}
 
 			_, err := rcd.Reconcile(context.TODO(), reconcile.Request{
@@ -4356,6 +4366,8 @@ func TestMergePullSecrets(t *testing.T) {
 				scheme:                        scheme,
 				logger:                        log.WithField("controller", "clusterDeployment"),
 				remoteClusterAPIClientBuilder: func(*hivev1.ClusterDeployment) remoteclient.Builder { return mockRemoteClientBuilder },
+				nodeSelector:                  &map[string]string{},
+				tolerations:                   &[]corev1.Toleration{},
 			}
 
 			cd := getCDFromClient(rcd.Client)
@@ -4422,6 +4434,8 @@ func TestCopyInstallLogSecret(t *testing.T) {
 				scheme:                        scheme,
 				logger:                        log.WithField("controller", "clusterDeployment"),
 				remoteClusterAPIClientBuilder: func(*hivev1.ClusterDeployment) remoteclient.Builder { return mockRemoteClientBuilder },
+				nodeSelector:                  &map[string]string{},
+				tolerations:                   &[]corev1.Toleration{},
 			}
 
 			for i, envVar := range test.existingEnvVars {
@@ -4604,6 +4618,8 @@ func TestEnsureManagedDNSZone(t *testing.T) {
 				scheme:                        scheme,
 				logger:                        log.WithField("controller", "clusterDeployment"),
 				remoteClusterAPIClientBuilder: func(*hivev1.ClusterDeployment) remoteclient.Builder { return mockRemoteClientBuilder },
+				nodeSelector:                  &map[string]string{},
+				tolerations:                   &[]corev1.Toleration{},
 			}
 
 			// act
@@ -4807,8 +4823,10 @@ spacing problem!
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := testfake.NewFakeClientBuilder().WithRuntimeObjects(filterNils(test.cd, test.icSecret)...).Build()
 			r := &ReconcileClusterDeployment{
-				Client: fakeClient,
-				scheme: scheme.GetScheme(),
+				Client:       fakeClient,
+				scheme:       scheme.GetScheme(),
+				nodeSelector: &map[string]string{},
+				tolerations:  &[]corev1.Toleration{},
 			}
 
 			if gotReturn := r.discoverAWSHostedZoneRole(test.cd, logger); gotReturn != test.wantReturn {
@@ -5062,6 +5080,8 @@ platform:
 				Client:                        fakeClient,
 				scheme:                        scheme,
 				remoteClusterAPIClientBuilder: func(*hivev1.ClusterDeployment) remoteclient.Builder { return mockRemoteClientBuilder },
+				nodeSelector:                  &map[string]string{},
+				tolerations:                   &[]corev1.Toleration{},
 			}
 
 			if gotReturn := r.discoverAzureResourceGroup(test.cd, logger); gotReturn != test.wantReturn {
@@ -5248,8 +5268,10 @@ spacing problem!
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := testfake.NewFakeClientBuilder().WithRuntimeObjects(filterNils(test.cd, test.icSecret)...).Build()
 			r := &ReconcileClusterDeployment{
-				Client: fakeClient,
-				scheme: scheme.GetScheme(),
+				Client:       fakeClient,
+				scheme:       scheme.GetScheme(),
+				nodeSelector: &map[string]string{},
+				tolerations:  &[]corev1.Toleration{},
 			}
 
 			if gotReturn := r.discoverGCPNetworkProjectID(test.cd, logger); gotReturn != test.wantReturn {

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller_test.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller_test.go
@@ -296,6 +296,8 @@ func TestClusterDeprovisionReconcile(t *testing.T) {
 				Client:               mocks.fakeKubeClient,
 				scheme:               scheme,
 				deprovisionsDisabled: test.deprovisionsDisabled,
+				nodeSelector:         &map[string]string{},
+				tolerations:          &[]corev1.Toleration{},
 			}
 
 			// Save the list of actuators so that it can be restored at the end of this test
@@ -375,7 +377,7 @@ func testClusterDeployment() *hivev1.ClusterDeployment {
 // specified conditions.
 func testUninstallJob(conditions ...batchv1.JobCondition) *batchv1.Job {
 	uninstallJob, _ := install.GenerateUninstallerJobForDeprovision(testClusterDeprovision(),
-		"someserviceaccount", "", "", "", nil)
+		"someserviceaccount", "", "", "", nil, map[string]string{}, []corev1.Toleration{})
 	hash, err := controllerutils.CalculateJobSpecHash(uninstallJob)
 	if err != nil {
 		panic("should never get error calculating job spec hash")

--- a/pkg/controller/clusterprovision/clusterprovision_controller_test.go
+++ b/pkg/controller/clusterprovision/clusterprovision_controller_test.go
@@ -272,6 +272,8 @@ func TestClusterProvisionReconcile(t *testing.T) {
 				scheme:       scheme,
 				logger:       logger,
 				expectations: controllerExpectations,
+				nodeSelector: &map[string]string{},
+				tolerations:  &[]corev1.Toleration{},
 			}
 
 			reconcileRequest := reconcile.Request{
@@ -348,7 +350,7 @@ func testProvision(opts ...tcp.Option) *hivev1.ClusterProvision {
 
 func testJob(opts ...testjob.Option) *batchv1.Job {
 	provision := testProvision()
-	job, err := install.GenerateInstallerJob(provision)
+	job, err := install.GenerateInstallerJob(provision, map[string]string{}, []corev1.Toleration{})
 	if err != nil {
 		panic("should not error while generating test install job")
 	}
@@ -558,8 +560,10 @@ compute:
 			}
 			fakeClient := testfake.NewFakeClientBuilder().WithRuntimeObjects(icSecret).Build()
 			rcp := &ReconcileClusterProvision{
-				Client: fakeClient,
-				logger: logger,
+				Client:       fakeClient,
+				logger:       logger,
+				nodeSelector: &map[string]string{},
+				tolerations:  &[]corev1.Toleration{},
 			}
 
 			if got := rcp.getWorkers(*cd); got != test.want {

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -392,3 +392,16 @@ func SafeDelete(cl client.Client, ctx context.Context, obj client.Object) error 
 	rv := obj.GetResourceVersion()
 	return cl.Delete(ctx, obj, client.Preconditions{ResourceVersion: &rv})
 }
+
+func GetThisPod(cl client.Client) (*corev1.Pod, error) {
+	podName := os.Getenv("POD_NAME")
+	podNamespace := os.Getenv("POD_NAMESPACE")
+	if podName == "" || podNamespace == "" {
+		return nil, fmt.Errorf("missing POD_NAME (%q) and/or POD_NAMESPACE (%q) env", podName, podNamespace)
+	}
+	po := &corev1.Pod{}
+	if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: podNamespace, Name: podName}, po); err != nil {
+		return nil, err
+	}
+	return po, nil
+}

--- a/pkg/imageset/generate.go
+++ b/pkg/imageset/generate.go
@@ -24,7 +24,7 @@ const (
 
 // GenerateImageSetJob creates a job to determine the installer image for a ClusterImageSet
 // given a release image
-func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAccountName, httpProxy, httpsProxy, noProxy string) *batchv1.Job {
+func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAccountName, httpProxy, httpsProxy, noProxy string, nodeSelector map[string]string, tolerations []corev1.Toleration) *batchv1.Job {
 	logger := log.WithFields(log.Fields{
 		"clusterdeployment": types.NamespacedName{Namespace: cd.Namespace, Name: cd.Name}.String(),
 	})
@@ -39,6 +39,8 @@ func GenerateImageSetJob(cd *hivev1.ClusterDeployment, releaseImage, serviceAcco
 	}
 
 	podSpec := corev1.PodSpec{
+		NodeSelector:  nodeSelector,
+		Tolerations:   tolerations,
 		RestartPolicy: corev1.RestartPolicyOnFailure,
 		InitContainers: []corev1.Container{
 			{

--- a/pkg/imageset/generate_test.go
+++ b/pkg/imageset/generate_test.go
@@ -6,6 +6,7 @@ import (
 	hiveassert "github.com/openshift/hive/pkg/test/assert"
 	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 )
@@ -17,7 +18,12 @@ const (
 )
 
 func TestGenerateImageSetJob(t *testing.T) {
-	job := GenerateImageSetJob(testClusterDeployment(), testImageSet().Spec.ReleaseImage, "test-service-account", testHttpProxy, testHttpsProxy, testNoProxy)
+	job := GenerateImageSetJob(
+		testClusterDeployment(),
+		testImageSet().Spec.ReleaseImage,
+		"test-service-account",
+		testHttpProxy, testHttpsProxy, testNoProxy,
+		map[string]string{}, []corev1.Toleration{})
 	assert.Equal(t, GetImageSetJobName(testClusterDeployment().Name), job.Name, "unexpected job name")
 	assert.Equal(t, testClusterDeployment().Namespace, job.Namespace, "unexpected job namespace")
 	assert.Len(t, job.Spec.Template.Spec.InitContainers, 1, "unexpected number of init containers")

--- a/pkg/install/generate_test.go
+++ b/pkg/install/generate_test.go
@@ -29,7 +29,11 @@ func init() {
 
 func TestGenerateDeprovision(t *testing.T) {
 	dr := testClusterDeprovision()
-	job, err := GenerateUninstallerJobForDeprovision(dr, "someseviceaccount", testHttpProxy, testHttpsProxy, testNoProxy, nil)
+	job, err := GenerateUninstallerJobForDeprovision(
+		dr, "someseviceaccount",
+		testHttpProxy, testHttpsProxy, testNoProxy,
+		nil,
+		map[string]string{}, []corev1.Toleration{})
 	assert.Nil(t, err)
 	assert.NotNil(t, job)
 	hiveassert.AssertAllContainersHaveEnvVar(t, &job.Spec.Template.Spec, "HTTP_PROXY", testHttpProxy)

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -901,6 +901,14 @@ spec:
         - name: tmp
           mountPath: /tmp
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: CLI_CACHE_DIR
           value: /var/cache/kubectl
         - name: HIVE_NS


### PR DESCRIPTION
We already copy `nodeSelector` and `tolerations` from hive-operator into the various controllers. But we weren't copying them into the Jobs for imageset, provision, and uninstall. This could result in their Pods e.g. being scheduled to Nodes that can't run them; or being totally unschedulable.

With this commit, we:
- Add the namespace and name of the running pod as env vars on hive-controllers.
- Use those env vars to retrieve the hive-controllers Pod spec.
- Copy the nodeSelector and tolerations from that Pod spec down into the (PodSpecs of the) Jobs for imageset, provision, and uninstall.

[HIVE-2496](https://issues.redhat.com//browse/HIVE-2496)