### PR TITLE
syncset: support templates in `patches`

### DIFF
--- a/apis/hive/v1/syncset_types.go
+++ b/apis/hive/v1/syncset_types.go
@@ -238,6 +238,16 @@ type SyncSetCommonSpec struct {
 	// empty string is interpolated if there are no labels, or if the indicated key does not exist.
 	// Note that this only works in values (not e.g. map keys) that are of type string.
 	EnableResourceTemplates bool `json:"enableResourceTemplates,omitempty"`
+
+	// EnablePatchTemplates, if True, causes hive to honor golang text/templates in Patches[].Patch
+	// strings. While the standard syntax is supported, it won't do you a whole lot of good as the
+	// parser does not pass a data object (i.e. there is no "dot" for you to use). This currently
+	// exists to expose a single function: {{ fromCDLabel "some.label/key" }} will be substituted
+	// with the string value of ClusterDeployment.Labels["some.label/key"]. The empty string is
+	// interpolated if there are no labels, or if the indicated key does not exist. Note that the
+	// patch string must be valid JSON after interpolation. This may make for odd-looking quoting
+	// in the uninterpolated string.
+	EnablePatchTemplates bool `json:"enablePatchTemplates,omitempty"`
 }
 
 // SelectorSyncSetSpec defines the SyncSetCommonSpec resources and patches to sync along

--- a/config/crds/hive.openshift.io_selectorsyncsets.yaml
+++ b/config/crds/hive.openshift.io_selectorsyncsets.yaml
@@ -108,6 +108,17 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              enablePatchTemplates:
+                description: |-
+                  EnablePatchTemplates, if True, causes hive to honor golang text/templates in Patches[].Patch
+                  strings. While the standard syntax is supported, it won't do you a whole lot of good as the
+                  parser does not pass a data object (i.e. there is no "dot" for you to use). This currently
+                  exists to expose a single function: {{ fromCDLabel "some.label/key" }} will be substituted
+                  with the string value of ClusterDeployment.Labels["some.label/key"]. The empty string is
+                  interpolated if there are no labels, or if the indicated key does not exist. Note that the
+                  patch string must be valid JSON after interpolation. This may make for odd-looking quoting
+                  in the uninterpolated string.
+                type: boolean
               enableResourceTemplates:
                 description: |-
                   EnableResourceTemplates, if True, causes hive to honor golang text/templates in Resources.

--- a/config/crds/hive.openshift.io_syncsets.yaml
+++ b/config/crds/hive.openshift.io_syncsets.yaml
@@ -81,6 +81,17 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              enablePatchTemplates:
+                description: |-
+                  EnablePatchTemplates, if True, causes hive to honor golang text/templates in Patches[].Patch
+                  strings. While the standard syntax is supported, it won't do you a whole lot of good as the
+                  parser does not pass a data object (i.e. there is no "dot" for you to use). This currently
+                  exists to expose a single function: {{ fromCDLabel "some.label/key" }} will be substituted
+                  with the string value of ClusterDeployment.Labels["some.label/key"]. The empty string is
+                  interpolated if there are no labels, or if the indicated key does not exist. Note that the
+                  patch string must be valid JSON after interpolation. This may make for odd-looking quoting
+                  in the uninterpolated string.
+                type: boolean
               enableResourceTemplates:
                 description: |-
                   EnableResourceTemplates, if True, causes hive to honor golang text/templates in Resources.

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -8843,6 +8843,30 @@ objects:
                       type: object
                   type: object
                   x-kubernetes-map-type: atomic
+                enablePatchTemplates:
+                  description: 'EnablePatchTemplates, if True, causes hive to honor
+                    golang text/templates in Patches[].Patch
+
+                    strings. While the standard syntax is supported, it won''t do
+                    you a whole lot of good as the
+
+                    parser does not pass a data object (i.e. there is no "dot" for
+                    you to use). This currently
+
+                    exists to expose a single function: {{ fromCDLabel "some.label/key"
+                    }} will be substituted
+
+                    with the string value of ClusterDeployment.Labels["some.label/key"].
+                    The empty string is
+
+                    interpolated if there are no labels, or if the indicated key does
+                    not exist. Note that the
+
+                    patch string must be valid JSON after interpolation. This may
+                    make for odd-looking quoting
+
+                    in the uninterpolated string.'
+                  type: boolean
                 enableResourceTemplates:
                   description: 'EnableResourceTemplates, if True, causes hive to honor
                     golang text/templates in Resources.
@@ -9888,6 +9912,30 @@ objects:
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
+                enablePatchTemplates:
+                  description: 'EnablePatchTemplates, if True, causes hive to honor
+                    golang text/templates in Patches[].Patch
+
+                    strings. While the standard syntax is supported, it won''t do
+                    you a whole lot of good as the
+
+                    parser does not pass a data object (i.e. there is no "dot" for
+                    you to use). This currently
+
+                    exists to expose a single function: {{ fromCDLabel "some.label/key"
+                    }} will be substituted
+
+                    with the string value of ClusterDeployment.Labels["some.label/key"].
+                    The empty string is
+
+                    interpolated if there are no labels, or if the indicated key does
+                    not exist. Note that the
+
+                    patch string must be valid JSON after interpolation. This may
+                    make for odd-looking quoting
+
+                    in the uninterpolated string.'
+                  type: boolean
                 enableResourceTemplates:
                   description: 'EnableResourceTemplates, if True, causes hive to honor
                     golang text/templates in Resources.

--- a/pkg/test/syncset/syncset.go
+++ b/pkg/test/syncset/syncset.go
@@ -144,6 +144,12 @@ func WithPatches(patches ...hivev1.SyncObjectPatch) Option {
 	}
 }
 
+func WithEnablePatchTemplates(on bool) Option {
+	return func(syncSet *hivev1.SyncSet) {
+		syncSet.Spec.EnablePatchTemplates = on
+	}
+}
+
 func WithEnableResourceTemplates(on bool) Option {
 	return func(syncSet *hivev1.SyncSet) {
 		syncSet.Spec.EnableResourceTemplates = on

--- a/vendor/github.com/openshift/hive/apis/hive/v1/syncset_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/syncset_types.go
@@ -238,6 +238,16 @@ type SyncSetCommonSpec struct {
 	// empty string is interpolated if there are no labels, or if the indicated key does not exist.
 	// Note that this only works in values (not e.g. map keys) that are of type string.
 	EnableResourceTemplates bool `json:"enableResourceTemplates,omitempty"`
+
+	// EnablePatchTemplates, if True, causes hive to honor golang text/templates in Patches[].Patch
+	// strings. While the standard syntax is supported, it won't do you a whole lot of good as the
+	// parser does not pass a data object (i.e. there is no "dot" for you to use). This currently
+	// exists to expose a single function: {{ fromCDLabel "some.label/key" }} will be substituted
+	// with the string value of ClusterDeployment.Labels["some.label/key"]. The empty string is
+	// interpolated if there are no labels, or if the indicated key does not exist. Note that the
+	// patch string must be valid JSON after interpolation. This may make for odd-looking quoting
+	// in the uninterpolated string.
+	EnablePatchTemplates bool `json:"enablePatchTemplates,omitempty"`
 }
 
 // SelectorSyncSetSpec defines the SyncSetCommonSpec resources and patches to sync along


### PR DESCRIPTION
[HIVE-1748](https://issues.redhat.com//browse/HIVE-1748) / #2192 added the ability to flip a switch in a [Selector]SyncSet that causes hive to process golang [text/template](https://pkg.go.dev/text/template)s in leaf values of objects in the [S]SS's `resources` section.

This does a similar thing for JSON patch strings in the `patches` section. For example:

```yaml
apiVersion: hive.openshift.io/v1
kind: SyncSet
metadata:
  name: paramss
spec:
  ...
  enablePatchTemplates: true
  ...

  patches:
  - apiVersion: v1
    kind: ConfigMap
    name: foo
    namespace: default
    patch: |-
      {"metadata": {"annotations": {"test": "{{ fromCDLabel "hive.openshift.io/cluster-platform" }}" }}}
    patchType: merge
```

Note that the data type of `patches[].patch` is `string`, so internal quotes must be escaped somehow (in the above example, it's via `|-`). But the value of the patch _once the template is rendered_ must be valid JSON, e.g. with double quotes surrounding string values. This can make the quoting in the unrendered patch look syntactically odd.

Enables [OSD-26538](https://issues.redhat.com//browse/OSD-26538) by allowing (almost)
[this](https://github.com/openshift/managed-cluster-config/blob/7b43b8354123bd1c7ee529109228be3da811b67b/deploy/osd-sdn-to-ovn-migration/network-operator.patch.yaml#L12-L14) to work.

[HIVE-2669](https://issues.redhat.com//browse/HIVE-2669)