### PR TITLE
MachinePool controller: Add env for AssumeRole

### DIFF
--- a/pkg/operator/hive/sharded_controllers.go
+++ b/pkg/operator/hive/sharded_controllers.go
@@ -51,6 +51,14 @@ var (
 		deploymentName:  hivev1.DeploymentNameMachinepool,
 		defaultReplicas: 1,
 		hashAnnotation:  "hive.openshift.io/machinepool-statefulset-spec-hash",
+		containerCustomization: func(hc *hivev1.HiveConfig, c *corev1.Container) {
+			if awssp := hc.Spec.ServiceProviderCredentialsConfig.AWS; awssp != nil && awssp.CredentialsSecretRef.Name != "" {
+				c.Env = append(c.Env, corev1.EnvVar{
+					Name:  constants.HiveAWSServiceProviderCredentialsSecretRefEnvVar,
+					Value: awssp.CredentialsSecretRef.Name,
+				})
+			}
+		},
 	}
 )
 


### PR DESCRIPTION
Since splitting out the MachinePool controller via #2341, the MachinePool controller was failing to authenticate to AWS for clusters configured with STS/AssumeRole:

```
error="could not generate machinesets: processing subnets: NoCredentialProviders: no valid providers in chain. Deprecated.\n\tFor verbose messaging see aws.Config.CredentialsChainVerboseErrors"
```

This is because we forgot to add the
`HIVE_AWS_SERVICE_PROVIDER_CREDENTIALS_SECRET` env var to the split-out controller pods. Fix.

[HIVE-2537](https://issues.redhat.com//browse/HIVE-2537)