### PR TITLE
HIVE-2792: Add Nutanix as a valid cloud provider in E2E tests

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -61,6 +61,9 @@ while [ $i -le ${max_tries} ]; do
     sleep ${sleep_between_tries}
   fi
 
+  # Delete test namespace if exist
+  oc delete ns ${CLUSTER_NAMESPACE} || true
+
   echo -n "Creating namespace ${CLUSTER_NAMESPACE}. Try #${i}/${max_tries}... "
   if oc create namespace "${CLUSTER_NAMESPACE}"; then
     echo "Success"
@@ -240,6 +243,22 @@ case "${CLOUD}" in
       --vsphere-ingress-vip=$INGRESS_VIP \
       --vsphere-network=$NETWORK_NAME \
       --vsphere-vcenter=$VCENTER"
+  ;;
+"nutanix")
+
+  USE_MANAGED_DNS=false
+  EXTRA_CREATE_CLUSTER_ARGS="--nutanix-pc-address=${NUTANIX_HOST} \
+      --nutanix-pc-port=${NUTANIX_PORT:-9440} \
+      --nutanix-pe-address=${PE_HOST} \
+      --nutanix-pe-port=${PE_PORT:-9440} \
+      --nutanix-ca-certs=${NUTANIX_CERT:-}
+      --nutanix-pe-uuid=${PE_UUID} \
+      --nutanix-pe-name=${PE_NAME} \
+      --nutanix-subnetUUIDs=${SUBNET_UUID} \
+      --nutanix-az-name=${NUTANIX_AZ_NAME-Local_AZ} \
+      --manifests=${MANIFESTS} \
+      --nutanix-api-vip=$API_VIP \
+      --nutanix-ingress-vip=$INGRESS_VIP"
   ;;
 *)
 	echo "unknown cloud: ${CLOUD}"


### PR DESCRIPTION
This PR add the option to run the `make test-e2e` target with Nutanix as cloud provider.

e.g.
```bash
MANIFESTS=nutanix_secrets \
  RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.19.0-ec.5-x86_64 \
  HIVE_IMAGE=quay.io/my-user/hive:latest \
  CLOUD=nutanix \
  make test-e2e
```


/cc @2uasimojo 
