### PR TITLE
ClusterVersion: tunable poll interval

### DIFF
--- a/apis/hive/v1/hiveconfig_types.go
+++ b/apis/hive/v1/hiveconfig_types.go
@@ -72,6 +72,11 @@ type HiveConfigSpec struct {
 	// The default interval is 30m.
 	MachinePoolPollInterval string `json:"machinePoolPollInterval,omitempty"`
 
+	// ClusterVersionPollInterval is a string duration indicating how much time must pass before checking
+	// whether we need to update the hive.openshift.io/version* labels on ClusterDeployment. If zero or unset,
+	// we'll only reconcile when the ClusterDeployment changes.
+	ClusterVersionPollInterval string `json:"clusterVersionPollInterval,omitempty"`
+
 	// MaintenanceMode can be set to true to disable the hive controllers in situations where we need to ensure
 	// nothing is running that will add or act upon finalizers on Hive types. This should rarely be needed.
 	// Sets replicas to 0 for the hive-controllers deployment to accomplish this.

--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -218,6 +218,12 @@ spec:
                         type: string
                     type: object
                 type: object
+              clusterVersionPollInterval:
+                description: ClusterVersionPollInterval is a string duration indicating
+                  how much time must pass before checking whether we need to update
+                  the hive.openshift.io/version* labels on ClusterDeployment. If zero
+                  or unset, we'll only reconcile when the ClusterDeployment changes.
+                type: string
               controllersConfig:
                 description: ControllersConfig is used to configure different hive
                   controllers

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -4642,6 +4642,13 @@ objects:
                           type: string
                       type: object
                   type: object
+                clusterVersionPollInterval:
+                  description: ClusterVersionPollInterval is a string duration indicating
+                    how much time must pass before checking whether we need to update
+                    the hive.openshift.io/version* labels on ClusterDeployment. If
+                    zero or unset, we'll only reconcile when the ClusterDeployment
+                    changes.
+                  type: string
                 controllersConfig:
                   description: ControllersConfig is used to configure different hive
                     controllers

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -539,6 +539,11 @@ const (
 	// of remote objects corresponding to MachinePools. It is how we plumb HiveConfig.Spec.MachinePoolPollInterval
 	// from hive-operator through to the machinepool controller.
 	MachinePoolPollIntervalEnvVar = "MACHINEPOOL_POLL_INTERVAL"
+
+	// ClusterVersionPollIntervalEnvVar is a Duration string indicating the interval (plus jitter) between polls
+	// of the clusterversion controller, which syncs hive.openshift.io/version* labels. It is how we plumb
+	// HiveConfig.Spec.ClusterVersionPollInterval from hive-operator through to the clusterversion controller.
+	ClusterVersionPollIntervalEnvVar = "CLUSTERVERSION_POLL_INTERVAL"
 )
 
 // GetMergedPullSecretName returns name for merged pull secret name per cluster deployment

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -150,6 +150,15 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 		hiveContainer.Env = append(hiveContainer.Env, machinePoolPollIntervalEnvVar)
 	}
 
+	if clusterVersionPollInterval := instance.Spec.ClusterVersionPollInterval; clusterVersionPollInterval != "" {
+		clusterVersionPollIntervalEnvVar := corev1.EnvVar{
+			Name:  constants.ClusterVersionPollIntervalEnvVar,
+			Value: clusterVersionPollInterval,
+		}
+
+		hiveContainer.Env = append(hiveContainer.Env, clusterVersionPollIntervalEnvVar)
+	}
+
 	addConfigVolume(&hiveDeployment.Spec.Template.Spec, managedDomainsConfigMapInfo, hiveContainer)
 	addConfigVolume(&hiveDeployment.Spec.Template.Spec, awsPrivateLinkConfigMapInfo, hiveContainer)
 	addConfigVolume(&hiveDeployment.Spec.Template.Spec, privateLinkConfigMapInfo, hiveContainer)

--- a/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
@@ -72,6 +72,11 @@ type HiveConfigSpec struct {
 	// The default interval is 30m.
 	MachinePoolPollInterval string `json:"machinePoolPollInterval,omitempty"`
 
+	// ClusterVersionPollInterval is a string duration indicating how much time must pass before checking
+	// whether we need to update the hive.openshift.io/version* labels on ClusterDeployment. If zero or unset,
+	// we'll only reconcile when the ClusterDeployment changes.
+	ClusterVersionPollInterval string `json:"clusterVersionPollInterval,omitempty"`
+
 	// MaintenanceMode can be set to true to disable the hive controllers in situations where we need to ensure
 	// nothing is running that will add or act upon finalizers on Hive types. This should rarely be needed.
 	// Sets replicas to 0 for the hive-controllers deployment to accomplish this.


### PR DESCRIPTION
Add HiveConfig.Spec.ClusterVersionPollInterval, a time.Duration value which (plus random jitter of 0-1s) will be used to requeue ClusterDeployments for the clusterversion controller, which is responsible for setting `hive.openshift.io/version*` labels on ClusterDeployment objects based on the ClusterVersion object on the spoke.

If unset or zero, this is disabled, resulting in the legacy behavior: we will reconcile on controller startup, ClusterDeployment changes, or (I think) the default controller-runtime interval of 1000s.

[HIVE-2619](https://issues.redhat.com//browse/HIVE-2619)