### PR TITLE
HIVE-2581: Trim trailing spaces in BASE_DOMAIN to fix install-config validation error

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -275,7 +275,7 @@ case "${CLOUD}" in
 "openstack")
   CREDS_FILE_ARG="--creds-file=${SHARED_DIR}/clouds.yaml"
   USE_MANAGED_DNS=false
-  BASE_DOMAIN="${BASE_DOMAIN:-shiftstack.devcluster.openshift.com }"
+  BASE_DOMAIN="${BASE_DOMAIN:-shiftstack.devcluster.openshift.com}"
   API_FLOATING_IP=$(get_osp_resources "${SHARED_DIR}/HIVE_FIP_API")
   INGRESS_FLOATING_IP=$(get_osp_resources "${SHARED_DIR}/HIVE_FIP_INGRESS")
   EXTERNAL_NETWORK=$(get_osp_resources "${SHARED_DIR}/OPENSTACK_EXTERNAL_NETWORK")


### PR DESCRIPTION
The install-config validation failed due to an invalid baseDomain value caused by a trailing space in the domain name.

> level=error msg=failed to fetch Master Machines: failed to load asset "Install Config": failed to create install config: invalid "install-config.yaml" file: baseDomain: Invalid value: "shiftstack.devcluster.openshift.com ": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')



This patch trims whitespace from the `BASE_DOMAIN` variable to ensure generated install-config files are valid.