### PR TITLE
[HIVE-2605] Update bundle-gen to create release-config

### DIFF
--- a/hack/bundle-gen.py
+++ b/hack/bundle-gen.py
@@ -260,6 +260,22 @@ def generate_csv_base(
         yaml_string = yaml.dump(yaml_annotations)
         file.write(yaml_string)
 
+    # Create release-config.yaml file. This file is only utilized by the Red Hat Ecosystem,
+    # for the automatic catalog update for all RH catalogs. Kubernetes Ecosystem will ignore the file.
+    file_path = os.path.join(version_dir, "release-config.yaml")
+    data = {
+        "catalog_templates": [
+            {
+                "channels": [CHANNEL_DEFAULT],
+                "replaces": "hive-operator.v"+prev_version,
+                "template_name": "basic.yaml"
+            }
+        ]
+    }
+    with open(file_path, 'w') as file:
+        yaml_string = yaml.dump(data)
+        file.write(yaml_string)
+
     owned_crds = []
 
     # Copy all CSV files over to the manifests dir:


### PR DESCRIPTION
Since Hive started using File Based Catalog system on the Red Hat OpenShift Ecosystem OperatorHub, we are required to upload a release-config.yaml file along with our bundle, which lists the replaces version, channel and the template mapping. The presence of this file with the bundle ensures an automatic PR post merge that will update all the catalogs.

Note: This file is only useful for RH ecosystem, however we build the same bundle for both OperatorHubs and the Kubernetes Ecosystem OperatorHub ignores this file.

/assign @2uasimojo 