### PR TITLE
OCPBUGS-41797: PrivateLink: GCP PSC to use global endpoints

### DIFF
--- a/pkg/gcpclient/client.go
+++ b/pkg/gcpclient/client.go
@@ -385,12 +385,13 @@ func (c *gcpClient) CreateForwardingRule(
 	defer cancel()
 
 	newForwardingRule := &compute.ForwardingRule{
-		Name:        forwardingRule,
-		Description: "",
-		IPAddress:   ipAddress,
-		Region:      region,
-		Subnetwork:  subnet,
-		Target:      target,
+		Name:                 forwardingRule,
+		AllowPscGlobalAccess: true,
+		Description:          "",
+		IPAddress:            ipAddress,
+		Region:               region,
+		Subnetwork:           subnet,
+		Target:               target,
 	}
 
 	op, err := c.computeClient.ForwardingRules.Insert(c.projectName, region, newForwardingRule).Context(ctx).Do()


### PR DESCRIPTION
Enabling AllowPscGlobalAccess so that the endpoint is available from all of the regions as is necessary when the endpoint exists in a region other than the one a VPN is connected to.