### PR TITLE
GOCACHE dir may not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 DOCKER_CMD ?= docker
 CONTAINER_BUILD_FLAGS ?= --file ./Dockerfile
 
-GOCACHE ?= $(shell go env GOCACHE)
+GOCACHE ?= $(shell C=`go env GOCACHE`; [[ -d $$C ]] && echo $$C)
 
 ifneq ($(GOCACHE),)
 GOCACHE_VOL_ARG = --volume "${GOCACHE}:/go/.cache:z"


### PR DESCRIPTION
...if this is the first build in this file system.

In this case, `podman` will freak out when passed that directory as a volume mount.

So check the directory and only use it if it exists.