### PR TITLE
HIVE-2847: Doc ListHostedZonesByName permission

### DIFF
--- a/docs/awsprivatelink.md
+++ b/docs/awsprivatelink.md
@@ -213,6 +213,7 @@ expectations of required permissions for these credentials.
 
     route53:CreateHostedZone
     route53:GetHostedZone
+    route53:ListHostedZonesByName
     route53:ListHostedZonesByVPC
     route53:AssociateVPCWithHostedZone
     route53:DisassociateVPCFromHostedZone


### PR DESCRIPTION
In #2682 / 23cf4efe we started using `ListHostedZonesByName` for AWSPrivateLink, but forgot to add it to our document that conveniently lists the necessary AWS permissions. Fix.