### PR TITLE
OSD-26538: Grant hive permission to patch networks.config.openshift.io

### DIFF
--- a/config/operator/operator_role.yaml
+++ b/config/operator/operator_role.yaml
@@ -235,3 +235,10 @@ rules:
   - get
   - list
   - watch
+# Required to patch the Network resource to initiate SDN to OVN migration via a SelectorSyncSet
+- apiGroups:
+    - config.openshift.io
+  resources:
+    - networks
+  verbs:
+    - patch

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -10257,6 +10257,12 @@ objects:
     - get
     - list
     - watch
+  - apiGroups:
+    - config.openshift.io
+    resources:
+    - networks
+    verbs:
+    - patch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:


### PR DESCRIPTION
As part of https://issues.redhat.com/browse/OSD-26538, Hive will need RBAC to be able to patch a ClusterDeployment's Network in reaction to a SelectorSyncSet patch.

Do we need any other verbs for the operator to acton this, my guess is no, but let me know if so.

Related to https://github.com/openshift/managed-cluster-config/pull/2281