### PR TITLE
Always reset hive_hiveconfig_conditions[Ready]

### DIFF
--- a/pkg/operator/metrics/metrics.go
+++ b/pkg/operator/metrics/metrics.go
@@ -106,6 +106,10 @@ func (mc *Calculator) Start(ctx context.Context) error {
 			return
 		}
 
+		// Clear the metricHiveConfigConditions for Ready condition before setting it, to ensure we are not reporting stale values during migration
+		metricHiveConfigConditions.DeletePartialMatch(map[string]string{
+			"condition": string(hivev1.HiveReadyCondition),
+		})
 		mc.setHiveConfigMetrics(hiveConfig)
 
 	}, mc.Interval)


### PR DESCRIPTION
Metric hive_hiveconfig_conditions reports the status of HiveConfig Ready condition. Under normal circumstances, this value can either be 1 (when reason = Success) or 0 (when reason = ErrorDeployingHive). Consequently we never bothered to clear the metric as it would be automatically reset when the pod is restarted.

However, during migration, this can result in conflicting values. First, the metric reports 1, but when migration is started, the metric starts reporting 0 without clearing the previous 1, resulting in two values at the same time.
Once the migration is successful, the previous metric value of 0 is also not cleared when we start reporting 1. Only when the pod is restarted, the correct value is reported.

This commit fixes the problem by deleting all the values for hive_hiveconfig_conditions for Ready condition every time we set the metric.

[Hive-2746](https://issues.redhat.com/browse/HIVE-2746)

/assign @2uasimojo 