### PR TITLE
HIVE-2819: Use annotation instead of label for upgradeable

### DIFF
--- a/pkg/controller/clusterversion/clusterversion_controller.go
+++ b/pkg/controller/clusterversion/clusterversion_controller.go
@@ -167,7 +167,7 @@ func (r *ReconcileClusterVersion) Reconcile(ctx context.Context, request reconci
 		return reconcile.Result{}, err
 	}
 
-	if err := r.updateClusterVersionLabels(cd, clusterVersion, cdLog); err != nil {
+	if err := r.updateClusterVersionMetadata(cd, clusterVersion, cdLog); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -182,7 +182,7 @@ func (r *ReconcileClusterVersion) Reconcile(ctx context.Context, request reconci
 	return reconcile.Result{RequeueAfter: requeueAfter}, nil
 }
 
-func (r *ReconcileClusterVersion) updateClusterVersionLabels(cd *hivev1.ClusterDeployment, clusterVersion *openshiftapiv1.ClusterVersion, cdLog log.FieldLogger) error {
+func (r *ReconcileClusterVersion) updateClusterVersionMetadata(cd *hivev1.ClusterDeployment, clusterVersion *openshiftapiv1.ClusterVersion, cdLog log.FieldLogger) error {
 	changed := false
 	cvoVersion := clusterVersion.Status.Desired.Version
 	if cd.Labels == nil {
@@ -221,20 +221,23 @@ func (r *ReconcileClusterVersion) updateClusterVersionLabels(cd *hivev1.ClusterD
 			break
 		}
 	}
-	changed = changed || upgradeableCondition != cd.Labels[constants.MinorVersionUpgradeUnavailable]
+	changed = changed || upgradeableCondition != cd.Annotations[constants.MinorVersionUpgradeUnavailable]
 	if upgradeableCondition == "" {
-		delete(cd.Labels, constants.MinorVersionUpgradeUnavailable)
+		delete(cd.Annotations, constants.MinorVersionUpgradeUnavailable)
 	} else {
-		cd.Labels[constants.MinorVersionUpgradeUnavailable] = upgradeableCondition
+		if cd.Annotations == nil {
+			cd.Annotations = map[string]string{}
+		}
+		cd.Annotations[constants.MinorVersionUpgradeUnavailable] = upgradeableCondition
 	}
 
 	if !changed {
-		cdLog.Debug("labels have not changed, nothing to update")
+		cdLog.Debug("cluster version metadata has not changed, nothing to update")
 		return nil
 	}
 
 	if err := r.Update(context.TODO(), cd); err != nil {
-		cdLog.WithError(err).Log(controllerutils.LogLevel(err), "error update cluster deployment labels")
+		cdLog.WithError(err).Log(controllerutils.LogLevel(err), "error updating cluster deployment metadata")
 		return err
 	}
 	return nil

--- a/pkg/controller/clusterversion/clusterversion_controller_test.go
+++ b/pkg/controller/clusterversion/clusterversion_controller_test.go
@@ -89,7 +89,7 @@ func TestClusterVersionReconcile(t *testing.T) {
 				Status: configv1.ConditionTrue,
 			}),
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
-				assert.Equal(t, "", cd.Labels[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
+				assert.Equal(t, "", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
 			},
 		},
 		{
@@ -103,7 +103,7 @@ func TestClusterVersionReconcile(t *testing.T) {
 				Status: configv1.ConditionFalse,
 			}),
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
-				assert.Equal(t, "Upgradeable: False", cd.Labels[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
+				assert.Equal(t, "Upgradeable: False", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
 			},
 		},
 		{
@@ -118,7 +118,7 @@ func TestClusterVersionReconcile(t *testing.T) {
 				Message: "Can't do the upgrade",
 			}),
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
-				assert.Equal(t, "Can't do the upgrade", cd.Labels[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
+				assert.Equal(t, "Can't do the upgrade", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
 			},
 		},
 		{
@@ -132,7 +132,7 @@ func TestClusterVersionReconcile(t *testing.T) {
 				Status: configv1.ConditionUnknown,
 			}),
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
-				assert.Equal(t, "Upgradeable: Unknown", cd.Labels[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
+				assert.Equal(t, "Upgradeable: Unknown", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
 			},
 		},
 		{
@@ -147,7 +147,7 @@ func TestClusterVersionReconcile(t *testing.T) {
 				Message: "Can't read status",
 			}),
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
-				assert.Equal(t, "Can't read status", cd.Labels[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
+				assert.Equal(t, "Can't read status", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
 			},
 		},
 		{
@@ -166,7 +166,7 @@ func TestClusterVersionReconcile(t *testing.T) {
 					Message: "It can't upgrade",
 				}),
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
-				assert.Equal(t, "It can't upgrade", cd.Labels[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
+				assert.Equal(t, "It can't upgrade", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
 			},
 		},
 	}


### PR DESCRIPTION
This is a follow up to https://github.com/openshift/hive/pull/2639 , but moving the value to the cluster deployment annotations instead of labels. This change is due to an issue found with certain allowed characters for labels that do not affect annotations.

For example, the following error was seen testing the labels from the previous PR:
```
time="2025-04-01T15:52:28.453Z" level=error msg="Reconciler error" controller=clusterversion-controller error="...a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')]"
```