### PR TITLE
HIVE-2827: Fix MachinePool thrashing on conditions

### DIFF
--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -419,16 +419,6 @@ func (r *ReconcileMachinePool) reconcile(pool *hivev1.MachinePool, cd *hivev1.Cl
 		// NOTE: err is nil unless condition update failed, in which case immediate requeue is appropriate.
 		return reconcile.Result{RequeueAfter: defaultErrorRequeueInterval}, err
 	}
-	if err := r.updateCondition(
-		pool,
-		hivev1.SyncedMachinePoolCondition,
-		corev1.ConditionTrue,
-		"MachineSetSyncSucceeded",
-		"MachineSets synced successfully",
-		logger,
-	); err != nil {
-		return reconcile.Result{}, err
-	}
 
 	if err := r.syncMachineAutoscalers(pool, cd, machineSets, remoteClusterAPIClient, logger); err != nil {
 		logger.WithError(err).Log(controllerutils.LogLevel(err), "could not syncMachineAutoscalers")
@@ -443,16 +433,6 @@ func (r *ReconcileMachinePool) reconcile(pool *hivev1.MachinePool, cd *hivev1.Cl
 		)
 		// NOTE: err is nil unless condition update failed, in which case immediate requeue is appropriate.
 		return reconcile.Result{RequeueAfter: defaultErrorRequeueInterval}, err
-	}
-	if err := r.updateCondition(
-		pool,
-		hivev1.SyncedMachinePoolCondition,
-		corev1.ConditionTrue,
-		"MachineAutoscalerSyncSucceeded",
-		"MachineAutoscalers synced successfully",
-		logger,
-	); err != nil {
-		return reconcile.Result{}, err
 	}
 
 	if err := r.syncClusterAutoscaler(pool, remoteClusterAPIClient, logger); err != nil {
@@ -473,8 +453,8 @@ func (r *ReconcileMachinePool) reconcile(pool *hivev1.MachinePool, cd *hivev1.Cl
 		pool,
 		hivev1.SyncedMachinePoolCondition,
 		corev1.ConditionTrue,
-		"ClusterAutoscalerSyncSucceeded",
-		"ClusterAutoscaler synced successfully",
+		"SyncSucceeded",
+		"Resources synced successfully",
 		logger,
 	); err != nil {
 		return reconcile.Result{}, err


### PR DESCRIPTION
[HIVE-2416](https://issues.redhat.com//browse/HIVE-2416) / #2628 / c2b9a17b made a mistake in the updating of status conditions in the green path: it updated the same condition multiple times in sequence with different reason/message values. Each update triggered an immediate requeue, resulting in thrashing.

Rookie mistake.

Fixed by consolidating to one reason/message for the green path.