### PR TITLE
HIVE-2891: Add new HiveConfig field "HiveImagePullSecretRef"

### DIFF
--- a/apis/hive/v1/hiveconfig_types.go
+++ b/apis/hive/v1/hiveconfig_types.go
@@ -41,6 +41,14 @@ type HiveConfigSpec struct {
 	// +optional
 	GlobalPullSecretRef *corev1.LocalObjectReference `json:"globalPullSecretRef,omitempty"`
 
+	// HiveImagePullSecretRef is used to specify a pull secret that can be used to pull Hive's own image.
+	// If hive has been deployed from a private registry, cluster installations will not succeed unless
+	// this reference is specified. This secret must live in the same namespace as the Hive operator's deployment.
+	// NOTE: This secret will be copied into Hive's TargetNamespace (if it is different than the namespace
+	// that the Hive operator is deployed in), as well as the namespace of every ClusterDeployment.
+	// +optional
+	HiveImagePullSecretRef *corev1.LocalObjectReference `json:"hiveImagePullSecretRef,omitempty"`
+
 	// Backup specifies configuration for backup integration.
 	// If absent, backup integration will be disabled.
 	// +optional

--- a/apis/hive/v1/zz_generated.deepcopy.go
+++ b/apis/hive/v1/zz_generated.deepcopy.go
@@ -2667,6 +2667,11 @@ func (in *HiveConfigSpec) DeepCopyInto(out *HiveConfigSpec) {
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
+	if in.HiveImagePullSecretRef != nil {
+		in, out := &in.HiveImagePullSecretRef, &out.HiveImagePullSecretRef
+		*out = new(corev1.LocalObjectReference)
+		**out = **in
+	}
 	in.Backup.DeepCopyInto(&out.Backup)
 	in.FailedProvisionConfig.DeepCopyInto(&out.FailedProvisionConfig)
 	in.ServiceProviderCredentialsConfig.DeepCopyInto(&out.ServiceProviderCredentialsConfig)

--- a/config/crds/hive.openshift.io_hiveconfigs.yaml
+++ b/config/crds/hive.openshift.io_hiveconfigs.yaml
@@ -666,6 +666,25 @@ spec:
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
+                hiveImagePullSecretRef:
+                  description: |-
+                    HiveImagePullSecretRef is used to specify a pull secret that can be used to pull Hive's own image.
+                    If hive has been deployed from a private registry, cluster installations will not succeed unless
+                    this reference is specified. This secret must live in the same namespace as the Hive operator's deployment.
+                    NOTE: This secret will be copied into Hive's TargetNamespace (if it is different than the namespace
+                    that the Hive operator is deployed in), as well as the namespace of every ClusterDeployment.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
                 logLevel:
                   description: |-
                     LogLevel is the level of logging to use for the Hive controllers.

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -6898,6 +6898,38 @@ objects:
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
+                hiveImagePullSecretRef:
+                  description: 'HiveImagePullSecretRef is used to specify a pull secret
+                    that can be used to pull Hive''s own image.
+
+                    If hive has been deployed from a private registry, cluster installations
+                    will not succeed unless
+
+                    this reference is specified. This secret must live in the same
+                    namespace as the Hive operator''s deployment.
+
+                    NOTE: This secret will be copied into Hive''s TargetNamespace
+                    (if it is different than the namespace
+
+                    that the Hive operator is deployed in), as well as the namespace
+                    of every ClusterDeployment.'
+                  properties:
+                    name:
+                      default: ''
+                      description: 'Name of the referent.
+
+                        This field is effectively required, but due to backwards compatibility
+                        is
+
+                        allowed to be empty. Instances of this type with an empty
+                        value here are
+
+                        almost certainly wrong.
+
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
                 logLevel:
                   description: 'LogLevel is the level of logging to use for the Hive
                     controllers.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -116,6 +116,9 @@ const (
 	// GlobalPullSecret is the environment variable for controllers to get the global pull secret
 	GlobalPullSecret = "GLOBAL_PULL_SECRET"
 
+	// HivePrivateImagePullSecret is the environment variable for controllers to get the pull secret for hive's own image
+	HivePrivateImagePullSecret = "HIVE_PRIVATE_IMAGE_PULL_SECRET"
+
 	// DefaultHiveNamespace is the default namespace where core hive components will run. It is used if the environment variable is not defined.
 	DefaultHiveNamespace = "hive"
 

--- a/pkg/controller/clusterdeployment/clusterprovisions.go
+++ b/pkg/controller/clusterdeployment/clusterprovisions.go
@@ -681,7 +681,8 @@ func (r *ReconcileClusterDeployment) copyInstallLogSecret(destNamespace string, 
 
 	src := types.NamespacedName{Name: srcSecretName, Namespace: hiveNS}
 	dest := types.NamespacedName{Name: destSecretName, Namespace: destNamespace}
-	return controllerutils.CopySecret(r, src, dest, nil, nil)
+	_, err := controllerutils.CopySecret(r, src, dest, nil, nil)
+	return err
 }
 
 // NOTE: Ugly-but-simple way to mock os.ReadFile for test purposes.

--- a/pkg/controller/utils/podconfig.go
+++ b/pkg/controller/utils/podconfig.go
@@ -10,12 +10,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// SharedPodConfig is initially created from the hive-operator pod and must be included in any Jobs or Pods
-// we create from downstream.
+// SharedPodConfig is initially determined from the hive-operator pod and must be included in any
+// Jobs or Pods we create downstream from there.
 type SharedPodConfig struct {
-	NodeSelector     map[string]string
-	Tolerations      []corev1.Toleration
-	ImagePullSecrets []corev1.LocalObjectReference
+	NodeSelector map[string]string
+	Tolerations  []corev1.Toleration
 }
 
 func ReadSharedConfigFromThisPod(cl client.Client) (*SharedPodConfig, error) {
@@ -25,9 +24,8 @@ func ReadSharedConfigFromThisPod(cl client.Client) (*SharedPodConfig, error) {
 	}
 
 	return &SharedPodConfig{
-		NodeSelector:     thisPod.Spec.NodeSelector,
-		Tolerations:      thisPod.Spec.Tolerations,
-		ImagePullSecrets: thisPod.Spec.ImagePullSecrets,
+		NodeSelector: thisPod.Spec.NodeSelector,
+		Tolerations:  thisPod.Spec.Tolerations,
 	}, nil
 }
 

--- a/pkg/imageset/generate.go
+++ b/pkg/imageset/generate.go
@@ -1,6 +1,7 @@
 package imageset
 
 import (
+	"os"
 	"time"
 
 	controllerutils "github.com/openshift/hive/pkg/controller/utils"
@@ -41,8 +42,6 @@ func GenerateImageSetJob(
 			MountPath: "/common",
 		},
 	}
-
-	imagePullSecrets := append(sharedPodConfig.ImagePullSecrets, corev1.LocalObjectReference{Name: constants.GetMergedPullSecretName(cd)})
 
 	podSpec := corev1.PodSpec{
 		NodeSelector:  sharedPodConfig.NodeSelector,
@@ -87,7 +86,13 @@ func GenerateImageSetJob(
 			},
 		},
 		ServiceAccountName: serviceAccountName,
-		ImagePullSecrets:   imagePullSecrets,
+		ImagePullSecrets: []corev1.LocalObjectReference{
+			{Name: constants.GetMergedPullSecretName(cd)},
+		},
+	}
+
+	if hiveImagePullSecret := os.Getenv(constants.HivePrivateImagePullSecret); hiveImagePullSecret != "" {
+		podSpec.ImagePullSecrets = append(podSpec.ImagePullSecrets, corev1.LocalObjectReference{Name: hiveImagePullSecret})
 	}
 
 	completions := int32(1)

--- a/pkg/operator/hive/dynamicclient.go
+++ b/pkg/operator/hive/dynamicclient.go
@@ -38,6 +38,10 @@ func (r *ReconcileHiveConfig) clientFor(blankObj runtime.Object, namespace strin
 		c = dc.Resource(corev1.SchemeGroupVersion.WithResource("namespaces"))
 	case *configv1.ProxyList, *configv1.Proxy:
 		c = dc.Resource(configv1.SchemeGroupVersion.WithResource("proxies"))
+	case *corev1.SecretList, *corev1.Secret:
+		c = dc.Resource(corev1.SchemeGroupVersion.WithResource("secrets"))
+	case *corev1.ServiceAccountList, *corev1.ServiceAccount:
+		c = dc.Resource(corev1.SchemeGroupVersion.WithResource("serviceaccounts"))
 	}
 	if c == nil {
 		panic(fmt.Sprintf("You forgot to make a case for clients of type %T", blankObj))

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -6,6 +6,8 @@ import (
 	"crypto/md5"
 	"fmt"
 	"os"
+	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -18,6 +20,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	oappsv1 "github.com/openshift/api/apps/v1"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
@@ -271,6 +274,7 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 	}
 
 	r.includeGlobalPullSecret(hLog, instance, hiveContainer)
+	r.includeHivePrivateImagePullSecret(hLog, instance, hiveContainer)
 
 	if instance.Spec.MaintenanceMode != nil && *instance.Spec.MaintenanceMode {
 		hLog.Warn("maintenanceMode enabled in HiveConfig, setting hive-controllers replicas to 0")
@@ -353,7 +357,9 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 	// Apply shared pod config passed through from the operator deployment
 	hiveDeployment.Spec.Template.Spec.NodeSelector = r.sharedPodConfig.NodeSelector
 	hiveDeployment.Spec.Template.Spec.Tolerations = r.sharedPodConfig.Tolerations
-	hiveDeployment.Spec.Template.Spec.ImagePullSecrets = r.sharedPodConfig.ImagePullSecrets
+	if ref := getImagePullSecretReference(instance); ref != nil {
+		hiveDeployment.Spec.Template.Spec.ImagePullSecrets = append(hiveDeployment.Spec.Template.Spec.ImagePullSecrets, *ref)
+	}
 
 	hiveDeployment.Namespace = hiveNSName
 	result, err := util.ApplyRuntimeObject(h, util.Passthrough(hiveDeployment), hLog, util.WithGarbageCollection(instance))
@@ -362,6 +368,10 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 		return err
 	}
 	hLog.Infof("hive-controllers deployment applied (%s)", result)
+
+	if err := r.copyHiveImagePullSecret(hLog, h, instance); err != nil {
+		return err
+	}
 
 	hLog.Info("all hive components successfully reconciled")
 	return nil
@@ -408,7 +418,7 @@ func (r *ReconcileHiveConfig) includeAdditionalCAs(hLog log.FieldLogger, h resou
 
 	caSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: GetHiveNamespace(instance),
+			Namespace: hiveNS,
 			Name:      hiveAdditionalCASecret,
 		},
 		Data: map[string][]byte{
@@ -462,6 +472,91 @@ func (r *ReconcileHiveConfig) includeGlobalPullSecret(hLog log.FieldLogger, inst
 		Value: instance.Spec.GlobalPullSecretRef.Name,
 	}
 	hiveContainer.Env = append(hiveContainer.Env, globalPullSecretEnvVar)
+}
+
+func (r *ReconcileHiveConfig) includeHivePrivateImagePullSecret(hLog log.FieldLogger, instance *hivev1.HiveConfig, hiveContainer *corev1.Container) {
+	ref := getImagePullSecretReference(instance)
+	if ref == nil {
+		hLog.Debug("HiveImagePullSecret is not provided in HiveConfig, it will not be deployed")
+		return
+	}
+
+	hiveImagePullSecretEnvVar := corev1.EnvVar{
+		Name:  constants.HivePrivateImagePullSecret,
+		Value: ref.Name,
+	}
+	hiveContainer.Env = append(hiveContainer.Env, hiveImagePullSecretEnvVar)
+}
+
+func (r *ReconcileHiveConfig) copyHiveImagePullSecret(hLog log.FieldLogger, h resource.Helper, instance *hivev1.HiveConfig) error {
+	ref := getImagePullSecretReference(instance)
+	if ref == nil {
+		hLog.Debug("HiveImagePullSecret is not provided in HiveConfig, it will not be copied")
+		return nil
+	}
+
+	srcNS := r.hiveOperatorNamespace
+	destNS := GetHiveNamespace(instance)
+	secretName := ref.Name
+
+	if srcNS == destNS {
+		hLog.WithField("namespace", srcNS).Debug("hive operator and hive controllers live in the same NS", srcNS)
+		return nil
+	}
+
+	srcSecret := &corev1.Secret{}
+	err := r.Get(context.TODO(), types.NamespacedName{Namespace: srcNS, Name: secretName}, srcSecret)
+	if err != nil {
+		return err
+	}
+
+	destSecret := &corev1.Secret{}
+	err = r.Get(context.TODO(), types.NamespacedName{Namespace: destNS, Name: secretName}, destSecret)
+
+	secretFound := true
+	if apierrors.IsNotFound(err) {
+		destSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: destNS,
+			},
+			Data: srcSecret.Data,
+			Type: srcSecret.Type,
+		}
+		secretFound = false
+	} else if err != nil {
+		return err
+	}
+
+	controllerSA := &corev1.ServiceAccount{}
+	if err := r.Get(context.TODO(), types.NamespacedName{Namespace: destNS, Name: "hive-controllers"}, controllerSA); err != nil {
+		hLog.WithError(err).Info("couldn't fetch hive-controllers service account, attempting to requeue...")
+		return err
+	}
+
+	if secretFound {
+		if reflect.DeepEqual(destSecret.Data, srcSecret.Data) {
+			if slices.ContainsFunc(destSecret.OwnerReferences, func(ref metav1.OwnerReference) bool {
+				return ref.UID == controllerSA.UID
+			}) {
+				hLog.WithField("name", secretName).WithField("namespace", destNS).Debug("target secret does exist, no update necessary")
+				return nil // no work as the dest and source data matches and secret is owned
+			}
+			hLog.WithField("name", secretName).WithField("namespace", destNS).Debug("target secret isn't owned, owning it")
+		} else {
+			destSecret.Data = srcSecret.Data
+			hLog.WithField("name", secretName).WithField("namespace", destNS).Debug("target secret is out of date, updating it")
+		}
+	} else {
+		hLog.WithField("name", secretName).WithField("namespace", destNS).Debug("target secret doesn't exist, creating it")
+	}
+
+	if err := controllerutil.SetOwnerReference(controllerSA, destSecret, r.scheme); err != nil {
+		return err
+	}
+
+	_, err = h.CreateOrUpdateRuntimeObject(destSecret, r.scheme)
+	return err
 }
 
 func (r *ReconcileHiveConfig) runningOnOpenShift() (bool, error) {

--- a/pkg/operator/hive/hive_controller.go
+++ b/pkg/operator/hive/hive_controller.go
@@ -311,7 +311,6 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 	log.Debugf("loaded nodeSelector from hive-operator deployment: %v", sharedPodConfig.NodeSelector)
 	log.Debugf("loaded tolerations from hive-operator deployment: %v", sharedPodConfig.Tolerations)
-	log.Debugf("loaded imagePullSecrets from hive-operator deployment: %v", sharedPodConfig.ImagePullSecrets)
 	r.(*ReconcileHiveConfig).sharedPodConfig = sharedPodConfig
 
 	// TODO: Monitor CRDs but do not try to use an owner ref. (as they are global,

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -192,7 +192,9 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h resour
 	// Apply shared pod config passed through from the operator deployment
 	hiveAdmDeployment.Spec.Template.Spec.NodeSelector = r.sharedPodConfig.NodeSelector
 	hiveAdmDeployment.Spec.Template.Spec.Tolerations = r.sharedPodConfig.Tolerations
-	hiveAdmDeployment.Spec.Template.Spec.ImagePullSecrets = r.sharedPodConfig.ImagePullSecrets
+	if ref := getImagePullSecretReference(instance); ref != nil {
+		hiveAdmDeployment.Spec.Template.Spec.ImagePullSecrets = append(hiveAdmDeployment.Spec.Template.Spec.ImagePullSecrets, *ref)
+	}
 
 	result, err := util.ApplyRuntimeObject(h, util.Passthrough(hiveAdmDeployment), hLog, util.WithGarbageCollection(instance))
 	if err != nil {

--- a/pkg/operator/hive/operatorutils.go
+++ b/pkg/operator/hive/operatorutils.go
@@ -88,3 +88,10 @@ func applyDeploymentConfig(hiveConfig *hivev1.HiveConfig, deploymentName hivev1.
 		container.Resources = *dc.Resources
 	}
 }
+
+func getImagePullSecretReference(config *hivev1.HiveConfig) *corev1.LocalObjectReference {
+	if config.Spec.HiveImagePullSecretRef != nil && config.Spec.HiveImagePullSecretRef.Name != "" {
+		return config.Spec.HiveImagePullSecretRef
+	}
+	return nil
+}

--- a/pkg/operator/hive/sharded_controllers.go
+++ b/pkg/operator/hive/sharded_controllers.go
@@ -238,7 +238,9 @@ func (r *ReconcileHiveConfig) deployStatefulSet(c ssCfg, hLog log.FieldLogger, h
 	// Apply shared pod config passed through from the operator deployment
 	newStatefulSet.Spec.Template.Spec.NodeSelector = r.sharedPodConfig.NodeSelector
 	newStatefulSet.Spec.Template.Spec.Tolerations = r.sharedPodConfig.Tolerations
-	newStatefulSet.Spec.Template.Spec.ImagePullSecrets = r.sharedPodConfig.ImagePullSecrets
+	if ref := getImagePullSecretReference(hiveconfig); ref != nil {
+		newStatefulSet.Spec.Template.Spec.ImagePullSecrets = append(newStatefulSet.Spec.Template.Spec.ImagePullSecrets, *ref)
+	}
 
 	newStatefulSet.Namespace = hiveNSName
 	result, err := util.ApplyRuntimeObject(h, util.Passthrough(newStatefulSet), hLog, util.WithGarbageCollection(hiveconfig))

--- a/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/hiveconfig_types.go
@@ -41,6 +41,14 @@ type HiveConfigSpec struct {
 	// +optional
 	GlobalPullSecretRef *corev1.LocalObjectReference `json:"globalPullSecretRef,omitempty"`
 
+	// HiveImagePullSecretRef is used to specify a pull secret that can be used to pull Hive's own image.
+	// If hive has been deployed from a private registry, cluster installations will not succeed unless
+	// this reference is specified. This secret must live in the same namespace as the Hive operator's deployment.
+	// NOTE: This secret will be copied into Hive's TargetNamespace (if it is different than the namespace
+	// that the Hive operator is deployed in), as well as the namespace of every ClusterDeployment.
+	// +optional
+	HiveImagePullSecretRef *corev1.LocalObjectReference `json:"hiveImagePullSecretRef,omitempty"`
+
 	// Backup specifies configuration for backup integration.
 	// If absent, backup integration will be disabled.
 	// +optional

--- a/vendor/github.com/openshift/hive/apis/hive/v1/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/zz_generated.deepcopy.go
@@ -2667,6 +2667,11 @@ func (in *HiveConfigSpec) DeepCopyInto(out *HiveConfigSpec) {
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
+	if in.HiveImagePullSecretRef != nil {
+		in, out := &in.HiveImagePullSecretRef, &out.HiveImagePullSecretRef
+		*out = new(corev1.LocalObjectReference)
+		**out = **in
+	}
 	in.Backup.DeepCopyInto(&out.Backup)
 	in.FailedProvisionConfig.DeepCopyInto(&out.FailedProvisionConfig)
 	in.ServiceProviderCredentialsConfig.DeepCopyInto(&out.ServiceProviderCredentialsConfig)


### PR DESCRIPTION
xref: [HIVE-2891](https://issues.redhat.com//browse/HIVE-2891)

/assign @2uasimojo 
/cc @huangmingxia 

When deploying hive from a private image repository, in addition to supplying an `imagePullSecret` to the hive operator deployment, users will need to specify this same secret on the `HiveConfig`.  With this change, private image users will be able to provision clusters from any namespace, not just Hive's namespace