### PR TITLE
No-op revendor installer

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -11,7 +11,7 @@ require (
 	// !WARNING! We intend this to pull in *only* pkg/types. Bringing in anything
 	// else could cause a dependency explosion, which we must avoid in this apis/
 	// package for the sake of our downstream consumers.
-	github.com/openshift/installer v0.9.0-master.0.20240405164943-304af6735c65
+	github.com/openshift/installer v0.90.100-0.20240406213052-b5ed3cde2669
 	k8s.io/api v0.29.2
 	k8s.io/apimachinery v0.29.2
 )

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -122,8 +122,8 @@ github.com/openshift/api v0.0.0-20240301093301-ce10821dc999 h1:+S998xHiJApsJZjRA
 github.com/openshift/api v0.0.0-20240301093301-ce10821dc999/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87 h1:cHyxR+Y8rAMT6m1jQCaYGRwikqahI0OjjUDhFNf3ySQ=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
-github.com/openshift/installer v0.9.0-master.0.20240405164943-304af6735c65 h1:Kfj+y+YE0EMOPpd7PkcUb9JXoApSf1qU0dNvdjfa7Pk=
-github.com/openshift/installer v0.9.0-master.0.20240405164943-304af6735c65/go.mod h1:P4jkk+gG3ovxgYlMZCiJDZ0fOX/iGXsAJj0PxF+yoA4=
+github.com/openshift/installer v0.90.100-0.20240406213052-b5ed3cde2669 h1:VXiISlziAlbrBQVRBrghL7nsGSNQiMY3tABnaEMhN4c=
+github.com/openshift/installer v0.90.100-0.20240406213052-b5ed3cde2669/go.mod h1:P4jkk+gG3ovxgYlMZCiJDZ0fOX/iGXsAJj0PxF+yoA4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=

--- a/apis/vendor/modules.txt
+++ b/apis/vendor/modules.txt
@@ -24,7 +24,7 @@ github.com/openshift/api/config/v1
 # github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
 ## explicit; go 1.12
 github.com/openshift/custom-resource-status/conditions/v1
-# github.com/openshift/installer v0.9.0-master.0.20240405164943-304af6735c65
+# github.com/openshift/installer v0.90.100-0.20240406213052-b5ed3cde2669
 ## explicit; go 1.21
 github.com/openshift/installer/pkg/types/gcp
 # golang.org/x/net v0.26.0

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
 	github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b298f
 	github.com/openshift/hive/apis v0.0.0
-	github.com/openshift/installer v0.9.0-master.0.20240405164943-304af6735c65
+	github.com/openshift/installer v0.90.100-0.20240406213052-b5ed3cde2669
 	github.com/openshift/library-go v0.0.0-20240207105404-126b47137408
 	github.com/openshift/machine-api-operator v0.2.1-0.20230929171041-2cc7fcf262f3
 	github.com/openshift/machine-api-provider-gcp v0.0.1-0.20231014045125-6096cc86f3ba

--- a/go.sum
+++ b/go.sum
@@ -1754,8 +1754,8 @@ github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b298f h1:LzKRLvLJkWW4+4KsuvMmXJQ81ZZJSm2xxu6jwtn5gN0=
 github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b298f/go.mod h1:/CLsleDcQ6AFTGKJe9VL3Y4rB9DqX3fQwQv47q2/ZJc=
-github.com/openshift/installer v0.9.0-master.0.20240405164943-304af6735c65 h1:Kfj+y+YE0EMOPpd7PkcUb9JXoApSf1qU0dNvdjfa7Pk=
-github.com/openshift/installer v0.9.0-master.0.20240405164943-304af6735c65/go.mod h1:P4jkk+gG3ovxgYlMZCiJDZ0fOX/iGXsAJj0PxF+yoA4=
+github.com/openshift/installer v0.90.100-0.20240406213052-b5ed3cde2669 h1:VXiISlziAlbrBQVRBrghL7nsGSNQiMY3tABnaEMhN4c=
+github.com/openshift/installer v0.90.100-0.20240406213052-b5ed3cde2669/go.mod h1:P4jkk+gG3ovxgYlMZCiJDZ0fOX/iGXsAJj0PxF+yoA4=
 github.com/openshift/library-go v0.0.0-20210811133500-5e31383de2a7/go.mod h1:3GagmGg6gikg+hAqma7E7axBzs2pjx4+GrAbdl4OYdY=
 github.com/openshift/library-go v0.0.0-20240207105404-126b47137408 h1:Evg6GEvEuyj9toFX14YenXI6hGRnhLWqYx/rHO7VnQ4=
 github.com/openshift/library-go v0.0.0-20240207105404-126b47137408/go.mod h1:ePlaOqUiPplRc++6aYdMe+2FmXb2xTNS9Nz5laG2YmI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -9283,7 +9283,7 @@ github.com/openshift/hive/apis/hive/v1/vsphere
 github.com/openshift/hive/apis/hivecontracts/v1alpha1
 github.com/openshift/hive/apis/hiveinternal/v1alpha1
 github.com/openshift/hive/apis/scheme
-# github.com/openshift/installer v0.9.0-master.0.20240405164943-304af6735c65
+# github.com/openshift/installer v0.90.100-0.20240406213052-b5ed3cde2669
 ## explicit; go 1.21
 github.com/openshift/installer/data
 github.com/openshift/installer/pkg/asset


### PR DESCRIPTION
This is a special revendor.

A prior commit (#2463 / d8ebe585) included installer as a dependency in our apis/ package for the first time. This was causing problems for downstream consumers seemingly because the pseudo-version generated by `go mod` represented a years-old tag with a recent commit, resulting in excessive churn in the go sum database -- see the referenced bug report.

Now a tag has been created at that commit to make this pseudo-version less gappy, hopefully eliminating this problem for downstreams.

So this commit revendors to that tag, which computes to the same commit, so there is no actual change in vendoring -- only to go module metadata.

OCPBUGS-42448

[HIVE-2512](https://issues.redhat.com//browse/HIVE-2512)