### PR TITLE
Revendor cluster-control-plane-machine-set-operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -418,7 +418,7 @@ require (
 	github.com/microsoftgraph/msgraph-sdk-go-core v0.34.1 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20240311123436-a58712e5c221
+	github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20240417192557-2b86969aeeee
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/quasilyte/gogrep v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1816,8 +1816,8 @@ github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20220323121149-e3f2850d
 github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20220323121149-e3f2850dd519/go.mod h1:C7unCUThP8eqT4xQfbvg3oIDn2S9TYtb0wbBoH/SR2U=
 github.com/openshift/cluster-autoscaler-operator v0.0.0-20211006175002-fe524080b551 h1:nGa6igwzG7smZOACUsovgf9XG8vT96Zdyc4H6r2rqS0=
 github.com/openshift/cluster-autoscaler-operator v0.0.0-20211006175002-fe524080b551/go.mod h1:72ieWchfTx9U7UbQO47vhSXBoCi2IJGZhXoCezan4EM=
-github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20240311123436-a58712e5c221 h1:MeWBjqH/e9ULu6Myaka/5lLDqxr2YJvXtxJpBjrfcT0=
-github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20240311123436-a58712e5c221/go.mod h1:fWDEaNFwshqjvE9irbMYjg5pBI+HS2TnWQGpoI/ARto=
+github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20240417192557-2b86969aeeee h1:golYbp3OK7U6XcsDhkjheQ55o3XjJRt6HPpVzN5F6Pg=
+github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20240417192557-2b86969aeeee/go.mod h1:fWDEaNFwshqjvE9irbMYjg5pBI+HS2TnWQGpoI/ARto=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87 h1:cHyxR+Y8rAMT6m1jQCaYGRwikqahI0OjjUDhFNf3ySQ=
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/openshift/generic-admission-server v1.14.1-0.20231020105858-8dcc3c9b298f h1:LzKRLvLJkWW4+4KsuvMmXJQ81ZZJSm2xxu6jwtn5gN0=

--- a/vendor/github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere.go
+++ b/vendor/github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig/vsphere.go
@@ -163,6 +163,11 @@ func (v VSphereProviderConfig) ExtractFailureDomain() machinev1.VSphereFailureDo
 		return machinev1.VSphereFailureDomain{}
 	}
 
+	// Older OCP installs will not have PlatformSpec set for infrastructure.
+	if v.infrastructure.Spec.PlatformSpec.VSphere == nil {
+		return machinev1.VSphereFailureDomain{}
+	}
+
 	failureDomains := v.infrastructure.Spec.PlatformSpec.VSphere.FailureDomains
 
 	for _, failureDomain := range failureDomains {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1435,7 +1435,7 @@ github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1
 ## explicit; go 1.16
 github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1
 github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1beta1
-# github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20240311123436-a58712e5c221
+# github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20240417192557-2b86969aeeee
 ## explicit; go 1.21
 github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1/failuredomain
 github.com/openshift/cluster-control-plane-machine-set-operator/pkg/machineproviders/providers/openshift/machine/v1beta1/providerconfig


### PR DESCRIPTION
...to pick up OCPBUGS-31808 /
https://github.com/openshift/cluster-control-plane-machine-set-operator/pull/287 which resolves a nil pointer exception referencing fields under Infrastructure.Spec.PlatformSpec, which apparently is not always present (on VSphere).

[HIVE-2627](https://issues.redhat.com//browse/HIVE-2627)