### PR TITLE
GCP: Hibernation: Support SSDs

### DIFF
--- a/apis/hive/v1/gcp/platform.go
+++ b/apis/hive/v1/gcp/platform.go
@@ -19,6 +19,14 @@ type Platform struct {
 	// of using public load balancers.
 	// +optional
 	PrivateServiceConnect *PrivateServiceConnect `json:"privateServiceConnect,omitempty"`
+
+	// DiscardLocalSsdOnHibernate passes the specified value through to the GCP API to indicate
+	// whether the content of any local SSDs should be preserved or discarded. See
+	// https://cloud.google.com/compute/docs/disks/local-ssd#stop_instance
+	// This field is required when attempting to hibernate clusters with instances possessing
+	// SSDs -- e.g. those with GPUs.
+	// +optional
+	DiscardLocalSsdOnHibernate *bool `json:"discardLocalSsdOnHibernate,omitempty"`
 }
 
 // PrivateServiceConnectAccess configures access to the cluster API using GCP Private Service Connect

--- a/apis/hive/v1/gcp/zz_generated.deepcopy.go
+++ b/apis/hive/v1/gcp/zz_generated.deepcopy.go
@@ -120,6 +120,11 @@ func (in *Platform) DeepCopyInto(out *Platform) {
 		*out = new(PrivateServiceConnect)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DiscardLocalSsdOnHibernate != nil {
+		in, out := &in.DiscardLocalSsdOnHibernate, &out.DiscardLocalSsdOnHibernate
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/config/crds/hive.openshift.io_clusterdeployments.yaml
+++ b/config/crds/hive.openshift.io_clusterdeployments.yaml
@@ -702,6 +702,14 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                      discardLocalSsdOnHibernate:
+                        description: |-
+                          DiscardLocalSsdOnHibernate passes the specified value through to the GCP API to indicate
+                          whether the content of any local SSDs should be preserved or discarded. See
+                          https://cloud.google.com/compute/docs/disks/local-ssd#stop_instance
+                          This field is required when attempting to hibernate clusters with instances possessing
+                          SSDs -- e.g. those with GPUs.
+                        type: boolean
                       privateServiceConnect:
                         description: |-
                           PrivateSericeConnect allows users to enable access to the cluster's API server using GCP

--- a/config/crds/hive.openshift.io_clusterpools.yaml
+++ b/config/crds/hive.openshift.io_clusterpools.yaml
@@ -542,6 +542,14 @@ spec:
                             type: string
                         type: object
                         x-kubernetes-map-type: atomic
+                      discardLocalSsdOnHibernate:
+                        description: |-
+                          DiscardLocalSsdOnHibernate passes the specified value through to the GCP API to indicate
+                          whether the content of any local SSDs should be preserved or discarded. See
+                          https://cloud.google.com/compute/docs/disks/local-ssd#stop_instance
+                          This field is required when attempting to hibernate clusters with instances possessing
+                          SSDs -- e.g. those with GPUs.
+                        type: boolean
                       privateServiceConnect:
                         description: |-
                           PrivateSericeConnect allows users to enable access to the cluster's API server using GCP

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -1332,6 +1332,20 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                        discardLocalSsdOnHibernate:
+                          description: 'DiscardLocalSsdOnHibernate passes the specified
+                            value through to the GCP API to indicate
+
+                            whether the content of any local SSDs should be preserved
+                            or discarded. See
+
+                            https://cloud.google.com/compute/docs/disks/local-ssd#stop_instance
+
+                            This field is required when attempting to hibernate clusters
+                            with instances possessing
+
+                            SSDs -- e.g. those with GPUs.'
+                          type: boolean
                         privateServiceConnect:
                           description: 'PrivateSericeConnect allows users to enable
                             access to the cluster''s API server using GCP
@@ -3481,6 +3495,20 @@ objects:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                        discardLocalSsdOnHibernate:
+                          description: 'DiscardLocalSsdOnHibernate passes the specified
+                            value through to the GCP API to indicate
+
+                            whether the content of any local SSDs should be preserved
+                            or discarded. See
+
+                            https://cloud.google.com/compute/docs/disks/local-ssd#stop_instance
+
+                            This field is required when attempting to hibernate clusters
+                            with instances possessing
+
+                            SSDs -- e.g. those with GPUs.'
+                          type: boolean
                         privateServiceConnect:
                           description: 'PrivateSericeConnect allows users to enable
                             access to the cluster''s API server using GCP

--- a/pkg/clusterresource/gcp.go
+++ b/pkg/clusterresource/gcp.go
@@ -34,8 +34,13 @@ type GCPCloudBuilder struct {
 	// Region is the GCP region to which to install the cluster.
 	Region string
 
-	// PrivateServiceConncet is true if the cluster should use GCP Private Service Connect
+	// PrivateServiceConnect is true if the cluster should use GCP Private Service Connect
 	PrivateServiceConnect bool
+
+	// DiscardLocalSsdOnHibernate describes the desired behavior of SSDs attached to certain
+	// VM types when instances are shut down on hibernate. See the field of the same name in
+	// the GCP Platform API.
+	DiscardLocalSsdOnHibernate *bool
 }
 
 func NewGCPCloudBuilderFromSecret(credsSecret *corev1.Secret) (*GCPCloudBuilder, error) {
@@ -77,6 +82,8 @@ func (p *GCPCloudBuilder) GetCloudPlatform(o *Builder) hivev1.Platform {
 			PrivateServiceConnect: &hivev1gcp.PrivateServiceConnect{
 				Enabled: p.PrivateServiceConnect,
 			},
+			// May be nil
+			DiscardLocalSsdOnHibernate: p.DiscardLocalSsdOnHibernate,
 		},
 	}
 }

--- a/pkg/controller/clusterpool/clusterpool_controller.go
+++ b/pkg/controller/clusterpool/clusterpool_controller.go
@@ -1227,6 +1227,8 @@ func (r *ReconcileClusterPool) createCloudBuilder(pool *hivev1.ClusterPool, logg
 			logger.WithError(err).Info("could not build GCP cloud builder")
 			return nil, err
 		}
+		// may be nil
+		cloudBuilder.DiscardLocalSsdOnHibernate = platform.GCP.DiscardLocalSsdOnHibernate
 		cloudBuilder.Region = platform.GCP.Region
 		return cloudBuilder, nil
 	case platform.Azure != nil:

--- a/pkg/controller/hibernation/aws_actuator_test.go
+++ b/pkg/controller/hibernation/aws_actuator_test.go
@@ -389,11 +389,9 @@ func testAWSActuator(awsClient awsclient.Client) *awsActuator {
 }
 
 func testClusterDeployment() *hivev1.ClusterDeployment {
-	return testcd.BasicBuilder().Options(func(cd *hivev1.ClusterDeployment) {
-		cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{
-			InfraID: "abcd1234",
-		}
-	}).Build()
+	return testcd.BasicBuilder().Options(testcd.WithClusterMetadata(&hivev1.ClusterMetadata{
+		InfraID: "abcd1234",
+	})).Build()
 }
 
 func setupClientInstances(awsClient *mockawsclient.MockClient, states map[string]int) {

--- a/pkg/gcpclient/mock/client_generated.go
+++ b/pkg/gcpclient/mock/client_generated.go
@@ -475,17 +475,22 @@ func (mr *MockClientMockRecorder) StartInstance(arg0 interface{}) *gomock.Call {
 }
 
 // StopInstance mocks base method.
-func (m *MockClient) StopInstance(arg0 *compute.Instance) error {
+func (m *MockClient) StopInstance(arg0 *compute.Instance, arg1 ...gcpclient.InstancesStopCallOption) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StopInstance", arg0)
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "StopInstance", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StopInstance indicates an expected call of StopInstance.
-func (mr *MockClientMockRecorder) StopInstance(arg0 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) StopInstance(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstance", reflect.TypeOf((*MockClient)(nil).StopInstance), arg0)
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopInstance", reflect.TypeOf((*MockClient)(nil).StopInstance), varargs...)
 }
 
 // UpdateResourceRecordSet mocks base method.

--- a/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook.go
+++ b/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook.go
@@ -47,7 +47,21 @@ const (
 )
 
 var (
-	mutableFields = []string{"CertificateBundles", "ClusterMetadata", "ControlPlaneConfig", "Ingress", "Installed", "PreserveOnDelete", "ClusterPoolRef", "PowerState", "HibernateAfter", "InstallAttemptsLimit", "Platform.AgentBareMetal.AgentSelector", "Platform.AWS.PrivateLink.AdditionalAllowedPrincipals"}
+	mutableFields = []string{
+		"CertificateBundles",
+		"ClusterMetadata",
+		"ControlPlaneConfig",
+		"Ingress",
+		"Installed",
+		"PreserveOnDelete",
+		"ClusterPoolRef",
+		"PowerState",
+		"HibernateAfter",
+		"InstallAttemptsLimit",
+		"Platform.AgentBareMetal.AgentSelector",
+		"Platform.AWS.PrivateLink.AdditionalAllowedPrincipals",
+		"Platform.GCP.DiscardLocalSsdOnHibernate",
+	}
 )
 
 // ClusterDeploymentValidatingAdmissionHook is a struct that is used to reference what code should be run by the generic-admission-server.

--- a/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook_test.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	hivev1agent "github.com/openshift/hive/apis/hive/v1/agent"
@@ -659,7 +659,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						AWS: &hivev1aws.Metadata{
-							HostedZoneRole: pointer.String("my-hzr"),
+							HostedZoneRole: ptr.To("my-hzr"),
 						},
 					},
 				}
@@ -683,7 +683,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						AWS: &hivev1aws.Metadata{
-							HostedZoneRole: pointer.String("my-hzr"),
+							HostedZoneRole: ptr.To("my-hzr"),
 						},
 					},
 				}
@@ -708,7 +708,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						AWS: &hivev1aws.Metadata{
-							HostedZoneRole: pointer.String("my-hzr"),
+							HostedZoneRole: ptr.To("my-hzr"),
 						},
 					},
 				}
@@ -726,7 +726,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						AWS: &hivev1aws.Metadata{
-							HostedZoneRole: pointer.String(""),
+							HostedZoneRole: ptr.To(""),
 						},
 					},
 				}
@@ -739,7 +739,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						AWS: &hivev1aws.Metadata{
-							HostedZoneRole: pointer.String("my-hzr"),
+							HostedZoneRole: ptr.To("my-hzr"),
 						},
 					},
 				}
@@ -757,7 +757,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						AWS: &hivev1aws.Metadata{
-							HostedZoneRole: pointer.String("my-hzr"),
+							HostedZoneRole: ptr.To("my-hzr"),
 						},
 					},
 				}
@@ -842,7 +842,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						Azure: &hivev1azure.Metadata{
-							ResourceGroupName: pointer.String("my-rg"),
+							ResourceGroupName: ptr.To("my-rg"),
 						},
 					},
 				}
@@ -866,7 +866,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						Azure: &hivev1azure.Metadata{
-							ResourceGroupName: pointer.String("my-rg"),
+							ResourceGroupName: ptr.To("my-rg"),
 						},
 					},
 				}
@@ -891,7 +891,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						Azure: &hivev1azure.Metadata{
-							ResourceGroupName: pointer.String("my-rg"),
+							ResourceGroupName: ptr.To("my-rg"),
 						},
 					},
 				}
@@ -909,7 +909,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						Azure: &hivev1azure.Metadata{
-							ResourceGroupName: pointer.String("old-rg"),
+							ResourceGroupName: ptr.To("old-rg"),
 						},
 					},
 				}
@@ -922,7 +922,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						Azure: &hivev1azure.Metadata{
-							ResourceGroupName: pointer.String("my-rg"),
+							ResourceGroupName: ptr.To("my-rg"),
 						},
 					},
 				}
@@ -940,7 +940,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						Azure: &hivev1azure.Metadata{
-							ResourceGroupName: pointer.String("my-rg"),
+							ResourceGroupName: ptr.To("my-rg"),
 						},
 					},
 				}
@@ -1185,6 +1185,43 @@ func TestClusterDeploymentValidate(t *testing.T) {
 			expectedAllowed: true,
 		},
 		{
+			name:      "GCP set DiscardLocalSsdOnHibernate allowed",
+			oldObject: validGCPClusterDeployment(),
+			newObject: func() *hivev1.ClusterDeployment {
+				cd := validGCPClusterDeployment()
+				cd.Spec.Platform.GCP.DiscardLocalSsdOnHibernate = ptr.To(true)
+				return cd
+			}(),
+			operation:       admissionv1beta1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "GCP unset DiscardLocalSsdOnHibernate allowed",
+			oldObject: func() *hivev1.ClusterDeployment {
+				cd := validGCPClusterDeployment()
+				cd.Spec.Platform.GCP.DiscardLocalSsdOnHibernate = ptr.To(true)
+				return cd
+			}(),
+			newObject:       validGCPClusterDeployment(),
+			operation:       admissionv1beta1.Update,
+			expectedAllowed: true,
+		},
+		{
+			name: "GCP edit DiscardLocalSsdOnHibernate allowed",
+			oldObject: func() *hivev1.ClusterDeployment {
+				cd := validGCPClusterDeployment()
+				cd.Spec.Platform.GCP.DiscardLocalSsdOnHibernate = ptr.To(true)
+				return cd
+			}(),
+			newObject: func() *hivev1.ClusterDeployment {
+				cd := validGCPClusterDeployment()
+				cd.Spec.Platform.GCP.DiscardLocalSsdOnHibernate = ptr.To(false)
+				return cd
+			}(),
+			operation:       admissionv1beta1.Update,
+			expectedAllowed: true,
+		},
+		{
 			name: "GCP set network project ID: installed",
 			oldObject: func() *hivev1.ClusterDeployment {
 				cd := validGCPClusterDeployment()
@@ -1201,7 +1238,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						GCP: &hivev1gcp.Metadata{
-							NetworkProjectID: pointer.String("my@np.id"),
+							NetworkProjectID: ptr.To("my@np.id"),
 						},
 					},
 				}
@@ -1225,7 +1262,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						GCP: &hivev1gcp.Metadata{
-							NetworkProjectID: pointer.String("my@np.id"),
+							NetworkProjectID: ptr.To("my@np.id"),
 						},
 					},
 				}
@@ -1250,7 +1287,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						GCP: &hivev1gcp.Metadata{
-							NetworkProjectID: pointer.String("my@np.id"),
+							NetworkProjectID: ptr.To("my@np.id"),
 						},
 					},
 				}
@@ -1268,7 +1305,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						GCP: &hivev1gcp.Metadata{
-							NetworkProjectID: pointer.String(""),
+							NetworkProjectID: ptr.To(""),
 						},
 					},
 				}
@@ -1281,7 +1318,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						GCP: &hivev1gcp.Metadata{
-							NetworkProjectID: pointer.String("my@np.id"),
+							NetworkProjectID: ptr.To("my@np.id"),
 						},
 					},
 				}
@@ -1299,7 +1336,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					InfraID: "an-infra-id",
 					Platform: &hivev1.ClusterPlatformMetadata{
 						GCP: &hivev1gcp.Metadata{
-							NetworkProjectID: pointer.String("my@np.id"),
+							NetworkProjectID: ptr.To("my@np.id"),
 						},
 					},
 				}

--- a/vendor/github.com/openshift/hive/apis/hive/v1/gcp/platform.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/gcp/platform.go
@@ -19,6 +19,14 @@ type Platform struct {
 	// of using public load balancers.
 	// +optional
 	PrivateServiceConnect *PrivateServiceConnect `json:"privateServiceConnect,omitempty"`
+
+	// DiscardLocalSsdOnHibernate passes the specified value through to the GCP API to indicate
+	// whether the content of any local SSDs should be preserved or discarded. See
+	// https://cloud.google.com/compute/docs/disks/local-ssd#stop_instance
+	// This field is required when attempting to hibernate clusters with instances possessing
+	// SSDs -- e.g. those with GPUs.
+	// +optional
+	DiscardLocalSsdOnHibernate *bool `json:"discardLocalSsdOnHibernate,omitempty"`
 }
 
 // PrivateServiceConnectAccess configures access to the cluster API using GCP Private Service Connect

--- a/vendor/github.com/openshift/hive/apis/hive/v1/gcp/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/gcp/zz_generated.deepcopy.go
@@ -120,6 +120,11 @@ func (in *Platform) DeepCopyInto(out *Platform) {
 		*out = new(PrivateServiceConnect)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DiscardLocalSsdOnHibernate != nil {
+		in, out := &in.DiscardLocalSsdOnHibernate, &out.DiscardLocalSsdOnHibernate
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
It would seem as though, when stopping an instance with SSDs, one is required to specify whether their contents should be preserved or discarded, despite what the documentation [1] says about defaulting that behavior to the latter. This will result in a failure to stop instances, with the following message appearing in the ClusterDeployment's Hibernating condition:

```
Error 400: VM has a Local SSD attached but
an undefined value for `discard-local-ssd`. If using gcloud, please add `--discard-local-ssd=false`
or `--discard-local-ssd=true` to your command.
```

This change adds
ClusterDeployment.Spec.Platform.GCP.DiscardLocalSsdOnHibernate, a _pointer_ to a bool that we will pass through to the GCP API if provided. The default behavior is as before: when the field is not populated, we will not pass the option to the GCP API at all, which continues to be fine for non-SSD-having VMs.

For usability purposes, we allow this field to be edited (most spec fields are immutable, enforced by validating webhook).

[1] https://cloud.google.com/compute/docs/disks/local-ssd#stop_instance

[HIVE-2693](https://issues.redhat.com//browse/HIVE-2693)