### PR TITLE
Azure MachinePool: Support OutboundType: UserDefinedRouting

### DIFF
--- a/apis/hive/v1/azure/machinepool.go
+++ b/apis/hive/v1/azure/machinepool.go
@@ -41,6 +41,10 @@ type MachinePool struct {
 	// +kubebuilder:validation:Enum="Accelerated"; "Basic"
 	// +optional
 	VMNetworkingType string `json:"vmNetworkingType,omitempty"`
+
+	// OutboundType is a strategy for how egress from cluster is achieved. When not specified default is "Loadbalancer".
+	// +optional
+	OutboundType string `json:"outboundType"`
 }
 
 // OSImage is the image to use for the OS of a machine.

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -284,6 +284,10 @@ spec:
                         - sku
                         - version
                         type: object
+                      outboundType:
+                        description: OutboundType is a strategy for how egress from
+                          cluster is achieved. When not specified default is "Loadbalancer".
+                        type: string
                       type:
                         description: |-
                           InstanceType defines the azure instance type.

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -7206,6 +7206,10 @@ objects:
                           - sku
                           - version
                           type: object
+                        outboundType:
+                          description: OutboundType is a strategy for how egress from
+                            cluster is achieved. When not specified default is "Loadbalancer".
+                          type: string
                         type:
                           description: 'InstanceType defines the azure instance type.
 

--- a/pkg/controller/machinepool/azureactuator.go
+++ b/pkg/controller/machinepool/azureactuator.go
@@ -76,6 +76,8 @@ func (a *AzureActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *
 				NetworkResourceGroupName: pool.Spec.Platform.Azure.NetworkResourceGroupName,
 				VirtualNetwork:           pool.Spec.Platform.Azure.VirtualNetwork,
 				ComputeSubnet:            pool.Spec.Platform.Azure.ComputeSubnet,
+				// This will be defaulted by the installer if empty
+				OutboundType: installertypesazure.OutboundType(pool.Spec.Platform.Azure.OutboundType),
 			},
 		},
 	}
@@ -117,7 +119,7 @@ func (a *AzureActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *
 	} else {
 		// An image was not provided so check if the installer created a "gen2" image
 		// to determine if we should allow resultant machinesets to consume a "gen2" image.
-		gen2ImageExists, err := a.gen2ImageExists(cd.Spec.ClusterMetadata.InfraID, ic.Platform.Azure.ClusterResourceGroupName(cd.Spec.ClusterMetadata.InfraID))
+		gen2ImageExists, err := a.gen2ImageExists(ic.Platform.Azure.ClusterResourceGroupName(cd.Spec.ClusterMetadata.InfraID))
 		if err != nil {
 			return nil, false, err
 		}
@@ -205,7 +207,7 @@ func (a *AzureActuator) getImagesByResourceGroup(resourceGroupName string) ([]co
 	return images, err
 }
 
-func (a *AzureActuator) gen2ImageExists(infraID, resourceGroupName string) (bool, error) {
+func (a *AzureActuator) gen2ImageExists(resourceGroupName string) (bool, error) {
 	images, err := a.getImagesByResourceGroup(resourceGroupName)
 	if err != nil {
 		return false, errors.Wrapf(err, "error listing images by resourceGroup: %s", resourceGroupName)

--- a/pkg/controller/machinepool/azureactuator_test.go
+++ b/pkg/controller/machinepool/azureactuator_test.go
@@ -100,6 +100,7 @@ func TestAzureActuator(t *testing.T) {
 				assert.Equal(t, testInfraID+"-worker-subnet", providerSpec.Subnet, "unexpected ComputeSubnet => Subnet")
 				assert.Equal(t, testInfraID+"-vnet", providerSpec.Vnet, "unexpected VirtualNetwork => Vnet")
 				assert.False(t, providerSpec.AcceleratedNetworking, "expected basic networking")
+				assert.Equal(t, providerSpec.PublicLoadBalancer, testInfraID, "expected default (clusterID) public load balancer")
 			},
 		},
 		{
@@ -111,6 +112,7 @@ func TestAzureActuator(t *testing.T) {
 				pool.Spec.Platform.Azure.ComputeSubnet = "some-subnet"
 				pool.Spec.Platform.Azure.VirtualNetwork = "some-vnet"
 				pool.Spec.Platform.Azure.VMNetworkingType = "Accelerated"
+				pool.Spec.Platform.Azure.OutboundType = "UserDefinedRouting"
 				return pool
 			}(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
@@ -128,6 +130,7 @@ func TestAzureActuator(t *testing.T) {
 				assert.Equal(t, "some-subnet", providerSpec.Subnet, "unexpected ComputeSubnet => Subnet")
 				assert.Equal(t, "some-vnet", providerSpec.Vnet, "unexpected VirtualNetwork => Vnet")
 				assert.True(t, providerSpec.AcceleratedNetworking, "expected accelerated networking")
+				assert.Equal(t, providerSpec.PublicLoadBalancer, "", "expected empty public load balancer with UserDefinedRouting")
 			},
 		},
 		{

--- a/vendor/github.com/openshift/hive/apis/hive/v1/azure/machinepool.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/azure/machinepool.go
@@ -41,6 +41,10 @@ type MachinePool struct {
 	// +kubebuilder:validation:Enum="Accelerated"; "Basic"
 	// +optional
 	VMNetworkingType string `json:"vmNetworkingType,omitempty"`
+
+	// OutboundType is a strategy for how egress from cluster is achieved. When not specified default is "Loadbalancer".
+	// +optional
+	OutboundType string `json:"outboundType"`
 }
 
 // OSImage is the image to use for the OS of a machine.


### PR DESCRIPTION
Add `OutboundType` to the Azure-specific MachinePool section so that `UserDefinedRouting` -- which results in an empty `PublicLoadBalancer` field in the MachineSet providerSpec -- can be used.

[HIVE-2674](https://issues.redhat.com//browse/HIVE-2674)