### PR TITLE
ClusterSync: Warn on resource conflicts

### DIFF
--- a/apis/hiveinternal/v1alpha1/clustersync_types.go
+++ b/apis/hiveinternal/v1alpha1/clustersync_types.go
@@ -16,6 +16,7 @@ import (
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[0].reason`
 // +kubebuilder:printcolumn:name="ControllerReplica",type=string,JSONPath=`.status.controlledByReplica`
 // +kubebuilder:printcolumn:name="Message",type=string,priority=1,JSONPath=`.status.conditions[?(@.type=="Failed")].message`
+// +kubebuilder:printcolumn:name="ResourceConflicts",type=string,priority=1,JSONPath=`.status.resourceConflicts`
 type ClusterSync struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -50,6 +51,12 @@ type ClusterSyncStatus struct {
 	// recently handled the ClusterSync. If the hive-clustersync statefulset is scaled up or down, the
 	// controlling replica can change, potentially causing logs to be spread across multiple pods.
 	ControlledByReplica *int64 `json:"controlledByReplica,omitempty"`
+
+	// ResourceConflicts is a list of human-readable messages warning when a resource is mentioned
+	// more than once across all [Selector]SyncSets affecting this ClusterSync. Note that this only
+	// counts Spec.Resources, not Patches or SecretMappings.
+	// +optional
+	ResourceConflicts []string `json:"resourceConflicts,omitempty"`
 }
 
 // SyncStatus is the status of applying a specific SyncSet or SelectorSyncSet to the cluster.

--- a/apis/hiveinternal/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/hiveinternal/v1alpha1/zz_generated.deepcopy.go
@@ -215,6 +215,11 @@ func (in *ClusterSyncStatus) DeepCopyInto(out *ClusterSyncStatus) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.ResourceConflicts != nil {
+		in, out := &in.ResourceConflicts, &out.ResourceConflicts
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
+++ b/config/crds/hiveinternal.openshift.io_clustersyncs.yaml
@@ -26,6 +26,10 @@ spec:
       name: Message
       priority: 1
       type: string
+    - jsonPath: .status.resourceConflicts
+      name: ResourceConflicts
+      priority: 1
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -103,6 +107,14 @@ spec:
                   all (selector)syncsets to a cluster.
                 format: date-time
                 type: string
+              resourceConflicts:
+                description: |-
+                  ResourceConflicts is a list of human-readable messages warning when a resource is mentioned
+                  more than once across all [Selector]SyncSets affecting this ClusterSync. Note that this only
+                  counts Spec.Resources, not Patches or SecretMappings.
+                items:
+                  type: string
+                type: array
               selectorSyncSets:
                 description: SelectorSyncSets is the sync status of all of the SelectorSyncSets
                   for the cluster.

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -4547,6 +4547,10 @@ objects:
         name: Message
         priority: 1
         type: string
+      - jsonPath: .status.resourceConflicts
+        name: ResourceConflicts
+        priority: 1
+        type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
@@ -4640,6 +4644,17 @@ objects:
                     applied all (selector)syncsets to a cluster.
                   format: date-time
                   type: string
+                resourceConflicts:
+                  description: 'ResourceConflicts is a list of human-readable messages
+                    warning when a resource is mentioned
+
+                    more than once across all [Selector]SyncSets affecting this ClusterSync.
+                    Note that this only
+
+                    counts Spec.Resources, not Patches or SecretMappings.'
+                  items:
+                    type: string
+                  type: array
                 selectorSyncSets:
                   description: SelectorSyncSets is the sync status of all of the SelectorSyncSets
                     for the cluster.

--- a/vendor/github.com/openshift/hive/apis/hiveinternal/v1alpha1/clustersync_types.go
+++ b/vendor/github.com/openshift/hive/apis/hiveinternal/v1alpha1/clustersync_types.go
@@ -16,6 +16,7 @@ import (
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[0].reason`
 // +kubebuilder:printcolumn:name="ControllerReplica",type=string,JSONPath=`.status.controlledByReplica`
 // +kubebuilder:printcolumn:name="Message",type=string,priority=1,JSONPath=`.status.conditions[?(@.type=="Failed")].message`
+// +kubebuilder:printcolumn:name="ResourceConflicts",type=string,priority=1,JSONPath=`.status.resourceConflicts`
 type ClusterSync struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -50,6 +51,12 @@ type ClusterSyncStatus struct {
 	// recently handled the ClusterSync. If the hive-clustersync statefulset is scaled up or down, the
 	// controlling replica can change, potentially causing logs to be spread across multiple pods.
 	ControlledByReplica *int64 `json:"controlledByReplica,omitempty"`
+
+	// ResourceConflicts is a list of human-readable messages warning when a resource is mentioned
+	// more than once across all [Selector]SyncSets affecting this ClusterSync. Note that this only
+	// counts Spec.Resources, not Patches or SecretMappings.
+	// +optional
+	ResourceConflicts []string `json:"resourceConflicts,omitempty"`
 }
 
 // SyncStatus is the status of applying a specific SyncSet or SelectorSyncSet to the cluster.

--- a/vendor/github.com/openshift/hive/apis/hiveinternal/v1alpha1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/hive/apis/hiveinternal/v1alpha1/zz_generated.deepcopy.go
@@ -215,6 +215,11 @@ func (in *ClusterSyncStatus) DeepCopyInto(out *ClusterSyncStatus) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.ResourceConflicts != nil {
+		in, out := &in.ResourceConflicts, &out.ResourceConflicts
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Add a new ClusterSync.Status field, ResourceConflicts, and a corresponding printColumn visible when `-o wide` is used.

When a single resource (GVK + name [+ namespace if ns-scoped]) is mentioned more than once in the `resources` sections (not `patches` or `secretMappings`) of the [Selector]SyncSets matching a ClusterDeployment, we will add a human-readable message to this status field indicating the resource and the [Selector]SyncSets in which it is mentioned.

Example message:

```
"Resource {v1 Namespace openshift-logging } is mentioned by 2 [Selector]SyncSets: mygroup, osd-logging1"
```

[HIVE-2634](https://issues.redhat.com//browse/HIVE-2634)