### PR TITLE
fix(controller-runtime): fix metricsprovider wiring

### DIFF
--- a/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controller.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/controller/controller.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/internal/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -160,7 +161,8 @@ func NewUnmanaged(name string, mgr manager.Manager, options Options) (Controller
 		Do: options.Reconciler,
 		MakeQueue: func() workqueue.RateLimitingInterface {
 			return workqueue.NewRateLimitingQueueWithConfig(options.RateLimiter, workqueue.RateLimitingQueueConfig{
-				Name: name,
+				Name:            name,
+				MetricsProvider: metrics.WorkqueueMetricsProvider,
 			})
 		},
 		MaxConcurrentReconciles: options.MaxConcurrentReconciles,

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/metrics/workqueue.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/metrics/workqueue.go
@@ -85,6 +85,8 @@ var (
 		Name:      RetriesKey,
 		Help:      "Total number of retries handled by workqueue",
 	}, []string{"name"})
+
+	WorkqueueMetricsProvider = workqueueMetricsProvider{}
 )
 
 func init() {
@@ -96,7 +98,7 @@ func init() {
 	Registry.MustRegister(longestRunningProcessor)
 	Registry.MustRegister(retries)
 
-	workqueue.SetProvider(workqueueMetricsProvider{})
+	workqueue.SetProvider(WorkqueueMetricsProvider)
 }
 
 type workqueueMetricsProvider struct{}


### PR DESCRIPTION
Upstream controller-runtime does not provide a way to pass a metricsprovider when creating a Controller. This results in metrics/workqueue not being exported.