### PR TITLE
MachinePool: Generated MachineLabels are not "owned"

### DIFF
--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -364,7 +364,7 @@ func (r *ReconcileMachinePool) reconcile(pool *hivev1.MachinePool, cd *hivev1.Cl
 		return reconcile.Result{}, err
 	}
 
-	generatedMachineSets, proceed, err := r.generateMachineSets(pool, cd, masterMachine, remoteMachineSets, logger)
+	generatedMachineSets, generatedMachineLabels, proceed, err := r.generateMachineSets(pool, cd, masterMachine, remoteMachineSets, logger)
 	if err != nil {
 		logger.WithError(err).Log(controllerutils.LogLevel(err), "could not generateMachineSets")
 		return reconcile.Result{}, err
@@ -399,7 +399,7 @@ func (r *ReconcileMachinePool) reconcile(pool *hivev1.MachinePool, cd *hivev1.Cl
 		return r.removeFinalizer(pool, logger)
 	}
 
-	return r.updatePoolStatusForMachineSets(pool, machineSets, remoteClusterAPIClient, logger)
+	return r.updatePoolStatusForMachineSets(pool, machineSets, generatedMachineLabels, remoteClusterAPIClient, logger)
 }
 
 func (r *ReconcileMachinePool) getInfrastructure(remoteClusterAPIClient client.Client, logger log.FieldLogger) (*configv1.Infrastructure, error) {
@@ -471,25 +471,28 @@ func (r *ReconcileMachinePool) generateMachineSets(
 	masterMachine *machineapi.Machine,
 	remoteMachineSets *machineapi.MachineSetList,
 	logger log.FieldLogger,
-) ([]*machineapi.MachineSet, bool, error) {
+) ([]*machineapi.MachineSet, sets.Set[string], bool, error) {
 	if pool.DeletionTimestamp != nil {
-		return nil, true, nil
+		return nil, nil, true, nil
 	}
 
 	actuator, err := r.actuatorBuilder(cd, pool, masterMachine, remoteMachineSets.Items, logger)
 	if err != nil {
 		logger.WithError(err).Error("unable to create actuator")
-		return nil, false, err
+		return nil, nil, false, err
 	}
 
 	// Generate expected MachineSets for Platform from InstallConfig
 	generatedMachineSets, proceed, err := actuator.GenerateMachineSets(cd, pool, logger)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "could not generate machinesets")
+		return nil, nil, false, errors.Wrap(err, "could not generate machinesets")
 	} else if !proceed {
 		logger.Info("actuator indicated not to proceed, returning")
-		return nil, false, nil
+		return nil, nil, false, nil
 	}
+
+	// HACK: Track generated machine labels so we don't add them to OwnedMachineLabels.
+	generatedMachineLabels := sets.Set[string]{}
 
 	for i, ms := range generatedMachineSets {
 		if pool.Spec.Autoscaling != nil {
@@ -519,21 +522,22 @@ func (r *ReconcileMachinePool) generateMachineSets(
 		if len(ms.Spec.Template.ObjectMeta.Labels) == 0 {
 			// This should never actually happen, as the generators (for all platforms)
 			// add labels and corresponding selectors used by MAPI.
-			ms.Spec.Template.ObjectMeta.Labels = pool.Spec.MachineLabels
-		} else {
-			for k, v := range pool.Spec.MachineLabels {
-				// Don't allow the user to shoot themselves in the foot by overriding generated labels.
-				if _, exists := ms.Spec.Template.ObjectMeta.Labels[k]; exists {
-					continue
-				}
-				ms.Spec.Template.ObjectMeta.Labels[k] = v
+			ms.Spec.Template.ObjectMeta.Labels = map[string]string{}
+		}
+		for k, v := range pool.Spec.MachineLabels {
+			// Don't allow the user to shoot themselves in the foot by overriding generated labels.
+			if _, exists := ms.Spec.Template.ObjectMeta.Labels[k]; exists {
+				logger.WithField("machineLabel", k).Warnf("conflict with generated label -- ignoring")
+				generatedMachineLabels.Insert(k)
+				continue
 			}
+			ms.Spec.Template.ObjectMeta.Labels[k] = v
 		}
 	}
 
 	logger.Infof("generated %v worker machine sets", len(generatedMachineSets))
 
-	return generatedMachineSets, true, nil
+	return generatedMachineSets, generatedMachineLabels, true, nil
 }
 
 // ensureEnoughReplicas ensures that the min replicas in the machine pool is
@@ -1099,6 +1103,7 @@ func (r *ReconcileMachinePool) syncClusterAutoscaler(
 func (r *ReconcileMachinePool) updatePoolStatusForMachineSets(
 	pool *hivev1.MachinePool,
 	machineSets []*machineapi.MachineSet,
+	generatedMachineLabels sets.Set[string],
 	remoteClusterAPIClient client.Client,
 	logger log.FieldLogger,
 ) (reconcile.Result, error) {
@@ -1144,7 +1149,7 @@ func (r *ReconcileMachinePool) updatePoolStatusForMachineSets(
 		}
 	}
 
-	pool.Status = updateOwnedLabelsAndTaints(pool)
+	pool.Status = updateOwnedLabelsAndTaints(pool, generatedMachineLabels)
 
 	if (len(origPool.Status.MachineSets) == 0 && len(pool.Status.MachineSets) == 0) ||
 		reflect.DeepEqual(origPool.Status, pool.Status) {
@@ -1155,22 +1160,23 @@ func (r *ReconcileMachinePool) updatePoolStatusForMachineSets(
 }
 
 // updateOwnedLabelsAndTaints updates OwnedLabels and OwnedTaints in the MachinePool.Status, by fetching the relevant entries sans duplicates from MachinePool.Spec.
-func updateOwnedLabelsAndTaints(pool *hivev1.MachinePool) hivev1.MachinePoolStatus {
+func updateOwnedLabelsAndTaints(pool *hivev1.MachinePool, generatedMachineLabels sets.Set[string]) hivev1.MachinePoolStatus {
 	// Update our tracked labels...
-	getOwnedLabels := func(labels map[string]string) []string {
-		ownedLabels := make([]string, len(labels))
-		i := 0
+	getOwnedLabels := func(labels map[string]string, excludes sets.Set[string]) []string {
+		ownedLabels := sets.Set[string]{}
 		for labelKey := range labels {
-			ownedLabels[i] = labelKey
-			i++
+			if excludes.Has(labelKey) {
+				continue
+			}
+			ownedLabels.Insert(labelKey)
 		}
-		sort.Strings(ownedLabels)
-		return ownedLabels
+		// sets.List sorts
+		return sets.List(ownedLabels)
 	}
-	pool.Status.OwnedLabels = getOwnedLabels(pool.Spec.Labels)
+	pool.Status.OwnedLabels = getOwnedLabels(pool.Spec.Labels, nil)
 	// NOTE: This only claims "ownership" of user-specified labels. Generated labels
 	// will be asserted regardless.
-	pool.Status.OwnedMachineLabels = getOwnedLabels(pool.Spec.MachineLabels)
+	pool.Status.OwnedMachineLabels = getOwnedLabels(pool.Spec.MachineLabels, generatedMachineLabels)
 
 	// ...and taints
 	uniqueTaints := *controllerutils.GetUniqueTaints(&pool.Spec.Taints)


### PR DESCRIPTION
The machinepool controller tracks labels, machineLabels, and taints in the MachinePool.Status (OwnedLabels, OwnedMachineLabels, OwnedTaints) so that, when the user removes them from the spec, we can idempotently know which ones to remove from the spoke MachineSet. This is to avoid removing any of those things if they were added directly by the user on the spoke rather than through the MachinePool.

Note that, in the case of a conflict (the same key in both the MachinePool and added directly on the spoke), the MachinePool would "win".

However, when MachineLabels were implemented (#2420 / 315aa266) we needed special handling to avoid stomping on *generated* labels -- those produced by the installer code that generates the MachineSet -- because these have special meaning and function to the controllers that manage the MachineSets. Thus, user-specified machineLabels conflicting with generated ones would be ignored -- the resulting MachineSet would retain the generated values.

But there was a bug: we were still adding the keys to OwnedMachineLabels; so if they were subsequently *removed* from MachinePool.Spec.MachineLabels, we would attempt to *remove* them from the MachineSets. This resulted in webhook errors creating the MachineSets, which is good, because otherwise the MachineSets would have been broken in some more subtle way that would be difficult to detect.

With this fix, we start tracking which machineLabels are generated, and avoid adding them to OwnedMachineLabels. So, as originally intended, MachinePool.Spec.MachineLabels whose keys conflict with generated labels are truly ignored.

[HIVE-2320](https://issues.redhat.com//browse/HIVE-2320)