### PR TITLE
HIVE-2871 | (fix): Update the clusterversion controller to handle the case where the upgradeable annotation doesn't exist and needs to be re-populated

### DIFF
--- a/pkg/controller/clusterversion/clusterversion_controller.go
+++ b/pkg/controller/clusterversion/clusterversion_controller.go
@@ -221,7 +221,8 @@ func (r *ReconcileClusterVersion) updateClusterVersionMetadata(cd *hivev1.Cluste
 			break
 		}
 	}
-	changed = changed || upgradeableCondition != cd.Annotations[constants.MinorVersionUpgradeUnavailable]
+	annotationValue, ok := cd.Annotations[constants.MinorVersionUpgradeUnavailable]
+	changed = changed || !ok || upgradeableCondition != annotationValue
 
 	if cd.Annotations == nil {
 		cd.Annotations = map[string]string{}


### PR DESCRIPTION
Currently, the controller will not recognize that the "upgradeable" annotation is missing and requires repopulation. This change treats a missing annotation as a required change that needs to be updated during reconcilation.