### PR TITLE
Fix AWS STS for RHEL8/9 transition

### DIFF
--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -77,7 +77,7 @@ func CopyAWSServiceProviderSecret(client client.Client, destNamespace string, en
 // AWSAssumeRoleCLIConfig creates a secret that can assume the role using the hiveutil
 // credential_process helper.
 func AWSAssumeRoleCLIConfig(client client.Client, role *hivev1aws.AssumeRole, secretName, secretNamespace string, owner metav1.Object, scheme *runtime.Scheme) error {
-	cmd := "/usr/bin/hiveutil"
+	cmd := "/output/hiveutil"
 	args := []string{"install-manager", "aws-credentials"}
 	args = append(args, []string{"--namespace", secretNamespace}...)
 	args = append(args, []string{"--role-arn", role.RoleARN}...)
@@ -352,7 +352,7 @@ func InstallerPodSpec(
 			Command:         []string{"/bin/sh", "-c"},
 			// Large file copy here has shown to cause problems in clusters under load, safer to copy then rename to the file the install manager is waiting for
 			// so it doesn't try to run a partially copied binary.
-			Args:         []string{fmt.Sprintf("cp -v /bin/openshift-install /output/openshift-install && major_version=$(sed -n 's/.*release \\([0-9]*\\).*/\\1/p' /etc/redhat-release) && /output/hiveutil.rhel${major_version} install-manager --work-dir /output --log-level debug %s %s", cd.Namespace, provisionName)},
+			Args:         []string{fmt.Sprintf("cp -v /bin/openshift-install /output/openshift-install.tmp && mv /output/openshift-install.tmp /output/openshift-install && major_version=$(sed -n 's/.*release \\([0-9]*\\).*/\\1/p' /etc/redhat-release) && ln -v /output/hiveutil.rhel${major_version} /output/hiveutil && /output/hiveutil install-manager --work-dir /output --log-level debug %s %s", cd.Namespace, provisionName)},
 			VolumeMounts: volumeMounts,
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{


### PR DESCRIPTION
In #2260 we changed how we're invoking the openshift-install binary.

Before: Copy openshift-install into the hive container and run it via `/usr/bin/hiveutil install-manager`

After: Copy hiveutil into the installer container and run installer via `/output/hiveutil.rhel$VER install-manager`

What we missed was that, for STS flows, we inject an AWS credentials file containing a `credential_process` that invoked `/usr/bin/hiveutil install-manager aws-credentials` -- but `hiveutil` no longer lives there.

Fix.

[HIVE-2400](https://issues.redhat.com//browse/HIVE-2400)