### PR TITLE
Remove existing Secret files in (deprovision) Pod

### DIFF
--- a/contrib/pkg/utils/generic.go
+++ b/contrib/pkg/utils/generic.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -200,6 +201,10 @@ func ProjectToDir(obj client.Object, dir string, filter ProjectToDirFileFilter) 
 			return
 		}
 		path := filepath.Join(dir, filename)
+		// Unlink if present, in case this is a recycled pod
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			log.WithError(err).WithField("path", path).Fatal("Failed to remove existing file")
+		}
 		if err := os.WriteFile(path, newBytes, 0400); err != nil {
 			log.WithError(err).WithField("path", path).Fatal("Failed to write file")
 		}


### PR DESCRIPTION
For Pods with `restartPolicy: OnFailure`, a failed container may be rerun in the same Pod, which will reuse the same file system as the initial run. When we project Secrets (for credentials, certs, etc) to directories in such containers, those writes can fail the second time around because the file already exists. Fix by removing the file, if it exists, before we write it.

Note that at the time of this commit, this only affects deprovision pods:
- imageset pods don't use ProjectToDir
- provision pods have `restartPolicy: Never`

HIVE-2604