### PR TITLE
HIVE-2871 - Always show the upgradeable annotation.

### DIFF
--- a/pkg/controller/clusterversion/clusterversion_controller.go
+++ b/pkg/controller/clusterversion/clusterversion_controller.go
@@ -222,14 +222,11 @@ func (r *ReconcileClusterVersion) updateClusterVersionMetadata(cd *hivev1.Cluste
 		}
 	}
 	changed = changed || upgradeableCondition != cd.Annotations[constants.MinorVersionUpgradeUnavailable]
-	if upgradeableCondition == "" {
-		delete(cd.Annotations, constants.MinorVersionUpgradeUnavailable)
-	} else {
-		if cd.Annotations == nil {
-			cd.Annotations = map[string]string{}
-		}
-		cd.Annotations[constants.MinorVersionUpgradeUnavailable] = upgradeableCondition
+
+	if cd.Annotations == nil {
+		cd.Annotations = map[string]string{}
 	}
+	cd.Annotations[constants.MinorVersionUpgradeUnavailable] = upgradeableCondition
 
 	if !changed {
 		cdLog.Debug("cluster version metadata has not changed, nothing to update")

--- a/pkg/controller/clusterversion/clusterversion_controller_test.go
+++ b/pkg/controller/clusterversion/clusterversion_controller_test.go
@@ -89,7 +89,7 @@ func TestClusterVersionReconcile(t *testing.T) {
 				Status: configv1.ConditionTrue,
 			}),
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
-				assert.Equal(t, "", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
+				assert.Equal(t, "", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected value for annotation hive.openshift.io/minor-version-upgrade-unavailable")
 			},
 		},
 		{
@@ -103,7 +103,7 @@ func TestClusterVersionReconcile(t *testing.T) {
 				Status: configv1.ConditionFalse,
 			}),
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
-				assert.Equal(t, "Upgradeable: False", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
+				assert.Equal(t, "Upgradeable: False", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected value for annotation hive.openshift.io/minor-version-upgrade-unavailable")
 			},
 		},
 		{
@@ -118,7 +118,7 @@ func TestClusterVersionReconcile(t *testing.T) {
 				Message: "Can't do the upgrade",
 			}),
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
-				assert.Equal(t, "Can't do the upgrade", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
+				assert.Equal(t, "Can't do the upgrade", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected value for annotation hive.openshift.io/minor-version-upgrade-unavailable")
 			},
 		},
 		{
@@ -132,7 +132,7 @@ func TestClusterVersionReconcile(t *testing.T) {
 				Status: configv1.ConditionUnknown,
 			}),
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
-				assert.Equal(t, "Upgradeable: Unknown", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
+				assert.Equal(t, "Upgradeable: Unknown", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected value for annotation hive.openshift.io/minor-version-upgrade-unavailable")
 			},
 		},
 		{
@@ -147,7 +147,7 @@ func TestClusterVersionReconcile(t *testing.T) {
 				Message: "Can't read status",
 			}),
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
-				assert.Equal(t, "Can't read status", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
+				assert.Equal(t, "Can't read status", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected value for annotation hive.openshift.io/minor-version-upgrade-unavailable")
 			},
 		},
 		{
@@ -166,7 +166,7 @@ func TestClusterVersionReconcile(t *testing.T) {
 					Message: "It can't upgrade",
 				}),
 			validate: func(t *testing.T, cd *hivev1.ClusterDeployment) {
-				assert.Equal(t, "It can't upgrade", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected version major-minor-patch label")
+				assert.Equal(t, "It can't upgrade", cd.Annotations[constants.MinorVersionUpgradeUnavailable], "unexpected value for annotation hive.openshift.io/minor-version-upgrade-unavailable")
 			},
 		},
 	}


### PR DESCRIPTION
Follow up to [HIVE-2819](https://issues.redhat.com//browse/HIVE-2819) - always show the upgradeable annotation. If the annotation is present with an empty string, this means that the cluster is upgradeable.