### PR TITLE
HIVE-2544: Support machinepool creation in Azure regions without availability zones

### DIFF
--- a/pkg/controller/machinepool/azureactuator.go
+++ b/pkg/controller/machinepool/azureactuator.go
@@ -156,10 +156,13 @@ func (a *AzureActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *
 			return nil, false, errors.Wrap(err, "compute pool not providing list of zones and failed to fetch list of zones")
 		}
 		if len(zones) == 0 {
-			return nil, false, fmt.Errorf("zero zones returned for region %s", cd.Spec.Platform.Azure.Region)
+			// No zones specified. Upstream will handle defaulting logic. Adding log here for visibility.
+			logger.WithField("region", cd.Spec.Platform.Azure.Region).Info("No availability zones detected for region. Using non-zoned deployment.")
+		} else {
+			computePool.Platform.Azure.Zones = zones
 		}
-		computePool.Platform.Azure.Zones = zones
 	}
+
 	// The imageID parameter is not used. The image is determined by the infraID.
 	const imageID = ""
 


### PR DESCRIPTION
When users created a MachinePool in an Azure region that does not support availability zones,since the region does not provide availability zones, the MachinePool creation failed.

**Solution:**

- Based on Eric’s comments in https://github.com/openshift/hive/pull/2732#pullrequestreview-3129384057 
If no zones are specified, and the region has no zones, just pass through "no zones", and let the mset generator do what it does for a "no AZ region". 
