### PR TITLE
HIVE-2887: Consolidate operator apply functions

### DIFF
--- a/pkg/operator/hive/configmap.go
+++ b/pkg/operator/hive/configmap.go
@@ -307,7 +307,7 @@ func (r *ReconcileHiveConfig) deployConfigMap(hLog log.FieldLogger, h resource.H
 		}
 	}
 
-	result, err := util.ApplyRuntimeObjectWithGC(h, cm, instance)
+	result, err := util.ApplyRuntimeObject(h, util.Passthrough(cm), hLog, util.WithGarbageCollection(instance))
 	if err != nil {
 		cmLog.WithError(err).Error("error applying configmap")
 		return "", err

--- a/pkg/operator/hive/sharded_controllers.go
+++ b/pkg/operator/hive/sharded_controllers.go
@@ -157,7 +157,7 @@ func (r *ReconcileHiveConfig) deployStatefulSet(c ssCfg, hLog log.FieldLogger, h
 
 	// Load namespaced assets, decode them, set to our target namespace, and apply:
 	for _, a := range namespacedAssets {
-		if err := util.ApplyAssetBytesWithNSOverrideAndGC(h, a.processed, hiveNSName, hiveconfig); err != nil {
+		if _, err := util.ApplyRuntimeObject(h, util.FromBytes(a.processed), hLog, util.WithNamespaceOverride(hiveNSName), util.WithGarbageCollection(hiveconfig)); err != nil {
 			hLog.WithError(err).WithField("asset", a.path).Error("error applying object with namespace override")
 			return err
 		}
@@ -240,7 +240,7 @@ func (r *ReconcileHiveConfig) deployStatefulSet(c ssCfg, hLog log.FieldLogger, h
 	newStatefulSet.Spec.Template.Spec.Tolerations = r.tolerations
 
 	newStatefulSet.Namespace = hiveNSName
-	result, err := util.ApplyRuntimeObjectWithGC(h, newStatefulSet, hiveconfig)
+	result, err := util.ApplyRuntimeObject(h, util.Passthrough(newStatefulSet), hLog, util.WithGarbageCollection(hiveconfig))
 	if err != nil {
 		hLog.WithError(err).Error("error applying statefulset")
 		return err


### PR DESCRIPTION
Modernize the code hive-operator uses to apply objects to the cluster, employing the options pattern so we can consolidate to just one function. This improves maintainability by, for example, allowing us to add a new object configuration without adding a whole new (set of) Apply function(s).