### PR TITLE
[mce-2.5] HIVE-2786: CVE-2025-22869: x/crypto/ssh v0.33.openshift.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -436,3 +436,7 @@ exclude (
 // CVE-2025-22868
 // This is from tag v0.26.openshift.1
 replace golang.org/x/oauth2 => github.com/openshift/golang-oauth2 v0.26.1-0.20250310184649-06a918c6239d
+
+// CVE-2025-22869
+// This is from tag v0.33.openshift.1
+replace golang/x/crypto => github.com/openshift/golang-crypto v0.33.1-0.20250310193910-9003f682e581

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11064,3 +11064,4 @@ sigs.k8s.io/yaml
 # github.com/dgrijalva/jwt-go v3.2.0+incompatible => github.com/golang-jwt/jwt v3.2.1+incompatible
 # vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787
 # golang.org/x/oauth2 => github.com/openshift/golang-oauth2 v0.26.1-0.20250310184649-06a918c6239d
+# golang/x/crypto => github.com/openshift/golang-crypto v0.33.1-0.20250310193910-9003f682e581


### PR DESCRIPTION
Replace x/crypto with the openshift fork containing the fix. (The upstream fix in 0.35.0 requires golang 1.23, and bumping in this release would be Hard™.)

https://security.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXCRYPTOSSH-8747056

[ACM-18369](https://issues.redhat.com//browse/ACM-18369)