### PR TITLE
hive-controllers: configurable Resources

### DIFF
--- a/apis/hive/v1/hiveconfig_types.go
+++ b/apis/hive/v1/hiveconfig_types.go
@@ -605,8 +605,6 @@ type ControllerConfig struct {
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
 	// Resources describes the compute resource requirements of the controller container.
-	// This is ONLY for controllers that have been split out into their own pods.
-	// This is ignored for all others.
 	// +optional
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 }
@@ -680,6 +678,8 @@ type ControllersConfig struct {
 	// default for client burst is 10
 	// default for queue qps is 10
 	// default for queue burst is 100
+	// default resource requests are 50m CPU, 512Mi memory
+	// There are no resource limits by default
 	// +optional
 	Default *ControllerConfig `json:"default,omitempty"`
 	// Controllers contains a list of configurations for different controllers

--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -280,10 +280,8 @@ spec:
                               format: int32
                               type: integer
                             resources:
-                              description: |-
-                                Resources describes the compute resource requirements of the controller container.
-                                This is ONLY for controllers that have been split out into their own pods.
-                                This is ignored for all others.
+                              description: Resources describes the compute resource
+                                requirements of the controller container.
                               properties:
                                 claims:
                                   description: |-
@@ -381,6 +379,8 @@ spec:
                       default for client burst is 10
                       default for queue qps is 10
                       default for queue burst is 100
+                      default resource requests are 50m CPU, 512Mi memory
+                      There are no resource limits by default
                     properties:
                       clientBurst:
                         description: ClientBurst specifies client rate limiter burst
@@ -415,10 +415,8 @@ spec:
                         format: int32
                         type: integer
                       resources:
-                        description: |-
-                          Resources describes the compute resource requirements of the controller container.
-                          This is ONLY for controllers that have been split out into their own pods.
-                          This is ignored for all others.
+                        description: Resources describes the compute resource requirements
+                          of the controller container.
                         properties:
                           claims:
                             description: |-

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -5700,13 +5700,8 @@ objects:
                                 format: int32
                                 type: integer
                               resources:
-                                description: 'Resources describes the compute resource
+                                description: Resources describes the compute resource
                                   requirements of the controller container.
-
-                                  This is ONLY for controllers that have been split
-                                  out into their own pods.
-
-                                  This is ignored for all others.'
                                 properties:
                                   claims:
                                     description: 'Claims lists the names of resources,
@@ -5826,7 +5821,11 @@ objects:
 
                         default for queue qps is 10
 
-                        default for queue burst is 100'
+                        default for queue burst is 100
+
+                        default resource requests are 50m CPU, 512Mi memory
+
+                        There are no resource limits by default'
                       properties:
                         clientBurst:
                           description: ClientBurst specifies client rate limiter burst
@@ -5864,13 +5863,8 @@ objects:
                           format: int32
                           type: integer
                         resources:
-                          description: 'Resources describes the compute resource requirements
+                          description: Resources describes the compute resource requirements
                             of the controller container.
-
-                            This is ONLY for controllers that have been split out
-                            into their own pods.
-
-                            This is ignored for all others.'
                           properties:
                             claims:
                               description: 'Claims lists the names of resources, defined

--- a/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
@@ -605,8 +605,6 @@ type ControllerConfig struct {
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
 	// Resources describes the compute resource requirements of the controller container.
-	// This is ONLY for controllers that have been split out into their own pods.
-	// This is ignored for all others.
 	// +optional
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 }
@@ -680,6 +678,8 @@ type ControllersConfig struct {
 	// default for client burst is 10
 	// default for queue qps is 10
 	// default for queue burst is 100
+	// default resource requests are 50m CPU, 512Mi memory
+	// There are no resource limits by default
 	// +optional
 	Default *ControllerConfig `json:"default,omitempty"`
 	// Controllers contains a list of configurations for different controllers


### PR DESCRIPTION
Prior to this change,
HiveConfig.Spec.ControllersConfig.Default.Resources was ignored. Now it is used to *replace* the default Resources for the hive-controllers Deployment (the one that runs all the controllers not sharded out into StatefulSets).

A quirk of the implementation is that, if you specify this field, you don't get the default values at all, even if you don't specify those values in your customization. For example, with Default.Resources omitted, you get:

```yaml
resources:
  requests:
    cpu: 50m
    memory: 512Mi
```

But if your HiveConfig says:

```yaml
resources:
  requests:
    cpu: 100m
    # memory not specified!
```

you get exactly that; you do *not* get:

```yaml
resources:
  requests:
    cpu: 100m
    memory: 512Mi
```

[HIVE-2650](https://issues.redhat.com//browse/HIVE-2650)