### PR TITLE
MachinePool API: MachineLabels

### DIFF
--- a/apis/hive/v1/machinepool_types.go
+++ b/apis/hive/v1/machinepool_types.go
@@ -46,10 +46,19 @@ type MachinePoolSpec struct {
 	Platform MachinePoolPlatform `json:"platform"`
 
 	// Map of label string keys and values that will be applied to the created MachineSet's
-	// MachineSpec. This list will overwrite any modifications made to Node labels on an
-	// ongoing basis.
+	// MachineSpec. This affects the labels that will end up on the *Nodes* (in contrast with
+	// the MachineLabels field). This list will overwrite any modifications made to Node labels
+	// on an ongoing basis.
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
+
+	// Map of label string keys and values that will be applied to the created MachineSet's
+	// MachineTemplateSpec. This affects the labels that will end up on the *Machines* (in
+	// contrast with the Labels field). This list will overwrite any modifications made to
+	// Machine labels on an ongoing basis. Note: We ignore entries that conflict with
+	// generated labels.
+	// +optional
+	MachineLabels map[string]string `json:"machineLabels,omitempty"`
 
 	// List of taints that will be applied to the created MachineSet's MachineSpec.
 	// This list will overwrite any modifications made to Node taints on an ongoing basis.
@@ -101,11 +110,20 @@ type MachinePoolStatus struct {
 	// +optional
 	Conditions []MachinePoolCondition `json:"conditions,omitempty"`
 
-	// OwnedLabels lists the keys of labels this MachinePool created on the remote MachineSet.
+	// OwnedLabels lists the keys of labels this MachinePool created on the remote MachineSet's
+	// MachineSpec. (In contrast with OwnedMachineLabels.)
 	// Used to identify labels to remove from the remote MachineSet when they are absent from
 	// the MachinePool's spec.labels.
 	// +optional
 	OwnedLabels []string `json:"ownedLabels,omitempty"`
+
+	// OwnedMachineLabels lists the keys of labels this MachinePool created on the remote
+	// MachineSet's MachineTemplateSpec. (In contrast with OwnedLabels.)
+	// Used to identify labels to remove from the remote MachineSet when they are absent from
+	// the MachinePool's spec.machineLabels.
+	// +optional
+	OwnedMachineLabels []string `json:"ownedMachineLabels,omitempty"`
+
 	// OwnedTaints lists identifiers of taints this MachinePool created on the remote MachineSet.
 	// Used to identify taints to remove from the remote MachineSet when they are absent from
 	// the MachinePool's spec.taints.

--- a/apis/hive/v1/zz_generated.deepcopy.go
+++ b/apis/hive/v1/zz_generated.deepcopy.go
@@ -3067,6 +3067,13 @@ func (in *MachinePoolSpec) DeepCopyInto(out *MachinePoolSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.MachineLabels != nil {
+		in, out := &in.MachineLabels, &out.MachineLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Taints != nil {
 		in, out := &in.Taints, &out.Taints
 		*out = make([]corev1.Taint, len(*in))
@@ -3106,6 +3113,11 @@ func (in *MachinePoolStatus) DeepCopyInto(out *MachinePoolStatus) {
 	}
 	if in.OwnedLabels != nil {
 		in, out := &in.OwnedLabels, &out.OwnedLabels
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.OwnedMachineLabels != nil {
+		in, out := &in.OwnedMachineLabels, &out.OwnedMachineLabels
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -82,8 +82,20 @@ spec:
                 additionalProperties:
                   type: string
                 description: Map of label string keys and values that will be applied
-                  to the created MachineSet's MachineSpec. This list will overwrite
-                  any modifications made to Node labels on an ongoing basis.
+                  to the created MachineSet's MachineSpec. This affects the labels
+                  that will end up on the *Nodes* (in contrast with the MachineLabels
+                  field). This list will overwrite any modifications made to Node
+                  labels on an ongoing basis.
+                type: object
+              machineLabels:
+                additionalProperties:
+                  type: string
+                description: 'Map of label string keys and values that will be applied
+                  to the created MachineSet''s MachineTemplateSpec. This affects the
+                  labels that will end up on the *Machines* (in contrast with the
+                  Labels field). This list will overwrite any modifications made to
+                  Machine labels on an ongoing basis. Note: We ignore entries that
+                  conflict with generated labels.'
                 type: object
               name:
                 description: Name is the name of the machine pool.
@@ -668,9 +680,17 @@ spec:
                 type: array
               ownedLabels:
                 description: OwnedLabels lists the keys of labels this MachinePool
-                  created on the remote MachineSet. Used to identify labels to remove
-                  from the remote MachineSet when they are absent from the MachinePool's
-                  spec.labels.
+                  created on the remote MachineSet's MachineSpec. (In contrast with
+                  OwnedMachineLabels.) Used to identify labels to remove from the
+                  remote MachineSet when they are absent from the MachinePool's spec.labels.
+                items:
+                  type: string
+                type: array
+              ownedMachineLabels:
+                description: OwnedMachineLabels lists the keys of labels this MachinePool
+                  created on the remote MachineSet's MachineTemplateSpec. (In contrast
+                  with OwnedLabels.) Used to identify labels to remove from the remote
+                  MachineSet when they are absent from the MachinePool's spec.machineLabels.
                 items:
                   type: string
                 type: array

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -5638,8 +5638,20 @@ objects:
                   additionalProperties:
                     type: string
                   description: Map of label string keys and values that will be applied
-                    to the created MachineSet's MachineSpec. This list will overwrite
-                    any modifications made to Node labels on an ongoing basis.
+                    to the created MachineSet's MachineSpec. This affects the labels
+                    that will end up on the *Nodes* (in contrast with the MachineLabels
+                    field). This list will overwrite any modifications made to Node
+                    labels on an ongoing basis.
+                  type: object
+                machineLabels:
+                  additionalProperties:
+                    type: string
+                  description: 'Map of label string keys and values that will be applied
+                    to the created MachineSet''s MachineTemplateSpec. This affects
+                    the labels that will end up on the *Machines* (in contrast with
+                    the Labels field). This list will overwrite any modifications
+                    made to Machine labels on an ongoing basis. Note: We ignore entries
+                    that conflict with generated labels.'
                   type: object
                 name:
                   description: Name is the name of the machine pool.
@@ -6230,9 +6242,19 @@ objects:
                   type: array
                 ownedLabels:
                   description: OwnedLabels lists the keys of labels this MachinePool
-                    created on the remote MachineSet. Used to identify labels to remove
-                    from the remote MachineSet when they are absent from the MachinePool's
+                    created on the remote MachineSet's MachineSpec. (In contrast with
+                    OwnedMachineLabels.) Used to identify labels to remove from the
+                    remote MachineSet when they are absent from the MachinePool's
                     spec.labels.
+                  items:
+                    type: string
+                  type: array
+                ownedMachineLabels:
+                  description: OwnedMachineLabels lists the keys of labels this MachinePool
+                    created on the remote MachineSet's MachineTemplateSpec. (In contrast
+                    with OwnedLabels.) Used to identify labels to remove from the
+                    remote MachineSet when they are absent from the MachinePool's
+                    spec.machineLabels.
                   items:
                     type: string
                   type: array

--- a/pkg/test/machinepool/machinepool.go
+++ b/pkg/test/machinepool/machinepool.go
@@ -174,6 +174,22 @@ func WithLabels(labels map[string]string) Option {
 	}
 }
 
+// WithMachineLabels returns an Option that *adds* labels on the target MachinePool's
+// *Spec* (not its metadata!)
+// Existing labels are not removed. When keys conflict, those given in the most
+// recent WithMachineLabels will win.
+func WithMachineLabels(labels map[string]string) Option {
+	return func(mp *hivev1.MachinePool) {
+		if mp.Spec.MachineLabels == nil {
+			mp.Spec.MachineLabels = labels
+		} else {
+			for k, v := range labels {
+				mp.Spec.MachineLabels[k] = v
+			}
+		}
+	}
+}
+
 // WithOwnedLabels returns an Option that *appends* labelKeys to the target's
 // Status.OwnedLabels. Existing keys are not removed. You are responsible for
 // avoiding duplicates.
@@ -183,6 +199,19 @@ func WithOwnedLabels(labelKeys ...string) Option {
 			mp.Status.OwnedLabels = labelKeys
 		} else {
 			mp.Status.OwnedLabels = append(mp.Status.OwnedLabels, labelKeys...)
+		}
+	}
+}
+
+// WithOwnedMachineLabels returns an Option that *appends* labelKeys to the target's
+// Status.OwnedMachineLabels. Existing keys are not removed. You are responsible for
+// avoiding duplicates.
+func WithOwnedMachineLabels(labelKeys ...string) Option {
+	return func(mp *hivev1.MachinePool) {
+		if mp.Status.OwnedMachineLabels == nil {
+			mp.Status.OwnedMachineLabels = labelKeys
+		} else {
+			mp.Status.OwnedMachineLabels = append(mp.Status.OwnedMachineLabels, labelKeys...)
 		}
 	}
 }

--- a/vendor/github.com/openshift/hive/apis/hive/v1/machinepool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/machinepool_types.go
@@ -46,10 +46,19 @@ type MachinePoolSpec struct {
 	Platform MachinePoolPlatform `json:"platform"`
 
 	// Map of label string keys and values that will be applied to the created MachineSet's
-	// MachineSpec. This list will overwrite any modifications made to Node labels on an
-	// ongoing basis.
+	// MachineSpec. This affects the labels that will end up on the *Nodes* (in contrast with
+	// the MachineLabels field). This list will overwrite any modifications made to Node labels
+	// on an ongoing basis.
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
+
+	// Map of label string keys and values that will be applied to the created MachineSet's
+	// MachineTemplateSpec. This affects the labels that will end up on the *Machines* (in
+	// contrast with the Labels field). This list will overwrite any modifications made to
+	// Machine labels on an ongoing basis. Note: We ignore entries that conflict with
+	// generated labels.
+	// +optional
+	MachineLabels map[string]string `json:"machineLabels,omitempty"`
 
 	// List of taints that will be applied to the created MachineSet's MachineSpec.
 	// This list will overwrite any modifications made to Node taints on an ongoing basis.
@@ -101,11 +110,20 @@ type MachinePoolStatus struct {
 	// +optional
 	Conditions []MachinePoolCondition `json:"conditions,omitempty"`
 
-	// OwnedLabels lists the keys of labels this MachinePool created on the remote MachineSet.
+	// OwnedLabels lists the keys of labels this MachinePool created on the remote MachineSet's
+	// MachineSpec. (In contrast with OwnedMachineLabels.)
 	// Used to identify labels to remove from the remote MachineSet when they are absent from
 	// the MachinePool's spec.labels.
 	// +optional
 	OwnedLabels []string `json:"ownedLabels,omitempty"`
+
+	// OwnedMachineLabels lists the keys of labels this MachinePool created on the remote
+	// MachineSet's MachineTemplateSpec. (In contrast with OwnedLabels.)
+	// Used to identify labels to remove from the remote MachineSet when they are absent from
+	// the MachinePool's spec.machineLabels.
+	// +optional
+	OwnedMachineLabels []string `json:"ownedMachineLabels,omitempty"`
+
 	// OwnedTaints lists identifiers of taints this MachinePool created on the remote MachineSet.
 	// Used to identify taints to remove from the remote MachineSet when they are absent from
 	// the MachinePool's spec.taints.

--- a/vendor/github.com/openshift/hive/apis/hive/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/zz_generated.deepcopy.go
@@ -3067,6 +3067,13 @@ func (in *MachinePoolSpec) DeepCopyInto(out *MachinePoolSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.MachineLabels != nil {
+		in, out := &in.MachineLabels, &out.MachineLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Taints != nil {
 		in, out := &in.Taints, &out.Taints
 		*out = make([]corev1.Taint, len(*in))
@@ -3106,6 +3113,11 @@ func (in *MachinePoolStatus) DeepCopyInto(out *MachinePoolStatus) {
 	}
 	if in.OwnedLabels != nil {
 		in, out := &in.OwnedLabels, &out.OwnedLabels
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.OwnedMachineLabels != nil {
+		in, out := &in.OwnedMachineLabels, &out.OwnedMachineLabels
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}


### PR DESCRIPTION
The existing MachinePool.Spec.Labels field populates the resulting MachineSets' *MachineSpec*, resulting in the specified labels ending up on *Nodes*.

This commit adds MachinePool.Spec.MachineLabels, which populates the *MachineTemplateSpec*, resulting in the specified labels ending up on *Machines*. But note that we will ignore labels that conflict with those generated by installer code:
- machine.openshift.io/cluster-api-cluster
- machine.openshift.io/cluster-api-machineset

We also add MachinePool.Status.OwnedMachineLabels, corresponding to the existing OwnedLabels, to help us merge values correctly.

[HIVE-2320](https://issues.redhat.com//browse/HIVE-2320)