### PR TITLE
Snyk: Ignore azidentity

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,3 +6,7 @@ exclude:
     - vendor/**
     - apis/vendor/**
     - "**/*_test.go"
+ignore:
+  'SNYK-GOLANG-GITHUBCOMAZUREAZURESDKFORGOSDKAZIDENTITY-7246767':
+  - '* > github.com/Azure/azure-sdk-for-go/sdk/azidentity':
+    reason: 'Updated azidentity lib incompatible with vendored installer code; and revendoring is hard here; and this is fixed in mce-2.6 and later, which is acceptable for a Moderate issue.'


### PR DESCRIPTION
Ignore https://security.snyk.io/vuln/SNYK-GOLANG-GITHUBCOMAZUREAZURESDKFORGOSDKAZIDENTITY-7246767

This is a Moderate CVE, fixed in mce-2.6 and later, thus deemed acceptable to disregard since it would be difficult to resolve.

[HIVE-2532](https://issues.redhat.com//browse/HIVE-2532)