### PR TITLE
HIVE-2416: Fix copypasta error in MachinePool Reasons

### DIFF
--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -448,7 +448,7 @@ func (r *ReconcileMachinePool) reconcile(pool *hivev1.MachinePool, cd *hivev1.Cl
 		pool,
 		hivev1.SyncedMachinePoolCondition,
 		corev1.ConditionTrue,
-		"MachineAutoscalerSyncFailed",
+		"MachineAutoscalerSyncSucceeded",
 		"MachineAutoscalers synced successfully",
 		logger,
 	); err != nil {
@@ -473,7 +473,7 @@ func (r *ReconcileMachinePool) reconcile(pool *hivev1.MachinePool, cd *hivev1.Cl
 		pool,
 		hivev1.SyncedMachinePoolCondition,
 		corev1.ConditionTrue,
-		"ClusterAutoscalerSyncFailed",
+		"ClusterAutoscalerSyncSucceeded",
 		"ClusterAutoscaler synced successfully",
 		logger,
 	); err != nil {


### PR DESCRIPTION
PR #2628 added a couple of new status conditions to MachinePool. Due to a copy/paste mistake, it was setting the wrong Reason code for a couple of the code paths. Fix.