### PR TITLE
fieldManager: "hive-$controllername"

### DIFF
--- a/contrib/pkg/adm/managedns/enable.go
+++ b/contrib/pkg/adm/managedns/enable.go
@@ -379,12 +379,12 @@ func (o *Options) getResourceHelper() (resource.Helper, error) {
 		log.WithError(err).Error("Cannot get client config")
 		return nil, err
 	}
-	return resource.NewHelperFromRESTConfig(cfg, log.WithField("command", "adm manage-dns enable"))
+	return resource.NewHelperFromRESTConfig(cfg, "util-managedns-enable", log.WithField("command", "adm manage-dns enable"))
 }
 
 func (o *Options) setupLocalClients() error {
 	log.Debug("creating cluster client config")
-	hiveClient, err := hiveutils.GetClient()
+	hiveClient, err := hiveutils.GetClient("hiveutil-managedns-enable")
 	if err != nil {
 		log.WithError(err).Error("failed to create a hive config client")
 		return err

--- a/contrib/pkg/awsprivatelink/awsprivatelink.go
+++ b/contrib/pkg/awsprivatelink/awsprivatelink.go
@@ -73,7 +73,7 @@ func getDynamicClient() client.Client {
 		log.WithError(err).Fatal("Failed to add Openshift configv1 types to the default scheme")
 	}
 
-	dynClient, err := hiveutils.GetClient()
+	dynClient, err := hiveutils.GetClient("hiveutil-awsprivatelink")
 	if err != nil {
 		log.WithError(err).Fatal("Failed to create controller-runtime client")
 	}

--- a/contrib/pkg/clusterpool/clusterclaim.go
+++ b/contrib/pkg/clusterpool/clusterclaim.go
@@ -54,7 +54,7 @@ func (o ClusterClaimOptions) run() error {
 	scheme := scheme.GetScheme()
 	claim := o.generateClaim()
 
-	rh, err := utils.GetResourceHelper(o.log)
+	rh, err := utils.GetResourceHelper("util-clusterpool-clusterclaim", o.log)
 	if err != nil {
 		return err
 	}

--- a/contrib/pkg/clusterpool/clusterpool.go
+++ b/contrib/pkg/clusterpool/clusterpool.go
@@ -231,7 +231,7 @@ func (o *ClusterPoolOptions) run() error {
 		return err
 	}
 
-	rh, err := utils.GetResourceHelper(o.log)
+	rh, err := utils.GetResourceHelper("util-clusterpool", o.log)
 	if err != nil {
 		return err
 	}

--- a/contrib/pkg/createcluster/create.go
+++ b/contrib/pkg/createcluster/create.go
@@ -513,7 +513,7 @@ func (o *Options) Run() error {
 		printObjects(objs, scheme, printer)
 		return err
 	}
-	rh, err := utils.GetResourceHelper(o.log)
+	rh, err := utils.GetResourceHelper("util-create-cluster", o.log)
 	if err != nil {
 		return err
 	}

--- a/contrib/pkg/deprovision/awstagdeprovision.go
+++ b/contrib/pkg/deprovision/awstagdeprovision.go
@@ -64,7 +64,7 @@ func completeAWSUninstaller(o *aws.ClusterUninstaller, logLevel string, args []s
 		return err
 	}
 
-	client, err := utils.GetClient()
+	client, err := utils.GetClient("hiveutil-aws-tag-deprovision")
 	if err != nil {
 		o.Logger.Warnf("Failed to get client: %v\n"+
 			"This is expected when in standalone mode. "+

--- a/contrib/pkg/deprovision/azure.go
+++ b/contrib/pkg/deprovision/azure.go
@@ -67,7 +67,7 @@ func completeAzureUninstaller(logLevel, cloudName, resourceGroupName string, arg
 		return nil, err
 	}
 
-	client, err := utils.GetClient()
+	client, err := utils.GetClient("hiveutil-deprovision-azure")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get client")
 	}

--- a/contrib/pkg/deprovision/gcp.go
+++ b/contrib/pkg/deprovision/gcp.go
@@ -55,7 +55,7 @@ func NewDeprovisionGCPCommand() *cobra.Command {
 func (o *gcpOptions) Complete(cmd *cobra.Command, args []string) error {
 	o.infraID = args[0]
 
-	client, err := utils.GetClient()
+	client, err := utils.GetClient("hiveutil-deprovision-gcp")
 	if err != nil {
 		return errors.Wrap(err, "failed to get client")
 	}

--- a/contrib/pkg/deprovision/ibmcloud.go
+++ b/contrib/pkg/deprovision/ibmcloud.go
@@ -64,7 +64,7 @@ func NewDeprovisionIBMCloudCommand() *cobra.Command {
 func (o *ibmCloudDeprovisionOptions) Complete(cmd *cobra.Command, args []string) error {
 	o.infraID = args[0]
 
-	client, err := utils.GetClient()
+	client, err := utils.GetClient("hiveutil-deprovision-ibmcloud")
 	if err != nil {
 		return errors.Wrap(err, "failed to get client")
 	}

--- a/contrib/pkg/deprovision/openstack.go
+++ b/contrib/pkg/deprovision/openstack.go
@@ -51,7 +51,7 @@ func NewDeprovisionOpenStackCommand() *cobra.Command {
 func (o *openStackOptions) Complete(cmd *cobra.Command, args []string) error {
 	o.infraID = args[0]
 
-	client, err := utils.GetClient()
+	client, err := utils.GetClient("hiveutil-deprovision-openstack")
 	if err != nil {
 		return errors.Wrap(err, "failed to get client")
 	}

--- a/contrib/pkg/deprovision/ovirt.go
+++ b/contrib/pkg/deprovision/ovirt.go
@@ -48,7 +48,7 @@ func NewDeprovisionOvirtCommand() *cobra.Command {
 func (o *oVirtOptions) Complete(cmd *cobra.Command, args []string) error {
 	o.infraID = args[0]
 
-	client, err := utils.GetClient()
+	client, err := utils.GetClient("hiveutil-deprovision-ovirt")
 	if err != nil {
 		return errors.Wrap(err, "failed to get client")
 	}

--- a/contrib/pkg/deprovision/vsphere.go
+++ b/contrib/pkg/deprovision/vsphere.go
@@ -55,7 +55,7 @@ func NewDeprovisionvSphereCommand() *cobra.Command {
 func (o *vSphereOptions) Complete(cmd *cobra.Command, args []string) error {
 	o.infraID = args[0]
 
-	client, err := utils.GetClient()
+	client, err := utils.GetClient("hiveutil-deprovision-vsphere")
 	if err != nil {
 		return errors.Wrap(err, "failed to get client")
 	}

--- a/contrib/pkg/report/deprovisioning.go
+++ b/contrib/pkg/report/deprovisioning.go
@@ -37,7 +37,7 @@ func NewDeprovisioningReportCommand() *cobra.Command {
 				return
 			}
 
-			dynClient, err := contributils.GetClient()
+			dynClient, err := contributils.GetClient("hiveutil-report-deprovisioning")
 			if err != nil {
 				log.WithError(err).Fatal("error creating kube clients")
 			}

--- a/contrib/pkg/report/provisioning.go
+++ b/contrib/pkg/report/provisioning.go
@@ -44,7 +44,7 @@ func NewProvisioningReportCommand() *cobra.Command {
 				return
 			}
 
-			dynClient, err := contributils.GetClient()
+			dynClient, err := contributils.GetClient("hiveutil-report-provisioning")
 			if err != nil {
 				log.WithError(err).Fatal("error creating kube clients")
 			}

--- a/contrib/pkg/utils/generic.go
+++ b/contrib/pkg/utils/generic.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/pkg/constants"
 	"github.com/openshift/hive/pkg/controller/utils"
 	"github.com/openshift/hive/pkg/resource"
@@ -50,13 +51,13 @@ func DetermineReleaseImageFromSource(sourceURL string) (string, error) {
 	return payload.PullSpec, nil
 }
 
-func GetResourceHelper(logger log.FieldLogger) (resource.Helper, error) {
+func GetResourceHelper(controllerName hivev1.ControllerName, logger log.FieldLogger) (resource.Helper, error) {
 	cfg, err := config.GetConfig()
 	if err != nil {
 		logger.WithError(err).Error("Cannot get client config")
 		return nil, err
 	}
-	return resource.NewHelperFromRESTConfig(cfg, logger)
+	return resource.NewHelperFromRESTConfig(cfg, controllerName, logger)
 }
 
 func DefaultNamespace() (string, error) {

--- a/docs/syncset.md
+++ b/docs/syncset.md
@@ -36,7 +36,7 @@ spec:
 
   resourceApplyMode: Upsert
 
-  enableResourceTemplates  : false
+  enableResourceTemplates: false
 
   resources:
   - apiVersion: user.openshift.io/v1
@@ -54,7 +54,7 @@ spec:
     patch: |-
       { "data": { "foo": "new-bar" } }
     patchType: merge
-    
+
   secretMappings:
   - sourceRef:
       name: ad-bind-password

--- a/pkg/controller/clusterrelocate/clusterrelocate_controller_test.go
+++ b/pkg/controller/clusterrelocate/clusterrelocate_controller_test.go
@@ -832,7 +832,7 @@ func TestReconcileClusterRelocate_Reconcile_Movement(t *testing.T) {
 			reconciler := &ReconcileClusterRelocate{
 				Client: srcClient,
 				logger: logger,
-				remoteClusterAPIClientBuilder: func(secret *corev1.Secret) remoteclient.Builder {
+				remoteClusterAPIClientBuilder: func(secret *corev1.Secret, cn hivev1.ControllerName) remoteclient.Builder {
 					assert.Equal(t, kubeconfigSecret, secret, "unexpected secret passed to remote client builder")
 					return mockRemoteClientBuilder
 				},
@@ -1190,7 +1190,7 @@ func TestReconcileClusterRelocate_Reconcile_RelocateStatus(t *testing.T) {
 			reconciler := &ReconcileClusterRelocate{
 				Client: srcClient,
 				logger: logger,
-				remoteClusterAPIClientBuilder: func(secret *corev1.Secret) remoteclient.Builder {
+				remoteClusterAPIClientBuilder: func(secret *corev1.Secret, cn hivev1.ControllerName) remoteclient.Builder {
 					assert.Equal(t, kubeconfigSecret, secret, "unexpected secret passed to remote client builder")
 					return mockRemoteClientBuilder
 				},

--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -172,7 +172,7 @@ func resourceHelperBuilderFunc(
 		return nil, err
 	}
 
-	return resource.NewHelperFromRESTConfig(restConfig, logger)
+	return resource.NewHelperFromRESTConfig(restConfig, ControllerName, logger)
 }
 
 // AddToManager adds a new Controller to mgr with r as the reconcile.Reconciler

--- a/pkg/controller/utils/clientwrapper.go
+++ b/pkg/controller/utils/clientwrapper.go
@@ -74,7 +74,7 @@ func NewClientWithMetricsOrDie(mgr manager.Manager, ctrlrName hivev1.ControllerN
 		log.WithError(err).Fatal("unable to initialize metrics wrapped client")
 	}
 
-	return dc
+	return client.WithFieldOwner(dc, "hive1-"+string(ctrlrName))
 }
 
 // AddControllerMetricsTransportWrapper adds a transport wrapper to the given rest config which

--- a/pkg/imageset/updateinstaller.go
+++ b/pkg/imageset/updateinstaller.go
@@ -97,7 +97,7 @@ func (o *UpdateInstallerImageOptions) Complete() error {
 		log.WithError(err).Error("Cannot obtain client config")
 		return err
 	}
-	o.client, err = getClient(cfg)
+	o.client, err = getClient(cfg, "hiveutil-update-installer-image")
 	if err != nil {
 		log.WithError(err).Error("Cannot obtain API client")
 		return err
@@ -263,7 +263,7 @@ func (o *UpdateInstallerImageOptions) setImageResolutionErrorCondition(cd *hivev
 	}
 }
 
-func getClient(kubeConfig *rest.Config) (client.Client, error) {
+func getClient(kubeConfig *rest.Config, fieldManager string) (client.Client, error) {
 	scheme := scheme.GetScheme()
 
 	managerOptions := manager.Options{
@@ -285,7 +285,7 @@ func getClient(kubeConfig *rest.Config) (client.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kube client: %v", err)
 	}
-	return kubeClient, nil
+	return client.WithFieldOwner(kubeClient, fieldManager), nil
 }
 
 // cincinnatiMetadata is the compact version of the release metadata

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -190,7 +190,7 @@ SSH_PRIV_KEY_PATH: File system path of a file containing the SSH private key cor
 			}
 
 			var err error
-			im.DynamicClient, err = contributils.GetClient()
+			im.DynamicClient, err = contributils.GetClient("hiveutil-installmanager")
 			if err != nil {
 				im.log.WithError(err).Fatal("error creating kube clients")
 			}

--- a/pkg/remoteclient/remoteclient.go
+++ b/pkg/remoteclient/remoteclient.go
@@ -212,9 +212,13 @@ func (b *builder) Build() (client.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return client.New(cfg, client.Options{
+	c, err := client.New(cfg, client.Options{
 		Scheme: scheme.GetScheme(),
 	})
+	if err != nil {
+		return nil, err
+	}
+	return client.WithFieldOwner(c, "hive2-"+string(b.controllerName)), nil
 }
 
 func (b *builder) BuildDynamic() (dynamic.Interface, error) {

--- a/pkg/resource/apply.go
+++ b/pkg/resource/apply.go
@@ -154,7 +154,10 @@ func (r *helper) createOnly(f cmdutil.Factory, obj []byte) (ApplyResult, error) 
 	}
 	// Object doesn't exist yet, create it
 	gvr := info.ResourceMapping().Resource
-	_, err = c.Resource(gvr).Namespace(info.Namespace).Create(context.TODO(), info.Object.(*unstructured.Unstructured), metav1.CreateOptions{})
+	_, err = c.Resource(gvr).Namespace(info.Namespace).Create(context.TODO(), info.Object.(*unstructured.Unstructured),
+		metav1.CreateOptions{
+			FieldManager: "hive4-" + string(r.controllerName),
+		})
 	if err != nil {
 		return "", err
 	}
@@ -177,7 +180,10 @@ func (r *helper) createOrUpdate(f cmdutil.Factory, obj []byte, errOut io.Writer)
 		}
 		// Object doesn't exist yet, create it
 		gvr := info.ResourceMapping().Resource
-		_, err := c.Resource(gvr).Namespace(info.Namespace).Create(context.TODO(), info.Object.(*unstructured.Unstructured), metav1.CreateOptions{})
+		_, err := c.Resource(gvr).Namespace(info.Namespace).Create(context.TODO(), info.Object.(*unstructured.Unstructured),
+			metav1.CreateOptions{
+				FieldManager: "hive5-" + string(r.controllerName),
+			})
 		if err != nil {
 			return "", err
 		}
@@ -224,6 +230,7 @@ func (r *helper) setupApplyCommand(f cmdutil.Factory, obj []byte, ioStreams gene
 		PrintFlags:        flags.PrintFlags,
 		Overwrite:         true,
 		OpenAPIPatch:      true,
+		FieldManager:      "hive6-" + string(r.controllerName),
 	}
 	dynamicClient, err := f.DynamicClient()
 	if err != nil {

--- a/pkg/resource/helper.go
+++ b/pkg/resource/helper.go
@@ -66,11 +66,12 @@ func (r *helper) cacheOpenAPISchema() error {
 }
 
 // NewHelperFromRESTConfig returns a new object that allows apply and patch operations
-func NewHelperFromRESTConfig(restConfig *rest.Config, logger log.FieldLogger) (Helper, error) {
+func NewHelperFromRESTConfig(restConfig *rest.Config, controllerName hivev1.ControllerName, logger log.FieldLogger) (Helper, error) {
 	r := &helper{
-		logger:     logger,
-		cacheDir:   getCacheDir(logger),
-		restConfig: restConfig,
+		logger:         logger,
+		cacheDir:       getCacheDir(logger),
+		restConfig:     restConfig,
+		controllerName: controllerName,
 	}
 	r.getFactory = r.getRESTConfigFactory
 	err := r.cacheOpenAPISchema()

--- a/pkg/resource/patch.go
+++ b/pkg/resource/patch.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"bytes"
 	"fmt"
+	"os"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -50,7 +51,11 @@ func (r *helper) Patch(name types.NamespacedName, kind, apiVersion string, patch
 }
 
 func (r *helper) setupPatchCommand(name, kind, apiVersion, patchType string, f cmdutil.Factory, patch string, ioStreams genericclioptions.IOStreams) (*kcmdpatch.PatchOptions, error) {
-
+	// This is bizarre and I don't know why it works, but it's the only way I could figure out
+	// to set the `manager` properly. HIVE-1744.
+	os.Args = []string{
+		"hive7-" + string(r.controllerName),
+	}
 	cmd := kcmdpatch.NewCmdPatch(f, ioStreams)
 	cmd.Flags().Parse([]string{})
 


### PR DESCRIPTION
When debugging CR updates, e.g. via `--show-managed-fields`, hive used to annoyingly show `manager: manager`, which is not helpful.

With this commit, we've tried to make sure all updates are driven by a fieldManager with a `hive` prefix:
- For many paths, the prefix will be `hiveN` where `N` is an integer unique to the code path that's configuring the fieldManager. We did this to make it easier to trace these paths in the code (which can otherwise be Very Hard™).
- `hiveutil` commands will show up as either `hiveutil-$subcommand` or `hiveN-util-$subcommand`, depending which path they go through to create their client.

If you find cases that still show up as `manager` -- or some other unhelpful string -- please open a bug!

[HIVE-1744](https://issues.redhat.com//browse/HIVE-1744)

**Note to reviewers:**
There's some weird stuff going on in this PR. Because of the way hive has grown organically, and at the hands of several different cadres of developers, the code paths that touch k8s objects do so in a dizzying variety of ways, and many of those have different ways of populating the value that shows up in the `manager` field.
- controller-runtime's client.Client allows you to set it up for all subsequent operations via a `WithFieldOwner` (**not** `WithFieldManager` :roll_eyes:) modifier.
- client-go's write-y REST functions accept a `FieldManager` field in their respective `*Options` arguments.
- In one case we're importing code from the kubectl CLI and using a path which currently only accepts the field manager via argv.
- Some paths may or may not default to using the `user-agent` header if the field manager is not explicitly set.

In conclusion:
- This PR is a scattered hodgepodge.
- Some of the changes may be redundant (though harmless).
- I easily could have missed some paths.