### PR TITLE
DNM: Test prow ignores

### DIFF
--- a/.tekton/hive-pull-request.yaml
+++ b/.tekton/hive-pull-request.yaml
@@ -1,3 +1,4 @@
+test: true
 apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:


### PR DESCRIPTION
- [DPTP-4372](https://issues.redhat.com//browse/DPTP-4372): While this is in draft state, we shouldn't run -- or even "expect" -- any prow jobs.
- [HIVE-2808](https://issues.redhat.com//browse/HIVE-2808): Main CI jobs shouldn't run for .tekton/-only changes.