### PR TITLE
Nil check for InstalledTimeStamp missing

### DIFF
--- a/pkg/controller/hibernation/hibernation_controller.go
+++ b/pkg/controller/hibernation/hibernation_controller.go
@@ -271,8 +271,12 @@ func (r *hibernationReconciler) Reconcile(ctx context.Context, request reconcile
 			var installedSince, runningSince, claimedSince time.Time
 			var isRunning bool
 
-			installedSince = cd.Status.InstalledTimestamp.Time
-			hibLog = hibLog.WithField("installedSince", installedSince)
+			// This really shouldn't happen because InstalledTimestamp should have been applied even for adopted clusters.
+			// This check is only for the event this code-path is hit before the clusterdeployment controller reconcile has had a chance to update it.
+			if cd.Status.InstalledTimestamp != nil {
+				installedSince = cd.Status.InstalledTimestamp.Time
+				hibLog = hibLog.WithField("installedSince", installedSince)
+			}
 
 			if poolRef != nil && poolRef.ClaimedTimestamp != nil {
 				claimedSince = poolRef.ClaimedTimestamp.Time

--- a/pkg/controller/hibernation/hibernation_controller_test.go
+++ b/pkg/controller/hibernation/hibernation_controller_test.go
@@ -1068,6 +1068,13 @@ func TestHibernateAfter(t *testing.T) {
 			expectedConditionReason: hivev1.HibernatingReasonUnsupported,
 		},
 		{
+			name: "cluster due for hibernate, InstalledTimeStamp missing)",
+			cd: cdBuilder.Build(
+				testcd.WithHibernateAfter(8 * time.Hour)),
+			cs:                 csBuilder.Build(),
+			expectedPowerState: hivev1.ClusterPowerStateHibernating,
+		},
+		{
 			name: "cluster not yet due for hibernate older version", // cluster that has never been hibernated and thus has no running condition
 			cd: cdBuilder.Build(
 				testcd.WithHibernateAfter(8*time.Hour),


### PR DESCRIPTION
Within the hibernateAfter code path, if the check for InstalledTimeStamp takes place before the clusterDeployment controller reconcile has had a chance to update it (for ex, for adopted clusters - aka the clusterdeployments created with installed field set to true but the InstalledTimeStamp nil, we set it to creationTimeStamp), the code would panic. This commit adds a nil check for the same to skip computing the installedSince. The logic for calculating if Hibernation should happen tried to find the latest one amongst installedSince, claimedSince, runningSince, and should work fine with the other values present.

xref: https://issues.redhat.com/browse/HIVE-2486