### PR TITLE
Update vSphere e2e parameter configuration

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -223,6 +223,7 @@ case "${CLOUD}" in
 	;;
 "vsphere")
   BASE_DOMAIN="${BASE_DOMAIN:-vmc.devcluster.openshift.com}"
+  USE_MANAGED_DNS=false
   if [ -z "$NETWORK_NAME" ]; then
     echo "Variable 'NETWORK_NAME' not set."
     exit 1
@@ -334,5 +335,5 @@ function get_vips() {
   fi
 
   vip=$(sed -n "${idx}p" "$vips")
-  echo "$vip"
+  printf "%s" "$vip"
 }


### PR DESCRIPTION
1. Set managed DNS to false.  
   Currently, managed DNS only supports AWS, GCP, and Azure clouds.  

2. This function `get_vips()` uses `echo` to obtain the value, and the `echo` output includes a [timestamp](https://github.com/openshift/hive/blob/master/hack/e2e-common.sh#L3-L4).