### PR TITLE
Fix MachinePool poll interval for sharded controller

### DIFF
--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -140,7 +140,7 @@ func Add(mgr manager.Manager) error {
 		var err error
 		pollInterval, err = time.ParseDuration(envPollInterval)
 		if err != nil {
-			log.WithError(err).WithField("reapplyInterval", envPollInterval).Errorf("unable to parse %s", constants.SyncSetReapplyIntervalEnvVar)
+			log.WithError(err).WithField("reapplyInterval", envPollInterval).Errorf("unable to parse %s", constants.MachinePoolPollIntervalEnvVar)
 			return err
 		}
 	}

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -139,6 +139,8 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 		hiveContainer.Env = append(hiveContainer.Env, syncsetReapplyIntervalEnvVar)
 	}
 
+	// TODO: Can this be removed? Is it still possible to deploy the machinepool controller in-band with
+	// hive-controllers?
 	if machinePoolPollInterval := instance.Spec.MachinePoolPollInterval; machinePoolPollInterval != "" {
 		machinePoolPollIntervalEnvVar := corev1.EnvVar{
 			Name:  constants.MachinePoolPollIntervalEnvVar,

--- a/pkg/operator/hive/sharded_controllers.go
+++ b/pkg/operator/hive/sharded_controllers.go
@@ -52,6 +52,14 @@ var (
 		defaultReplicas: 1,
 		hashAnnotation:  "hive.openshift.io/machinepool-statefulset-spec-hash",
 		containerCustomization: func(hc *hivev1.HiveConfig, c *corev1.Container) {
+			if machinePoolPollInterval := hc.Spec.MachinePoolPollInterval; machinePoolPollInterval != "" {
+				machinePoolPollIntervalEnvVar := corev1.EnvVar{
+					Name:  constants.MachinePoolPollIntervalEnvVar,
+					Value: machinePoolPollInterval,
+				}
+
+				c.Env = append(c.Env, machinePoolPollIntervalEnvVar)
+			}
 			if awssp := hc.Spec.ServiceProviderCredentialsConfig.AWS; awssp != nil && awssp.CredentialsSecretRef.Name != "" {
 				c.Env = append(c.Env, corev1.EnvVar{
 					Name:  constants.HiveAWSServiceProviderCredentialsSecretRefEnvVar,


### PR DESCRIPTION
Previous work (#2310 / 4117577) added a knob to control the poll interval for the MachinePool controller.

Then a subsequent effort (#2341 / 35ce9c6) split the MachinePool controller into its own StatefulSet.

But the latter forgot to carry the poll interval plumbing into the sharded version of the controller.

Fix.

[HIVE-2536](https://issues.redhat.com//browse/HIVE-2536)