### PR TITLE
Remove redundant import of generic admission server cmd

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -23,8 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	_ "github.com/openshift/generic-admission-server/pkg/cmd"
-
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	cmdutil "github.com/openshift/hive/cmd/util"
 	"github.com/openshift/hive/pkg/constants"


### PR DESCRIPTION
I have no idea why this package was imported, but, at present, importing this package imports a [single Go file](https://github.com/openshift/generic-admission-server/blob/8dcc3c9b298fefaf4d31c60001907222bf2c3f83/pkg/cmd/cmd.go) which does not have an init function, but, does pull in other packages that eventually do have init functions.

The result of this being imported in `main.go` is that it ends up calling the component base metrics workqueue stuff first, which means the controller-runtime stuff doesn't win the race currently.

This removal could have unintended side effects if there are other `init` functions that we are relying on, but it does remove the component-base workqueue metrics from the init tree, fixing the metrics issue at hand. If there are other `init`s that we are relying on, perhaps those packages should be imported explicitly rather than implicitly as they are today anyway?

Suggest to go through some testing before merge.