### PR TITLE
HIVE-2819: Lift upgradeable condition from CVO to cluster deployment label

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -357,6 +357,10 @@ const (
 	// in the form "[MAJOR].[MINOR].[PATCH]".
 	VersionMajorMinorPatchLabel = "hive.openshift.io/version-major-minor-patch"
 
+	// MinorVersionUpgradeUnavailable is a label applied to ClusterDeployments to show concerns about upgrades to the
+	// next minor version. i.e 4.y -> 4.(y+1)
+	MinorVersionUpgradeUnavailable = "hive.openshift.io/minor-version-upgrade-unavailable"
+
 	// OvirtCredentialsDir is the directory containing Ovirt credentials files.
 	OvirtCredentialsDir = "/.ovirt"
 


### PR DESCRIPTION
This PR lifts the `Upgradeable` status from the ClusterVersion into a new `hive.openshift.io/minor-version-upgrade-unavailable` label on the ClusterDeployment.

Higher level tools can consume this message to warn users about minor version upgrades that CVO would reject with a reason.