### PR TITLE
modcheck -f phase 1: fix `require`s

### DIFF
--- a/hack/modcheck.go
+++ b/hack/modcheck.go
@@ -7,16 +7,64 @@ import (
 	"golang.org/x/mod/modfile"
 )
 
+const (
+	rootpath = "go.mod"
+	apispath = "apis/go.mod"
+)
+
+// TODO: un-global
+var doFix bool
+
 func main() {
-	rootgmf := readGoMod("go.mod")
-	apisgmf := readGoMod("apis/go.mod")
-	insync := true
-	insync = cmp1("require", mapRequire(rootgmf.Require), mapRequire(apisgmf.Require)) && insync
-	insync = cmp1("exclude", mapExclude(rootgmf.Exclude), mapExclude(apisgmf.Exclude)) && insync
-	insync = cmp2("replace", mapReplace(rootgmf.Replace), mapReplace(apisgmf.Replace)) && insync
+	// TODO: Actual arg parsing
+	if len(os.Args) > 1 && os.Args[1] == "-f" {
+		doFix = true
+	}
+	rootgmf := readGoMod(rootpath)
+	apisgmf := readGoMod(apispath)
+	needWrite := false
+	insync, err := processRequire(*apisgmf, mapRequire(rootgmf.Require), mapRequire(apisgmf.Require))
+	if err != nil {
+		// processRequire() printed the error
+		os.Exit(2)
+	}
+	if doFix && !insync {
+		needWrite = true
+		// *Now* the files are in sync. This informs the exit code, which should be "success"
+		// if we fully fixed the file. (May still be "failure" if other mismatches are found.)
+		insync = true
+	}
+
+	// TODO: Make these respond to doFix
+	insync = cmpExclude(mapExclude(rootgmf.Exclude), mapExclude(apisgmf.Exclude)) && insync
+	insync = cmpReplace(mapReplace(rootgmf.Replace), mapReplace(apisgmf.Replace)) && insync
+
+	if needWrite {
+		fmt.Printf("Writing modified %s\n", apispath)
+		apisgmf.Cleanup()
+		b, err := apisgmf.Format()
+		if err != nil {
+			fmt.Printf("Couldn't format modified %s: %s\n", apispath, err)
+			os.Exit(2)
+		}
+		if err = os.WriteFile(apispath, b, 0); err != nil {
+			fmt.Printf("Failed to write modified %s: %s\n", apispath, err)
+			os.Exit(2)
+		}
+		fmt.Printf("\tDone\n")
+	}
+
 	if insync {
+		fmt.Printf("%s is in sync\n", apispath)
+		if needWrite {
+			fmt.Printf("\t(after fixing)\n")
+		}
 		os.Exit(0)
 	} else {
+		fmt.Printf("\n%s is out of sync\n", apispath)
+		if needWrite {
+			fmt.Printf("\t(despite partial fixing)\n")
+		}
 		os.Exit(1)
 	}
 }
@@ -85,7 +133,9 @@ func mapReplace(theList []*modfile.Replace) map[string]replacement {
 	return ret
 }
 
-func cmp1(category string, root, apis map[string]string) bool {
+func processRequire(apisfile modfile.File, root, apis map[string]string) (bool, error) {
+	// insync indicates whether the require versions were in sync *to start*. I.e. if fixing,
+	// false indicates that we fixed something (so the files are *now* in sync, pending write).
 	insync := true
 	for path, rootver := range root {
 		apisver, ok := apis[path]
@@ -98,14 +148,45 @@ func cmp1(category string, root, apis map[string]string) bool {
 			// For a future "verbose mode":
 			// fmt.Printf("\tOK %s %s\n", path, rootver)
 		} else {
-			fmt.Printf("XX %s %s: root(%s) apis(%s)\n", category, path, rootver, apisver)
+			fmt.Printf("XX require %s: root(%s) apis(%s)\n", path, rootver, apisver)
+			insync = false
+			if doFix {
+				if err := apisfile.DropRequire(path); err != nil {
+					fmt.Printf("Error dropping requirement for %s: %s\n", path, err)
+					return false, err
+				}
+				if err := apisfile.AddRequire(path, rootver); err != nil {
+					fmt.Printf("Error adding requirement for %s: %s\n", path, err)
+					return false, err
+				}
+				fmt.Printf("\tFixed\n")
+			}
+		}
+	}
+	return insync, nil
+}
+
+func cmpExclude(root, apis map[string]string) bool {
+	insync := true
+	for path, rootver := range root {
+		apisver, ok := apis[path]
+		if !ok {
+			// For a future "verbose mode":
+			// fmt.Printf("\t(path in root but not apis: %s)\n", path)
+			continue
+		}
+		if rootver == apisver {
+			// For a future "verbose mode":
+			// fmt.Printf("\tOK %s %s\n", path, rootver)
+		} else {
+			fmt.Printf("XX exclude %s: root(%s) apis(%s)\n", path, rootver, apisver)
 			insync = false
 		}
 	}
 	return insync
 }
 
-func cmp2(category string, root, apis map[string]replacement) bool {
+func cmpReplace(root, apis map[string]replacement) bool {
 	insync := true
 	for path, rootrepl := range root {
 		apisrepl, ok := apis[path]
@@ -118,7 +199,7 @@ func cmp2(category string, root, apis map[string]replacement) bool {
 			// For a future "verbose mode":
 			// fmt.Printf("\tOK %s %s\n", path, rootrepl)
 		} else {
-			fmt.Printf("XX %s %s: root(%s) apis(%s)\n", category, path, rootrepl, apisrepl)
+			fmt.Printf("XX replace %s: root(%s) apis(%s)\n", path, rootrepl, apisrepl)
 			insync = false
 		}
 	}


### PR DESCRIPTION
Our modcheck tool looks at the go.mod files in the repository root and the apis/ directory, and fails if any entries in the latter exist in the former at a different version. Heretofore, such failures would have to be addressed by manually updating the apis/go.mod to sync those versions.

With this change, we add a `-f` flag which asks modcheck to `f`ix discrepancies it encounters.

In this first phase, we add the ability for modcheck to fix `require` entries, as these are by far the most common discrepancies we encounter.

*Further work is required to make the tool fix `exclude` and `replace` entries.*

The tool will succeed (exit zero) if the files are in sync when it completes -- whether because they started that way, or because it fixed everything it encountered.

The tool will fail (exit nonzero) if it encounters a processing error; or if the files are out of sync when it completes -- even if *partially* fixed.

Put another way: barring errors, the exit code is the same as if modcheck were run again without `-f`.

[HIVE-2624](https://issues.redhat.com//browse/HIVE-2624)