### PR TITLE
MachinePool failure domain logging

### DIFF
--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -627,7 +627,11 @@ func matchFailureDomains(gMS *machineapi.MachineSet, rMS machineapi.MachineSet, 
 	}
 
 	// Otherwise the FailureDomain should be unambiguous and we can just compare them.
-	return rfd.Equal(gfd), nil
+	equal := rfd.Equal(gfd)
+	if !equal {
+		logger.WithField("failureDomainRemote", rfd).WithField("failureDomainGenerated", gfd).Info("failure domains not equal")
+	}
+	return equal, nil
 }
 
 // matchMachineSets decides whether gMS ("generated MachineSet") and rMS ("remote MachineSet" -- the one already extant


### PR DESCRIPTION
We are having lots of problems with MachinePool scaling since we introduced failure domain matching as the way to tell whether a generated MachineSet needs to be created, updated, or deleted on the spoke. This commit adds logging that prints the contents of the generated and remote failure domains when a mismatch is detected. It should help with FFDC in the field.