### PR TITLE
Make MachinePool poll interval tunable

### DIFF
--- a/apis/hive/v1/hiveconfig_types.go
+++ b/apis/hive/v1/hiveconfig_types.go
@@ -66,6 +66,12 @@ type HiveConfigSpec struct {
 	// The default reapply interval is two hours.
 	SyncSetReapplyInterval string `json:"syncSetReapplyInterval,omitempty"`
 
+	// MachinePoolPollInterval is a string duration indicating how much time must pass before checking whether
+	// remote resources related to MachinePools need to be reapplied. Set to zero to disable polling -- we'll
+	// only reconcile when hub objects change.
+	// The default interval is 30m.
+	MachinePoolPollInterval string `json:"machinePoolPollInterval,omitempty"`
+
 	// MaintenanceMode can be set to true to disable the hive controllers in situations where we need to ensure
 	// nothing is running that will add or act upon finalizers on Hive types. This should rarely be needed.
 	// Sets replicas to 0 for the hive-controllers deployment to accomplish this.

--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -627,6 +627,13 @@ spec:
                   fatal, error, warn, info, debug, and trace. The default level is
                   info.
                 type: string
+              machinePoolPollInterval:
+                description: MachinePoolPollInterval is a string duration indicating
+                  how much time must pass before checking whether remote resources
+                  related to MachinePools need to be reapplied. Set to zero to disable
+                  polling -- we'll only reconcile when hub objects change. The default
+                  interval is 30m.
+                type: string
               maintenanceMode:
                 description: MaintenanceMode can be set to true to disable the hive
                   controllers in situations where we need to ensure nothing is running

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -4479,6 +4479,13 @@ objects:
                     fatal, error, warn, info, debug, and trace. The default level
                     is info.
                   type: string
+                machinePoolPollInterval:
+                  description: MachinePoolPollInterval is a string duration indicating
+                    how much time must pass before checking whether remote resources
+                    related to MachinePools need to be reapplied. Set to zero to disable
+                    polling -- we'll only reconcile when hub objects change. The default
+                    interval is 30m.
+                  type: string
                 maintenanceMode:
                   description: MaintenanceMode can be set to true to disable the hive
                     controllers in situations where we need to ensure nothing is running

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -525,6 +525,16 @@ const (
 	// OverrideInstallerImageNameAnnotation specifies the name of the image within release metadata containing the
 	// `openshift-install` command. By default we look for the image named `installer`.
 	OverrideInstallerImageNameAnnotation = "hive.openshift.io/installer-image-name-override"
+
+	// SyncSetReapplyIntervalEnvVar is a Duration string indicating the interval (plus jitter) between full reapplies
+	// of remote objects corresponding to [Selector]SyncSets. It is how we plumb HiveConfig.Spec.SyncSetReapplyInterval
+	// from hive-operator through to the clustersync controller.
+	SyncSetReapplyIntervalEnvVar = "SYNCSET_REAPPLY_INTERVAL"
+
+	// MachinePoolPollIntervalEnvVar is a Duration string indicating the interval (plus jitter) between polls
+	// of remote objects corresponding to MachinePools. It is how we plumb HiveConfig.Spec.MachinePoolPollInterval
+	// from hive-operator through to the machinepool controller.
+	MachinePoolPollIntervalEnvVar = "MACHINEPOOL_POLL_INTERVAL"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -47,7 +47,6 @@ import (
 const (
 	ControllerName         = hivev1.ClustersyncControllerName
 	defaultReapplyInterval = 2 * time.Hour
-	reapplyIntervalEnvKey  = "SYNCSET_REAPPLY_INTERVAL"
 	reapplyIntervalJitter  = 0.1
 	secretAPIVersion       = "v1"
 	secretKind             = "Secret"
@@ -150,11 +149,11 @@ func Add(mgr manager.Manager) error {
 func NewReconciler(mgr manager.Manager, rateLimiter flowcontrol.RateLimiter) (*ReconcileClusterSync, error) {
 	logger := log.WithField("controller", ControllerName)
 	reapplyInterval := defaultReapplyInterval
-	if envReapplyInterval := os.Getenv(reapplyIntervalEnvKey); len(envReapplyInterval) > 0 {
+	if envReapplyInterval := os.Getenv(constants.SyncSetReapplyIntervalEnvVar); len(envReapplyInterval) > 0 {
 		var err error
 		reapplyInterval, err = time.ParseDuration(envReapplyInterval)
 		if err != nil {
-			log.WithError(err).WithField("reapplyInterval", envReapplyInterval).Errorf("unable to parse %s", reapplyIntervalEnvKey)
+			log.WithError(err).WithField("reapplyInterval", envReapplyInterval).Errorf("unable to parse %s", constants.SyncSetReapplyIntervalEnvVar)
 			return nil, err
 		}
 	}

--- a/pkg/operator/hive/clustersync.go
+++ b/pkg/operator/hive/clustersync.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/controller/images"
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/operator/assets"
@@ -78,7 +79,7 @@ func (r *ReconcileHiveConfig) deployClusterSync(hLog log.FieldLogger, h resource
 
 	if syncSetReapplyInterval := hiveconfig.Spec.SyncSetReapplyInterval; syncSetReapplyInterval != "" {
 		syncsetReapplyIntervalEnvVar := corev1.EnvVar{
-			Name:  "SYNCSET_REAPPLY_INTERVAL",
+			Name:  constants.SyncSetReapplyIntervalEnvVar,
 			Value: syncSetReapplyInterval,
 		}
 

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -126,13 +126,24 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 		hiveContainer.Args = append(hiveContainer.Args, "--log-level", level)
 	}
 
+	// TODO: Can this be removed? Is it still possible to deploy the clustersync controller in-band with
+	// hive-controllers?
 	if syncSetReapplyInterval := instance.Spec.SyncSetReapplyInterval; syncSetReapplyInterval != "" {
 		syncsetReapplyIntervalEnvVar := corev1.EnvVar{
-			Name:  "SYNCSET_REAPPLY_INTERVAL",
+			Name:  constants.SyncSetReapplyIntervalEnvVar,
 			Value: syncSetReapplyInterval,
 		}
 
 		hiveContainer.Env = append(hiveContainer.Env, syncsetReapplyIntervalEnvVar)
+	}
+
+	if machinePoolPollInterval := instance.Spec.MachinePoolPollInterval; machinePoolPollInterval != "" {
+		machinePoolPollIntervalEnvVar := corev1.EnvVar{
+			Name:  constants.MachinePoolPollIntervalEnvVar,
+			Value: machinePoolPollInterval,
+		}
+
+		hiveContainer.Env = append(hiveContainer.Env, machinePoolPollIntervalEnvVar)
 	}
 
 	addConfigVolume(&hiveDeployment.Spec.Template.Spec, managedDomainsConfigMapInfo, hiveContainer)

--- a/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
@@ -66,6 +66,12 @@ type HiveConfigSpec struct {
 	// The default reapply interval is two hours.
 	SyncSetReapplyInterval string `json:"syncSetReapplyInterval,omitempty"`
 
+	// MachinePoolPollInterval is a string duration indicating how much time must pass before checking whether
+	// remote resources related to MachinePools need to be reapplied. Set to zero to disable polling -- we'll
+	// only reconcile when hub objects change.
+	// The default interval is 30m.
+	MachinePoolPollInterval string `json:"machinePoolPollInterval,omitempty"`
+
 	// MaintenanceMode can be set to true to disable the hive controllers in situations where we need to ensure
 	// nothing is running that will add or act upon finalizers on Hive types. This should rarely be needed.
 	// Sets replicas to 0 for the hive-controllers deployment to accomplish this.


### PR DESCRIPTION
In addition to `Watch()`ing the local MachinePool and ClusterDeployment objects, the machinepool controller also sets up a poll. Previously the interval was hardcoded to 30m. With this commit, we retain that as the default, but allow it to be tuned via a new field: `HiveConfig.Spec.MachinePoolPollInterval`.

This is a Duration string -- e.g. `"30m"`. If set to zero or less (e.g. `"0m"`) we won't poll at all.

[HIVE-2536](https://issues.redhat.com//browse/HIVE-2536)