### PR TITLE
HIVE-2764: Upstream builds for operatorhub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,12 @@ ARG BASE_IMAGE=${BASE_IMAGE:-registry.ci.openshift.org/ocp/4.16:base-rhel9}
 
 FROM ${EL8_BUILD_IMAGE} as builder_rhel8
 ARG GO=${GO:-go}
+ARG BUILD_IMAGE_CUSTOMIZATION
 RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .
 
+RUN if [ -f "${BUILD_IMAGE_CUSTOMIZATION}" ]; then "${BUILD_IMAGE_CUSTOMIZATION}"; fi
 
 RUN if [ -e "/activation-key/org" ]; then unlink /etc/rhsm-host; subscription-manager register --force --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
 RUN python3 -m ensurepip
@@ -18,9 +20,12 @@ RUN make build-hiveutil
 FROM ${EL9_BUILD_IMAGE} as builder_rhel9
 ARG GO=${GO:-go}
 ARG CONTAINER_SUB_MANAGER_OFF
+ARG BUILD_IMAGE_CUSTOMIZATION
 RUN mkdir -p /go/src/github.com/openshift/hive
 WORKDIR /go/src/github.com/openshift/hive
 COPY . .
+
+RUN if [ -f "${BUILD_IMAGE_CUSTOMIZATION}" ]; then "${BUILD_IMAGE_CUSTOMIZATION}"; fi
 
 ENV SMDEV_CONTAINER_OFF=${CONTAINER_SUB_MANAGER_OFF}
 RUN if [ -e "/activation-key/org" ]; then unlink /etc/rhsm-host; subscription-manager register --force --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
@@ -44,7 +49,7 @@ RUN if ! rpm -q openssh-clients; then dnf install -y openssh-clients && dnf clea
 RUN if ! rpm -q libvirt-libs; then dnf install -y libvirt-libs && dnf clean all && rm -rf /var/cache/dnf/*; fi
 
 # tar is needed to package must-gathers on install failure
-RUN if ! which tar; then dnf install -y tar && dnf clean all && rm -rf /var/cache/dnf/*; fi
+RUN if ! command -v tar; then dnf install -y tar && dnf clean all && rm -rf /var/cache/dnf/*; fi
 
 COPY --from=builder_rhel9 /go/src/github.com/openshift/hive/bin/manager /opt/services/
 COPY --from=builder_rhel9 /go/src/github.com/openshift/hive/bin/hiveadmission /opt/services/

--- a/Makefile
+++ b/Makefile
@@ -318,6 +318,14 @@ buildah-dev-build:
 podman-dev-build:
 	podman build --tag ${IMG} $(GOCACHE_VOL_ARG) -f ./Dockerfile .
 
+podman-operatorhub-build:
+	podman build --tag ${IMG} ${GOCACHE_VOL_ARG} \
+		--build-arg=BASE_IMAGE=quay.io/centos/centos:stream9 \
+		--build-arg=BUILD_IMAGE_CUSTOMIZATION=./hack/ubi-build-deps.sh \
+		--build-arg=EL8_BUILD_IMAGE=registry.access.redhat.com/ubi8/ubi:8.10 \
+		--build-arg=EL9_BUILD_IMAGE=registry.access.redhat.com/ubi9:9.5 \
+		-f ./Dockerfile .
+
 # Build and push the dev image with buildah
 .PHONY: buildah-dev-push
 buildah-dev-push: buildah-dev-build

--- a/hack/ubi-build-deps.sh
+++ b/hack/ubi-build-deps.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+dnf install -y \
+	git \
+	golang \
+	make \
+	python3


### PR DESCRIPTION
This adds a Makefile target that relies on ubi8, ubi9 and centos stream to provide an upstream image that is fit for OperatorHub.