### PR TITLE
fix(builds): Operatorhub golang bump to 1.23

### DIFF
--- a/.tekton/hive-pull-request.yaml
+++ b/.tekton/hive-pull-request.yaml
@@ -236,8 +236,8 @@ spec:
         value:
         - $(params.build-args[*])
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23.2-202411290846.g6707acc.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23.4
         - BASE_IMAGE=registry.redhat.io/rhel9-2-els/rhel:9.2
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)

--- a/.tekton/hive-push.yaml
+++ b/.tekton/hive-push.yaml
@@ -233,8 +233,8 @@ spec:
         value:
         - $(params.build-args[*])
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23.2-202411290846.g6707acc.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23.4
         - BASE_IMAGE=registry.redhat.io/rhel9-2-els/rhel:9.2
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)

--- a/hack/ubi-build-deps.sh
+++ b/hack/ubi-build-deps.sh
@@ -4,3 +4,9 @@ dnf install -y \
 	golang \
 	make \
 	python3
+
+# Since go 1.23.x is not available in ubi8, let's go upstream
+go install golang.org/dl/go1.23.6@latest
+/root/go/bin/go1.23.6 download
+rm /usr/bin/go
+ln -s /root/go/bin/go1.23.6 /usr/bin/go


### PR DESCRIPTION
Use upstream golang for Operatorhub builds since ubi8 does not have go 1.23 available.