### PR TITLE
HIVE-2807: SyncSet: Accept empty patchType

### DIFF
--- a/pkg/validating-webhooks/hive/v1/syncset_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/syncset_validating_admission_hook_test.go
@@ -67,6 +67,12 @@ func TestSyncSetValidate(t *testing.T) {
 			expectedAllowed: false,
 		},
 		{
+			name:            "Test empty patch type create",
+			operation:       admissionv1beta1.Create,
+			syncSet:         testPatchSyncSet(""),
+			expectedAllowed: true,
+		},
+		{
 			name:            "Test valid patch type update",
 			operation:       admissionv1beta1.Update,
 			syncSet:         testValidPatchSyncSet(),
@@ -77,6 +83,12 @@ func TestSyncSetValidate(t *testing.T) {
 			operation:       admissionv1beta1.Update,
 			syncSet:         testInvalidPatchSyncSet(),
 			expectedAllowed: false,
+		},
+		{
+			name:            "Test empty patch type update",
+			operation:       admissionv1beta1.Update,
+			syncSet:         testPatchSyncSet(""),
+			expectedAllowed: true,
 		},
 		{
 			name:            "Test create with no patches",


### PR DESCRIPTION
[Selector]SyncSet.Spec.Patches[].PatchType is defaulted in code to `strategic` if empty or missing. However, our webhook was not accepting the empty string as a valid value. Relax it accordingly.

Note: We could have removed the webhook entirely and added enum schema validation on the field itself, but that would _technically_ be a breaking API change.