### PR TITLE
Revert "HIVE-2400: Bump build-image to rhel9"

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-openshift-4.16
+FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16
 
 # setting Git username and email for workaround of
 # https://github.com/jenkinsci/docker/issues/519


### PR DESCRIPTION
Reverts openshift/hive#2305

We're having trouble (understanding and) executing the multi-step process to get this bumped in hive and CI, and we need to get other commits merged while we figure it out.