### PR TITLE
Tech Debt: nix SyncSetPatchApplyMode

### DIFF
--- a/apis/hive/v1/syncset_types.go
+++ b/apis/hive/v1/syncset_types.go
@@ -44,20 +44,6 @@ const (
 	CreateOrUpdateSyncSetApplyBehavior SyncSetApplyBehavior = "CreateOrUpdate"
 )
 
-// SyncSetPatchApplyMode is a string representing the mode with which to apply
-// SyncSet Patches.
-type SyncSetPatchApplyMode string
-
-const (
-	// ApplyOncePatchApplyMode indicates that the patch should be applied
-	// only once.
-	ApplyOncePatchApplyMode SyncSetPatchApplyMode = "ApplyOnce"
-
-	// AlwaysApplyPatchApplyMode indicates that the patch should be
-	// continuously applied.
-	AlwaysApplyPatchApplyMode SyncSetPatchApplyMode = "AlwaysApply"
-)
-
 // SyncObjectPatch represents a patch to be applied to a specific object
 type SyncObjectPatch struct {
 	// APIVersion is the Group and Version of the object to be patched.

--- a/docs/syncset.md
+++ b/docs/syncset.md
@@ -74,7 +74,7 @@ spec:
 | `applyBehavior` | One of `Apply` (the default), `CreateOnly`, `CreateOrUpdate`. Affects how the controller computes the patch to apply to `resources` and `secretMappings` (but not `patches`). More details [below](#how-to-use-applybehavior). |
 | `enableResourceTemplates  ` | If true, special use of golang's `text/templates` is allowed in `resources`. More details [below](#resource-parameters). |
 | `resources` | A list of resource object definitions. Resources will be created in the referenced clusters. |
-| `patches` | A list of patches to apply to existing resources in the referenced clusters. You can include any valid cluster object type in the list. By default, the `patch` `applyMode` value is `"AlwaysApply"`, which applies the patch every 2 hours. |
+| `patches` | A list of patches to apply to existing resources in the referenced clusters. You can include any valid cluster object type in the list. |
 | `secretMappings` | A list of secret mappings. The secrets will be copied from the existing sources to the target resources in the referenced clusters |
 
 ### How to use `applyBehavior`

--- a/vendor/github.com/openshift/hive/apis/hive/v1/syncset_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/syncset_types.go
@@ -44,20 +44,6 @@ const (
 	CreateOrUpdateSyncSetApplyBehavior SyncSetApplyBehavior = "CreateOrUpdate"
 )
 
-// SyncSetPatchApplyMode is a string representing the mode with which to apply
-// SyncSet Patches.
-type SyncSetPatchApplyMode string
-
-const (
-	// ApplyOncePatchApplyMode indicates that the patch should be applied
-	// only once.
-	ApplyOncePatchApplyMode SyncSetPatchApplyMode = "ApplyOnce"
-
-	// AlwaysApplyPatchApplyMode indicates that the patch should be
-	// continuously applied.
-	AlwaysApplyPatchApplyMode SyncSetPatchApplyMode = "AlwaysApply"
-)
-
 // SyncObjectPatch represents a patch to be applied to a specific object
 type SyncObjectPatch struct {
 	// APIVersion is the Group and Version of the object to be patched.


### PR DESCRIPTION
We were exporting a data type, SyncSetPatchApplyMode, whose code was either removed or never implemented. Scrub it to avoid confusion for consumers.

[HIVE-2658](https://issues.redhat.com//browse/HIVE-2658)