### PR TITLE
AWS: Forbid case-insensitive `credential_process`

### DIFF
--- a/pkg/awsclient/client.go
+++ b/pkg/awsclient/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -630,7 +631,7 @@ func NewSessionFromSecret(secret *corev1.Secret, region string) (*session.Sessio
 	return s, nil
 }
 
-var credentialProcessRE = regexp.MustCompile(`\bcredential_process\b`)
+var credentialProcessRE = regexp.MustCompile(`(?i)\bcredential_process\b`)
 
 func ContainsCredentialProcess(config []byte) bool {
 	return len(credentialProcessRE.Find(config)) != 0
@@ -648,7 +649,7 @@ func awsCLIConfigFromSecret(secret *corev1.Secret) ([]byte, error) {
 	buf := &bytes.Buffer{}
 	fmt.Fprint(buf, "[default]\n")
 	for k, v := range secret.Data {
-		if k == "credential_process" {
+		if strings.ToLower(k) == "credential_process" {
 			return nil, errors.New("credential_process is insecure and thus forbidden")
 		}
 		fmt.Fprintf(buf, "%s = %s\n", k, v)


### PR DESCRIPTION
A previous commit (#2306 / 13ea4f47) put in checks to forbid the use of `credential_process` in AWS config/credentials files. It turns out that AWS accepts this key case-insensitively, so this commit updates our checks accordingly.

[HIVE-2485](https://issues.redhat.com//browse/HIVE-2485)