### PR TITLE
Azure MachinePool: NetworkResourceGroupName, ComputSubnet, VirtualNetwork

### DIFF
--- a/apis/hive/v1/azure/machinepool.go
+++ b/apis/hive/v1/azure/machinepool.go
@@ -17,6 +17,21 @@ type MachinePool struct {
 	// OSImage defines the image to use for the OS.
 	// +optional
 	OSImage *OSImage `json:"osImage,omitempty"`
+
+	// NetworkResourceGroupName specifies the network resource group that contains an existing VNet.
+	// Ignored unless VirtualNetwork is also specified.
+	// +optional
+	NetworkResourceGroupName string `json:"networkResourceGroupName,omitempty"`
+
+	// ComputeSubnet specifies an existing subnet for use by compute nodes.
+	// If omitted, the default (${infraID}-worker-subnet) will be used.
+	// +optional
+	ComputeSubnet string `json:"computeSubnet,omitempty"`
+
+	// VirtualNetwork specifies the name of an existing VNet for the Machines to use
+	// If omitted, the default (${infraID}-vnet) will be used.
+	// +optional
+	VirtualNetwork string `json:"virtualNetwork,omitempty"`
 }
 
 // OSImage is the image to use for the OS of a machine.

--- a/apis/hive/v1/machinepool_types.go
+++ b/apis/hive/v1/machinepool_types.go
@@ -43,6 +43,9 @@ type MachinePoolSpec struct {
 	Autoscaling *MachinePoolAutoscaling `json:"autoscaling,omitempty"`
 
 	// Platform is configuration for machine pool specific to the platform.
+	// When using a MachinePool to control the default worker machines
+	// created by installer, these must match the values provided in the
+	// install-config.
 	Platform MachinePoolPlatform `json:"platform"`
 
 	// Map of label string keys and values that will be applied to the created MachineSet's

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -90,7 +90,9 @@ spec:
                 type: string
               platform:
                 description: Platform is configuration for machine pool specific to
-                  the platform.
+                  the platform. When using a MachinePool to control the default worker
+                  machines created by installer, these must match the values provided
+                  in the install-config.
                 properties:
                   aws:
                     description: AWS is the configuration used when installing on
@@ -191,6 +193,16 @@ spec:
                     description: Azure is the configuration used when installing on
                       Azure.
                     properties:
+                      computeSubnet:
+                        description: ComputeSubnet specifies an existing subnet for
+                          use by compute nodes. If omitted, the default (${infraID}-worker-subnet)
+                          will be used.
+                        type: string
+                      networkResourceGroupName:
+                        description: NetworkResourceGroupName specifies the network
+                          resource group that contains an existing VNet. Ignored unless
+                          VirtualNetwork is also specified.
+                        type: string
                       osDisk:
                         description: OSDisk defines the storage for instance.
                         properties:
@@ -255,6 +267,11 @@ spec:
                       type:
                         description: InstanceType defines the azure instance type.
                           eg. Standard_DS_V2
+                        type: string
+                      virtualNetwork:
+                        description: VirtualNetwork specifies the name of an existing
+                          VNet for the Machines to use If omitted, the default (${infraID}-vnet)
+                          will be used.
                         type: string
                       zones:
                         description: Zones is list of availability zones that can

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -5646,7 +5646,9 @@ objects:
                   type: string
                 platform:
                   description: Platform is configuration for machine pool specific
-                    to the platform.
+                    to the platform. When using a MachinePool to control the default
+                    worker machines created by installer, these must match the values
+                    provided in the install-config.
                   properties:
                     aws:
                       description: AWS is the configuration used when installing on
@@ -5748,6 +5750,16 @@ objects:
                       description: Azure is the configuration used when installing
                         on Azure.
                       properties:
+                        computeSubnet:
+                          description: ComputeSubnet specifies an existing subnet
+                            for use by compute nodes. If omitted, the default (${infraID}-worker-subnet)
+                            will be used.
+                          type: string
+                        networkResourceGroupName:
+                          description: NetworkResourceGroupName specifies the network
+                            resource group that contains an existing VNet. Ignored
+                            unless VirtualNetwork is also specified.
+                          type: string
                         osDisk:
                           description: OSDisk defines the storage for instance.
                           properties:
@@ -5813,6 +5825,11 @@ objects:
                         type:
                           description: InstanceType defines the azure instance type.
                             eg. Standard_DS_V2
+                          type: string
+                        virtualNetwork:
+                          description: VirtualNetwork specifies the name of an existing
+                            VNet for the Machines to use If omitted, the default (${infraID}-vnet)
+                            will be used.
                           type: string
                         zones:
                           description: Zones is list of availability zones that can

--- a/pkg/controller/machinepool/azureactuator.go
+++ b/pkg/controller/machinepool/azureactuator.go
@@ -71,8 +71,11 @@ func (a *AzureActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *
 	ic := &installertypes.InstallConfig{
 		Platform: installertypes.Platform{
 			Azure: &installertypesazure.Platform{
-				Region:            cd.Spec.Platform.Azure.Region,
-				ResourceGroupName: rg,
+				Region:                   cd.Spec.Platform.Azure.Region,
+				ResourceGroupName:        rg,
+				NetworkResourceGroupName: pool.Spec.Platform.Azure.NetworkResourceGroupName,
+				VirtualNetwork:           pool.Spec.Platform.Azure.VirtualNetwork,
+				ComputeSubnet:            pool.Spec.Platform.Azure.ComputeSubnet,
 			},
 		},
 	}

--- a/vendor/github.com/openshift/hive/apis/hive/v1/azure/machinepool.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/azure/machinepool.go
@@ -17,6 +17,21 @@ type MachinePool struct {
 	// OSImage defines the image to use for the OS.
 	// +optional
 	OSImage *OSImage `json:"osImage,omitempty"`
+
+	// NetworkResourceGroupName specifies the network resource group that contains an existing VNet.
+	// Ignored unless VirtualNetwork is also specified.
+	// +optional
+	NetworkResourceGroupName string `json:"networkResourceGroupName,omitempty"`
+
+	// ComputeSubnet specifies an existing subnet for use by compute nodes.
+	// If omitted, the default (${infraID}-worker-subnet) will be used.
+	// +optional
+	ComputeSubnet string `json:"computeSubnet,omitempty"`
+
+	// VirtualNetwork specifies the name of an existing VNet for the Machines to use
+	// If omitted, the default (${infraID}-vnet) will be used.
+	// +optional
+	VirtualNetwork string `json:"virtualNetwork,omitempty"`
 }
 
 // OSImage is the image to use for the OS of a machine.

--- a/vendor/github.com/openshift/hive/apis/hive/v1/machinepool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/machinepool_types.go
@@ -43,6 +43,9 @@ type MachinePoolSpec struct {
 	Autoscaling *MachinePoolAutoscaling `json:"autoscaling,omitempty"`
 
 	// Platform is configuration for machine pool specific to the platform.
+	// When using a MachinePool to control the default worker machines
+	// created by installer, these must match the values provided in the
+	// install-config.
 	Platform MachinePoolPlatform `json:"platform"`
 
 	// Map of label string keys and values that will be applied to the created MachineSet's


### PR DESCRIPTION
Add networking fields to the Azure MachinePool API:

MachinePool.Spec.Platform.Azure.NetworkResourceGroupName will end up in MachineSet.Spec.Template.Spec.ProviderSpec.Value.NetworkResourceGroupName...
unless VirtualNetwork is unspecified, in which case the ResourceGroup is used. (This logic lives in the upstream installer code and is accurate at the time of this writing 😇)

MachinePool.Spec.Platform.Azure.ComputeSubnet will end up in MachineSet.Spec.Template.Spec.ProviderSpec.Value.Subnet.

MachinePool.Spec.Platform.Azure.VirtualNetwork will end up in MachineSet.Spec.Template.Spec.ProviderSpec.Value.Vnet.

The MachinePool API field names are taken from their install-config.yaml equivalents.

[HIVE-2582](https://issues.redhat.com//browse/HIVE-2582)