### PR TITLE
Azure: Pass BaseDomainResourceGroupName to destroyer

### DIFF
--- a/apis/hive/v1/clusterdeprovision_types.go
+++ b/apis/hive/v1/clusterdeprovision_types.go
@@ -89,6 +89,10 @@ type AzureClusterDeprovision struct {
 	// Required for new deprovisions (schema notwithstanding).
 	// +optional
 	ResourceGroupName *string `json:"resourceGroupName,omitempty"`
+	// BaseDomainResourceGroupName is the name of the resource group where the cluster's DNS records
+	// were created, if different from the default or the custom ResourceGroupName.
+	// +optional
+	BaseDomainResourceGroupName *string `json:"baseDomainResourceGroupName,omitempty"`
 }
 
 // GCPClusterDeprovision contains GCP-specific configuration for a ClusterDeprovision

--- a/apis/hive/v1/zz_generated.deepcopy.go
+++ b/apis/hive/v1/zz_generated.deepcopy.go
@@ -278,6 +278,11 @@ func (in *AzureClusterDeprovision) DeepCopyInto(out *AzureClusterDeprovision) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.BaseDomainResourceGroupName != nil {
+		in, out := &in.BaseDomainResourceGroupName, &out.BaseDomainResourceGroupName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/config/crds/hive.openshift.io_clusterdeprovisions.yaml
+++ b/config/crds/hive.openshift.io_clusterdeprovisions.yaml
@@ -124,6 +124,11 @@ spec:
                   azure:
                     description: Azure contains Azure-specific deprovision settings
                     properties:
+                      baseDomainResourceGroupName:
+                        description: |-
+                          BaseDomainResourceGroupName is the name of the resource group where the cluster's DNS records
+                          were created, if different from the default or the custom ResourceGroupName.
+                        type: string
                       cloudName:
                         description: |-
                           cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -2380,6 +2380,13 @@ objects:
                     azure:
                       description: Azure contains Azure-specific deprovision settings
                       properties:
+                        baseDomainResourceGroupName:
+                          description: 'BaseDomainResourceGroupName is the name of
+                            the resource group where the cluster''s DNS records
+
+                            were created, if different from the default or the custom
+                            ResourceGroupName.'
+                          type: string
                         cloudName:
                           description: 'cloudName is the name of the Azure cloud environment
                             which can be used to configure the Azure SDK

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -1880,9 +1880,10 @@ func generateDeprovision(cd *hivev1.ClusterDeployment) (*hivev1.ClusterDeprovisi
 			return nil, err
 		}
 		req.Spec.Platform.Azure = &hivev1.AzureClusterDeprovision{
-			CredentialsSecretRef: &cd.Spec.Platform.Azure.CredentialsSecretRef,
-			CloudName:            &cd.Spec.Platform.Azure.CloudName,
-			ResourceGroupName:    &rg,
+			CredentialsSecretRef:        &cd.Spec.Platform.Azure.CredentialsSecretRef,
+			CloudName:                   &cd.Spec.Platform.Azure.CloudName,
+			ResourceGroupName:           &rg,
+			BaseDomainResourceGroupName: &cd.Spec.Platform.Azure.BaseDomainResourceGroupName,
 		}
 	case cd.Spec.Platform.GCP != nil:
 		// If we haven't discovered the NetworkProjectID yet, fail

--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -736,6 +736,9 @@ func completeAzureDeprovisionJob(req *hivev1.ClusterDeprovision, job *batchv1.Jo
 	if req.Spec.Platform.Azure.ResourceGroupName != nil {
 		containers[0].Args = append(containers[0].Args, "--azure-resource-group-name", *req.Spec.Platform.Azure.ResourceGroupName)
 	}
+	if req.Spec.Platform.Azure.BaseDomainResourceGroupName != nil {
+		containers[0].Args = append(containers[0].Args, "--azure-base-domain-resource-group-name", *req.Spec.Platform.Azure.BaseDomainResourceGroupName)
+	}
 	job.Spec.Template.Spec.Containers = containers
 	job.Spec.Template.Spec.Volumes = volumes
 

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeprovision_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterdeprovision_types.go
@@ -89,6 +89,10 @@ type AzureClusterDeprovision struct {
 	// Required for new deprovisions (schema notwithstanding).
 	// +optional
 	ResourceGroupName *string `json:"resourceGroupName,omitempty"`
+	// BaseDomainResourceGroupName is the name of the resource group where the cluster's DNS records
+	// were created, if different from the default or the custom ResourceGroupName.
+	// +optional
+	BaseDomainResourceGroupName *string `json:"baseDomainResourceGroupName,omitempty"`
 }
 
 // GCPClusterDeprovision contains GCP-specific configuration for a ClusterDeprovision

--- a/vendor/github.com/openshift/hive/apis/hive/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/zz_generated.deepcopy.go
@@ -278,6 +278,11 @@ func (in *AzureClusterDeprovision) DeepCopyInto(out *AzureClusterDeprovision) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.BaseDomainResourceGroupName != nil {
+		in, out := &in.BaseDomainResourceGroupName, &out.BaseDomainResourceGroupName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
If an Azure spoke was provisioned with a custom
BaseDomainResourceGroupName, DNS records were being leaked when destroying because we weren't passing that information through to the deprovisioner.

We were already requiring this value on input in
ClusterDeployment.Spec.Platform.Azure.BaseDomainResourceGroupName. This change plumbs it through ClusterDeprovision and into the Azure deprovision helper.

[HIVE-2651](https://issues.redhat.com//browse/HIVE-2651)