### PR TITLE
Correct len parameters of make() in some tests

### DIFF
--- a/pkg/controller/dnsendpoint/dnsendpoint_controller_test.go
+++ b/pkg/controller/dnsendpoint/dnsendpoint_controller_test.go
@@ -413,7 +413,7 @@ func TestDNSEndpointReconcile(t *testing.T) {
 			if tc.configureQuery != nil {
 				tc.configureQuery(mockQuery)
 			}
-			rootDomains := make([]string, len(tc.nameServers))
+			rootDomains := make([]string, 0, len(tc.nameServers))
 			for rootDomain := range tc.nameServers {
 				rootDomains = append(rootDomains, rootDomain)
 			}

--- a/pkg/controller/machinepool/gcpactuator_test.go
+++ b/pkg/controller/machinepool/gcpactuator_test.go
@@ -393,11 +393,11 @@ func TestGCPActuator(t *testing.T) {
 					// UserTags
 					if eTags := platform.UserTags; len(eTags) != 0 {
 						if aTags := gcpProvider.ResourceManagerTags; assert.Equal(t, len(eTags), len(aTags), "unexpected number of userTags") {
-							uta := make([]string, len(eTags))
+							uta := make([]string, 0, len(eTags))
 							for _, ut := range eTags {
 								uta = append(uta, fmt.Sprintf("%s|%s|%s", ut.ParentID, ut.Key, ut.Value))
 							}
-							rmta := make([]string, len(aTags))
+							rmta := make([]string, 0, len(aTags))
 							for _, rmt := range aTags {
 								rmta = append(rmta, fmt.Sprintf("%s|%s|%s", rmt.ParentID, rmt.Key, rmt.Value))
 							}

--- a/pkg/controller/metrics/custom_collectors_test.go
+++ b/pkg/controller/metrics/custom_collectors_test.go
@@ -878,7 +878,7 @@ func FailingSince(t time.Time) testcs.Option {
 }
 
 func metricPretty(d *dto.Metric) string {
-	labels := make([]string, len(d.Label))
+	labels := make([]string, 0, len(d.Label))
 	for _, label := range d.Label {
 		labels = append(labels, fmt.Sprintf("%s = %s", *label.Name, *label.Value))
 	}


### PR DESCRIPTION
Issue: N/A

Some len parameters of make() look non-zero unintentionally. These slices had leading non-zero values and essential values followed them.