### PR TITLE
HIVE-2870: hiveadmission: proper authn to the KAS

### DIFF
--- a/config/hiveadmission/apiservice.yaml
+++ b/config/hiveadmission/apiservice.yaml
@@ -12,8 +12,6 @@ apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1.admission.hive.openshift.io
-  annotations:
-    service.alpha.openshift.io/inject-cabundle: "true"
 spec:
   group: admission.hive.openshift.io
   groupPriorityMinimum: 1000

--- a/config/hiveadmission/clusterdeployment-webhook.yaml
+++ b/config/hiveadmission/clusterdeployment-webhook.yaml
@@ -2,8 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
   name: clusterdeploymentvalidators.admission.hive.openshift.io
 webhooks:
 - name: clusterdeploymentvalidators.admission.hive.openshift.io

--- a/config/hiveadmission/clusterimageset-webhook.yaml
+++ b/config/hiveadmission/clusterimageset-webhook.yaml
@@ -2,8 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
   name: clusterimagesetvalidators.admission.hive.openshift.io
 webhooks:
 - name: clusterimagesetvalidators.admission.hive.openshift.io

--- a/config/hiveadmission/clusterprovision-webhook.yaml
+++ b/config/hiveadmission/clusterprovision-webhook.yaml
@@ -2,8 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
   name: clusterprovisionvalidators.admission.hive.openshift.io
 webhooks:
 - name: clusterprovisionvalidators.admission.hive.openshift.io

--- a/config/hiveadmission/dnszones-webhook.yaml
+++ b/config/hiveadmission/dnszones-webhook.yaml
@@ -3,8 +3,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
   name: dnszonevalidators.admission.hive.openshift.io
 webhooks:
 - name: dnszonevalidators.admission.hive.openshift.io

--- a/config/hiveadmission/machinepool-webhook.yaml
+++ b/config/hiveadmission/machinepool-webhook.yaml
@@ -2,8 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
   name: machinepoolvalidators.admission.hive.openshift.io
 webhooks:
 - name: machinepoolvalidators.admission.hive.openshift.io

--- a/config/hiveadmission/selectorsyncset-webhook.yaml
+++ b/config/hiveadmission/selectorsyncset-webhook.yaml
@@ -2,8 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
   name: selectorsyncsetvalidators.admission.hive.openshift.io
 webhooks:
 - name: selectorsyncsetvalidators.admission.hive.openshift.io

--- a/config/hiveadmission/syncset-webhook.yaml
+++ b/config/hiveadmission/syncset-webhook.yaml
@@ -2,8 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
   name: syncsetvalidators.admission.hive.openshift.io
 webhooks:
 - name: syncsetvalidators.admission.hive.openshift.io

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -243,8 +243,6 @@ apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1.admission.hive.openshift.io
-  annotations:
-    service.alpha.openshift.io/inject-cabundle: "true"
 spec:
   group: admission.hive.openshift.io
   groupPriorityMinimum: 1000
@@ -274,8 +272,6 @@ var _configHiveadmissionClusterdeploymentWebhookYaml = []byte(`---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
   name: clusterdeploymentvalidators.admission.hive.openshift.io
 webhooks:
 - name: clusterdeploymentvalidators.admission.hive.openshift.io
@@ -321,8 +317,6 @@ var _configHiveadmissionClusterimagesetWebhookYaml = []byte(`---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
   name: clusterimagesetvalidators.admission.hive.openshift.io
 webhooks:
 - name: clusterimagesetvalidators.admission.hive.openshift.io
@@ -367,8 +361,6 @@ var _configHiveadmissionClusterprovisionWebhookYaml = []byte(`---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
   name: clusterprovisionvalidators.admission.hive.openshift.io
 webhooks:
 - name: clusterprovisionvalidators.admission.hive.openshift.io
@@ -498,8 +490,6 @@ var _configHiveadmissionDnszonesWebhookYaml = []byte(`---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
   name: dnszonevalidators.admission.hive.openshift.io
 webhooks:
 - name: dnszonevalidators.admission.hive.openshift.io
@@ -644,8 +634,6 @@ var _configHiveadmissionMachinepoolWebhookYaml = []byte(`---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
   name: machinepoolvalidators.admission.hive.openshift.io
 webhooks:
 - name: machinepoolvalidators.admission.hive.openshift.io
@@ -715,8 +703,6 @@ var _configHiveadmissionSelectorsyncsetWebhookYaml = []byte(`---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
   name: selectorsyncsetvalidators.admission.hive.openshift.io
 webhooks:
 - name: selectorsyncsetvalidators.admission.hive.openshift.io
@@ -816,8 +802,6 @@ var _configHiveadmissionSyncsetWebhookYaml = []byte(`---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
   name: syncsetvalidators.admission.hive.openshift.io
 webhooks:
 - name: syncsetvalidators.admission.hive.openshift.io


### PR DESCRIPTION
This change corrects the hiveadmission service's authentication to the hub's kube-apiserver by injecting the correct CA bundle into the ValidatingWebhookConfigurations (VWHCs) when running on OpenShift.

Previously we were relying on the `service.beta.openshift.io/inject-cabundle` annotation. It turns out this injects the *wrong* bundle for VWHCs (though, accidentally, the right one for the aggregated APIService). Our webhooks still worked because the KAS has special handling, ignoring the VWHC's caBundle entirely, for clients using the aggregated API service, which hiveadmission does. However, OpenShift's kube-apiserver-operator (KASO) has a webhook validator that lacks this special handling (see OCPBUGS-50978) and thus generates error logs. While these errors are harmless and do not reflect any functional problem, they can be annoying/distracting for customers.

Modern (all currently-supported) versions of OpenShift create ConfigMaps in every namespace containing the service CA cert, which is needed by the APIService to authn to the KAS, and the kube root CA cert, which is needed in the VWHCs by KASO (though not by the KAS) to validate the webhooks. So this change:
- Removes the `inject-cabundle` annotation from the APIService and all VWHCs.
- Adds a code path for OpenShift clusters to look up these ConfigMaps and inject the respective certs into the respective objects explicitly.

The logic for non-OpenShift clusters remains the same.

Related-To: OCPBUGS-50978