### PR TITLE
fix(builds): Only unlink rhsm-host when act key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ WORKDIR /go/src/github.com/openshift/hive
 COPY . .
 
 
-RUN unlink /etc/rhsm-host
-RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
+RUN if [ -e "/activation-key/org" ]; then unlink /etc/rhsm-host; subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
 RUN dnf -y install git python3-pip
 RUN make build-hiveutil
 
@@ -17,9 +16,8 @@ RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .
 
-RUN unlink /etc/rhsm-host
 ENV SMDEV_CONTAINER_OFF=${CONTAINER_SUB_MANAGER_OFF}
-RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
+RUN if [ -e "/activation-key/org" ]; then unlink /etc/rhsm-host; subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
 RUN dnf -y install git python3-pip
 RUN make build-hiveadmission build-manager build-operator && \
   make build-hiveutil
@@ -28,8 +26,7 @@ FROM registry.redhat.io/rhel9-4-els/rhel:9.4
 ARG CONTAINER_SUB_MANAGER_OFF
 ENV SMDEV_CONTAINER_OFF=${CONTAINER_SUB_MANAGER_OFF}
 
-RUN unlink /etc/rhsm-host
-RUN if [ -e "/activation-key/org" ]; then subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
+RUN if [ -e "/activation-key/org" ]; then unlink /etc/rhsm-host; subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
 
 
 ##
@@ -62,8 +59,8 @@ RUN mkdir -p /output/hive-trusted-cabundle && \
   chgrp -R 0 /output/hive-trusted-cabundle && \
   chmod -R g=u /output/hive-trusted-cabundle
 
-# replace removed symlink
-RUN ln -s /etc/rhsm-host /run/secrets/rhsm
+# replace removed symlink when using activation-key
+RUN if [ -e "/activation-key/org" ]; then ln -s /etc/rhsm-host /run/secrets/rhsm ; fi
 
 # TODO: should this be the operator?
 ENTRYPOINT ["/opt/services/manager"]


### PR DESCRIPTION
We should not be touching the red hat subscription manager link when we are not using an activation key. Doing so harms the local builds on developers using a Red Hat developer subscription (as well as the jenkins builds).