### PR TITLE
bundle-gen.py: build and push public images

### DIFF
--- a/hack/version2.py
+++ b/hack/version2.py
@@ -10,7 +10,7 @@ import git
 # Match things like 'mce-2.0' or origin/mce-2.0, capturing:
 # 1: 'origin/'
 # 2: '2.0' (used for the bundle semver prefix)
-MCE_BRANCH_RE = re.compile("^([^/]+/)?mce-(\d+\.\d+)$")
+MCE_BRANCH_RE = re.compile("^([^/]+/)?mce-(\\d+\\.\\d+)$")
 
 MASTER_BRANCH_RE = re.compile("^([^/]+/)?master$")
 


### PR DESCRIPTION
Our OperatorHub bundle generator validates the discovered/specified operator image by querying the repository to see if it exists. Previously if it did not exist, we would simply fail. With this change, we instead attempt to build and push it.

This also changes the default repository from AppSRE's to hive's.

...and addresses a latent syntax error in a regex used to generate semvers from MCE branch names.

[HIVE-2766](https://issues.redhat.com//browse/HIVE-2766)