### PR TITLE
ClusterPool: Label owned ClusterDeployments

### DIFF
--- a/pkg/controller/clusterpool/clusterpool_controller_test.go
+++ b/pkg/controller/clusterpool/clusterpool_controller_test.go
@@ -1314,6 +1314,10 @@ func TestReconcileClusterPool(t *testing.T) {
 			expectedTotalClusters:              1,
 			expectedObservedSize:               0,
 			expectedObservedReady:              0,
+			// Wedge in a check for the default labels. We're doing this on a test case that ends
+			// up with at least one cluster, but where we don't prepopulate any (which we would
+			// have to label explicitly -- see note in the test driver).
+			expectedLabels: map[string]string{},
 		},
 		{
 			name: "max size should include the deleting unclaimed clusters",
@@ -2144,7 +2148,12 @@ func TestReconcileClusterPool(t *testing.T) {
 					actualHibernating++
 				}
 
+				// Many tests set up pre-existing pool clusters. Those won't have the default labels
+				// (and we don't want to add them because then we might miss a regression in the actual
+				// code) so only check for them if the test explicitly requests it.
 				if test.expectedLabels != nil {
+					assert.Equal(t, testNamespace, cd.Labels[clusterPoolNamespaceLabelKey], "unexpected namespace label")
+					assert.Equal(t, testLeasePoolName, cd.Labels[clusterPoolNameLabelKey], "unexpected name label")
 					for k, v := range test.expectedLabels {
 						assert.Equal(t, v, cd.Labels[k])
 					}


### PR DESCRIPTION
Since ClusterPools create their ClusterDeployments in unique namespaces, it could be tricky to find them -- you would have to do some variant of `oc get cd -A | grep $clusterpoolName` or some fancy jq'ing.

With this commit, we add two labels to ClusterDeployments created by a ClusterPool:
- `hive.openshift.io/clusterpool-namespace`
- `hive.openshift.io/clusterpool-name`

...with the obvious values. With this, you should be able to find all CDs for a pool unambiguously with a query like:

`oc get cd -A -l hive.openshift.io/clusterpool-namespace=poolns,hive.openshift.io/clusterpool-name=poolname`

Often you'll only have one pool in a namespace, or your pool name will be unique in your cluster, so you'll be able to get away with just one of those filters.

Note that upgrading your hive to/past this commit will not automatically label existing ClusterPool-owned ClusterDeployments. If this is crucial:
- Scale your pool down to zero
- Delete all existing ClusterClaims
- Scale your pool back to the desired size

...or manually label them :)

[HIVE-2597](https://issues.redhat.com//browse/HIVE-2597)