### PR TITLE
Build faster and leaner: podman-dev-build uses local go cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,12 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 DOCKER_CMD ?= docker
 CONTAINER_BUILD_FLAGS ?= --file ./Dockerfile
 
+GOCACHE ?= $(shell go env GOCACHE)
+
+ifneq ($(GOCACHE),)
+GOCACHE_VOL_ARG = --volume "${GOCACHE}:/go/.cache:z"
+endif
+
 # Namespace hive-operator will run:
 HIVE_OPERATOR_NS ?= hive
 
@@ -304,7 +310,7 @@ buildah-dev-build:
 
 .PHONY: podman-dev-build
 podman-dev-build:
-	podman build --tag ${IMG} -f ./Dockerfile .
+	podman build --tag ${IMG} $(GOCACHE_VOL_ARG) -f ./Dockerfile .
 
 # Build and push the dev image with buildah
 .PHONY: buildah-dev-push


### PR DESCRIPTION
If a go cache is configured (per `go env GOCACHE`), mount it into the container when running `make podman-dev-build`. This should speed up the build, and also reduce the size of interim container layers.

NOTE: This currently only affects `podman-dev-build`. If you're using docker, or the real `image-hive` target, this doesn't help you.