### PR TITLE
Backport all the Dockerfile Makefile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,39 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.20-openshift-4.14 as builder
+ARG CONTAINER_SUB_MANAGER_OFF=0
+ARG EL8_BUILD_IMAGE=registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14
+ARG EL9_BUILD_IMAGE=registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14
+ARG BASE_IMAGE=registry.ci.openshift.org/ocp/4.14:base
+
+FROM ${EL8_BUILD_IMAGE} as builder_rhel8
 RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .
+
+RUN if [ -e "/activation-key/org" ]; then unlink /etc/rhsm-host; subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
+RUN python3 -m ensurepip
 RUN make build
+RUN make build-hiveutil
 
-FROM quay.io/centos/centos:stream
+FROM ${BASE_IMAGE}
+ARG CONTAINER_SUB_MANAGER_OFF
+ENV SMDEV_CONTAINER_OFF=${CONTAINER_SUB_MANAGER_OFF}
 
-ARG DNF=dnf
+RUN if [ -e "/activation-key/org" ]; then unlink /etc/rhsm-host; subscription-manager register --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
 
-RUN $DNF -y update && $DNF clean all
 
+##
 # ssh-agent required for gathering logs in some situations:
-RUN if ! rpm -q openssh-clients; then $DNF install -y openssh-clients && $DNF clean all && rm -rf /var/cache/dnf/*; fi
+RUN if ! rpm -q openssh-clients; then dnf install -y openssh-clients && dnf clean all && rm -rf /var/cache/dnf/*; fi
 
 # libvirt libraries required for running bare metal installer.
-RUN if ! rpm -q libvirt-libs; then $DNF install -y libvirt-libs && $DNF clean all && rm -rf /var/cache/dnf/*; fi
+RUN if ! rpm -q libvirt-libs; then dnf install -y libvirt-libs && dnf clean all && rm -rf /var/cache/dnf/*; fi
 
-COPY --from=builder /go/src/github.com/openshift/hive/bin/manager /opt/services/
-COPY --from=builder /go/src/github.com/openshift/hive/bin/hiveadmission /opt/services/
-COPY --from=builder /go/src/github.com/openshift/hive/bin/hiveutil /usr/bin
-COPY --from=builder /go/src/github.com/openshift/hive/bin/operator /opt/services/hive-operator
+# tar is needed to package must-gathers on install failure
+RUN if ! which tar; then dnf install -y tar && dnf clean all && rm -rf /var/cache/dnf/*; fi
+
+COPY --from=builder_rhel8 /go/src/github.com/openshift/hive/bin/manager /opt/services/
+COPY --from=builder_rhel8 /go/src/github.com/openshift/hive/bin/hiveadmission /opt/services/
+COPY --from=builder_rhel8 /go/src/github.com/openshift/hive/bin/operator /opt/services/hive-operator
+COPY --from=builder_rhel8 /go/src/github.com/openshift/hive/bin/hiveutil /usr/bin/hiveutil
 
 # Hacks to allow writing known_hosts, homedir is / by default in OpenShift.
 # Bare metal installs need to write to $HOME/.cache, and $HOME/.ssh for as long as
@@ -27,20 +41,22 @@ COPY --from=builder /go/src/github.com/openshift/hive/bin/operator /opt/services
 # by default so we must setup some permissions here.
 ENV HOME /home/hive
 RUN mkdir -p /home/hive && \
-    chgrp -R 0 /home/hive && \
-    chmod -R g=u /home/hive
+  chgrp -R 0 /home/hive && \
+  chmod -R g=u /home/hive
 
-# This is so that we can write source certificate anchors during container start up.
 RUN mkdir -p /etc/pki/ca-trust/source/anchors && \
-    chgrp -R 0 /etc/pki/ca-trust/source/anchors && \
-    chmod -R g=u /etc/pki/ca-trust/source/anchors
+  chgrp -R 0 /etc/pki/ca-trust/source/anchors && \
+  chmod -R g=u /etc/pki/ca-trust/source/anchors
 
 # This is so that we can run update-ca-trust during container start up.
 RUN mkdir -p /etc/pki/ca-trust/extracted/openssl && \
-    mkdir -p /etc/pki/ca-trust/extracted/pem && \
-    mkdir -p /etc/pki/ca-trust/extracted/java && \
-    chgrp -R 0 /etc/pki/ca-trust/extracted && \
-    chmod -R g=u /etc/pki/ca-trust/extracted
+  mkdir -p /etc/pki/ca-trust/extracted/pem && \
+  mkdir -p /etc/pki/ca-trust/extracted/java && \
+  chgrp -R 0 /etc/pki/ca-trust/extracted && \
+  chmod -R g=u /etc/pki/ca-trust/extracted
+
+# replace removed symlink when using activation-key
+RUN if [ -e "/activation-key/org" ]; then ln -s /etc/rhsm-host /run/secrets/rhsm ; fi
 
 # TODO: should this be the operator?
 ENTRYPOINT ["/opt/services/manager"]

--- a/Makefile
+++ b/Makefile
@@ -120,10 +120,10 @@ define patch-crd-yq
 endef
 
 CONTROLLER_GEN_SRC := $(shell realpath vendor/sigs.k8s.io/controller-tools/cmd/controller-gen)
-CONTROLLER_GEN := $(shell go list -f '{{.Target}}' $(CONTROLLER_GEN_SRC))
+CONTROLLER_GEN := $(shell go list -f '{{.Target}}-{{.Module.Version}}' $(CONTROLLER_GEN_SRC))
 
 $(CONTROLLER_GEN): $(CONTROLLER_GEN_SRC)
-	go install $(CONTROLLER_GEN_SRC)
+	go build -o $(CONTROLLER_GEN) $(CONTROLLER_GEN_SRC)
 
 # Generate CRD yaml from our api types:
 .PHONY: crd

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ endif
 # Include the library makefile
 include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	golang.mk \
-	targets/openshift/controller-gen.mk \
 	targets/openshift/yq.mk \
 	targets/openshift/bindata.mk \
 	targets/openshift/deps.mk \
@@ -21,6 +20,12 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 
 DOCKER_CMD ?= docker
 CONTAINER_BUILD_FLAGS ?= --file ./Dockerfile
+
+GOCACHE ?= $(shell C=`go env GOCACHE`; [[ -d $$C ]] && echo $$C)
+
+ifneq ($(GOCACHE),)
+GOCACHE_VOL_ARG = --volume "${GOCACHE}:/go/.cache:z"
+endif
 
 # Namespace hive-operator will run:
 HIVE_OPERATOR_NS ?= hive
@@ -35,7 +40,7 @@ LOG_LEVEL ?= debug
 IMG ?= hive-controller:latest
 
 GO_PACKAGES :=./...
-GO_BUILD_PACKAGES :=./cmd/... ./contrib/cmd/hiveutil
+GO_BUILD_PACKAGES :=./cmd/...
 GO_BUILD_BINDIR :=bin
 # Exclude e2e tests from unit testing
 GO_TEST_PACKAGES :=./pkg/... ./cmd/... ./contrib/...
@@ -66,7 +71,7 @@ endif
 # v{major}.{minor}.{commitcount}-{sha}
 # Note that building against a local commit may result in {major}.{minor} being rendered as
 # `UnknownBranch`. However, the {commitcount} and {sha} should still be accurate.
-SOURCE_GIT_TAG := $(shell export HOME=$(HOME); python3 -mpip install --user gitpython >&2; hack/version2.py)
+SOURCE_GIT_TAG := $(shell export HOME=$(HOME); python3 -m ensurepip >&2; python3 -mpip --no-cache install --user gitpython pyyaml >&2; hack/version2.py)
 
 BINDATA_INPUTS :=./config/clustersync/... ./config/hiveadmission/... ./config/controllers/... ./config/rbac/... ./config/configmaps/...
 $(call add-bindata,operator,$(BINDATA_INPUTS),,assets,pkg/operator/assets/bindata.go)
@@ -74,7 +79,6 @@ $(call add-bindata,operator,$(BINDATA_INPUTS),,assets,pkg/operator/assets/bindat
 $(call build-image,hive,$(IMG),./Dockerfile,.)
 $(call build-image,hive-fedora-dev-base,hive-fedora-dev-base,./build/fedora-dev/Dockerfile.devbase,.)
 $(call build-image,hive-fedora-dev,$(IMG),./build/fedora-dev/Dockerfile.dev,.)
-$(call build-image,hive-build,"hive-build:latest",./build/build-image/Dockerfile,.)
 
 clean:
 	rm -rf $(GO_BUILD_BINDIR)
@@ -92,11 +96,6 @@ vendor: vendor-submodules
 $(addprefix vendor-submodules-,$(GO_SUB_MODULES)):
 	# handle tidy for submodules
 	(cd $(subst vendor-submodules-,,$@); go mod tidy && go mod vendor)
-
-.PHONY: verify-vendor
-verify-vendor: vendor
-	git diff --exit-code vendor/
-verify: verify-vendor
 
 # Update the manifest directory of artifacts OLM will deploy. Copies files in from
 # the locations kubebuilder generates them.
@@ -120,11 +119,17 @@ define patch-crd-yq
 
 endef
 
+CONTROLLER_GEN_SRC := $(shell realpath vendor/sigs.k8s.io/controller-tools/cmd/controller-gen)
+CONTROLLER_GEN := $(shell go list -f '{{.Target}}' $(CONTROLLER_GEN_SRC))
+
+$(CONTROLLER_GEN): $(CONTROLLER_GEN_SRC)
+	go install $(CONTROLLER_GEN_SRC)
+
 # Generate CRD yaml from our api types:
 .PHONY: crd
-crd: ensure-controller-gen ensure-yq
+crd: $(CONTROLLER_GEN) ensure-yq
 	rm -rf ./config/crds
-	(cd apis; '../$(CONTROLLER_GEN)' crd:crdVersions=v1 paths=./hive/v1 paths=./hiveinternal/v1alpha1 output:dir=../config/crds)
+	(cd apis; $(CONTROLLER_GEN) crd:crdVersions=v1 paths=./hive/v1 paths=./hiveinternal/v1alpha1 output:dir=../config/crds)
 	@echo Stripping yaml breaks from CRD files
 	$(foreach p,$(wildcard ./config/crds/*.yaml),$(call strip-yaml-break,$(p)))
 	@echo Patching CRD files for additional static information
@@ -144,7 +149,7 @@ crd: ensure-controller-gen ensure-yq
 update: crd
 
 .PHONY: verify-crd
-verify-crd: ensure-controller-gen ensure-yq
+verify-crd: $(CONTROLLER_GEN) ensure-yq
 	./hack/verify-crd.sh
 verify: verify-crd
 
@@ -216,6 +221,12 @@ update-codegen:
 	hack/update-codegen.sh
 update: update-codegen
 
+# This needs to come after codegen to copy zz_generated.deepcopy files down into vendor/
+.PHONY: verify-vendor
+verify-vendor: vendor
+	git diff --exit-code vendor/
+verify: verify-vendor
+
 # Build the template file used for direct (OLM-less) deploy by app-sre
 build-app-sre-template: ensure-kustomize
 	# Sync CRDs into kustomize resources
@@ -278,7 +289,7 @@ generate: generate-submodules
 
 
 .PHONY: $(addprefix generate-submodules-,$(GO_SUB_MODULES))
-$(addprefix generate-submodules-,$(GO_SUB_MODULES)):
+$(addprefix generate-submodules-,$(GO_SUB_MODULES)): $(addprefix vendor-submodules-,$(GO_SUB_MODULES))
 	# hande go generate for submodule
 	(cd $(subst generate-submodules-,,$@); $(GOFLAGS_FOR_GENERATE) $(GO) generate ./...)
 
@@ -300,7 +311,11 @@ docker-dev-push: build image-hive-fedora-dev docker-push
 # Build the dev image using builah
 .PHONY: buildah-dev-build
 buildah-dev-build:
-	buildah bud --ulimit nofile=10239:10240 -f ./Dockerfile --tag ${IMG}
+	buildah bud --tag ${IMG} -f ./Dockerfile .
+
+.PHONY: podman-dev-build
+podman-dev-build:
+	podman build --tag ${IMG} $(GOCACHE_VOL_ARG) -f ./Dockerfile .
 
 # Build and push the dev image with buildah
 .PHONY: buildah-dev-push
@@ -320,6 +335,29 @@ lint: install-tools
 	golangci-lint run -c ./golangci.yml ./pkg/... ./cmd/... ./contrib/...
 # Remove the golangci-lint from the verify until a fix is in place for permisions for writing to the /.cache directory.
 #verify: lint
+
+# Target to build only hiveadmission
+.PHONY: build-hiveadmission
+build-hiveadmission:
+	$(call build-package, ./cmd/hiveadmission)
+build: build-hiveadmission
+
+# Target to build only hiveutil. This is used so that on the dual build RHEL8/RHEL9, RHEL8 stage only needs to build hiveutil.
+.PHONY: build-hiveutil
+build-hiveutil:
+	$(call build-package, ./contrib/cmd/hiveutil)
+
+# Target to build only manager
+.PHONY: build-manager
+build-manager:
+	$(call build-package, ./cmd/manager)
+build: build-manager
+
+# Target to build only manager
+.PHONY: build-operator
+build-operator:
+	$(call build-package, ./cmd/operator)
+build: build-operator
 
 .PHONY: modcheck
 modcheck:

--- a/config/crds/hive.openshift.io_checkpoints.yaml
+++ b/config/crds/hive.openshift.io_checkpoints.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: checkpoints.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_clusterclaims.yaml
+++ b/config/crds/hive.openshift.io_clusterclaims.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: clusterclaims.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_clusterdeploymentcustomizations.yaml
+++ b/config/crds/hive.openshift.io_clusterdeploymentcustomizations.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: clusterdeploymentcustomizations.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: clusterdeployments.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_clusterdeprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterdeprovisions.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: clusterdeprovisions.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_clusterimagesets.yaml
+++ b/config/crds/hive.openshift.io_clusterimagesets.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: clusterimagesets.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: clusterpools.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_clusterprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterprovisions.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   labels:
     contracts.hive.openshift.io/clusterinstall: "false"
   name: clusterprovisions.hive.openshift.io
@@ -100,6 +99,7 @@ spec:
                   We think because the thing it''s storing (ClusterMetadata from installer)
                   is not a runtime.Object, so can''t be put in a RawExtension.'
                 type: object
+                x-kubernetes-preserve-unknown-fields: true
               metadataJSON:
                 description: MetadataJSON is a JSON representation of the ClusterMetadata
                   produced by the installer. We don't use a runtime.RawExtension because

--- a/config/crds/hive.openshift.io_clusterrelocates.yaml
+++ b/config/crds/hive.openshift.io_clusterrelocates.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: clusterrelocates.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_clusterstates.yaml
+++ b/config/crds/hive.openshift.io_clusterstates.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: clusterstates.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_dnszones.yaml
+++ b/config/crds/hive.openshift.io_dnszones.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: dnszones.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: hiveconfigs.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_machinepoolnameleases.yaml
+++ b/config/crds/hive.openshift.io_machinepoolnameleases.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: machinepoolnameleases.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: machinepools.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_selectorsyncidentityproviders.yaml
+++ b/config/crds/hive.openshift.io_selectorsyncidentityproviders.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: selectorsyncidentityproviders.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_selectorsyncsets.yaml
+++ b/config/crds/hive.openshift.io_selectorsyncsets.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: selectorsyncsets.hive.openshift.io
 spec:
   group: hive.openshift.io
@@ -146,8 +145,8 @@ spec:
                   definitions.
                 items:
                   type: object
-                  x-kubernetes-embedded-resource: true
                   x-kubernetes-preserve-unknown-fields: true
+                  x-kubernetes-embedded-resource: true
                 type: array
               secretMappings:
                 description: Secrets is the list of secrets to sync along with their

--- a/config/crds/hive.openshift.io_syncidentityproviders.yaml
+++ b/config/crds/hive.openshift.io_syncidentityproviders.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: syncidentityproviders.hive.openshift.io
 spec:
   group: hive.openshift.io

--- a/config/crds/hive.openshift.io_syncsets.yaml
+++ b/config/crds/hive.openshift.io_syncsets.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: syncsets.hive.openshift.io
 spec:
   group: hive.openshift.io
@@ -115,8 +114,8 @@ spec:
                   definitions.
                 items:
                   type: object
-                  x-kubernetes-embedded-resource: true
                   x-kubernetes-preserve-unknown-fields: true
+                  x-kubernetes-embedded-resource: true
                 type: array
               secretMappings:
                 description: Secrets is the list of secrets to sync along with their

--- a/config/crds/hiveinternal.openshift.io_clustersyncleases.yaml
+++ b/config/crds/hiveinternal.openshift.io_clustersyncleases.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: clustersyncleases.hiveinternal.openshift.io
 spec:
   group: hiveinternal.openshift.io

--- a/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
+++ b/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   name: clustersyncs.hiveinternal.openshift.io
 spec:
   group: hiveinternal.openshift.io

--- a/config/crds/hiveinternal.openshift.io_fakeclusterinstalls.yaml
+++ b/config/crds/hiveinternal.openshift.io_fakeclusterinstalls.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.12.0
   labels:
     contracts.hive.openshift.io/clusterinstall: "true"
   name: fakeclusterinstalls.hiveinternal.openshift.io

--- a/go.mod
+++ b/go.mod
@@ -438,6 +438,8 @@ replace github.com/hashicorp/go-slug => github.com/hashicorp/go-slug v0.5.0
 // taken from https://github.com/openshift/installer/blob/21cd5218bb58288cd7b03018b9a2513aca3a13a5/terraform/providers/ibm/go.mod
 replace github.com/dgrijalva/jwt-go v3.2.0+incompatible => github.com/golang-jwt/jwt v3.2.1+incompatible
 
+replace vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787
+
 // needed for fixing CVE-2018-1099
 exclude (
 	go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738

--- a/go.sum
+++ b/go.sum
@@ -356,6 +356,7 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/fvbommel/sortorder v1.0.1 h1:dSnXLt4mJYH25uDDGa3biZNQsozaUWDSWeKJ0qqFfzE=
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
+github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787/go.mod h1:AlRx4sdoz6EdWGYPMeunQWYf46cKnq7J4iVvLgyb5cY=
 github.com/fzipp/gocyclo v0.6.0 h1:lsblElZG7d3ALtGMx9fmxeTKZaLLpU8mET09yN4BBLo=
 github.com/fzipp/gocyclo v0.6.0/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlyaLkLoA=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
@@ -2194,4 +2195,3 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-vbom.ml/util v0.0.0-20180919145318-efcd4e0f9787/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -7,8 +7,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: checkpoints.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -79,8 +78,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: clusterclaims.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -244,8 +242,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: clusterdeploymentcustomizations.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -376,8 +373,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: clusterdeployments.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -1622,8 +1618,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: clusterdeprovisions.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -1979,8 +1974,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: clusterimagesets.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -2037,8 +2031,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: clusterpools.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -2752,8 +2745,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     labels:
       contracts.hive.openshift.io/clusterinstall: 'false'
     name: clusterprovisions.hive.openshift.io
@@ -2853,6 +2845,7 @@ objects:
                     We think because the thing it''s storing (ClusterMetadata from
                     installer) is not a runtime.Object, so can''t be put in a RawExtension.'
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 metadataJSON:
                   description: MetadataJSON is a JSON representation of the ClusterMetadata
                     produced by the installer. We don't use a runtime.RawExtension
@@ -2942,8 +2935,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: clusterrelocates.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -3057,8 +3049,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: clusterstates.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -3158,8 +3149,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: clustersyncleases.hiveinternal.openshift.io
   spec:
     group: hiveinternal.openshift.io
@@ -3209,8 +3199,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: clustersyncs.hiveinternal.openshift.io
   spec:
     group: hiveinternal.openshift.io
@@ -3459,8 +3448,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: dnszones.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -3699,8 +3687,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     labels:
       contracts.hive.openshift.io/clusterinstall: 'true'
     name: fakeclusterinstalls.hiveinternal.openshift.io
@@ -3870,8 +3857,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: hiveconfigs.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -4713,8 +4699,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: machinepoolnameleases.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -4773,8 +4758,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: machinepools.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -5463,8 +5447,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: selectorsyncidentityproviders.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -6125,8 +6108,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: selectorsyncsets.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -6331,8 +6313,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: syncidentityproviders.hive.openshift.io
   spec:
     group: hive.openshift.io
@@ -6963,8 +6944,7 @@ objects:
   kind: CustomResourceDefinition
   metadata:
     annotations:
-      controller-gen.kubebuilder.io/version: (devel)
-    creationTimestamp: null
+      controller-gen.kubebuilder.io/version: v0.12.0
     name: syncsets.hive.openshift.io
   spec:
     group: hive.openshift.io

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11050,3 +11050,4 @@ sigs.k8s.io/yaml
 # k8s.io/client-go => k8s.io/client-go v0.27.2
 # github.com/hashicorp/go-slug => github.com/hashicorp/go-slug v0.5.0
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible => github.com/golang-jwt/jwt v3.2.1+incompatible
+# vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787


### PR DESCRIPTION
There's been quite a lot of improvements on Hive's Dockerfile and Makefile that speed up development and delivery work. We should bring them in mce-2.4 to to make backports less of a chore.