### PR TITLE
Add python dep 'semver' to hack/requirements.txt

### DIFF
--- a/hack/requirements.txt
+++ b/hack/requirements.txt
@@ -1,3 +1,4 @@
 GitPython
+semver
 PyYAML>=6.0
 requests


### PR DESCRIPTION
When I tried to run hack/bundle-gen.py from within venve this week, I encountered the following error message:

```bash
$ ./bundle-gen.py
Traceback (most recent call last):
  File "./bundle-gen.py", line 10, in <module>
    import semver
ModuleNotFoundError: No module named 'semver'
```

Adding 'semver' to the requirement.txt and re-running pip install fixed the problem