### PR TITLE
machinepool: sort ownedLabels, ownedTaints

### DIFF
--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1089,19 +1090,27 @@ func (r *ReconcileMachinePool) updatePoolStatusForMachineSets(
 // updateOwnedLabelsAndTaints updates OwnedLabels and OwnedTaints in the MachinePool.Status, by fetching the relevant entries sans duplicates from MachinePool.Spec.
 func updateOwnedLabelsAndTaints(pool *hivev1.MachinePool) hivev1.MachinePoolStatus {
 	// Update our tracked labels...
-	pool.Status.OwnedLabels = make([]string, len(pool.Spec.Labels))
+	ownedLabels := make([]string, len(pool.Spec.Labels))
 	i := 0
 	for labelKey := range pool.Spec.Labels {
-		pool.Status.OwnedLabels[i] = labelKey
+		ownedLabels[i] = labelKey
 		i++
 	}
+	sort.Strings(ownedLabels)
+	pool.Status.OwnedLabels = ownedLabels
 
 	// ...and taints
 	uniqueTaints := *controllerutils.GetUniqueTaints(&pool.Spec.Taints)
-	pool.Status.OwnedTaints = make([]hivev1.TaintIdentifier, len(uniqueTaints))
+	ownedTaints := make([]hivev1.TaintIdentifier, len(uniqueTaints))
 	for i, taint := range uniqueTaints {
-		pool.Status.OwnedTaints[i] = controllerutils.IdentifierForTaint(&taint)
+		ownedTaints[i] = controllerutils.IdentifierForTaint(&taint)
 	}
+	sort.Slice(ownedTaints, func(i, j int) bool {
+		// It is not important that these be actually "sorted" -- just that they are
+		// ordered deterministically.
+		return fmt.Sprintf("%v", ownedTaints[i]) < fmt.Sprintf("%v", ownedTaints[j])
+	})
+	pool.Status.OwnedTaints = ownedTaints
 	return pool.Status
 }
 

--- a/pkg/controller/machinepool/machinepool_controller_test.go
+++ b/pkg/controller/machinepool/machinepool_controller_test.go
@@ -1392,21 +1392,35 @@ func TestUpdateOwnedLabelsTaints(t *testing.T) {
 			name: "Carry over labels from spec",
 			machinePool: testMachinePoolWithoutLabelsTaints(
 				testmp.WithLabels(map[string]string{
-					"test-label": "test-value",
+					"test-label":              "test-value",
+					"a-smaller-sorting-label": "z-bigger-value",
 				}),
 			),
-			expectedOwnedLabels: []string{"test-label"},
+			expectedOwnedLabels: []string{"a-smaller-sorting-label", "test-label"},
 		},
 		{
 			name: "Carry over taints from spec",
 			machinePool: testMachinePoolWithoutLabelsTaints(
-				testmp.WithTaints(corev1.Taint{
-					Key:    "test-taint",
-					Value:  "test-value",
-					Effect: "NoSchedule",
-				}),
+				testmp.WithTaints(
+					corev1.Taint{
+						Key:    "test-taint",
+						Value:  "test-value",
+						Effect: "NoSchedule",
+					},
+				),
+				testmp.WithTaints(
+					corev1.Taint{
+						Key:    "another-taint",
+						Value:  "test-value",
+						Effect: "NoSchedule",
+					},
+				),
 			),
 			expectedOwnedTaints: []hivev1.TaintIdentifier{
+				{
+					Key:    "another-taint",
+					Effect: "NoSchedule",
+				},
 				{
 					Key:    "test-taint",
 					Effect: "NoSchedule",


### PR DESCRIPTION
With these unsorted, it was possible to thrash MachinePools.

[HIVE-2541](https://issues.redhat.com//browse/HIVE-2541)