### PR TITLE
No-op revendor installer

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -11,7 +11,7 @@ require (
 	// !WARNING! We intend this to pull in *only* pkg/types. Bringing in anything
 	// else could cause a dependency explosion, which we must avoid in this apis/
 	// package for the sake of our downstream consumers.
-	github.com/openshift/installer v0.9.0-master.0.20240912103450-dcf8320c8c4e
+	github.com/openshift/installer v0.90.101-0.20240912203725-dfd4c085a721
 	k8s.io/api v0.31.0-alpha.2
 	k8s.io/apimachinery v0.31.0-alpha.2
 )

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -124,8 +124,8 @@ github.com/openshift/api v0.0.0-20240809035623-d6942fb7294e h1:gEw+Gxu4r3g9WAYOI
 github.com/openshift/api v0.0.0-20240809035623-d6942fb7294e/go.mod h1:OOh6Qopf21pSzqNVCB5gomomBXb8o5sGKZxG2KNpaXM=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87 h1:cHyxR+Y8rAMT6m1jQCaYGRwikqahI0OjjUDhFNf3ySQ=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
-github.com/openshift/installer v0.9.0-master.0.20240912103450-dcf8320c8c4e h1:U3L33gBLBNaQvefq/S/8KyfCa3sDV6LtJO1rxRabSBI=
-github.com/openshift/installer v0.9.0-master.0.20240912103450-dcf8320c8c4e/go.mod h1:PSL94uUGGsuOvuqfQ4wv9I4reGGiQk1PajnfU7N71Xo=
+github.com/openshift/installer v0.90.101-0.20240912203725-dfd4c085a721 h1:R7PJ171uREaK1dXIPSIaFDWMBDKWcTzt4o5VbPAD5Ao=
+github.com/openshift/installer v0.90.101-0.20240912203725-dfd4c085a721/go.mod h1:PSL94uUGGsuOvuqfQ4wv9I4reGGiQk1PajnfU7N71Xo=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=

--- a/apis/vendor/modules.txt
+++ b/apis/vendor/modules.txt
@@ -27,7 +27,7 @@ github.com/openshift/api/config/v1
 # github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
 ## explicit; go 1.12
 github.com/openshift/custom-resource-status/conditions/v1
-# github.com/openshift/installer v0.9.0-master.0.20240912103450-dcf8320c8c4e
+# github.com/openshift/installer v0.90.101-0.20240912203725-dfd4c085a721
 ## explicit; go 1.22.0
 github.com/openshift/installer/pkg/types/gcp
 # github.com/x448/float16 v0.8.4

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
 	github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b298f
 	github.com/openshift/hive/apis v0.0.0
-	github.com/openshift/installer v0.9.0-master.0.20240912103450-dcf8320c8c4e
+	github.com/openshift/installer v0.90.101-0.20240912203725-dfd4c085a721
 	github.com/openshift/library-go v0.0.0-20240715191351-e0aa70d55678
 	github.com/openshift/machine-api-operator v0.2.1-0.20240722145313-3a817c78946a
 	github.com/openshift/machine-api-provider-gcp v0.0.1-0.20231014045125-6096cc86f3ba

--- a/go.sum
+++ b/go.sum
@@ -1822,8 +1822,8 @@ github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b298f h1:LzKRLvLJkWW4+4KsuvMmXJQ81ZZJSm2xxu6jwtn5gN0=
 github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b298f/go.mod h1:/CLsleDcQ6AFTGKJe9VL3Y4rB9DqX3fQwQv47q2/ZJc=
-github.com/openshift/installer v0.9.0-master.0.20240912103450-dcf8320c8c4e h1:U3L33gBLBNaQvefq/S/8KyfCa3sDV6LtJO1rxRabSBI=
-github.com/openshift/installer v0.9.0-master.0.20240912103450-dcf8320c8c4e/go.mod h1:PSL94uUGGsuOvuqfQ4wv9I4reGGiQk1PajnfU7N71Xo=
+github.com/openshift/installer v0.90.101-0.20240912203725-dfd4c085a721 h1:R7PJ171uREaK1dXIPSIaFDWMBDKWcTzt4o5VbPAD5Ao=
+github.com/openshift/installer v0.90.101-0.20240912203725-dfd4c085a721/go.mod h1:PSL94uUGGsuOvuqfQ4wv9I4reGGiQk1PajnfU7N71Xo=
 github.com/openshift/library-go v0.0.0-20210811133500-5e31383de2a7/go.mod h1:3GagmGg6gikg+hAqma7E7axBzs2pjx4+GrAbdl4OYdY=
 github.com/openshift/library-go v0.0.0-20240715191351-e0aa70d55678 h1:H08EzrqjY63m1jlZ+D4sTy9fSGlHsPwViyxFrWTIh4A=
 github.com/openshift/library-go v0.0.0-20240715191351-e0aa70d55678/go.mod h1:PdASVamWinll2BPxiUpXajTwZxV8A1pQbWEsCN1od7I=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1468,7 +1468,7 @@ github.com/openshift/hive/apis/hive/v1/vsphere
 github.com/openshift/hive/apis/hivecontracts/v1alpha1
 github.com/openshift/hive/apis/hiveinternal/v1alpha1
 github.com/openshift/hive/apis/scheme
-# github.com/openshift/installer v0.9.0-master.0.20240912103450-dcf8320c8c4e
+# github.com/openshift/installer v0.90.101-0.20240912203725-dfd4c085a721
 ## explicit; go 1.22.0
 github.com/openshift/installer/data
 github.com/openshift/installer/pkg/asset


### PR DESCRIPTION
This is a special revendor.

A prior commit (https://github.com/openshift/hive/pull/2460 / https://github.com/2uasimojo/hive/commit/c7581516b99535b743844d12fa574828d5ea53b7) included installer as a dependency in our apis/ package for the first time. This was causing problems for downstream consumers seemingly because the pseudo-version generated by `go mod`  represented a years-old tag with a recent commit, resulting in excessive churn in the go sum database -- see the referenced bug report.

Now a tag has been created at that commit to make this pseudo-version less gappy, hopefully eliminating this problem for downstreams.

However, when I tried to revendor to that tag, go replaced it with a pseudo-version... and then complained that we shouldn't use a pseudo-version when there's a tag available!! (Shakes fist.)

So this commit revendors to the *next* commit, which should mean that a pseudo-version is the only way to reference it. The delta on that commit is null for vendoring purposes (the changed file is not one that makes its way into the vendor/ directory) so this is just a bump of pseudo-versions.

OCPBUGS-42448

[HIVE-2512](https://issues.redhat.com//browse/HIVE-2512)