### PR TITLE
HIVE-2769: bundle-gen: skip konflux branches

### DIFF
--- a/hack/version2.py
+++ b/hack/version2.py
@@ -120,7 +120,7 @@ class Version:
                 return commit_ish
 
             refname = ref.remote_head if ref.is_remote() else ref.name
-            if refname == "HEAD":
+            if refname == "HEAD" or 'konflux/' in refname:
                 continue
 
             # Okay, now start using self._commit, which is already rev_parse()d.


### PR DESCRIPTION
- With the coordinated release process, we will often be generating OperatorHub bundles from an explicit commit that is behind the tip of `master`.
- The routine that searches for the branch associated with such a commit (used to determine the semver major.minor) was written before konflux started polluting our ref space.

The combination was resulting in errors like:

```
$ ./hack/bundle-gen.py --commit  b19773ecfc98ab9819f56e30433dd3716c14b9ce
Cloning git@github.com:openshift/hive.git to /tmp/hive-repo-h5ctac_7
Working in /tmp/hive-repo-h5ctac_7
Trying to discover a suitable branch from commit b19773e...
descendants: {'master', 'konflux/references/master'}
Could not determine a branch! Please specify one explicitly.
```

This change explicitly skips refs with `konflux/` in their name, as they're never* the one we're looking for.

*...until, perhaps, such a time as we start using konflux builds for OperatorHub bundles? Even then, though, I'm pretty sure we would still be wanting to discover `master` in this routine.