### PR TITLE
HIVE-2510: deprecated image check to 0.4

### DIFF
--- a/.tekton/hive-pull-request.yaml
+++ b/.tekton/hive-pull-request.yaml
@@ -270,8 +270,10 @@ spec:
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
-      runAfter:
-      - build-container
+      - name: IMAGE_URL
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       taskRef:
         params:
         - name: name

--- a/.tekton/hive-push.yaml
+++ b/.tekton/hive-push.yaml
@@ -267,8 +267,10 @@ spec:
       params:
       - name: BASE_IMAGES_DIGESTS
         value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
-      runAfter:
-      - build-container
+      - name: IMAGE_URL
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
There are new mandatory parameters for the deprecated-base-image-check in Konflux that we need to update tekton to [0].

[0]https://github.com/konflux-ci/build-definitions/blob/main/task/deprecated-image-check/0.4/MIGRATION.md
Signed-off-by: Antoni Segura Puimedon <antoni@redhat.com>