### PR TITLE
fix(build): update to the fixed clamav image

### DIFF
--- a/.tekton/hive-pull-request.yaml
+++ b/.tekton/hive-pull-request.yaml
@@ -363,7 +363,7 @@ spec:
         - name: name
           value: clamav-scan
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-clamav-scan:0.1@sha256:fbdd8b4ca9235f73d630d5a71c71d1042bbe7971eefba081dea827b6ee489c19
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:46fcff23fd21772572c5fd62f6bbaf8fa2913d3d464c685bf7a2d0da05a448c0
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/hive-push.yaml
+++ b/.tekton/hive-push.yaml
@@ -360,7 +360,7 @@ spec:
         - name: name
           value: clamav-scan
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-clamav-scan:0.1@sha256:fbdd8b4ca9235f73d630d5a71c71d1042bbe7971eefba081dea827b6ee489c19
+          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:46fcff23fd21772572c5fd62f6bbaf8fa2913d3d464c685bf7a2d0da05a448c0
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
The upcoming OpenShift Pipelines which will be deployed shortly has stricter validations on Pipelines and Task manifests. Clamav would fail the new validations. This commit should make us ready.

Fixes: #[HIVE-2563](https://issues.redhat.com//browse/HIVE-2563)