### PR TITLE
Set default shell to Bash in Hive's Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 .PHONY: all
 all: vendor update test build
 


### PR DESCRIPTION
Trying to build `hiveutil` on Debian (and most likely all Debian derivatives) fails because not only does the default Bourne shell not support Bash-isms like `shopt` but neither does the shell that it's commonly symlinked to, Dash.

For example:

```
$ make build-hiveutil
/bin/sh: 1: set: Illegal option -o pipefail
...
$ readlink -f /bin/sh
/usr/bin/dash
```


I currently don't have access to my Red Hat-issued Fedora machine, but spinning up a Fedora VM in Vagrant shows that `sh` is linked to Bash:

```
[vagrant@vagrant-fedora hive]$ readlink -f /bin/sh
/usr/bin/bash
```

Even though it's probably safe that Fedora will continue to symlink to Bash, it doesn't hurt to harden the Makefile by adding the SHELL variable.

This was tested on both Debian and Fedora.

https://issues.redhat.com/browse/SREP-1163