### PR TITLE
HIVE-2785: Remove obsolete version check

### DIFF
--- a/pkg/controller/machinepool/gcpactuator_test.go
+++ b/pkg/controller/machinepool/gcpactuator_test.go
@@ -766,55 +766,21 @@ func TestObtainLeaseChar(t *testing.T) {
 func TestRequireLeases(t *testing.T) {
 	cases := []struct {
 		name            string
-		clusterVersion  string
 		machineSetNames []string
 		expectedResult  bool
 	}{
 		{
-			name:           "before 4.4.7",
-			clusterVersion: "4.4.6",
-			expectedResult: true,
-		},
-		{
-			name:           "4.4.7",
-			clusterVersion: "4.4.7",
-			expectedResult: false,
-		},
-		{
-			name:           "after 4.4.7",
-			clusterVersion: "4.4.8",
-			expectedResult: false,
-		},
-		{
-			name:           "4.5",
-			clusterVersion: "4.5.0",
-			expectedResult: false,
-		},
-		{
-			name:           "after 4.5",
-			clusterVersion: "4.6.0",
-			expectedResult: false,
-		},
-		{
-			name:           "invalid version",
-			clusterVersion: "bad-version",
-			expectedResult: false,
-		},
-		{
 			name:            "worker machine pool",
-			clusterVersion:  "4.5.0",
 			machineSetNames: []string{"cluster-id-worker-a", "cluster-id-worker-b"},
 			expectedResult:  false,
 		},
 		{
 			name:            "w machine pool",
-			clusterVersion:  "4.5.0",
 			machineSetNames: []string{"cluster-id-w-a", "cluster-id-w-a"},
 			expectedResult:  true,
 		},
 		{
 			name:            "worker and w machine pools",
-			clusterVersion:  "4.5.0",
 			machineSetNames: []string{"cluster-id-worker-a", "cluster-id-worker-a", "cluster-id-w-a", "cluster-id-w-a"},
 			expectedResult:  false,
 		},
@@ -825,7 +791,7 @@ func TestRequireLeases(t *testing.T) {
 			for i, n := range tc.machineSetNames {
 				machineSets[i].Name = n
 			}
-			actualResult := requireLeases(tc.clusterVersion, machineSets, log.WithFields(nil))
+			actualResult := requireLeases(machineSets, log.WithFields(nil))
 			assert.Equal(t, tc.expectedResult, actualResult)
 		})
 	}

--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -1286,11 +1286,7 @@ func (r *ReconcileMachinePool) createActuator(
 		); err != nil {
 			return nil, err
 		}
-		clusterVersion, err := getClusterVersion(cd)
-		if err != nil {
-			return nil, err
-		}
-		return NewGCPActuator(r.Client, creds, pool, clusterVersion, masterMachine, remoteMachineSets, r.scheme, r.expectations, logger)
+		return NewGCPActuator(r.Client, creds, pool, masterMachine, remoteMachineSets, r.scheme, r.expectations, logger)
 	case cd.Spec.Platform.Azure != nil:
 		creds := &corev1.Secret{}
 		if err := r.Get(


### PR DESCRIPTION
Remove logic associated with checking whether the spoke cluster's version is >=4.4.8, since that's way out of service.