### PR TITLE
Build faster and leaner: pip fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 
 
 RUN if [ -e "/activation-key/org" ]; then unlink /etc/rhsm-host; subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
-RUN dnf -y install git python3-pip
+RUN python3 -m ensurepip
 RUN make build-hiveutil
 
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.21-openshift-4.16 as builder_rhel9
@@ -18,7 +18,7 @@ COPY . .
 
 ENV SMDEV_CONTAINER_OFF=${CONTAINER_SUB_MANAGER_OFF}
 RUN if [ -e "/activation-key/org" ]; then unlink /etc/rhsm-host; subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
-RUN dnf -y install git python3-pip
+RUN python3 -m ensurepip
 RUN make build-hiveadmission build-manager build-operator && \
   make build-hiveutil
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ endif
 # v{major}.{minor}.{commitcount}-{sha}
 # Note that building against a local commit may result in {major}.{minor} being rendered as
 # `UnknownBranch`. However, the {commitcount} and {sha} should still be accurate.
-SOURCE_GIT_TAG := $(shell export HOME=$(HOME); python3 -m ensurepip >&2; python3 -mpip install --user gitpython pyyaml >&2; hack/version2.py)
+SOURCE_GIT_TAG := $(shell export HOME=$(HOME); python3 -m ensurepip >&2; python3 -mpip --no-cache install --user gitpython pyyaml >&2; hack/version2.py)
 
 BINDATA_INPUTS :=./config/sharded_controllers/... ./config/hiveadmission/... ./config/controllers/... ./config/rbac/... ./config/configmaps/...
 $(call add-bindata,operator,$(BINDATA_INPUTS),,assets,pkg/operator/assets/bindata.go)


### PR DESCRIPTION
- Modern python comes with `ensurepip` [1], which installs the `pip` module from local files (doesn't need the network). Using this instead of `dnf install python3-pip` makes our build faster and leaner.
- In the part of our build process where we use `pip` to install modules, ask it not to use a cache. This saves space in the container layers.

[1] https://docs.python.org/3/library/ensurepip.html