### PR TITLE
fix(konflux): use activation key

### DIFF
--- a/.tekton/hive-pull-request.yaml
+++ b/.tekton/hive-pull-request.yaml
@@ -233,6 +233,7 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
+        - CONTAINER_SUB_MANAGER_OFF=1
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       runAfter:

--- a/.tekton/hive-push.yaml
+++ b/.tekton/hive-push.yaml
@@ -230,6 +230,7 @@ spec:
       - name: BUILD_ARGS
         value:
         - $(params.build-args[*])
+        - CONTAINER_SUB_MANAGER_OFF=1
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
       runAfter:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY . .
 RUN mount && \
   ls /etc/pki/entitlement && \ 
   ls /run/secrets/rhsm && \ 
-RUN rmdir /run/secrets/rhsm
+  rmdir /run/secrets/rhsm
 ##
 
 RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
@@ -26,7 +26,7 @@ COPY . .
 RUN mount && \
   ls /etc/pki/entitlement && \ 
   ls /run/serets/rhsm && \ 
-RUN rmdir /run/secrets/rhsm
+  rmdir /run/secrets/rhsm
 ##
 
 RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
@@ -41,7 +41,7 @@ FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 RUN mount && \
   ls /etc/pki/entitlement && \ 
   ls /run/serets/rhsm && \ 
-RUN rmdir /run/secrets/rhsm
+  rmdir /run/secrets/rhsm
 ##
 
 RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,9 @@ RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .
 
-## debugging
-# https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721932345729919?thread_ts=1717698403.965519&cid=C04PZ7H0VA8
- RUN mount 
- RUN ls /etc/pki/entitlement 
- RUN ls /run/secrets/rhsm 
- RUN unlink /etc/rhsm-host
-##
 
+RUN unlink /etc/rhsm-host
 RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
-
 RUN dnf -y install git python3-pip
 RUN make build-hiveutil
 
@@ -21,14 +14,7 @@ RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .
 
-## debugging
-# https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721932345729919?thread_ts=1717698403.965519&cid=C04PZ7H0VA8
-RUN mount && \
-  ls /etc/pki/entitlement && \ 
-  ls /run/serets/rhsm && \ 
-  unlink /etc/rhsm-host
-##
-
+RUN unlink /etc/rhsm-host
 RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
 RUN dnf -y install git python3-pip
 RUN make build-hiveadmission build-manager build-operator && \
@@ -36,14 +22,8 @@ RUN make build-hiveadmission build-manager build-operator && \
 
 FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 
-## debugging
-# https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721932345729919?thread_ts=1717698403.965519&cid=C04PZ7H0VA8
-RUN mount && \
-  ls /etc/pki/entitlement && \ 
-  ls /run/serets/rhsm && \ 
-  unlink /etc/rhsm-host
-##
 
+RUN unlink /etc/rhsm-host
 RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
 
 
@@ -76,6 +56,9 @@ RUN mkdir -p /home/hive && \
 RUN mkdir -p /output/hive-trusted-cabundle && \
   chgrp -R 0 /output/hive-trusted-cabundle && \
   chmod -R g=u /output/hive-trusted-cabundle
+
+# replace removed symlink
+RUN ln -s /etc/rhsm-host /run/secrets/rhsm
 
 # TODO: should this be the operator?
 ENTRYPOINT ["/opt/services/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-open
 RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .
+RUN mount
+RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
+
 RUN dnf -y install git python3-pip
 RUN make build-hiveutil
 
@@ -9,11 +12,16 @@ FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-open
 RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .
+RUN mount
+RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
 RUN dnf -y install git python3-pip
 RUN make build-hiveadmission build-manager build-operator && \
   make build-hiveutil
 
 FROM registry.redhat.io/rhel9-4-els/rhel:9.4
+
+RUN mount
+RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
 
 # ssh-agent required for gathering logs in some situations:
 RUN if ! rpm -q openssh-clients; then dnf install -y openssh-clients && dnf clean all && rm -rf /var/cache/dnf/*; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 ## debugging
 # https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721932345729919?thread_ts=1717698403.965519&cid=C04PZ7H0VA8
  RUN mount 
- RUN ls/etc/pki/entitlement 
+ RUN ls /etc/pki/entitlement 
  RUN ls /run/secrets/rhsm 
  RUN unlink /etc/rhsm-host
 ##

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG CONTAINER_SUB_MANAGER_OFF=0
+
 FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.16 as builder_rhel8
 RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
@@ -10,18 +12,21 @@ RUN dnf -y install git python3-pip
 RUN make build-hiveutil
 
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-openshift-4.16 as builder_rhel9
+ARG CONTAINER_SUB_MANAGER_OFF
 RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .
 
 RUN unlink /etc/rhsm-host
+ENV SMDEV_CONTAINER_OFF=${CONTAINER_SUB_MANAGER_OFF}
 RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
 RUN dnf -y install git python3-pip
 RUN make build-hiveadmission build-manager build-operator && \
   make build-hiveutil
 
 FROM registry.redhat.io/rhel9-4-els/rhel:9.4
-
+ARG CONTAINER_SUB_MANAGER_OFF
+ENV SMDEV_CONTAINER_OFF=${CONTAINER_SUB_MANAGER_OFF}
 
 RUN unlink /etc/rhsm-host
 RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ COPY . .
 
 ## debugging
 # https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721932345729919?thread_ts=1717698403.965519&cid=C04PZ7H0VA8
-RUN mount && \
-  ls /etc/pki/entitlement && \ 
-  ls /run/secrets/rhsm && \ 
-  rmdir /run/secrets/rhsm
+ RUN mount 
+ RUN ls/etc/pki/entitlement 
+ RUN ls /run/secrets/rhsm 
+ RUN unlink /etc/rhsm-host
 ##
 
 RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
@@ -26,7 +26,7 @@ COPY . .
 RUN mount && \
   ls /etc/pki/entitlement && \ 
   ls /run/serets/rhsm && \ 
-  rmdir /run/secrets/rhsm
+  unlink /etc/rhsm-host
 ##
 
 RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
@@ -41,7 +41,7 @@ FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 RUN mount && \
   ls /etc/pki/entitlement && \ 
   ls /run/serets/rhsm && \ 
-  rmdir /run/secrets/rhsm
+  unlink /etc/rhsm-host
 ##
 
 RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,12 @@ FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 
 ## debugging
 # https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721932345729919?thread_ts=1717698403.965519&cid=C04PZ7H0VA8
-RUN mount && \
-    ls /etc/pki/entitlement && \
-    ls /run/serets/rhsm
- 
+RUN mount 
+RUN ls /etc/pki/entitlement 
+RUN ls /run/serets/rhsm
+RUN rmdir /run/secrets/rhsm
+
+
 RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 # https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721932345729919?thread_ts=1717698403.965519&cid=C04PZ7H0VA8
 RUN mount && \
   ls /etc/pki/entitlement && \ 
-  ls /run/serets/rhsm && \ 
+  ls /run/secrets/rhsm && \ 
 RUN rmdir /run/secrets/rhsm
 ##
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,16 @@ RUN make build-hiveadmission build-manager build-operator && \
 
 FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 
-RUN mount
+## debugging
+# https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721932345729919?thread_ts=1717698403.965519&cid=C04PZ7H0VA8
+RUN mount && \
+    ls /etc/pki/entitlement && \
+    ls /run/serets/rhsm
+ 
 RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
 
+
+##
 # ssh-agent required for gathering logs in some situations:
 RUN if ! rpm -q openssh-clients; then dnf install -y openssh-clients && dnf clean all && rm -rf /var/cache/dnf/*; fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,15 @@ FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-open
 RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .
-RUN mount
+
+## debugging
+# https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721932345729919?thread_ts=1717698403.965519&cid=C04PZ7H0VA8
+RUN mount && \
+  ls /etc/pki/entitlement && \ 
+  ls /run/serets/rhsm && \ 
+RUN rmdir /run/secrets/rhsm
+##
+
 RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
 
 RUN dnf -y install git python3-pip
@@ -12,7 +20,15 @@ FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-open
 RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .
-RUN mount
+
+## debugging
+# https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721932345729919?thread_ts=1717698403.965519&cid=C04PZ7H0VA8
+RUN mount && \
+  ls /etc/pki/entitlement && \ 
+  ls /run/serets/rhsm && \ 
+RUN rmdir /run/secrets/rhsm
+##
+
 RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
 RUN dnf -y install git python3-pip
 RUN make build-hiveadmission build-manager build-operator && \
@@ -22,11 +38,11 @@ FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 
 ## debugging
 # https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721932345729919?thread_ts=1717698403.965519&cid=C04PZ7H0VA8
-RUN mount 
-RUN ls /etc/pki/entitlement 
-RUN ls /run/serets/rhsm
+RUN mount && \
+  ls /etc/pki/entitlement && \ 
+  ls /run/serets/rhsm && \ 
 RUN rmdir /run/secrets/rhsm
-
+##
 
 RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
 


### PR DESCRIPTION
In order to be able to download non ubi packages in the konflux builds, we need to use the activation key mechanism.