### PR TITLE
HIVE-2571: fixing build not to end up erroring out on too many open files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .
 RUN dnf -y install git python3-pip
-RUN make build
+RUN make build-hiveadmission build-manager build-operator && \
+  make build-hiveutil
 
 FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 
@@ -36,12 +37,12 @@ COPY --from=builder_rhel9 /go/src/github.com/openshift/hive/bin/hiveutil /usr/bi
 # by default so we must setup some permissions here.
 ENV HOME /home/hive
 RUN mkdir -p /home/hive && \
-    chgrp -R 0 /home/hive && \
-    chmod -R g=u /home/hive
+  chgrp -R 0 /home/hive && \
+  chmod -R g=u /home/hive
 
 RUN mkdir -p /output/hive-trusted-cabundle && \
-    chgrp -R 0 /output/hive-trusted-cabundle && \
-    chmod -R g=u /output/hive-trusted-cabundle
+  chgrp -R 0 /output/hive-trusted-cabundle && \
+  chmod -R g=u /output/hive-trusted-cabundle
 
 # TODO: should this be the operator?
 ENTRYPOINT ["/opt/services/manager"]

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ LOG_LEVEL ?= debug
 IMG ?= hive-controller:latest
 
 GO_PACKAGES :=./...
-GO_BUILD_PACKAGES :=./cmd/... ./contrib/cmd/hiveutil
+GO_BUILD_PACKAGES :=./cmd/...
 GO_BUILD_BINDIR :=bin
 # Exclude e2e tests from unit testing
 GO_TEST_PACKAGES :=./pkg/... ./cmd/... ./contrib/...
@@ -300,11 +300,11 @@ docker-dev-push: build image-hive-fedora-dev docker-push
 # Build the dev image using builah
 .PHONY: buildah-dev-build
 buildah-dev-build:
-	buildah bud --ulimit nofile=10239:10240 -f ./Dockerfile --tag ${IMG}
+	buildah bud --tag ${IMG} -f ./Dockerfile .
 
 .PHONY: podman-dev-build
 podman-dev-build:
-	podman build --tag ${IMG} --ulimit nofile=10239:10240 -f ./Dockerfile .
+	podman build --tag ${IMG} -f ./Dockerfile .
 
 # Build and push the dev image with buildah
 .PHONY: buildah-dev-push
@@ -325,10 +325,28 @@ lint: install-tools
 # Remove the golangci-lint from the verify until a fix is in place for permisions for writing to the /.cache directory.
 #verify: lint
 
+# Target to build only hiveadmission
+.PHONY: build-hiveadmission
+build-hiveadmission:
+	$(call build-package, ./cmd/hiveadmission)
+build: build-hiveadmission
+
 # Target to build only hiveutil. This is used so that on the dual build RHEL8/RHEL9, RHEL8 stage only needs to build hiveutil.
 .PHONY: build-hiveutil
 build-hiveutil:
 	$(call build-package, ./contrib/cmd/hiveutil)
+
+# Target to build only manager
+.PHONY: build-manager
+build-manager:
+	$(call build-package, ./cmd/manager)
+build: build-manager
+
+# Target to build only manager
+.PHONY: build-operator
+build-operator:
+	$(call build-package, ./cmd/operator)
+build: build-operator
 
 .PHONY: modcheck
 modcheck:


### PR DESCRIPTION
This prevents the hiveutil go compilation from ending up in too many open files error in both podman, buildah and Konflux.