### PR TITLE
Hibernation: Requeue without error when ClusterSync doesn't exist yet

### DIFF
--- a/pkg/controller/hibernation/hibernation_controller_test.go
+++ b/pkg/controller/hibernation/hibernation_controller_test.go
@@ -66,6 +66,7 @@ func TestReconcile(t *testing.T) {
 		setupRemote            func(builder *remoteclientmock.MockBuilder)
 		validate               func(t *testing.T, cd *hivev1.ClusterDeployment)
 		expectError            bool
+		expectRequeue          bool
 		expectRequeueAfter     time.Duration
 	}{
 		{
@@ -292,9 +293,9 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
-			name:        "clustersync not yet created",
-			cd:          cdBuilder.Options(o.shouldHibernate).Build(),
-			expectError: true,
+			name:          "clustersync not yet created",
+			cd:            cdBuilder.Options(o.shouldHibernate).Build(),
+			expectRequeue: true,
 		},
 		{
 			name: "start hibernating, no syncsets",
@@ -998,6 +999,9 @@ func TestReconcile(t *testing.T) {
 				NamespacedName: types.NamespacedName{Namespace: namespace, Name: cdName},
 			})
 
+			if test.expectRequeue {
+				assert.True(t, result.Requeue, "expected result.Requeue to be true")
+			}
 			// Need to do fuzzy requeue after matching
 			if test.expectRequeueAfter == 0 {
 				assert.Zero(t, result.RequeueAfter)


### PR DESCRIPTION
When installation finishes, the clustersync and hibernation controllers race to start their business. But the latter needs to make use of the ClusterSync object. When the clustersync controller hasn't created it yet, the hibernation controller needs to requeue and wait for it.

Previously we were just letting the 404 from Get(ClusterSync) to bubble up; but this counts against the reconciler error budget for which alerts may be triggered. Since this is an expected scenario, we change this code path to do a non-error immediate requeue instead.

[HIVE-2611](https://issues.redhat.com//browse/HIVE-2611)