### PR TITLE
HIVE-2416: MachinePool errors in status conditions

### DIFF
--- a/apis/hive/v1/machinepool_types.go
+++ b/apis/hive/v1/machinepool_types.go
@@ -228,6 +228,14 @@ const (
 	// UnsupportedConfigurationMachinePoolCondition is true when the configuration of the MachinePool is unsupported
 	// by the cluster.
 	UnsupportedConfigurationMachinePoolCondition MachinePoolConditionType = "UnsupportedConfiguration"
+
+	// MachineSetsGeneratedMachinePoolCondition is true when the most recent pass of the controller successfully
+	// generated MachineSet manifests to sync to the spoke cluster, false if it failed.
+	MachineSetsGeneratedMachinePoolCondition MachinePoolConditionType = "MachineSetsGenerated"
+
+	// SyncedMachinePoolCondition indicates whether the most recent pass of the controller successfully synced
+	// objects (MachineSets, and {Machine|Cluster}Autoscaler(s) if appropriate) to the spoke cluster.
+	SyncedMachinePoolCondition MachinePoolConditionType = "Synced"
 )
 
 // +genclient

--- a/pkg/test/machinepool/machinepool.go
+++ b/pkg/test/machinepool/machinepool.go
@@ -118,6 +118,14 @@ func WithInitializedStatusConditions() Option {
 				Status: corev1.ConditionUnknown,
 				Type:   hivev1.UnsupportedConfigurationMachinePoolCondition,
 			},
+			{
+				Status: corev1.ConditionUnknown,
+				Type:   hivev1.MachineSetsGeneratedMachinePoolCondition,
+			},
+			{
+				Status: corev1.ConditionUnknown,
+				Type:   hivev1.SyncedMachinePoolCondition,
+			},
 		}
 	}
 }

--- a/vendor/github.com/openshift/hive/apis/hive/v1/machinepool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/machinepool_types.go
@@ -228,6 +228,14 @@ const (
 	// UnsupportedConfigurationMachinePoolCondition is true when the configuration of the MachinePool is unsupported
 	// by the cluster.
 	UnsupportedConfigurationMachinePoolCondition MachinePoolConditionType = "UnsupportedConfiguration"
+
+	// MachineSetsGeneratedMachinePoolCondition is true when the most recent pass of the controller successfully
+	// generated MachineSet manifests to sync to the spoke cluster, false if it failed.
+	MachineSetsGeneratedMachinePoolCondition MachinePoolConditionType = "MachineSetsGenerated"
+
+	// SyncedMachinePoolCondition indicates whether the most recent pass of the controller successfully synced
+	// objects (MachineSets, and {Machine|Cluster}Autoscaler(s) if appropriate) to the spoke cluster.
+	SyncedMachinePoolCondition MachinePoolConditionType = "Synced"
 )
 
 // +genclient


### PR DESCRIPTION
Previously there was a whole class of errors in the MachinePool controller that would result in the user seeing nothing -- no change on the spoke, and no update to the MachinePool CR. Ultimately it was necessary to look at logs to triage further.

With this change, we have introduced two new status conditions covering four code paths which comprise the majority of the controller:
- `MachineSetsGenerated` indicates the success or failure of the actuator's `GenerateMachineSets()` function.
- `Synced` indicates the success or failure of our attempt to sync MachineSets, MachineAutoscalers and the ClusterAutoscaler -- disambiguated by way of the condition's reason code -- to the spoke cluster.

For failure conditions in each case, we copy the error text to the condition's `message` field. This is ordinarily dangerous in that it can cause thrashing, e.g. if error messages contain unique identifiers, or if errors occur randomly on one of several objects whose names are included in the text. We are attempting to mitigate this by deliberately using a static `requeueAfter` of one minute.