### PR TITLE
HIVE-2565: hiveutil awsprivatelink to be compatbile with CAPI based installer

### DIFF
--- a/contrib/pkg/utils/aws/aws.go
+++ b/contrib/pkg/utils/aws/aws.go
@@ -182,7 +182,7 @@ func GetWorkerSGFromVpcId(awsClients awsclient.Client, vpcId *string) (string, e
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("tag:Name"),
-				Values: []*string{aws.String(infraID + "-worker-sg")},
+				Values: []*string{aws.String(infraID + "-worker-sg"), aws.String(infraID + "-node")},
 			},
 		},
 	})
@@ -190,7 +190,7 @@ func GetWorkerSGFromVpcId(awsClients awsclient.Client, vpcId *string) (string, e
 		return "", err
 	}
 	if len(describeSecurityGroupsOutput.SecurityGroups) == 0 {
-		return "", fmt.Errorf("default SG not found for VPC %v", vpcId)
+		return "", fmt.Errorf("worker SG not found for VPC %v", vpcId)
 	}
 
 	return *describeSecurityGroupsOutput.SecurityGroups[0].GroupId, err

--- a/docs/awsprivatelink.md
+++ b/docs/awsprivatelink.md
@@ -405,11 +405,17 @@ You can use security groups from peered VPCs to allow flow of traffic using [AWS
 
 1. Find the security group for workers in Hive Cluster
 
+For v4.16 and newer (CAPI based install)
+WORKER_SG_SUFFIX="node"
+
+For versions prior to 4.16
+WORKER_SG_SUFFIX="worker-sg"
+
 Use the Hive VPC id to list the security groups.
 
 ```
 aws --region us-east-1 ec2 describe-security-groups \
-  --filter Name=vpc-id,Values=$HIVE_VPC_ID Name=tag:Name,Values=$HIVE_CLUSTER_INFRA_ID-worker-sg \
+  --filter Name=vpc-id,Values=$HIVE_VPC_ID Name=tag:Name,Values=${HIVE_CLUSTER_INFRA_ID}-${WORKER_SG_SUFFIX} \
   --query "SecurityGroups[*].{GroupName:GroupName,GroupId:GroupId}"
 ```
 


### PR DESCRIPTION
In the terraform based installer, the worker security group was named INFRA_ID-worker-sg. However, when the installer transitioned to the CAPI based installer, the worker security group name became INFRA_ID-node. As a result, the hiveutil awsprivatelink endpoint command failed to find the security group.

This change adds the new name in addition to the old one so that both formats will be found when searching for the worker security group.