### PR TITLE
Add alternate regex for TerraformFailedToDeleteResources

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -205,6 +205,7 @@ data:
     - name: TerraformFailedToDeleteResources
       searchRegexStrings:
         - "terraform destroy: failed to destroy using Terraform"
+        - "terraform destroy: failed doing terraform destroy"
       installFailingReason: InstallerFailedToDestroyResources
       installFailingMessage: The installer failed to destroy installation resources
     - name: AWSAccountBlocked

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -55,6 +55,7 @@ const (
 	targetGroupNotFound                     = "level=error msg=Error: error updating LB Target Group (arn:aws:elasticloadbalancing:us-east-1:xxxx:targetgroup/aaaabbbbcccc/dddd) tags: error tagging resource (arn:aws:elasticloadbalancing:us-east-1:0123445698:targetgroup/aaaabbbbcccc/dddd): TargetGroupNotFound: Target groups 'arn:aws:elasticloadbalancing:us-east-1:xxxx:targetgroup/aaaabbbbcccc/dddd' not found"
 	errorCreatingNLB                        = "time=\"2022-01-27T03:33:08Z\" level=error msg=\"Error: Error creating network Load Balancer: InternalFailure: \""
 	terraformFailedDelete                   = "level=fatal msg=terraform destroy: failed to destroy using Terraform"
+	terraformFailedDestroy                  = "level=error\nlevel=fatal msg=terraform destroy: failed doing terraform destroy: exit status 1\n"
 	noMatchLog                              = "an example of something that doesn't match the log regexes"
 	bootstrapFailed                         = "time=\"2022-01-27T03:33:08Z\" level=error msg=\"Failed to wait for bootstrapping to complete. This error usually happens when there is a problem with control plane hosts that prevents the control plane operators from creating the control plane.\""
 	awsDeniedByScp                          = "AccessDenied: entity is not authorized to perform: iam:PressTheButton on resource: Thing with an explicit deny in a service control policy"
@@ -448,6 +449,11 @@ func TestParseInstallLog(t *testing.T) {
 		{
 			name:           "ErrorDestroyingBootstrapResources",
 			log:            pointer.String(terraformFailedDelete),
+			expectedReason: "InstallerFailedToDestroyResources",
+		},
+		{
+			name:           "AltErrorDestroyingBootstrapResources",
+			log:            pointer.String(terraformFailedDestroy),
 			expectedReason: "InstallerFailedToDestroyResources",
 		},
 		{

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1867,6 +1867,7 @@ data:
     - name: TerraformFailedToDeleteResources
       searchRegexStrings:
         - "terraform destroy: failed to destroy using Terraform"
+        - "terraform destroy: failed doing terraform destroy"
       installFailingReason: InstallerFailedToDestroyResources
       installFailingMessage: The installer failed to destroy installation resources
     - name: AWSAccountBlocked


### PR DESCRIPTION
Per OSD-22828, sometimes an install can fail if Terraform can't properly cleanup after itself (e.g., because the user attached the bootstrap node's security group to an unrelated network interface). While TerraformFailedToDeleteResources already covered this scenario, it seems that Terraform gives a slightly different error message in some cases, tripping up the existing regex. This PR adds an additional regex to TerraformFailedToDeleteResources that should recognize the alternative error message.