### PR TITLE
HIVE-2400: fix obsolete python references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ endif
 # v{major}.{minor}.{commitcount}-{sha}
 # Note that building against a local commit may result in {major}.{minor} being rendered as
 # `UnknownBranch`. However, the {commitcount} and {sha} should still be accurate.
-SOURCE_GIT_TAG := $(shell export HOME=$(HOME); python3 -mpip install --user gitpython >&2; hack/version2.py)
+SOURCE_GIT_TAG := $(shell export HOME=$(HOME); python3 -m ensurepip >&2; python3 -mpip install --user gitpython pyyaml >&2; hack/version2.py)
 
 BINDATA_INPUTS :=./config/clustersync/... ./config/hiveadmission/... ./config/controllers/... ./config/rbac/... ./config/configmaps/...
 $(call add-bindata,operator,$(BINDATA_INPUTS),,assets,pkg/operator/assets/bindata.go)

--- a/hack/app-sre/generate-saas-template.py
+++ b/hack/app-sre/generate-saas-template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/hack/bundle-gen.py
+++ b/hack/bundle-gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import datetime

--- a/hack/statuspatch
+++ b/hack/statuspatch
@@ -117,7 +117,7 @@ fi
 
 # Proxy through a unix socket so we don't have to dork with ports
 socket=$patchfile.sock
-python -c "import os, socket as s; s.socket(s.AF_UNIX).bind('$socket')"
+/usr/bin/env python3 -c "import os, socket as s; s.socket(s.AF_UNIX).bind('$socket')"
 oc proxy -u $socket &
 # TODO: Better way to wait for the socket to spin up
 sleep 1


### PR DESCRIPTION
New builder images do not alias python to python3