### PR TITLE
HIVE-2788: MachinePool/GCP: Remove DiskType enum

### DIFF
--- a/apis/hive/v1/gcp/machinepools.go
+++ b/apis/hive/v1/gcp/machinepools.go
@@ -52,9 +52,8 @@ type MachinePool struct {
 // OSDisk defines the disk for machines on GCP.
 type OSDisk struct {
 	// DiskType defines the type of disk.
-	// The valid values are pd-standard and pd-ssd.
+	// The valid values at this time are: pd-standard, pd-ssd, local-ssd, pd-balanced, hyperdisk-balanced.
 	// Defaulted internally to pd-ssd.
-	// +kubebuilder:validation:Enum=pd-ssd;pd-standard
 	// +optional
 	DiskType string `json:"diskType,omitempty"`
 

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -352,11 +352,8 @@ spec:
                           diskType:
                             description: |-
                               DiskType defines the type of disk.
-                              The valid values are pd-standard and pd-ssd.
+                              The valid values at this time are: pd-standard, pd-ssd, local-ssd, pd-balanced, hyperdisk-balanced.
                               Defaulted internally to pd-ssd.
-                            enum:
-                            - pd-ssd
-                            - pd-standard
                             type: string
                           encryptionKey:
                             description: EncryptionKey defines the KMS key to be used

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -7359,12 +7359,10 @@ objects:
                             diskType:
                               description: 'DiskType defines the type of disk.
 
-                                The valid values are pd-standard and pd-ssd.
+                                The valid values at this time are: pd-standard, pd-ssd,
+                                local-ssd, pd-balanced, hyperdisk-balanced.
 
                                 Defaulted internally to pd-ssd.'
-                              enum:
-                              - pd-ssd
-                              - pd-standard
                               type: string
                             encryptionKey:
                               description: EncryptionKey defines the KMS key to be

--- a/vendor/github.com/openshift/hive/apis/hive/v1/gcp/machinepools.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/gcp/machinepools.go
@@ -52,9 +52,8 @@ type MachinePool struct {
 // OSDisk defines the disk for machines on GCP.
 type OSDisk struct {
 	// DiskType defines the type of disk.
-	// The valid values are pd-standard and pd-ssd.
+	// The valid values at this time are: pd-standard, pd-ssd, local-ssd, pd-balanced, hyperdisk-balanced.
 	// Defaulted internally to pd-ssd.
-	// +kubebuilder:validation:Enum=pd-ssd;pd-standard
 	// +optional
 	DiskType string `json:"diskType,omitempty"`
 


### PR DESCRIPTION
GCP seems to have added some disk types since we wrote our API for MachinePool.Spec.Platform.GCP.OSDisk.DiskType with an enum restricting it to two values (`pd-standard` and `pd-ssd`).

The proximate need is to be able to stand up C3 instances such as `c3-standard-192-metal`, which require a disk type of `hyperdisk-balanced`.

However, for future compatibility -- i.e. against the advent of GCP adding more disk types down the road -- this change simply removes the restriction, allowing the user to enter any string value. If they get it wrong, it just means it will be GCP rather than k8s that bounces the request.

Note that absorbing this change should only be a matter of reinstalling CRDs (specifically MachinePool). Controller code is not affected, here or downstream.