### PR TITLE
controller-gen: use vendor/, not build-machinery-go

### DIFF
--- a/config/crds/hive.openshift.io_checkpoints.yaml
+++ b/config/crds/hive.openshift.io_checkpoints.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: checkpoints.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_clusterclaims.yaml
+++ b/config/crds/hive.openshift.io_clusterclaims.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: clusterclaims.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_clusterdeploymentcustomizations.yaml
+++ b/config/crds/hive.openshift.io_clusterdeploymentcustomizations.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: clusterdeploymentcustomizations.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: clusterdeployments.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_clusterdeprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterdeprovisions.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: clusterdeprovisions.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_clusterimagesets.yaml
+++ b/config/crds/hive.openshift.io_clusterimagesets.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: clusterimagesets.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: clusterpools.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_clusterprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterprovisions.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     contracts.hive.openshift.io/clusterinstall: "false"
   name: clusterprovisions.hive.openshift.io
@@ -118,6 +117,7 @@ spec:
                   We think because the thing it''s storing (ClusterMetadata from installer)
                   is not a runtime.Object, so can''t be put in a RawExtension.'
                 type: object
+                x-kubernetes-preserve-unknown-fields: true
               metadataJSON:
                 description: MetadataJSON is a JSON representation of the ClusterMetadata
                   produced by the installer. We don't use a runtime.RawExtension because

--- a/config/crds/hive.openshift.io_clusterrelocates.yaml
+++ b/config/crds/hive.openshift.io_clusterrelocates.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: clusterrelocates.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_clusterstates.yaml
+++ b/config/crds/hive.openshift.io_clusterstates.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: clusterstates.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_dnszones.yaml
+++ b/config/crds/hive.openshift.io_dnszones.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: dnszones.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: hiveconfigs.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_machinepoolnameleases.yaml
+++ b/config/crds/hive.openshift.io_machinepoolnameleases.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: machinepoolnameleases.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: machinepools.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_selectorsyncidentityproviders.yaml
+++ b/config/crds/hive.openshift.io_selectorsyncidentityproviders.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: selectorsyncidentityproviders.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_selectorsyncsets.yaml
+++ b/config/crds/hive.openshift.io_selectorsyncsets.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: selectorsyncsets.hive.openshift.io
 spec:
   group: hive.openshift.io
@@ -160,8 +159,8 @@ spec:
                   definitions.
                 items:
                   type: object
-                  x-kubernetes-embedded-resource: true
                   x-kubernetes-preserve-unknown-fields: true
+                  x-kubernetes-embedded-resource: true
                 type: array
               secretMappings:
                 description: Secrets is the list of secrets to sync along with their

--- a/config/crds/hive.openshift.io_syncidentityproviders.yaml
+++ b/config/crds/hive.openshift.io_syncidentityproviders.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: syncidentityproviders.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_syncsets.yaml
+++ b/config/crds/hive.openshift.io_syncsets.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: syncsets.hive.openshift.io
 spec:
   group: hive.openshift.io
@@ -133,8 +132,8 @@ spec:
                   definitions.
                 items:
                   type: object
-                  x-kubernetes-embedded-resource: true
                   x-kubernetes-preserve-unknown-fields: true
+                  x-kubernetes-embedded-resource: true
                 type: array
               secretMappings:
                 description: Secrets is the list of secrets to sync along with their

--- a/config/crds/hiveinternal.openshift.io_clustersyncleases.yaml
+++ b/config/crds/hiveinternal.openshift.io_clustersyncleases.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: clustersyncleases.hiveinternal.openshift.io
 spec:
   group: hiveinternal.openshift.io

--- a/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
+++ b/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: clustersyncs.hiveinternal.openshift.io
 spec:
   group: hiveinternal.openshift.io

--- a/config/crds/hiveinternal.openshift.io_fakeclusterinstalls.yaml
+++ b/config/crds/hiveinternal.openshift.io_fakeclusterinstalls.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.13.0
   labels:
     contracts.hive.openshift.io/clusterinstall: "true"
   name: fakeclusterinstalls.hiveinternal.openshift.io
@@ -42,6 +41,7 @@ spec:
                   associated with this AgentClusterInstall.
                 properties:
                   name:
+                    default: ""
                     description: 'Name of the referent. This field is effectively
                       required, but due to backwards compatibility is allowed to be
                       empty. Instances of this type with an empty value here are almost
@@ -51,6 +51,7 @@ spec:
                       need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.'
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               clusterMetadata:
                 description: ClusterMetadata contains metadata information about the
                   installed cluster. It should be populated once the cluster install

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -7,8 +7,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: checkpoints.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -79,8 +78,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: clusterclaims.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -244,8 +242,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: clusterdeploymentcustomizations.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -388,8 +385,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: clusterdeployments.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -1857,8 +1853,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: clusterdeprovisions.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -2260,8 +2255,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: clusterimagesets.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -2318,8 +2312,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: clusterpools.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -3266,8 +3259,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     labels:
       contracts.hive.openshift.io/clusterinstall: 'false'
     name: clusterprovisions.hive.openshift.io
@@ -3385,6 +3377,7 @@ objects:
                     We think because the thing it''s storing (ClusterMetadata from
                     installer) is not a runtime.Object, so can''t be put in a RawExtension.'
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 metadataJSON:
                   description: MetadataJSON is a JSON representation of the ClusterMetadata
                     produced by the installer. We don't use a runtime.RawExtension
@@ -3480,8 +3473,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: clusterrelocates.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -3597,8 +3589,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: clusterstates.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -3698,8 +3689,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: clustersyncleases.hiveinternal.openshift.io
   spec:
     group: hiveinternal.openshift.io
@@ -3749,8 +3739,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: clustersyncs.hiveinternal.openshift.io
   spec:
     group: hiveinternal.openshift.io
@@ -4002,8 +3991,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: dnszones.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -4260,8 +4248,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     labels:
       contracts.hive.openshift.io/clusterinstall: 'true'
     name: fakeclusterinstalls.hiveinternal.openshift.io
@@ -4302,6 +4289,7 @@ objects:
                     associated with this AgentClusterInstall.
                   properties:
                     name:
+                      default: ''
                       description: 'Name of the referent. This field is effectively
                         required, but due to backwards compatibility is allowed to
                         be empty. Instances of this type with an empty value here
@@ -4311,6 +4299,7 @@ objects:
                         need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.'
                       type: string
                   type: object
+                  x-kubernetes-map-type: atomic
                 clusterMetadata:
                   description: ClusterMetadata contains metadata information about
                     the installed cluster. It should be populated once the cluster
@@ -4465,8 +4454,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: hiveconfigs.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -5546,8 +5534,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: machinepoolnameleases.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -5606,8 +5593,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: machinepools.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -6423,8 +6409,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: selectorsyncidentityproviders.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -7087,8 +7072,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: selectorsyncsets.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -7307,8 +7291,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: syncidentityproviders.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -7945,8 +7928,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.13.0
     name: syncsets.hive.openshift.io
   spec:
     group: hive.openshift.io


### PR DESCRIPTION
The build-machinery-go project is suffering from bit rot, which is making it difficult to upgrade the version of controller-gen we use to generate CRDs, which we're going to need to do in order to upgrade k8s dependencies (see [HIVE-2616](https://issues.redhat.com//browse/HIVE-2616)).

With this change, we stop using the piece of build-machinery-go that deals with controller-gen, and instead install it directly from our vendor directory.

[HIVE-2626](https://issues.redhat.com//browse/HIVE-2626)