### PR TITLE
HIVE-2812: e2e: MachinePool tests retry on 409

### DIFF
--- a/test/e2e/common/machinepool.go
+++ b/test/e2e/common/machinepool.go
@@ -8,12 +8,12 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 )
 
-func GetMachinePool(cd *hivev1.ClusterDeployment, poolName string) *hivev1.MachinePool {
-	c := MustGetClient()
+func GetMachinePool(c client.Client, cd *hivev1.ClusterDeployment, poolName string) *hivev1.MachinePool {
 	pool := &hivev1.MachinePool{}
 	switch err := c.Get(
 		context.TODO(),


### PR DESCRIPTION
This is to reduce/eliminate flakes like:

```
=== RUN   TestScaleMachinePool
time="2025-03-26T17:11:35Z" level=info msg="expected Machine name prefix: hiveci-67e42826-a44-54t2j-worker-" pool=hiveci-67e42826-a44-worker test=TestScaleMachinePool
time="2025-03-26T17:11:35Z" level=info msg="scaling pool to 1 replicas" pool=hiveci-67e42826-a44-worker test=TestScaleMachinePool
    infra_test.go:67:
        	Error Trace:	/go/src/github.com/openshift/hive/test/e2e/postinstall/machinesets/infra_test.go:67
        	Error:      	Received unexpected error:
        	            	Operation cannot be fulfilled on machinepools.hive.openshift.io "hiveci-67e42826-a44-worker": the object has been modified; please apply your changes to the latest version and try again
        	Test:       	TestScaleMachinePool
        	Messages:   	cannot update worker machine pool to reduce replicas
--- FAIL: TestScaleMachinePool (0.19s)
```