### PR TITLE
OSD-29996: Handle TagLimitExceeded failures for AWS subnets during install

### DIFF
--- a/config/configmaps/install-log-regexes-configmap.yaml
+++ b/config/configmaps/install-log-regexes-configmap.yaml
@@ -46,6 +46,11 @@ data:
       - "InvalidSubnet: Not enough IP space available in"
       installFailingReason: AWSSubnetInsufficientIPSpace
       installFailingMessage: Insufficient IP space available in subnet
+    - name: AWSSubnetTagLimitExceeded
+      searchRegexStrings:
+      - "could not add tags to subnets: TagLimitExceeded"
+      installFailingReason: AWSSubnetTagLimitExceeded
+      installFailingMessage: AWS Subnet exceeds the maximum number of tags allowed (50)
     - name: MissingPublicSubnetForZone
       searchRegexStrings:
       - "No public subnet provided for zone"

--- a/pkg/controller/clusterprovision/installlogmonitor_test.go
+++ b/pkg/controller/clusterprovision/installlogmonitor_test.go
@@ -68,6 +68,7 @@ const (
 	awsAccountBlocked                       = "Error: creating EC2 Instance: Blocked: This account is currently blocked and not recognized as a valid account. Please contact aws-verification@amazon.com if you have questions."
 	ingressOperatorDegraded                 = "Cluster operator authentication Degraded is True with OAuthServerRouteEndpointAccessibleController_SyncError\nCluster operator ingress Degraded is True with IngressDegraded"
 	awsSubnetInsufficientIPSpace            = "IngressControllerUnavailable: One or more status conditions indicate unavailable: LoadBalancerReady=False (SyncLoadBalancerFailed: The service-controller component is reporting SyncLoadBalancerFailed events like: Error syncing load balancer: failed to ensure load balancer: InvalidSubnet: Not enough IP space available in subnet-08dcf1a15b3330b1d. ELB requires at least 8 free IP addresses in each subnet.\\n\\tstatus code: 400, request id: ac141e76-b455-4082-8ff3-556107921222\\nThe kube-controller-manager logs may contain more details.)\""
+	awsSubnetTagLimitExceeded               = "could not add tags to subnets: TagLimitExceeded: The resultant tag set must not have more than 50 user tags."
 	installConfigAuthFail                   = `failed to fetch Master Machines: failed to load asset "Install Config": failed to create install config: failed to create a network client: Authentication failed`
 	installConfigBadCACert                  = `failed to fetch Master Machines: failed to load asset "Install Config": failed to create install config: failed to create a network client: Error parsing CA Cert from /etc/pki/ca-trust/extracted/pem/tls-ca-bundle1111.pem`
 )
@@ -84,6 +85,11 @@ func TestParseInstallLog(t *testing.T) {
 			name:           "AWSSubnetInsufficientIPSpace",
 			log:            pointer.String(awsSubnetInsufficientIPSpace),
 			expectedReason: "AWSSubnetInsufficientIPSpace",
+		},
+		{
+			name:           "AWSSubnetTagLimitExceeded",
+			log:            pointer.String(awsSubnetTagLimitExceeded),
+			expectedReason: "AWSSubnetTagLimitExceeded",
 		},
 		{
 			name:           "IngressOperatorDegraded",

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -1714,6 +1714,11 @@ data:
       - "InvalidSubnet: Not enough IP space available in"
       installFailingReason: AWSSubnetInsufficientIPSpace
       installFailingMessage: Insufficient IP space available in subnet
+    - name: AWSSubnetTagLimitExceeded
+      searchRegexStrings:
+      - "could not add tags to subnets: TagLimitExceeded"
+      installFailingReason: AWSSubnetTagLimitExceeded
+      installFailingMessage: AWS Subnet exceeds the maximum number of tags allowed (50)
     - name: MissingPublicSubnetForZone
       searchRegexStrings:
       - "No public subnet provided for zone"


### PR DESCRIPTION
We recently saw a cluster fail to install on AWS where at least one subnet had reached the maximum number of tags (50) and therefore the install could not proceed.

The exact log from the installer was:
```
time=\"2025-05-06T11:12:26Z\" level=fatal msg=\"failed to fetch Cluster: failed to generate asset \\"Cluster\\": could not add tags to subnets: TagLimitExceeded: The resultant tag set must not have more than 50 user tags.\n\tstatus code: 400, request id: b097f663-0c2e-4403-9efa-73ca2ca3051c\"
```

This adds a handling for `could not add tags to subnets: TagLimitExceeded` which should cover this specific scenario.