### PR TITLE
Don't generate long-lived token for hiveadmission on OpenShift

### DIFF
--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -54,11 +54,16 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h resour
 	namespacedAssets := []string{
 		"config/hiveadmission/service.yaml",
 		"config/hiveadmission/service-account.yaml",
-		// This secret was automatically generated prior to k8s 1.24. We're including it to cover later versions.
-		// Note that overwriting it should have no effect as k8s will still populate it for us.
-		// Also note that this secret will be deleted automatically when the serviceaccount is deleted; our deletion
-		// is redundant, but harmless.
-		"config/hiveadmission/sa-token-secret.yaml",
+	}
+	// In OpenShift, tokens are automatically generated and attached to the hiveadmission pods.
+	if !r.isOpenShift {
+		namespacedAssets = append(namespacedAssets,
+			// This secret was automatically generated prior to k8s 1.24. We're including it to cover later versions.
+			// Note that overwriting it should have no effect as k8s will still populate it for us.
+			// Also note that this secret will be deleted automatically when the serviceaccount is deleted; our deletion
+			// is redundant, but harmless.
+			"config/hiveadmission/sa-token-secret.yaml",
+		)
 	}
 	// Delete the assets from previous target namespaces
 	assetsToClean := append(namespacedAssets, deploymentAsset)


### PR DESCRIPTION
HIVE-2219 / [https://github.com/openshift/hive/pull/2012](#2012) / 7f27836e started injecting a hiveadmission-sa-token Secret into the targetNamespace because k8s, which used to create it automatically, stopped doing so in 1.24. In OpenShift, this Secret was/is unnecessary, but for simplicity we did not differentiate.

Apparently this long-lived token is not desirable in OpenShift, so we're moving its deployment to a non-OpenShift-only code path.

Once this commit is deployed in your OpenShift environment, you should be able to delete the Secret and it will not be restored.

ACM-14645