### PR TITLE
MachinePool/AWS: Match MachineSets by AZ only (not subnet)

### DIFF
--- a/apis/hive/v1/aws/machinepool.go
+++ b/apis/hive/v1/aws/machinepool.go
@@ -13,7 +13,8 @@ type MachinePoolPlatform struct {
 	// private and one public subnet for each availability zone. In this case, the public
 	// subnets will be filtered out and only the private subnets will be used.
 	// If empty/omitted, we will look for subnets in each availability zone tagged with
-	// Name=<clusterID>-private-<az>.
+	// Name=<clusterID>-private-<az> (legacy terraform) or <clusterID>-subnet-private-<az>
+	// (CAPA).
 	Subnets []string `json:"subnets,omitempty"`
 
 	// InstanceType defines the ec2 instance type.

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -154,7 +154,8 @@ spec:
                           for each availability zone. In this case, the public subnets
                           will be filtered out and only the private subnets will be
                           used. If empty/omitted, we will look for subnets in each
-                          availability zone tagged with Name=<clusterID>-private-<az>.
+                          availability zone tagged with Name=<clusterID>-private-<az>
+                          (legacy terraform) or <clusterID>-subnet-private-<az> (CAPA).
                         items:
                           type: string
                         type: array

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -5011,7 +5011,8 @@ objects:
                             case, the public subnets will be filtered out and only
                             the private subnets will be used. If empty/omitted, we
                             will look for subnets in each availability zone tagged
-                            with Name=<clusterID>-private-<az>.
+                            with Name=<clusterID>-private-<az> (legacy terraform)
+                            or <clusterID>-subnet-private-<az> (CAPA).
                           items:
                             type: string
                           type: array

--- a/pkg/controller/machinepool/awsactuator.go
+++ b/pkg/controller/machinepool/awsactuator.go
@@ -335,8 +335,14 @@ func (a *AWSActuator) updateProviderConfig(machineSet *machineapi.MachineSet, in
 	if providerConfig.Subnet.ID == nil {
 		providerConfig.Subnet = machineapi.AWSResourceReference{
 			Filters: []machineapi.Filter{{
-				Name:   "tag:Name",
-				Values: []string{fmt.Sprintf("%s-private-%s", infraID, providerConfig.Placement.AvailabilityZone)},
+				Name: "tag:Name",
+				Values: []string{
+					// Legacy terraform -- should be harmless for newer CAPI-based clusters.
+					// TODO: Remove when the last non-CAPI-mandatory release is EOL.
+					fmt.Sprintf("%s-private-%s", infraID, providerConfig.Placement.AvailabilityZone),
+					// Newer CAPA -- should be harmless for older/non-CAPI-based clusters.
+					fmt.Sprintf("%s-subnet-private-%s", infraID, providerConfig.Placement.AvailabilityZone),
+				},
 			}},
 		}
 	}

--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -579,9 +579,23 @@ func matchFailureDomains(gMS *machineapi.MachineSet, rMS machineapi.MachineSet, 
 		logger.WithError(err).Errorf("unable to parse generated MachineSet %v provider config", gMS.Name)
 		return false, err
 	}
-	fd1 := rMS_providerconfig.ExtractFailureDomain()
-	fd2 := gMS_providerconfig.ExtractFailureDomain()
-	return fd1.Equal(fd2), nil
+	rfd := rMS_providerconfig.ExtractFailureDomain()
+	gfd := gMS_providerconfig.ExtractFailureDomain()
+
+	rfdtype, gfdtype := rfd.Type(), gfd.Type()
+	// This should never happen
+	if rfdtype != gfdtype {
+		return false, errors.Errorf("Unexpectedly got differing failure domain types for remote (%s) and generated (%s) MachineSets!", rfdtype, gfdtype)
+	}
+	// HIVE-2443: Special case for AWS: Failure domains for AWS contain a subnet which may be
+	// described by ID, ARN, or Filters. These can't be reliably compared. However, MachineSets are
+	// generated/named based only on the AZ name, so we'll just compare that and ignore the subnet.
+	if rfdtype == configv1.AWSPlatformType { // only necessary to check one since we verified they're equal above
+		return rfd.AWS().Placement.AvailabilityZone == gfd.AWS().Placement.AvailabilityZone, nil
+	}
+
+	// Otherwise the FailureDomain should be unambiguous and we can just compare them.
+	return rfd.Equal(gfd), nil
 }
 
 // matchMachineSets decides whether gMS ("generated MachineSet") and rMS ("remote MachineSet" -- the one already extant

--- a/vendor/github.com/openshift/hive/apis/hive/v1/aws/machinepool.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/aws/machinepool.go
@@ -13,7 +13,8 @@ type MachinePoolPlatform struct {
 	// private and one public subnet for each availability zone. In this case, the public
 	// subnets will be filtered out and only the private subnets will be used.
 	// If empty/omitted, we will look for subnets in each availability zone tagged with
-	// Name=<clusterID>-private-<az>.
+	// Name=<clusterID>-private-<az> (legacy terraform) or <clusterID>-subnet-private-<az>
+	// (CAPA).
 	Subnets []string `json:"subnets,omitempty"`
 
 	// InstanceType defines the ec2 instance type.


### PR DESCRIPTION
The MachinePool controller compares generated MachineSets with existing remote MachineSets to figure out which to add, update, or delete.

We used to do this matching based on naming conventions, but those have been changing upstream, so we recently ([HIVE-2254](https://issues.redhat.com//browse/HIVE-2254) / #2179) changed to matching by label + failure domain. The latter is extracted using code from control-plane-machine-set.

Unfortunately, in AWS, the same failure domain can contain a subnet represented in three different ways:

- ID (canonical)
- ARN (canonical; not used)
- Filters (ambiguous)

If the generated and remote MachineSets differ in either the way the failure domain subnet is represented (e.g. ID vs Filters) or both are using Filters that differ despite resolving to the same subnet, our existing algorithm will fail to match them, and the reconcile will fail quietly (remote MachineSets are not updated, local MachinePool status is not changed).

Prior to [HIVE-2254](https://issues.redhat.com//browse/HIVE-2254), the name matching relied only on the availability zone (e.g. `us-east-1a`). So with this commit, we special-case the matching for AWS to ignore the subnet piece of the failure domain and just match by that AZ.

(A future effort may reinstate matching by subnet in an unambiguous way by always resolving both sides to IDs.)

This commit also resolves a latent bug whereby we were replacing by-name subnet filters with just the legacy terraform name (`${clusterID}-private-${az}`), which would have broken in newer CAPI-based installs. We now include both the legacy name and `${clusterID}-subnet-private-${az}` which is used by CAPI-based installs.

[HIVE-2443](https://issues.redhat.com//browse/HIVE-2443)