### PR TITLE
HIVE-2624: `make modfix`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,6 +373,10 @@ modcheck:
 	go run ./hack/modcheck.go
 verify: modcheck
 
+.PHONY: modfix
+modfix:
+	go run ./hack/modcheck.go -f
+
 .PHONY: install-tools
 install-tools:
 	go install $(GO_MOD_FLAGS) github.com/golang/mock/mockgen

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -378,6 +378,8 @@ make: *** [Makefile:325: modcheck] Error 1
 ```
 In this example, address the first error by updating the version of the `require github.com/go-logr/logr` dependency in `apis/go.mod` from `v1.2.0` to `v1.2.2`.
 Repeat for the other errors until the output is clean.
+For convenience, `make modfix` will attempt to make these updates for you.
+
 Don't forget to `make vendor` when you're done to sync the vendor directories with your go.mod changes.
 
 ### Vendoring the OpenShift Installer


### PR DESCRIPTION
PR #2476 / 60592842 introduced syntax to our modcheck utility to ask it to fix discrepancies it finds. This commit adds and documents a `make` rule to invoke it thusly.