### PR TITLE
HIVE-2509: Skip Konflux builds when possible

### DIFF
--- a/.tekton/hive-pull-request.yaml
+++ b/.tekton/hive-pull-request.yaml
@@ -7,8 +7,10 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request"
+      && target_branch == "master"
+      && !files.all.all(x, x.matches('^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: hive-operator

--- a/.tekton/hive-push.yaml
+++ b/.tekton/hive-push.yaml
@@ -6,8 +6,10 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "master"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push"
+      && target_branch == "master"
+      && !files.all.all(x, x.matches('^docs/|\.md$|^(?:.*/)?(?:\.gitignore|OWNERS|PROJECT|LICENSE)$'))
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: hive-operator


### PR DESCRIPTION
This copies the golang (Re2)regular expression S that we use in prow[0] and leverages the fact that according to [1] on-cell-expression has a special "files.all" value that contains a list of all the added/modified/removed/renamed files. It also says that you can use CEL[2] expressions on those. Thus, we should only run the build if all the files in "files.all" do not match the aforementioned regular expression S.

[0] https://github.com/openshift/release/blob/ee0afebfe1ca88b8c35426120cb175fc8d989ffc/ci-operator/jobs/openshift/hive/openshift-hive-master-presubmits.yaml#L83
[1] https://pipelinesascode.com/docs/guide/authoringprs/
[2] https://github.com/google/cel-spec/blob/master/doc/langdef.md#macros