### PR TITLE
OCPBUGS-42740: PrivateLink Actuators should return errors on failure.

### DIFF
--- a/pkg/controller/privatelink/actuator/gcpactuator/gcplinkactuator.go
+++ b/pkg/controller/privatelink/actuator/gcpactuator/gcplinkactuator.go
@@ -166,11 +166,8 @@ func (a *GCPLinkActuator) Reconcile(cd *hivev1.ClusterDeployment, metadata *hive
 		logger.Debug("reconciling Service Attachment Subnet")
 		subnetModified, newSubnet, err := a.ensureServiceAttachmentSubnet(cd, metadata, network)
 		if err != nil {
-			logger.WithError(err).Error("failed to reconcile the Service Attachment Subnet")
-
-			err := conditions.SetErrConditionWithRetry(*a.client, cd, "ServiceAttachmentSubnetReconcileFailed", errors.New(controllerutils.ErrorScrub(err)), logger)
-			if err != nil {
-				return reconcile.Result{}, errors.Wrap(err, "failed to update condition on cluster deployment")
+			if err := conditions.SetErrConditionWithRetry(*a.client, cd, "ServiceAttachmentSubnetReconcileFailed", errors.New(controllerutils.ErrorScrub(err)), logger); err != nil {
+				logger.WithError(err).Error("failed to update condition on cluster deployment")
 			}
 			return reconcile.Result{}, errors.Wrap(err, "failed to reconcile the Service Attachment Subnet")
 		}
@@ -188,11 +185,8 @@ func (a *GCPLinkActuator) Reconcile(cd *hivev1.ClusterDeployment, metadata *hive
 		logger.Debug("reconciling Service Attachment Firewall")
 		firewallModified, _, err := a.ensureServiceAttachmentFirewall(cd, metadata, network)
 		if err != nil {
-			logger.WithError(err).Error("failed to reconcile the Service Attachment Firewall")
-
-			err := conditions.SetErrConditionWithRetry(*a.client, cd, "ServiceAttachmentFirewallReconcileFailed", errors.New(controllerutils.ErrorScrub(err)), logger)
-			if err != nil {
-				return reconcile.Result{}, errors.Wrap(err, "failed to update condition on cluster deployment")
+			if err := conditions.SetErrConditionWithRetry(*a.client, cd, "ServiceAttachmentFirewallReconcileFailed", errors.New(controllerutils.ErrorScrub(err)), logger); err != nil {
+				logger.WithError(err).Error("failed to update condition on cluster deployment")
 			}
 			return reconcile.Result{}, errors.Wrap(err, "failed to reconcile the Service Attachment Firwall")
 		}
@@ -210,11 +204,8 @@ func (a *GCPLinkActuator) Reconcile(cd *hivev1.ClusterDeployment, metadata *hive
 	logger.Debug("reconciling Service Attachment")
 	serviceAttachmentModified, serviceAttachment, err := a.ensureServiceAttachment(cd, metadata, forwardingRule, subnet)
 	if err != nil {
-		logger.WithError(err).Error("failed to reconcile the Service Attachment")
-
-		err := conditions.SetErrConditionWithRetry(*a.client, cd, "ServiceAttachmentReconcileFailed", errors.New(controllerutils.ErrorScrub(err)), logger)
-		if err != nil {
-			return reconcile.Result{}, errors.Wrap(err, "failed to update condition on cluster deployment")
+		if err := conditions.SetErrConditionWithRetry(*a.client, cd, "ServiceAttachmentReconcileFailed", errors.New(controllerutils.ErrorScrub(err)), logger); err != nil {
+			logger.WithError(err).Error("failed to update condition on cluster deployment")
 		}
 		return reconcile.Result{}, errors.Wrap(err, "failed to reconcile the Service Attachment")
 	}
@@ -231,11 +222,8 @@ func (a *GCPLinkActuator) Reconcile(cd *hivev1.ClusterDeployment, metadata *hive
 	logger.Debug("reconciling Endpoint Address")
 	addressModified, ipAddress, err := a.ensureEndpointAddress(cd, metadata, endpointSubnet)
 	if err != nil {
-		logger.WithError(err).Error("failed to reconcile the Endpoint Address")
-
-		err := conditions.SetErrConditionWithRetry(*a.client, cd, "EndpointAddressReconcileFailed", errors.New(controllerutils.ErrorScrub(err)), logger)
-		if err != nil {
-			return reconcile.Result{}, errors.Wrap(err, "failed to update condition on cluster deployment")
+		if err := conditions.SetErrConditionWithRetry(*a.client, cd, "EndpointAddressReconcileFailed", errors.New(controllerutils.ErrorScrub(err)), logger); err != nil {
+			logger.WithError(err).Error("failed to update condition on cluster deployment")
 		}
 		return reconcile.Result{}, errors.Wrap(err, "failed to reconcile the Endpoint Address")
 	}
@@ -252,11 +240,8 @@ func (a *GCPLinkActuator) Reconcile(cd *hivev1.ClusterDeployment, metadata *hive
 	logger.Debug("reconciling Endpoint")
 	endpointModified, endpoint, err := a.ensureEndpoint(cd, metadata, ipAddress.SelfLink, ipAddress.Subnetwork, serviceAttachment.SelfLink)
 	if err != nil {
-		logger.WithError(err).Error("failed to reconcile the Endpoint")
-
-		err := conditions.SetErrConditionWithRetry(*a.client, cd, "EndpointReconcileFailed", errors.New(controllerutils.ErrorScrub(err)), logger)
-		if err != nil {
-			return reconcile.Result{}, errors.Wrap(err, "failed to update condition on cluster deployment")
+		if err := conditions.SetErrConditionWithRetry(*a.client, cd, "EndpointReconcileFailed", errors.New(controllerutils.ErrorScrub(err)), logger); err != nil {
+			logger.WithError(err).Error("failed to update condition on cluster deployment")
 		}
 		return reconcile.Result{}, errors.Wrap(err, "failed to reconcile the Endpoint")
 	}


### PR DESCRIPTION
Prior to this change, the GCP Link actuator failed to return an error when a failure was experienced while creating certian cloud resources. This is because the actuators were overriding the value of the err varliabe prior to using it in a following return statement. As a result, the controller would assume the link actuator was successful and continue calling the hub actuator. This caused, the PrivateLinkFailed condidtion would show an error regarding the failed provisioning of DNS resources instead of the underlying issue in the link actuator.

This change fixes the problem by placing the secondary assignment of the err variable into the corrisponding if block, thereby maintaining the origional value of the variable. This causes the final return to act as expected by condition of the origional error. It also ensures the origional error is always returned while logging any condition status update errorrs inline.

https://issues.redhat.com/browse/OCPBUGS-42740