### PR TITLE
HIVE-2862: Remove python dependency from makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ COPY . .
 RUN if [ -f "${BUILD_IMAGE_CUSTOMIZATION}" ]; then "${BUILD_IMAGE_CUSTOMIZATION}"; fi
 
 RUN if [ -e "/activation-key/org" ]; then unlink /etc/rhsm-host; subscription-manager register --force --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
-RUN python3 -m ensurepip
 ENV GO=${GO}
 RUN make build-hiveutil
 
@@ -29,7 +28,6 @@ RUN if [ -f "${BUILD_IMAGE_CUSTOMIZATION}" ]; then "${BUILD_IMAGE_CUSTOMIZATION}
 
 ENV SMDEV_CONTAINER_OFF=${CONTAINER_SUB_MANAGER_OFF}
 RUN if [ -e "/activation-key/org" ]; then unlink /etc/rhsm-host; subscription-manager register --force --org $(cat "/activation-key/org") --activationkey $(cat "/activation-key/activationkey"); fi
-RUN python3 -m ensurepip
 ENV GO=${GO}
 RUN make build-hiveadmission build-manager build-operator && \
   make build-hiveutil

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,9 @@ endif
 # we don't tag versions. Override using the same versioning we apply to OperatorHub builds:
 # v{major}.{minor}.{commitcount}-{sha}
 # Note that building against a local commit may result in {major}.{minor} being rendered as
-# `UnknownBranch`. However, the {commitcount} and {sha} should still be accurate.
-SOURCE_GIT_TAG := $(shell export HOME=$(HOME); python3 -m ensurepip >&2; python3 -mpip --no-cache install --user gitpython pyyaml >&2; hack/version2.py)
+# 0.0.x-y if it is an `UnknownBranch`. However, the {commitcount} and {sha}
+# should still be accurate.
+SOURCE_GIT_TAG := $(shell hack/version2.sh)
 
 BINDATA_INPUTS :=./config/sharded_controllers/... ./config/hiveadmission/... ./config/controllers/... ./config/rbac/... ./config/configmaps/...
 $(call add-bindata,operator,$(BINDATA_INPUTS),,assets,pkg/operator/assets/bindata.go)

--- a/hack/ubi-build-deps.sh
+++ b/hack/ubi-build-deps.sh
@@ -2,8 +2,7 @@
 dnf install -y \
 	git \
 	golang \
-	make \
-	python3
+	make
 
 # Since go 1.23.x is not available in ubi8, let's go upstream
 go install golang.org/dl/go1.23.6@latest

--- a/hack/version2.sh
+++ b/hack/version2.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+declare -r UNKNOWN_BRANCH_PREFIX="0.0"
+declare -r MASTER_BRANCH_PREFIX="1.2"
+
+function prefix_from_branch() {
+	declare -r branch_name="$1"
+
+	if [[ "$branch_name" =~ ^([^/]+/)?mce-([[:digit:]]+.[[:digit:]]+) ]]; then
+		echo "${BASH_REMATCH[2]}"
+	elif [[ "$branch_name" =~ ^([^/]+/)?master$ ]]; then
+		echo "$MASTER_BRANCH_PREFIX"
+	else
+		echo "$UNKNOWN_BRANCH_PREFIX"
+	fi
+}
+
+function commit_count() {
+	git rev-list --count "$(git rev-list --max-parents=0 HEAD)..HEAD"
+}
+
+function short_sha() {
+	git rev-parse --short HEAD
+}
+
+echo "$(prefix_from_branch "$(git rev-parse --abbrev-ref HEAD)").$(commit_count)-$(short_sha)"


### PR DESCRIPTION
This change allows building the container images without the python dependencies that are getting harder to get by.

xref: HIVE-2862