### PR TITLE
Use Duration Pattern for syncset, machinepool, clusterversion polls

### DIFF
--- a/apis/hive/v1/hiveconfig_types.go
+++ b/apis/hive/v1/hiveconfig_types.go
@@ -64,17 +64,41 @@ type HiveConfigSpec struct {
 	// SyncSetReapplyInterval is a string duration indicating how much time must pass before SyncSet resources
 	// will be reapplied.
 	// The default reapply interval is two hours.
+	// This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
+	// Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. See
+	// https://bugzilla.redhat.com/show_bug.cgi?id=2050332
+	// https://github.com/kubernetes/apimachinery/issues/131
+	// https://github.com/kubernetes/apiextensions-apiserver/issues/56
+	// +optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
 	SyncSetReapplyInterval string `json:"syncSetReapplyInterval,omitempty"`
 
 	// MachinePoolPollInterval is a string duration indicating how much time must pass before checking whether
 	// remote resources related to MachinePools need to be reapplied. Set to zero to disable polling -- we'll
 	// only reconcile when hub objects change.
 	// The default interval is 30m.
+	// This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
+	// Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. See
+	// https://bugzilla.redhat.com/show_bug.cgi?id=2050332
+	// https://github.com/kubernetes/apimachinery/issues/131
+	// https://github.com/kubernetes/apiextensions-apiserver/issues/56
+	// +optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
 	MachinePoolPollInterval string `json:"machinePoolPollInterval,omitempty"`
 
 	// ClusterVersionPollInterval is a string duration indicating how much time must pass before checking
 	// whether we need to update the hive.openshift.io/version* labels on ClusterDeployment. If zero or unset,
 	// we'll only reconcile when the ClusterDeployment changes.
+	// This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
+	// Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. See
+	// https://bugzilla.redhat.com/show_bug.cgi?id=2050332
+	// https://github.com/kubernetes/apimachinery/issues/131
+	// https://github.com/kubernetes/apiextensions-apiserver/issues/56
+	// +optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
 	ClusterVersionPollInterval string `json:"clusterVersionPollInterval,omitempty"`
 
 	// MaintenanceMode can be set to true to disable the hive controllers in situations where we need to ensure

--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -225,6 +225,12 @@ spec:
                   ClusterVersionPollInterval is a string duration indicating how much time must pass before checking
                   whether we need to update the hive.openshift.io/version* labels on ClusterDeployment. If zero or unset,
                   we'll only reconcile when the ClusterDeployment changes.
+                  This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
+                  Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. See
+                  https://bugzilla.redhat.com/show_bug.cgi?id=2050332
+                  https://github.com/kubernetes/apimachinery/issues/131
+                  https://github.com/kubernetes/apiextensions-apiserver/issues/56
+                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
               controllersConfig:
                 description: ControllersConfig is used to configure different hive
@@ -698,6 +704,12 @@ spec:
                   remote resources related to MachinePools need to be reapplied. Set to zero to disable polling -- we'll
                   only reconcile when hub objects change.
                   The default interval is 30m.
+                  This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
+                  Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. See
+                  https://bugzilla.redhat.com/show_bug.cgi?id=2050332
+                  https://github.com/kubernetes/apimachinery/issues/131
+                  https://github.com/kubernetes/apiextensions-apiserver/issues/56
+                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
               maintenanceMode:
                 description: |-
@@ -1015,6 +1027,12 @@ spec:
                   SyncSetReapplyInterval is a string duration indicating how much time must pass before SyncSet resources
                   will be reapplied.
                   The default reapply interval is two hours.
+                  This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
+                  Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. See
+                  https://bugzilla.redhat.com/show_bug.cgi?id=2050332
+                  https://github.com/kubernetes/apimachinery/issues/131
+                  https://github.com/kubernetes/apiextensions-apiserver/issues/56
+                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
               targetNamespace:
                 description: |-

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -5612,7 +5612,20 @@ objects:
                     whether we need to update the hive.openshift.io/version* labels
                     on ClusterDeployment. If zero or unset,
 
-                    we''ll only reconcile when the ClusterDeployment changes.'
+                    we''ll only reconcile when the ClusterDeployment changes.
+
+                    This is a Duration value; see https://pkg.go.dev/time#ParseDuration
+                    for accepted formats.
+
+                    Note: due to discrepancies in validation vs parsing, we use a
+                    Pattern instead of `Format=duration`. See
+
+                    https://bugzilla.redhat.com/show_bug.cgi?id=2050332
+
+                    https://github.com/kubernetes/apimachinery/issues/131
+
+                    https://github.com/kubernetes/apiextensions-apiserver/issues/56'
+                  pattern: "^([0-9]+(\\.[0-9]+)?(ns|us|\xB5s|ms|s|m|h))+$"
                   type: string
                 controllersConfig:
                   description: ControllersConfig is used to configure different hive
@@ -6208,7 +6221,20 @@ objects:
 
                     only reconcile when hub objects change.
 
-                    The default interval is 30m.'
+                    The default interval is 30m.
+
+                    This is a Duration value; see https://pkg.go.dev/time#ParseDuration
+                    for accepted formats.
+
+                    Note: due to discrepancies in validation vs parsing, we use a
+                    Pattern instead of `Format=duration`. See
+
+                    https://bugzilla.redhat.com/show_bug.cgi?id=2050332
+
+                    https://github.com/kubernetes/apimachinery/issues/131
+
+                    https://github.com/kubernetes/apiextensions-apiserver/issues/56'
+                  pattern: "^([0-9]+(\\.[0-9]+)?(ns|us|\xB5s|ms|s|m|h))+$"
                   type: string
                 maintenanceMode:
                   description: 'MaintenanceMode can be set to true to disable the
@@ -6628,7 +6654,20 @@ objects:
 
                     will be reapplied.
 
-                    The default reapply interval is two hours.'
+                    The default reapply interval is two hours.
+
+                    This is a Duration value; see https://pkg.go.dev/time#ParseDuration
+                    for accepted formats.
+
+                    Note: due to discrepancies in validation vs parsing, we use a
+                    Pattern instead of `Format=duration`. See
+
+                    https://bugzilla.redhat.com/show_bug.cgi?id=2050332
+
+                    https://github.com/kubernetes/apimachinery/issues/131
+
+                    https://github.com/kubernetes/apiextensions-apiserver/issues/56'
+                  pattern: "^([0-9]+(\\.[0-9]+)?(ns|us|\xB5s|ms|s|m|h))+$"
                   type: string
                 targetNamespace:
                   description: 'TargetNamespace is the namespace where the core Hive

--- a/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
@@ -64,17 +64,41 @@ type HiveConfigSpec struct {
 	// SyncSetReapplyInterval is a string duration indicating how much time must pass before SyncSet resources
 	// will be reapplied.
 	// The default reapply interval is two hours.
+	// This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
+	// Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. See
+	// https://bugzilla.redhat.com/show_bug.cgi?id=2050332
+	// https://github.com/kubernetes/apimachinery/issues/131
+	// https://github.com/kubernetes/apiextensions-apiserver/issues/56
+	// +optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
 	SyncSetReapplyInterval string `json:"syncSetReapplyInterval,omitempty"`
 
 	// MachinePoolPollInterval is a string duration indicating how much time must pass before checking whether
 	// remote resources related to MachinePools need to be reapplied. Set to zero to disable polling -- we'll
 	// only reconcile when hub objects change.
 	// The default interval is 30m.
+	// This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
+	// Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. See
+	// https://bugzilla.redhat.com/show_bug.cgi?id=2050332
+	// https://github.com/kubernetes/apimachinery/issues/131
+	// https://github.com/kubernetes/apiextensions-apiserver/issues/56
+	// +optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
 	MachinePoolPollInterval string `json:"machinePoolPollInterval,omitempty"`
 
 	// ClusterVersionPollInterval is a string duration indicating how much time must pass before checking
 	// whether we need to update the hive.openshift.io/version* labels on ClusterDeployment. If zero or unset,
 	// we'll only reconcile when the ClusterDeployment changes.
+	// This is a Duration value; see https://pkg.go.dev/time#ParseDuration for accepted formats.
+	// Note: due to discrepancies in validation vs parsing, we use a Pattern instead of `Format=duration`. See
+	// https://bugzilla.redhat.com/show_bug.cgi?id=2050332
+	// https://github.com/kubernetes/apimachinery/issues/131
+	// https://github.com/kubernetes/apiextensions-apiserver/issues/56
+	// +optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
 	ClusterVersionPollInterval string `json:"clusterVersionPollInterval,omitempty"`
 
 	// MaintenanceMode can be set to true to disable the hive controllers in situations where we need to ensure


### PR DESCRIPTION
Today our backstop for invalid (i.e. not parseable as Duration) values for HiveConfig.Spec.
- SyncSetReapplyInterval
- MachinePoolPollInterval
- ClusterVersionPollInterval

...is to crash the respective controllers.

With this change, we add schema validation, which should cause invalid values to be rejected by the kube API server before they even get into etcd. (We leave the backstops in place for invalid values in pre-existing deployments.)

[HIVE-2635](https://issues.redhat.com//browse/HIVE-2635)