### PR TITLE
DNM: Try revendoring installer with a 1.* tag

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -13,3 +13,6 @@ ignore:
     'SNYK-GOLANG-K8SIOCLIENTGOTRANSPORT-7538822':
      - '* > k8s.io/client-go/transport':
         reason: 'Snyk mistakenly identifies v1.17.0-alpha.1 as newer than v0.29.7. client-go has a complicated history of versioning. Presumably, v1.20.0-alpha.1 referred to kubernetes-v1.20. kubernetes tags have since been prefaced by "kubernetes", whereas actual client-go versions resumed numbering from 0.x'
+    'SNYK-GOLANG-GITHUBCOMOPENSHIFTINSTALLERDATA-1070553':
+    - '* > github.com/openshift/installer/data':
+      reason: 'Snyk incorrectly flags this exposure because the semver of the tag we are referencing in go.mod sorts lower than the semver of the release branch in which the fix appeared several years ago.'

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/openshift/cluster-autoscaler-operator v0.0.0-20211006175002-fe524080b551
 	github.com/openshift/generic-admission-server v1.14.1-0.20250203204636-21579bd45f95
 	github.com/openshift/hive/apis v0.0.0
-	github.com/openshift/installer v0.90.101-0.20240912203725-dfd4c085a721
+	github.com/openshift/installer v1.14.16-dcf8320c8c4e
 	github.com/openshift/library-go v0.0.0-20240919205913-c96b82b3762b
 	github.com/openshift/machine-api-operator v0.2.1-0.20240930121047-57b7917e6140
 	github.com/openshift/machine-api-provider-gcp v0.0.1-0.20231014045125-6096cc86f3ba

--- a/go.sum
+++ b/go.sum
@@ -1193,8 +1193,8 @@ github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-202409090
 github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20240909043600-373ac49835bf/go.mod h1:2fZsjZ3QSPkoMUc8QntXfeBb8AnvW+WIYwwQX8vmgvQ=
 github.com/openshift/generic-admission-server v1.14.1-0.20250203204636-21579bd45f95 h1:Q8aJJZByWM5OP3nhqufRYxMy6qlBvJkGA2ii0Ksttzs=
 github.com/openshift/generic-admission-server v1.14.1-0.20250203204636-21579bd45f95/go.mod h1:9kXlVwaJd1fWlzDf8pzFQ1/FLLXe1Q1Wxq7s7dBEH/o=
-github.com/openshift/installer v0.90.101-0.20240912203725-dfd4c085a721 h1:R7PJ171uREaK1dXIPSIaFDWMBDKWcTzt4o5VbPAD5Ao=
-github.com/openshift/installer v0.90.101-0.20240912203725-dfd4c085a721/go.mod h1:PSL94uUGGsuOvuqfQ4wv9I4reGGiQk1PajnfU7N71Xo=
+github.com/openshift/installer v1.14.16-dcf8320c8c4e h1:GP9wv2Bv5cbBqGh57xXiI2kmaPSWwSOnUODxw+ljypU=
+github.com/openshift/installer v1.14.16-dcf8320c8c4e/go.mod h1:PSL94uUGGsuOvuqfQ4wv9I4reGGiQk1PajnfU7N71Xo=
 github.com/openshift/library-go v0.0.0-20210811133500-5e31383de2a7/go.mod h1:3GagmGg6gikg+hAqma7E7axBzs2pjx4+GrAbdl4OYdY=
 github.com/openshift/library-go v0.0.0-20240919205913-c96b82b3762b h1:y2DduJug7UZqTu0QTkRPAu73nskuUbFA66fmgxVf/fI=
 github.com/openshift/library-go v0.0.0-20240919205913-c96b82b3762b/go.mod h1:f8QcnrooSwGa96xI4UaKbKGJZskhTCGeimXKyc4t/ZU=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1590,7 +1590,7 @@ github.com/openshift/hive/apis/hive/v1/vsphere
 github.com/openshift/hive/apis/hivecontracts/v1alpha1
 github.com/openshift/hive/apis/hiveinternal/v1alpha1
 github.com/openshift/hive/apis/scheme
-# github.com/openshift/installer v0.90.101-0.20240912203725-dfd4c085a721
+# github.com/openshift/installer v1.14.16-dcf8320c8c4e
 ## explicit; go 1.22.0
 github.com/openshift/installer/data
 github.com/openshift/installer/pkg/asset


### PR DESCRIPTION
This is to see whether snyk still incorrectly flags https://security.snyk.io/vuln/SNYK-GOLANG-GITHUBCOMOPENSHIFTINSTALLERDATA-1070553