### PR TITLE
DNM: Error clustersync controller for backoff

### DIFF
--- a/pkg/controller/clustersync/clustersync_controller.go
+++ b/pkg/controller/clustersync/clustersync_controller.go
@@ -458,10 +458,14 @@ func (r *ReconcileClusterSync) Reconcile(ctx context.Context, request reconcile.
 	}
 
 	result := reconcile.Result{Requeue: true, RequeueAfter: r.timeUntilRenew(lease)}
+	err = nil
 	if syncSetsNeedRequeue || selectorSyncSetsNeedRequeue {
 		result.RequeueAfter = 0
+		// HIVE-2585: if any syncset errored, return a non-nil error so we get the advantage of exponential backoff
+		// TODO: Make sure this condition actually represents "any [s]ss failed"
+		err = errors.New("at least one [Selector]SyncSet failed")
 	}
-	return result, nil
+	return result, err
 }
 
 func (r *ReconcileClusterSync) applySyncSets(


### PR DESCRIPTION
Without this commit, the clustersync controller returns `reconcile.Result{Requeue: true, RequeueAfter: 0}, nil` when it fails to apply any syncset resource. I.e. "This is not an error, but requeue this request immediately". Per the referenced card, and from activity seen in SD aka HCM when a syntax error was causing a large number of syncset failures, we suspected that this was _actually_ requeueing such requests immediately, resulting in thrashing. This commit was conceived to return a non-nil error in these cases, on the theory that this would cause the rate limiter to kick in and back off the requests exponentially.

However, it was discovered that the rate limiter is doing its thang anyway. So we don't need to do anything here.

[HIVE-2585](https://issues.redhat.com//browse/HIVE-2585)