### PR TITLE
Build improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .
 RUN dnf -y install git python3-pip
-RUN make build
+RUN make build-hiveutil
 
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-openshift-4.16 as builder_rhel9
 RUN mkdir -p /go/src/github.com/openshift/hive

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@ RUN make build
 
 FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 
-RUN dnf -y update && dnf clean all
-
 # ssh-agent required for gathering logs in some situations:
 RUN if ! rpm -q openssh-clients; then dnf install -y openssh-clients && dnf clean all && rm -rf /var/cache/dnf/*; fi
 

--- a/Makefile
+++ b/Makefile
@@ -325,6 +325,11 @@ lint: install-tools
 # Remove the golangci-lint from the verify until a fix is in place for permisions for writing to the /.cache directory.
 #verify: lint
 
+# Target to build only hiveutil. This is used so that on the dual build RHEL8/RHEL9, RHEL8 stage only needs to build hiveutil.
+.PHONY: build-hiveutil
+build-hiveutil:
+	$(call build-package, ./contrib/cmd/hiveutil)
+
 .PHONY: modcheck
 modcheck:
 	go run ./hack/modcheck.go

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,6 @@ $(call add-bindata,operator,$(BINDATA_INPUTS),,assets,pkg/operator/assets/bindat
 $(call build-image,hive,$(IMG),./Dockerfile,.)
 $(call build-image,hive-fedora-dev-base,hive-fedora-dev-base,./build/fedora-dev/Dockerfile.devbase,.)
 $(call build-image,hive-fedora-dev,$(IMG),./build/fedora-dev/Dockerfile.dev,.)
-$(call build-image,hive-build,"hive-build:latest",./build/build-image/Dockerfile,.)
 
 clean:
 	rm -rf $(GO_BUILD_BINDIR)


### PR DESCRIPTION
perf(build): Build hiveutil only for RHEL8

    In the hive operator image we take all the binaries from the RHEL9 stage
    and only hiveutil from the RHEL8 stage. Thus, we waste a lot of time
    building the non-hiveutil Go components. This commit:

    - Adds a build-machinery-go using target to build only hiveutil
    - Changes the Dockerfile to build only the new target for RHEL8

fix(build): Drop obsolete build-image call

    This build-machinery-go call was referencing a no longer existing:

      /build/build-image/Dockerfile

fix(build): Drop dnf updates from image build

    In order to progress towards hermetic builds, i.e., builds that do not
    need to access the internet and can have a prepared list of RPMs to be
    supplied, we need to drop the dnf update which can take any random
    package and update it.

    To sum up, this:
    - Improves Build reproducibility
    - Limits internet access needs.
    - Shaves down one ~32MB layer
    - Allows the update management done by the base image layer to take the
      entire responsibility