### PR TITLE
MachinePool GCP: fix zone filter

### DIFF
--- a/pkg/controller/machinepool/gcpactuator.go
+++ b/pkg/controller/machinepool/gcpactuator.go
@@ -246,8 +246,15 @@ func (a *GCPActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *hi
 func (a *GCPActuator) getZones(region string) ([]string, error) {
 	zones := []string{}
 
-	// Filter to regions matching '.*<region>.*' (where the zone is actually UP)
-	zoneFilter := fmt.Sprintf("(region eq '.*%s.*') (status eq UP)", region)
+	// Filter to UP zones by region, which is a URI, so:
+	// - Bind the left side to a path delimiter.
+	// - The right side is implicitly bound to the end of the string. (At this time, the URI ends
+	//   with the region. If this changes at some point in the future -- e.g. a querystring is
+	//   added -- it will break.)
+	// Notably, it is important that the neither side be allowed to match [\w-], as this could
+	// cause us to retrieve zones for regions whose names are a substring of the region we're
+	// actually in. HIVE-2610.
+	zoneFilter := fmt.Sprintf("(region eq '.*/%s') (status eq UP)", region)
 
 	pageToken := ""
 

--- a/pkg/controller/machinepool/gcpactuator_test.go
+++ b/pkg/controller/machinepool/gcpactuator_test.go
@@ -902,7 +902,7 @@ func mockListComputeZones(gClient *mockgcp.MockClient, zones []string, region st
 	}
 
 	filter := gcpclient.ListComputeZonesOptions{
-		Filter: fmt.Sprintf("(region eq '.*%s.*') (status eq UP)", region),
+		Filter: fmt.Sprintf("(region eq '.*/%s') (status eq UP)", region),
 	}
 	gClient.EXPECT().ListComputeZones(gomock.Eq(filter)).Return(
 		zoneList, nil,


### PR DESCRIPTION
When `MachinePool.Spec.Platform.GCP.Zones` does not explicitly enumerate the zones to use, we attempt to default to all zones in the configured region. However, this query was using an overly-broad regex which matched any zone whose region was a *substring* of the configured region. This broke when GCP added regions `europe-west10` and `europe-west12`, which our filter would retrieve when the cluster was in region `europe-west1`.

The zone list response includes the region as a full URI (e.g. `https://www.googleapis.com/compute/v1/projects/openshift-hive-dev/regions/europe-west1`). Fix our regex to match our full region string, anchored by the last `/` and the end of the string.

[HIVE-2610](https://issues.redhat.com//browse/HIVE-2610)