### PR TITLE
Hive Logs: Make limit custom

### DIFF
--- a/hack/grafana-dashboards/grafana-dashboard-hive-logs.configmap.yaml
+++ b/hack/grafana-dashboards/grafana-dashboard-hive-logs.configmap.yaml
@@ -21,7 +21,6 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 936510,
       "links": [],
       "panels": [
         {
@@ -53,7 +52,7 @@ data:
                 "uid": "P1A97A9592CB7F392"
               },
               "dimensions": {},
-              "expression": "fields @timestamp, @message, level |\nfilter kubernetes.pod_name like /$pod/ |\nfilter level like /(?i)$log_level/ |\nparse message \"controller=* \" as @controller |\nfilter @controller like /(?i)$controller/ |\nparse message \"clusterDeployment=*/* \" as @namespace, @name |\nfilter @name like /(?i)$name/ |\nfilter @namespace like /(?i)$namespace/ |\nfilter message like /(?i)$text/ |\ndisplay @timestamp, message, level |\nsort @timestamp desc |\nlimit 20",
+              "expression": "fields @timestamp, @message, level |\nfilter kubernetes.pod_name like /$pod/ |\nfilter level like /(?i)$log_level/ |\nparse message \"controller=* \" as @controller |\nfilter @controller like /(?i)$controller/ |\nparse message \"clusterDeployment=*/* \" as @namespace, @name |\nfilter @name like /(?i)$name/ |\nfilter @namespace like /(?i)$namespace/ |\nfilter message like /(?i)$text/ |\ndisplay @timestamp, message, level |\nsort @timestamp desc |\nlimit $limit",
               "id": "",
               "label": "",
               "logGroups": [
@@ -301,6 +300,70 @@ data:
             "query": "",
             "skipUrlSync": false,
             "type": "textbox"
+          },
+          {
+            "current": {
+              "selected": true,
+              "text": "20",
+              "value": "20"
+            },
+            "description": "Maximum number of log events that you want your query to return.",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Limit",
+            "multi": false,
+            "name": "limit",
+            "options": [
+              {
+                "selected": true,
+                "text": "20",
+                "value": "20"
+              },
+              {
+                "selected": false,
+                "text": "50",
+                "value": "50"
+              },
+              {
+                "selected": false,
+                "text": "100",
+                "value": "100"
+              },
+              {
+                "selected": false,
+                "text": "200",
+                "value": "200"
+              },
+              {
+                "selected": false,
+                "text": "500",
+                "value": "500"
+              },
+              {
+                "selected": false,
+                "text": "1000",
+                "value": "1000"
+              },
+              {
+                "selected": false,
+                "text": "2000",
+                "value": "2000"
+              },
+              {
+                "selected": false,
+                "text": "5000",
+                "value": "5000"
+              },
+              {
+                "selected": false,
+                "text": "10000",
+                "value": "10000"
+              }
+            ],
+            "query": "20, 50, 100, 200, 500, 1000, 2000, 5000, 10000",
+            "queryValue": "",
+            "skipUrlSync": false,
+            "type": "custom"
           }
         ]
       },
@@ -312,7 +375,7 @@ data:
       "timezone": "browser",
       "title": "Hive Logs",
       "uid": "edy3mdkcmzfnkb",
-      "version": 13,
+      "version": 14,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
The limit - aka the total number of log events the query will fetch - was set to 20. This commit allows the user to choose larger limits based on their needs. The largest is set to 10,000, assuming anything larger might result in hitting the CloudWatch timeout.

/assign @2uasimojo 