### PR TITLE
HIVE-2656: Various fixes related to hive developer experience (dx)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 bin/**
 **/__debug_bin
 **/__pycache__
+**/venv
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -317,6 +317,10 @@ buildah-dev-build:
 podman-dev-build:
 	podman build --tag ${IMG} $(GOCACHE_VOL_ARG) -f ./Dockerfile .
 
+.PHONY: podman-dev-push
+podman-dev-push: podman-dev-build
+	podman push --tls-verify=false ${IMG}
+
 # Build and push the dev image with buildah
 .PHONY: buildah-dev-push
 buildah-dev-push: buildah-dev-build

--- a/hack/create-service-account-secrets.sh
+++ b/hack/create-service-account-secrets.sh
@@ -5,7 +5,7 @@
 # - hiveadmission
 # - hive-controllers
 #
-cat <<EOF | kubectl apply -f -
+cat <<EOF | oc apply -f -
 apiVersion: v1
 kind: List
 items:

--- a/hack/hiveadmission-dev-cert.sh
+++ b/hack/hiveadmission-dev-cert.sh
@@ -24,7 +24,7 @@ cat <<EOF | cfssl genkey - | cfssljson -bare server
 }
 EOF
 
-cat <<EOF | kubectl apply -f -
+cat <<EOF | oc apply -f -
 apiVersion: certificates.k8s.io/v1
 kind: CertificateSigningRequest
 metadata:
@@ -38,14 +38,14 @@ spec:
   - server auth
 EOF
 
-kubectl certificate approve hiveadmission.${HIVE_NS}
+oc adm certificate approve hiveadmission.${HIVE_NS}
 
 sleep 5
-kubectl get csr hiveadmission.${HIVE_NS} -o jsonpath='{.status.certificate}' | base64 --decode > server.crt
+oc get csr hiveadmission.${HIVE_NS} -o jsonpath='{.status.certificate}' | base64 --decode > server.crt
 
 cat server.crt
 
-cat <<EOF | kubectl apply -f -
+cat <<EOF | oc apply -f -
 kind: Secret
 apiVersion: v1
 data:


### PR DESCRIPTION
`.gitignore`: add venv so I stop accidentally adding it with `git add hack/`

`hack/*.sh`: use `oc` instead of `kubectl`

`Makefile`: add target for using podman to push to registry (local registry running in podman has no security setup, hence ignore TLS)

/assign @2uasimojo 

card: [HIVE-2656](https://issues.redhat.com//browse/HIVE-2656)