### PR TITLE
HIVE-2752: PrivateLink: add control-plane network tags to gcp psc

### DIFF
--- a/pkg/controller/privatelink/actuator/gcpactuator/gcplinkactuator.go
+++ b/pkg/controller/privatelink/actuator/gcpactuator/gcplinkactuator.go
@@ -383,7 +383,10 @@ func (a *GCPLinkActuator) ensureServiceAttachmentFirewall(cd *hivev1.ClusterDepl
 	firewall, err := a.gcpClientSpoke.GetFirewall(firewallName)
 	if isNotFound(err) {
 		cidr := getServiceAttachmentSubnetCIDR(cd)
-		targets := []string{metadata.InfraID + "-master"}
+		targets := []string{
+			metadata.InfraID + "-master",        // 4.15 and older
+			metadata.InfraID + "-control-plane", // 4.16 and newer
+		}
 		newFirewall, err := a.createServiceAttachmentFirewall(firewallName, cidr, network, targets)
 		if err != nil {
 			return false, nil, err

--- a/pkg/controller/privatelink/actuator/gcpactuator/gcplinkactuator_test.go
+++ b/pkg/controller/privatelink/actuator/gcpactuator/gcplinkactuator_test.go
@@ -1419,8 +1419,8 @@ func Test_ensureServiceAttachmentFirewall(t *testing.T) {
 			m.EXPECT().CreateFirewall(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, newGoogleApiError(http.StatusUnauthorized, "AccessDenied", "not authorized to CreateFirewall"))
 		},
 		expectError: "error creating the Service Attachment Firewall: googleapi: Error 401: not authorized to CreateFirewall, AccessDenied",
-	}, { // Should return modified on createServiceAttachment success
-		name: "createServiceAttachment success",
+	}, { // Should return modified on createServiceAttachmentFirewall success
+		name: "createServiceAttachmentFirewall success",
 		cd: cdBuilder.Build(
 			testcd.WithGCPPlatform(&hivev1gcp.Platform{}),
 			testcd.WithGCPPlatformStatus(&hivev1gcp.PlatformStatus{
@@ -1430,7 +1430,9 @@ func Test_ensureServiceAttachmentFirewall(t *testing.T) {
 		),
 		gcpClientConfig: func(m *mockclient.MockClient) {
 			m.EXPECT().GetFirewall(gomock.Any()).Return(nil, newGoogleApiError(http.StatusNotFound, "NotFound", "Firewall not found"))
-			m.EXPECT().CreateFirewall(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockFirewall, nil)
+			m.EXPECT().CreateFirewall(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				[]string{testInfraID + "-master", testInfraID + "-control-plane"},
+			).Return(mockFirewall, nil)
 		},
 		expect:         mockFirewall,
 		expectModified: true,


### PR DESCRIPTION
Prior to this change, the gcp privatelink firewall rule was targeting the <infraid>-master network tag. However, in 4.16 the installer changed to using <infraid>-control-plane. This change adds the newer tag to the firewall rule.