### PR TITLE
Azure MachinePool: Add VMNetworkType

### DIFF
--- a/apis/hive/v1/azure/machinepool.go
+++ b/apis/hive/v1/azure/machinepool.go
@@ -32,6 +32,15 @@ type MachinePool struct {
 	// If omitted, the default (${infraID}-vnet) will be used.
 	// +optional
 	VirtualNetwork string `json:"virtualNetwork,omitempty"`
+
+	// VMNetworkingType specifies whether to enable accelerated networking.
+	// Accelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its
+	// networking performance.
+	// eg. values: "Accelerated", "Basic"
+	//
+	// +kubebuilder:validation:Enum="Accelerated"; "Basic"
+	// +optional
+	VMNetworkingType string `json:"vmNetworkingType,omitempty"`
 }
 
 // OSImage is the image to use for the OS of a machine.

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -285,6 +285,15 @@ spec:
                           VNet for the Machines to use If omitted, the default (${infraID}-vnet)
                           will be used.
                         type: string
+                      vmNetworkingType:
+                        description: 'VMNetworkingType specifies whether to enable
+                          accelerated networking. Accelerated networking enables single
+                          root I/O virtualization (SR-IOV) to a VM, greatly improving
+                          its networking performance. eg. values: "Accelerated", "Basic"'
+                        enum:
+                        - Accelerated
+                        - Basic
+                        type: string
                       zones:
                         description: Zones is list of availability zones that can
                           be used. eg. ["1", "2", "3"]

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -5843,6 +5843,16 @@ objects:
                             VNet for the Machines to use If omitted, the default (${infraID}-vnet)
                             will be used.
                           type: string
+                        vmNetworkingType:
+                          description: 'VMNetworkingType specifies whether to enable
+                            accelerated networking. Accelerated networking enables
+                            single root I/O virtualization (SR-IOV) to a VM, greatly
+                            improving its networking performance. eg. values: "Accelerated",
+                            "Basic"'
+                          enum:
+                          - Accelerated
+                          - Basic
+                          type: string
                         zones:
                           description: Zones is list of availability zones that can
                             be used. eg. ["1", "2", "3"]

--- a/pkg/controller/machinepool/azureactuator.go
+++ b/pkg/controller/machinepool/azureactuator.go
@@ -87,6 +87,7 @@ func (a *AzureActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *
 		OSDisk: installertypesazure.OSDisk{
 			DiskSizeGB: pool.Spec.Platform.Azure.OSDisk.DiskSizeGB,
 		},
+		VMNetworkingType: pool.Spec.Platform.Azure.VMNetworkingType,
 	}
 
 	if pool.Spec.Platform.Azure.OSDisk.DiskType != "" {

--- a/pkg/controller/machinepool/azureactuator_test.go
+++ b/pkg/controller/machinepool/azureactuator_test.go
@@ -3,8 +3,9 @@ package machinepool
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/hive/pkg/constants"
 	"testing"
+
+	"github.com/openshift/hive/pkg/constants"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 	"github.com/golang/mock/gomock"
@@ -40,10 +41,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1"})
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-				})
+				mockGetVMCapabilities(client, "V1,V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 3,
@@ -55,10 +54,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-				})
+				mockGetVMCapabilities(client, "V1,V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -75,10 +72,8 @@ func TestAzureActuator(t *testing.T) {
 				return pool
 			}(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-				})
+				mockGetVMCapabilities(client, "V1,V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -98,10 +93,8 @@ func TestAzureActuator(t *testing.T) {
 			}(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-				})
+				mockGetVMCapabilities(client, "V1,V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -124,10 +117,8 @@ func TestAzureActuator(t *testing.T) {
 			}(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-				})
+				mockGetVMCapabilities(client, "V1,V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 2,
@@ -141,10 +132,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3", "zone4", "zone5"})
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-				})
+				mockGetVMCapabilities(client, "V1,V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -160,10 +149,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{})
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-				})
+				mockGetVMCapabilities(client, "V1,V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedErr: true,
 		},
@@ -173,10 +160,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-				})
+				mockGetVMCapabilities(client, "V1,V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -194,11 +179,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(mockCtrl, client, "V1")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-					testAzureImage(compute.HyperVGenerationTypesV2),
-				})
+				mockGetVMCapabilities(client, "V1")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1), testAzureImage(compute.HyperVGenerationTypesV2)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -216,11 +198,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-					testAzureImage(compute.HyperVGenerationTypesV2),
-				})
+				mockGetVMCapabilities(client, "V1,V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1), testAzureImage(compute.HyperVGenerationTypesV2)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -238,11 +217,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(mockCtrl, client, "V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-					testAzureImage(compute.HyperVGenerationTypesV2),
-				})
+				mockGetVMCapabilities(client, "V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1), testAzureImage(compute.HyperVGenerationTypesV2)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -268,7 +244,7 @@ func TestAzureActuator(t *testing.T) {
 				return mp
 			}(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
+				mockGetVMCapabilities(client, "V1,V2")
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 			},
 			expectedMachineSetReplicas: map[string]int64{
@@ -291,10 +267,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1"})
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-				})
+				mockGetVMCapabilities(client, "V1,V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 3,
@@ -306,10 +280,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-				})
+				mockGetVMCapabilities(client, "V1,V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -326,10 +298,8 @@ func TestAzureActuator(t *testing.T) {
 				return pool
 			}(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-				})
+				mockGetVMCapabilities(client, "V1,V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -347,10 +317,8 @@ func TestAzureActuator(t *testing.T) {
 			}(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-				})
+				mockGetVMCapabilities(client, "V1,V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 2,
@@ -364,10 +332,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3", "zone4", "zone5"})
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-				})
+				mockGetVMCapabilities(client, "V1,V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -383,10 +349,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{})
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-				})
+				mockGetVMCapabilities(client, "V1,V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedErr: true,
 		},
@@ -396,10 +360,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-				})
+				mockGetVMCapabilities(client, "V1,V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -417,11 +379,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(mockCtrl, client, "V1")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-					testAzureImage(compute.HyperVGenerationTypesV2),
-				})
+				mockGetVMCapabilities(client, "V1")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1), testAzureImage(compute.HyperVGenerationTypesV2)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -439,11 +398,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-					testAzureImage(compute.HyperVGenerationTypesV2),
-				})
+				mockGetVMCapabilities(client, "V1,V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1), testAzureImage(compute.HyperVGenerationTypesV2)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -461,11 +417,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(mockCtrl, client, "V2")
-				mockListImagesByResourceGroup(mockCtrl, client, []compute.Image{
-					testAzureImage(compute.HyperVGenerationTypesV1),
-					testAzureImage(compute.HyperVGenerationTypesV2),
-				})
+				mockGetVMCapabilities(client, "V2")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1), testAzureImage(compute.HyperVGenerationTypesV2)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -491,7 +444,7 @@ func TestAzureActuator(t *testing.T) {
 				return mp
 			}(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
-				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
+				mockGetVMCapabilities(client, "V1,V2")
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 			},
 			expectedMachineSetReplicas: map[string]int64{
@@ -577,14 +530,14 @@ func mockListResourceSKUs(mockCtrl *gomock.Controller, client *mockazure.MockCli
 	)
 }
 
-func mockGetVMCapabilities(mockCtrl *gomock.Controller, client *mockazure.MockClient, hyperVGenerations string) {
+func mockGetVMCapabilities(client *mockazure.MockClient, hyperVGenerations string) {
 	capabilities := map[string]string{
 		"HyperVGenerations": hyperVGenerations,
 	}
 	client.EXPECT().GetVMCapabilities(gomock.Any(), gomock.Any(), gomock.Any()).Return(capabilities, nil)
 }
 
-func mockListImagesByResourceGroup(mockCtrl *gomock.Controller, client *mockazure.MockClient, images []compute.Image) {
+func mockListImagesByResourceGroup(client *mockazure.MockClient, images []compute.Image) {
 	resultPage := compute.NewImageListResultPage(compute.ImageListResult{Value: &images}, func(context.Context, compute.ImageListResult) (compute.ImageListResult, error) {
 		return compute.ImageListResult{}, nil
 	})

--- a/vendor/github.com/openshift/hive/apis/hive/v1/azure/machinepool.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/azure/machinepool.go
@@ -32,6 +32,15 @@ type MachinePool struct {
 	// If omitted, the default (${infraID}-vnet) will be used.
 	// +optional
 	VirtualNetwork string `json:"virtualNetwork,omitempty"`
+
+	// VMNetworkingType specifies whether to enable accelerated networking.
+	// Accelerated networking enables single root I/O virtualization (SR-IOV) to a VM, greatly improving its
+	// networking performance.
+	// eg. values: "Accelerated", "Basic"
+	//
+	// +kubebuilder:validation:Enum="Accelerated"; "Basic"
+	// +optional
+	VMNetworkingType string `json:"vmNetworkingType,omitempty"`
 }
 
 // OSImage is the image to use for the OS of a machine.


### PR DESCRIPTION
Add MachinePool.Spec.Azure.VMNetworkType to the API. Vendored installer code maps this to MachineSet...ProviderSpec...AcceleratedNetworking:
- "Accelerated" => true
- ""/unset or "Basic" => false

[HIVE-2530](https://issues.redhat.com//browse/HIVE-2530)