### PR TITLE
HIVE-2581: OpenStack e2e

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -123,6 +123,24 @@ function wait_for_namespace {
   exit 1
 }
 
+function get_osp_resources() {
+  local resource_path=$1
+
+  # Check if SHARED_DIR is set
+  if [ -z "$SHARED_DIR" ]; then
+    echo "Variable 'SHARED_DIR' not set."
+    exit 1
+  fi
+
+  # Check if the file exists
+  if [ ! -f "$1" ]; then
+    echo "Error: Resource file '$1' not found."
+    exit 1
+  fi
+
+  cat "$1"
+}
+
 function save_hive_logs() {
   tmpf=$(mktemp)
   for x in  "deploy  hive-controllers  ${HIVE_NS}" \
@@ -240,6 +258,23 @@ case "${CLOUD}" in
       --vsphere-ingress-vip=$INGRESS_VIP \
       --vsphere-network=$NETWORK_NAME \
       --vsphere-vcenter=$VCENTER"
+  ;;
+"openstack")
+  CREDS_FILE_ARG="--creds-file=${SHARED_DIR}/clouds.yaml"
+  USE_MANAGED_DNS=false
+  BASE_DOMAIN="${BASE_DOMAIN:-shiftstack.devcluster.openshift.com }"
+  API_FLOATING_IP=$(get_osp_resources "${SHARED_DIR}/HIVE_FIP_API")
+  INGRESS_FLOATING_IP=$(get_osp_resources "${SHARED_DIR}/HIVE_FIP_INGRESS")
+  EXTERNAL_NETWORK=$(get_osp_resources "${SHARED_DIR}/OPENSTACK_EXTERNAL_NETWORK")
+  COMPUTE_FLAVOR=$(get_osp_resources "${SHARED_DIR}/OPENSTACK_COMPUTE_FLAVOR")
+  CONTROLPLANE_FLAVOR=$(get_osp_resources "${SHARED_DIR}/OPENSTACK_CONTROLPLANE_FLAVOR")
+  EXTRA_CREATE_CLUSTER_ARGS="--openstack-api-floating-ip=$API_FLOATING_IP \
+      --openstack-ingress-floating-ip=$INGRESS_FLOATING_IP \
+      --machine-network="10.0.0.0/16" \
+      --openstack-cloud="openstack" \
+      --openstack-external-network=$EXTERNAL_NETWORK \
+      --openstack-compute-flavor=$COMPUTE_FLAVOR \
+      --openstack-master-flavor=$CONTROLPLANE_FLAVOR"
   ;;
 *)
 	echo "unknown cloud: ${CLOUD}"

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -88,7 +88,11 @@ if [[ $rc -ne 0 ]]; then
   exit 1
 fi
 
-export CLUSTER_NAME="${CLUSTER_NAME:-hive-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
+if [[ "${CLOUD}" == "openstack" ]]; then
+  export CLUSTER_NAME=$(get_osp_resources "${SHARED_DIR}/HIVE_CLUSTER_NAME")
+else
+  export CLUSTER_NAME="${CLUSTER_NAME:-hive-$(uuidgen | tr '[:upper:]' '[:lower:]')}"
+fi
 
 echo "Creating cluster deployment"
 # - Add a bogus API URL override to validate that our unreachable controller correctly


### PR DESCRIPTION
This PR aims to add e2e testing for Hive on the OpenStack cloud.

The cluster parameters match those used to create the OpenStack hub cluster in Prow CI.  The following resources are pre-created in CI and used in the Hive e2e:
  -  api floating ip - API_FLOATING_IP
  -  ingress floating ip - INGRESS_FLOATING_IP 
  -  spoke cluster name - HIVE_CLUSTER_NAME

Below is the log from my local run:

- The test parameters are consistent with those in Prow CI.  [local-e2e-test-openstack.log](https://github.com/user-attachments/files/19018775/local-e2e-test-openstack.log)
- The test parameters were created manually. [local-e2e-openstack.log](https://github.com/user-attachments/files/19018773/local-e2e-openstack.log)