### PR TITLE
HIVE-2837: Revert AWSPrivateLink cleanup code

### DIFF
--- a/pkg/controller/awsprivatelink/awsprivatelink_controller.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller.go
@@ -54,19 +54,10 @@ const (
 
 // clusterDeploymentAWSPrivateLinkConditions are the cluster deployment conditions controlled by
 // AWS private link controller
-var (
-	clusterDeploymentAWSPrivateLinkConditions = []hivev1.ClusterDeploymentConditionType{
-		hivev1.AWSPrivateLinkFailedClusterDeploymentCondition,
-		hivev1.AWSPrivateLinkReadyClusterDeploymentCondition,
-	}
-	goodVpceStates = sets.New(
-		// NOTE: Depending where you look, these strings are sometimes lowercase; so we'll just
-		// compare them case-insensitive.
-		strings.ToLower(ec2.StatePendingAcceptance),
-		strings.ToLower(ec2.StatePending),
-		strings.ToLower(ec2.StateAvailable),
-	)
-)
+var clusterDeploymentAWSPrivateLinkConditions = []hivev1.ClusterDeploymentConditionType{
+	hivev1.AWSPrivateLinkFailedClusterDeploymentCondition,
+	hivev1.AWSPrivateLinkReadyClusterDeploymentCondition,
+}
 
 // Add creates a new AWSPrivateLink Controller and adds it to the Manager with default RBAC.
 // The Manager will set fields on the Controller and Start it when the Manager is Started.
@@ -517,7 +508,7 @@ func (r *ReconcileAWSPrivateLink) reconcilePrivateLink(cd *hivev1.ClusterDeploym
 	}
 
 	// Create the VPC endpoint with the chosen VPC.
-	endpointReconciled, vpcEndpoint, err := r.reconcileVPCEndpoint(awsClient, cd, clusterMetadata, vpcEndpointService, logger)
+	endpointModified, vpcEndpoint, err := r.reconcileVPCEndpoint(awsClient, cd, clusterMetadata, vpcEndpointService, logger)
 	if err != nil {
 		logger.WithError(err).Error("failed to reconcile the VPC Endpoint")
 		reason := "VPCEndpointReconcileFailed"
@@ -531,7 +522,7 @@ func (r *ReconcileAWSPrivateLink) reconcilePrivateLink(cd *hivev1.ClusterDeploym
 		return reconcile.Result{}, errors.Wrap(err, "failed to reconcile the VPC Endpoint")
 	}
 
-	if endpointReconciled {
+	if endpointModified {
 		if err := r.setReadyCondition(cd, corev1.ConditionFalse,
 			"ReconciledVPCEndpoint",
 			"reconciled the VPC Endpoint for the cluster",
@@ -646,7 +637,7 @@ func waitForState(state string, timeout time.Duration, currentState func() (stri
 			logger.WithError(err).Error("failed to get the current state")
 			return false, nil
 		}
-		if strings.ToLower(curr) != strings.ToLower(state) {
+		if curr != state {
 			logger.Debugf("Desired state %q is not yet achieved, currently %q", state, curr)
 			return false, nil
 		}
@@ -859,7 +850,7 @@ func (r *ReconcileAWSPrivateLink) reconcileVPCEndpoint(awsClient *awsClient,
 	cd *hivev1.ClusterDeployment, metadata *hivev1.ClusterMetadata,
 	vpcEndpointService *ec2.ServiceConfiguration,
 	logger log.FieldLogger) (bool, *ec2.VpcEndpoint, error) {
-	endpointReconciled := false
+	modified := false
 	tag := ec2FilterForCluster(metadata)
 	endpointLog := logger.WithField("tag:key", aws.StringValue(tag.Name)).WithField("tag:value", aws.StringValueSlice(tag.Values))
 
@@ -869,24 +860,15 @@ func (r *ReconcileAWSPrivateLink) reconcileVPCEndpoint(awsClient *awsClient,
 		Filters: []*ec2.Filter{tag},
 	}
 
-	// HIVE-2837: Clean up redundant VPCEs (e.g. "Rejected")
-	var vpcEndpointsToDelete []*string
+	var allVpcEndpoints []*ec2.VpcEndpoint
 	for {
 		resp, err := awsClient.hub.DescribeVpcEndpoints(input)
 		if err != nil {
 			endpointLog.WithError(err).Error("error getting VPC Endpoint")
-			return endpointReconciled, nil, err
+			return modified, nil, err
 		}
 
-		// HIVE-2838: First page may be empty even when there are results!
-		for _, vpce := range resp.VpcEndpoints {
-			if vpcEndpoint == nil && goodVpceStates.Has(strings.ToLower(*vpce.State)) {
-				vpcEndpoint = vpce
-				endpointReconciled = true
-				continue
-			}
-			vpcEndpointsToDelete = append(vpcEndpointsToDelete, vpce.VpcEndpointId)
-		}
+		allVpcEndpoints = append(allVpcEndpoints, resp.VpcEndpoints...)
 
 		if resp.NextToken == nil {
 			break
@@ -894,33 +876,26 @@ func (r *ReconcileAWSPrivateLink) reconcileVPCEndpoint(awsClient *awsClient,
 		input.NextToken = resp.NextToken
 	}
 
-	if numVpcEndpoints := len(vpcEndpointsToDelete); numVpcEndpoints != 0 {
-		endpointLog.WithField("numVpcEndpoints", numVpcEndpoints).Info("Deleting unused VPC Endpoints")
-		resp, err := awsClient.hub.DeleteVpcEndpoints(&ec2.DeleteVpcEndpointsInput{VpcEndpointIds: vpcEndpointsToDelete})
-		if err != nil || len(resp.Unsuccessful) != 0 {
-			endpointLog.WithError(err).WithField("numUnsuccessful", len(resp.Unsuccessful)).Error("error deleting VPC Endpoints")
-			return endpointReconciled, nil, err
-		}
-	}
-
-	if vpcEndpoint == nil {
-		endpointReconciled = true
+	if len(allVpcEndpoints) == 0 {
+		modified = true
 		var err error
 		vpcEndpoint, err = r.createVPCEndpoint(awsClient.hub, cd, metadata, vpcEndpointService, logger)
 		if err != nil {
 			logger.WithError(err).Error("error creating VPC Endpoint for service")
-			return endpointReconciled, nil, err
+			return modified, nil, err
 		}
+	} else {
+		vpcEndpoint = allVpcEndpoints[0]
 	}
 
 	initPrivateLinkStatus(cd)
 	cd.Status.Platform.AWS.PrivateLink.VPCEndpointID = *vpcEndpoint.VpcEndpointId
 	if err := r.updatePrivateLinkStatus(cd); err != nil {
 		logger.WithError(err).Error("error updating clusterdeployment status with vpcEndpointID")
-		return endpointReconciled, nil, err
+		return modified, nil, err
 	}
 
-	return endpointReconciled, vpcEndpoint, nil
+	return modified, vpcEndpoint, nil
 }
 
 func (r *ReconcileAWSPrivateLink) createVPCEndpoint(awsClient awsclient.Client,
@@ -980,11 +955,6 @@ func (r *ReconcileAWSPrivateLink) reconcileHostedZone(awsClient *awsClient,
 		return modified, "", err
 	}
 
-	if err := r.scrubHostedZones(awsClient.hub, apiDomain, cd.Spec.Platform.AWS.Region, hostedZoneID, logger); err != nil {
-		logger.WithError(err).Error("failed to scrub redundant Hosted Zones")
-		return modified, "", err
-	}
-
 	hzLog := logger.WithField("hostedZoneID", hostedZoneID)
 
 	rSet, err := r.recordSet(awsClient.hub, apiDomain, vpcEndpoint)
@@ -1020,7 +990,8 @@ func (r *ReconcileAWSPrivateLink) recordSet(awsClient awsclient.Client, apiDomai
 		rSet.TTL = aws.Int64(10)
 
 		// get the ips from the elastic networking interfaces attached to the VPC endpoint
-		if len(vpcEndpoint.NetworkInterfaceIds) == 0 {
+		enis := vpcEndpoint.NetworkInterfaceIds
+		if len(enis) == 0 {
 			return nil, errors.New("No network interfaces attached to the vpc endpoint")
 		}
 		res, err := awsClient.DescribeNetworkInterfaces(&ec2.DescribeNetworkInterfacesInput{NetworkInterfaceIds: vpcEndpoint.NetworkInterfaceIds})
@@ -1084,39 +1055,6 @@ func (r *ReconcileAWSPrivateLink) ensureHostedZone(awsClient awsclient.Client,
 	}
 
 	return modified, hzID, nil
-}
-
-// scrubHostedZones looks through all VPCs configured in the inventory and deletes any HostedZones
-// that are associated with the given apiDomain EXCEPT the one identified by goodHZID.
-// The idea is to end up with exactly one HostedZone for the given apiDomain.
-func (r *ReconcileAWSPrivateLink) scrubHostedZones(awsClient awsclient.Client, apiDomain, region, goodHZID string, logger log.FieldLogger) error {
-	for _, entry := range r.controllerconfig.EndpointVPCInventory {
-		vpcId := entry.AWSPrivateLinkVPC.VPCID
-		vlog := logger.WithField("vpcId", vpcId)
-
-		// NOTE: If there is >1 HZ for this domain in this VPC (which should not be possible), we will miss all but the first.
-		hzID, err := findHostedZone(awsClient, vpcId, region, apiDomain)
-		if err != nil {
-			if errors.Is(err, errNoHostedZoneFoundForVPC) {
-				continue
-			}
-			vlog.WithError(err).Error("failed to get Hosted Zone")
-			return err
-		}
-
-		// Skip the good one
-		if hzID == goodHZID {
-			continue
-		}
-
-		zlog := vlog.WithField("hzID", hzID)
-		zlog.Info("cleaning up stale hosted zone")
-		if err := r.deleteHostedZone(awsClient, hzID, vlog); err != nil {
-			zlog.WithError(err).Error("failed to delete Hosted Zone")
-			return err
-		}
-	}
-	return nil
 }
 
 var errNoHostedZoneFoundForVPC = errors.New("no hosted zone found")

--- a/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
@@ -566,243 +566,59 @@ users:
 		return service
 	}
 
-	// HIVE-2837/HIVE-2838: We'll use this in the closure below to cycle through different
-	// green-path ways DescribeVpcEndpoints can respond, depending on a) what VPCEs already exist;
-	// and b) its apparent whims wrt returning empty pages even when there are more results
-	// available.
-	dvpce_scenario := 0
 	mockCreateEndpoint := func(m *mock.MockClient, service *ec2.ServiceConfiguration) *ec2.VpcEndpoint {
+		m.EXPECT().DescribeVpcEndpoints(
+			&ec2.DescribeVpcEndpointsInput{
+				Filters: []*ec2.Filter{{
+					Name:   aws.String("tag:hive.openshift.io/private-link-access-for"),
+					Values: aws.StringSlice([]string{"test-cd-1234"}),
+				}}}).
+			Return(&ec2.DescribeVpcEndpointsOutput{}, nil)
+		m.EXPECT().DescribeVpcEndpointsPages(
+			&ec2.DescribeVpcEndpointsInput{
+				Filters: []*ec2.Filter{{
+					Name:   aws.String("vpc-id"),
+					Values: aws.StringSlice([]string{"vpc-1"}),
+				}}}, gomock.Any()).
+			Do(func(input *ec2.DescribeVpcEndpointsInput, fn func(*ec2.DescribeVpcEndpointsOutput, bool) bool) {
+				describeVpcEndpointsOutput := &ec2.DescribeVpcEndpointsOutput{}
+				fn(describeVpcEndpointsOutput, true)
+			})
+		m.EXPECT().DescribeVpcEndpointServices(&ec2.DescribeVpcEndpointServicesInput{
+			ServiceNames: aws.StringSlice([]string{*service.ServiceName}),
+		}).Return(&ec2.DescribeVpcEndpointServicesOutput{
+			ServiceDetails: []*ec2.ServiceDetail{{AvailabilityZones: service.AvailabilityZones}},
+		}, nil)
+
 		endpoint := &ec2.VpcEndpoint{
 			VpcEndpointId: aws.String("vpce-12345"),
 			VpcId:         aws.String("vpc-1"),
-			// Validate case insensitivity
-			State: aws.String("AvAiLaBlE"),
+			State:         aws.String("available"),
 			DnsEntries: []*ec2.DnsEntry{{
 				DnsName:      aws.String("vpce-12345-us-east-1.vpce-svc-12345.vpc.amazonaws.com"),
 				HostedZoneId: aws.String("HZ23456"),
 			}},
 		}
-		scenario := dvpce_scenario % 4 // total number of scenarios
-		dvpce_scenario++
-		tagFilters := []*ec2.Filter{{
-			Name:   aws.String("tag:hive.openshift.io/private-link-access-for"),
-			Values: aws.StringSlice([]string{"test-cd-1234"}),
-		}}
-
-		switch scenario {
-		case 0: // No VPCEs exist ahead of time
-			m.EXPECT().DescribeVpcEndpoints(
-				&ec2.DescribeVpcEndpointsInput{Filters: tagFilters}).
-				Return(&ec2.DescribeVpcEndpointsOutput{}, nil)
-		case 1: // No VPCEs exist, but we don't find that out until the second page
-			m.EXPECT().DescribeVpcEndpoints(
-				&ec2.DescribeVpcEndpointsInput{Filters: tagFilters}).
-				Return(
-					&ec2.DescribeVpcEndpointsOutput{
-						NextToken: aws.String("abc123"),
-					},
-					nil,
-				)
-			m.EXPECT().DescribeVpcEndpoints(
-				&ec2.DescribeVpcEndpointsInput{
-					Filters:   tagFilters,
-					NextToken: aws.String("abc123"),
-				}).
-				Return(&ec2.DescribeVpcEndpointsOutput{}, nil)
-		case 2: // "Bad" VPCEs exist on both pages
-			m.EXPECT().DescribeVpcEndpoints(
-				&ec2.DescribeVpcEndpointsInput{Filters: tagFilters}).
-				Return(
-					&ec2.DescribeVpcEndpointsOutput{
-						VpcEndpoints: []*ec2.VpcEndpoint{
-							{
-								VpcEndpointId: aws.String("badvpc1"),
-								State:         aws.String("rejected"),
-							},
-							{
-								VpcEndpointId: aws.String("badvpc2"),
-								State:         aws.String("expired"),
-							},
-						},
-						NextToken: aws.String("abc123"),
-					},
-					nil,
-				)
-			m.EXPECT().DescribeVpcEndpoints(
-				&ec2.DescribeVpcEndpointsInput{
-					Filters:   tagFilters,
-					NextToken: aws.String("abc123"),
-				}).
-				Return(
-					&ec2.DescribeVpcEndpointsOutput{
-						VpcEndpoints: []*ec2.VpcEndpoint{
-							{
-								VpcEndpointId: aws.String("badvpc3"),
-								State:         aws.String("Deleted"),
-							},
-							{
-								VpcEndpointId: aws.String("badvpc4"),
-								State:         aws.String("Failed"),
-							},
-						},
-					},
-					nil,
-				)
-		case 3: // Our VPCE exists, but it's on the second page, along with some others needing cleanup
-			m.EXPECT().DescribeVpcEndpoints(
-				&ec2.DescribeVpcEndpointsInput{Filters: tagFilters}).
-				Return(
-					&ec2.DescribeVpcEndpointsOutput{
-						NextToken: aws.String("abc123"),
-					},
-					nil,
-				)
-			m.EXPECT().DescribeVpcEndpoints(
-				&ec2.DescribeVpcEndpointsInput{
-					Filters:   tagFilters,
-					NextToken: aws.String("abc123"),
-				}).
-				Return(
-					&ec2.DescribeVpcEndpointsOutput{
-						VpcEndpoints: []*ec2.VpcEndpoint{
-							{
-								VpcEndpointId: aws.String("badvpc1"),
-								State:         aws.String("rejected"),
-							},
-							{
-								VpcEndpointId: aws.String("badvpc2"),
-								State:         aws.String("expired"),
-							},
-							// The first good one
-							endpoint,
-							{
-								VpcEndpointId: aws.String("badvpc3"),
-								// Prove we'll still scrub subsequent "good" ones
-								State: aws.String("available"),
-							},
-							{
-								VpcEndpointId: aws.String("badvpc4"),
-								// Prove we'll still scrub subsequent "good" ones
-								State: aws.String("pending"),
-							},
-						},
-					},
-					nil,
-				)
-		}
-
-		// If there were VPCEs that needed cleanup...
-		switch scenario {
-		case 2, 3:
-			m.EXPECT().DeleteVpcEndpoints(
-				&ec2.DeleteVpcEndpointsInput{
-					VpcEndpointIds: []*string{
-						aws.String("badvpc1"),
-						aws.String("badvpc2"),
-						aws.String("badvpc3"),
-						aws.String("badvpc4"),
-					},
-				},
-			).Return(&ec2.DeleteVpcEndpointsOutput{}, nil)
-		}
-
-		// Iff an available VPCE did not exist, we'll go down the creation path
-		switch scenario {
-		case 0, 1, 2:
-			m.EXPECT().DescribeVpcEndpointsPages(
-				&ec2.DescribeVpcEndpointsInput{
-					Filters: []*ec2.Filter{{
-						Name:   aws.String("vpc-id"),
-						Values: aws.StringSlice([]string{"vpc-1"}),
-					}}}, gomock.Any()).
-				Do(func(input *ec2.DescribeVpcEndpointsInput, fn func(*ec2.DescribeVpcEndpointsOutput, bool) bool) {
-					describeVpcEndpointsOutput := &ec2.DescribeVpcEndpointsOutput{}
-					fn(describeVpcEndpointsOutput, true)
-				})
-			m.EXPECT().DescribeVpcEndpointServices(&ec2.DescribeVpcEndpointServicesInput{
-				ServiceNames: aws.StringSlice([]string{*service.ServiceName}),
-			}).Return(&ec2.DescribeVpcEndpointServicesOutput{
-				ServiceDetails: []*ec2.ServiceDetail{{AvailabilityZones: service.AvailabilityZones}},
-			}, nil)
-
-			m.EXPECT().CreateVpcEndpoint(gomock.Any()).
-				Return(&ec2.CreateVpcEndpointOutput{VpcEndpoint: endpoint}, nil)
-			m.EXPECT().DescribeVpcEndpoints(&ec2.DescribeVpcEndpointsInput{
-				VpcEndpointIds: aws.StringSlice([]string{*endpoint.VpcEndpointId}),
-			}).Return(&ec2.DescribeVpcEndpointsOutput{
-				VpcEndpoints: []*ec2.VpcEndpoint{endpoint},
-			}, nil)
-		}
-
+		m.EXPECT().CreateVpcEndpoint(gomock.Any()).
+			Return(&ec2.CreateVpcEndpointOutput{VpcEndpoint: endpoint}, nil)
+		m.EXPECT().DescribeVpcEndpoints(&ec2.DescribeVpcEndpointsInput{
+			VpcEndpointIds: aws.StringSlice([]string{*endpoint.VpcEndpointId}),
+		}).Return(&ec2.DescribeVpcEndpointsOutput{
+			VpcEndpoints: []*ec2.VpcEndpoint{endpoint},
+		}, nil)
 		return endpoint
 	}
 
-	mockPHZ := func(m *mock.MockClient, endpoint *ec2.VpcEndpoint, apiDomain string, existingSummary *route53.HostedZoneSummary, inventoryVPCs ...string) string {
-		if len(inventoryVPCs) == 0 {
-			inventoryVPCs = []string{"vpc-1"}
-		}
-
-		byVPCOut := []*route53.ListHostedZonesByVPCOutput{
-			{},
-			// This one will only get used when inventoryVPCs has >1 entry
-			{},
-		}
+	mockPHZ := func(m *mock.MockClient, endpoint *ec2.VpcEndpoint, apiDomain string, existingSummary *route53.HostedZoneSummary) string {
+		byVPCOut := &route53.ListHostedZonesByVPCOutput{}
 		if existingSummary != nil {
-			byVPCOut[0].HostedZoneSummaries = []*route53.HostedZoneSummary{existingSummary}
+			byVPCOut.HostedZoneSummaries = []*route53.HostedZoneSummary{existingSummary}
 		}
-
-		// Inject HZs to scrub
-		byVPCOut[1].HostedZoneSummaries = []*route53.HostedZoneSummary{{
-			HostedZoneId: aws.String("notTheGoodOne"),
-			Name:         aws.String("api.test-cluster"),
-		}}
-
 		m.EXPECT().ListHostedZonesByVPC(&route53.ListHostedZonesByVPCInput{
 			MaxItems:  aws.String("100"),
 			VPCId:     endpoint.VpcId,
 			VPCRegion: aws.String("us-east-1"),
-		}).Return(byVPCOut[0], nil)
-
-		// These are the calls to discover & scrub stale HZs
-		rr := &route53.ResourceRecordSet{
-			Type: aws.String("A"),
-			Name: aws.String("api.test-cluster"),
-			AliasTarget: &route53.AliasTarget{
-				DNSName: aws.String("vpc.."),
-			},
-		}
-		for i, vpcId := range inventoryVPCs {
-			m.EXPECT().ListHostedZonesByVPC(&route53.ListHostedZonesByVPCInput{
-				MaxItems:  aws.String("100"),
-				VPCId:     &vpcId,
-				VPCRegion: aws.String("us-east-1"),
-			}).Return(byVPCOut[i], nil)
-			// We only have HZs to scrub on the >1st VPC
-			if i == 0 {
-				continue
-			}
-			m.EXPECT().ListResourceRecordSets(&route53.ListResourceRecordSetsInput{
-				HostedZoneId: aws.String("notTheGoodOne"),
-			}).Return(&route53.ListResourceRecordSetsOutput{
-				ResourceRecordSets: []*route53.ResourceRecordSet{
-					{Type: aws.String("NS")},
-					{Type: aws.String("SOA")},
-					rr},
-			}, nil)
-			m.EXPECT().ChangeResourceRecordSets(&route53.ChangeResourceRecordSetsInput{
-				HostedZoneId: aws.String("notTheGoodOne"),
-				ChangeBatch: &route53.ChangeBatch{
-					Changes: []*route53.Change{{
-						Action:            aws.String("DELETE"),
-						ResourceRecordSet: rr,
-					}},
-				},
-			}).Return(nil, nil)
-			m.EXPECT().DeleteHostedZone(&route53.DeleteHostedZoneInput{
-				Id: aws.String("notTheGoodOne"),
-			}).Return(nil, nil)
-		}
-
+		}).Return(byVPCOut, nil)
 		var hzID string
 		if existingSummary == nil {
 			hzID = "HZ12345"
@@ -854,14 +670,6 @@ users:
 			VPCId:     endpoint.VpcId,
 			VPCRegion: aws.String("us-east-1"),
 		}).Return(byVPCOut, nil)
-
-		// This is the call to discover HZs to scrub
-		m.EXPECT().ListHostedZonesByVPC(&route53.ListHostedZonesByVPCInput{
-			MaxItems:  aws.String("100"),
-			VPCId:     aws.String("vpc-1"),
-			VPCRegion: aws.String("us-east-1"),
-		}).Return(byVPCOut, nil)
-
 		var hzID string
 		if existingSummary == nil {
 			hzID = "HZ12345"
@@ -1466,7 +1274,7 @@ users:
 			hzID := mockPHZ(m, createdEndpoint, "api.test-cluster", &route53.HostedZoneSummary{
 				HostedZoneId: aws.String("HZ22"),
 				Name:         aws.String("api.test-cluster"),
-			}, "vpc-1", "vpc-2")
+			})
 
 			m.EXPECT().GetHostedZone(gomock.Any()).Return(&route53.GetHostedZoneOutput{
 				HostedZone: &route53.HostedZone{


### PR DESCRIPTION
The reverted commits were attempting to introduce code to clean up stale resources from AWSPrivateLink reconciles. This turned out to be too fragile, error-prone, and expensive to be worth the benefit we would derive from it.