### PR TITLE
DPTP-4372: Test prow ignores again

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 	golang.org/x/mod v0.23.0
 	golang.org/x/net v0.35.0 // indirect
-	golang.org/x/oauth2 v0.27.0
+	golang.org/x/oauth2 v0.27.0 // testing
 	golang.org/x/time v0.9.0
 	google.golang.org/api v0.220.0
 	gopkg.in/ini.v1 v1.67.0


### PR DESCRIPTION
It has now been long enough that branch protection rules should have been refreshed. Testing that `images` and `periodic-images` don't show up as "Expected" anymore for draft PRs.