### PR TITLE
HIVE-2923: AWS started spelling it `RequestID`

### DIFF
--- a/pkg/controller/awsprivatelink/awsprivatelink_controller.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/url"
 	"os"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -395,7 +394,7 @@ func (r *ReconcileAWSPrivateLink) setErrCondition(cd *hivev1.ClusterDeployment,
 	if errGet != nil {
 		return errGet
 	}
-	message := filterErrorMessage(err)
+	message := controllerutils.ErrorScrub(err)
 	conditions, failedChanged := controllerutils.SetClusterDeploymentConditionWithChangeCheck(
 		curr.Status.Conditions,
 		hivev1.AWSPrivateLinkFailedClusterDeploymentCondition,
@@ -1316,11 +1315,6 @@ func ec2TagSpecification(metadata *hivev1.ClusterMetadata, resource ec2types.Res
 			Value: aws.String(metadata.InfraID + "-" + string(resource)),
 		}},
 	}
-}
-
-func filterErrorMessage(err error) string {
-	skipRequestIDRE := regexp.MustCompile(`(request id|Request ID): ([-0-9a-f]+)`)
-	return skipRequestIDRE.ReplaceAllString(err.Error(), "${1}: XXXX")
 }
 
 type awsClient struct {

--- a/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
+++ b/pkg/controller/awsprivatelink/awsprivatelink_controller_test.go
@@ -2464,27 +2464,3 @@ func Test_toSupportedSubnets(t *testing.T) {
 		}},
 	}}, inv)
 }
-
-func Test_filterErrorMessage(t *testing.T) {
-	tests := []struct {
-		err  error
-		want string
-	}{{
-		err:  errors.New(`AccessDenied: Failed to verify the given VPC by calling ec2:DescribeVpcs: You are not authorized to perform this operation. (Service: AmazonEC2; Status Code: 403; Error Code: UnauthorizedOperation; Request ID: 42a5a4ce-9c1a-4916-a62a-72a2e6d9ae59; Proxy: null)\n\tstatus code: 403, request id: 9cc3b1f9-e161-402c-a942-d0ed7c7e5fd4`),
-		want: `AccessDenied: Failed to verify the given VPC by calling ec2:DescribeVpcs: You are not authorized to perform this operation. (Service: AmazonEC2; Status Code: 403; Error Code: UnauthorizedOperation; Request ID: XXXX; Proxy: null)\n\tstatus code: 403, request id: XXXX`,
-	}, {
-		err: errors.New(`AccessDenied: Failed to verify the given VPC by calling ec2:DescribeVpcs: You are not authorized to perform this operation. (Service: AmazonEC2; Status Code: 403; Error Code: UnauthorizedOperation; Request ID: 42a5a4ce-9c1a-4916-a62a-72a2e6d9ae59; Proxy: null)
-		status code: 403, request id: 9cc3b1f9-e161-402c-a942-d0ed7c7e5fd4`),
-		want: `AccessDenied: Failed to verify the given VPC by calling ec2:DescribeVpcs: You are not authorized to perform this operation. (Service: AmazonEC2; Status Code: 403; Error Code: UnauthorizedOperation; Request ID: XXXX; Proxy: null)
-		status code: 403, request id: XXXX`,
-	}, {
-		err:  errors.New(`AccessDenied: User: arn:aws:iam::12345:user/test-user is not authorized to perform: route53:ChangeResourceRecordSets on resource: arn:aws:route53:::hostedzone/12345\n\tstatus code: 403, request id: 22bc2e2e-9381-485f-8a46-c7ce8aad2a4d`),
-		want: `AccessDenied: User: arn:aws:iam::12345:user/test-user is not authorized to perform: route53:ChangeResourceRecordSets on resource: arn:aws:route53:::hostedzone/12345\n\tstatus code: 403, request id: XXXX`,
-	}}
-	for _, tt := range tests {
-		t.Run("", func(t *testing.T) {
-			got := filterErrorMessage(tt.err)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}

--- a/pkg/controller/privatelink/conditions/conditions.go
+++ b/pkg/controller/privatelink/conditions/conditions.go
@@ -2,7 +2,6 @@ package conditions
 
 import (
 	"context"
-	"regexp"
 	"time"
 
 	"github.com/pkg/errors"
@@ -25,11 +24,6 @@ var clusterDeploymentPrivateLinkConditions = []hivev1.ClusterDeploymentCondition
 	hivev1.PrivateLinkReadyClusterDeploymentCondition,
 }
 
-func filterErrorMessage(err error) string {
-	skipRequestIDRE := regexp.MustCompile(`(request id|Request ID): ([-0-9a-f]+)`)
-	return skipRequestIDRE.ReplaceAllString(err.Error(), "${1}: XXXX")
-}
-
 func InitializeConditions(cd *hivev1.ClusterDeployment) ([]hivev1.ClusterDeploymentCondition, bool) {
 	return controllerutils.InitializeClusterDeploymentConditions(cd.Status.Conditions, clusterDeploymentPrivateLinkConditions)
 }
@@ -40,7 +34,7 @@ func SetErrCondition(client client.Client, cd *hivev1.ClusterDeployment, reason 
 	if errGet != nil {
 		return errors.Wrap(errGet, "failed to get cluster deployment")
 	}
-	message := filterErrorMessage(err)
+	message := controllerutils.ErrorScrub(err)
 	conditions, failedChanged := controllerutils.SetClusterDeploymentConditionWithChangeCheck(
 		curr.Status.Conditions,
 		hivev1.PrivateLinkFailedClusterDeploymentCondition,

--- a/pkg/controller/utils/errorscrub.go
+++ b/pkg/controller/utils/errorscrub.go
@@ -8,7 +8,7 @@ var (
 	newlineTabRE           = regexp.MustCompile(`\n\t`)
 	certificateTimeErrorRE = regexp.MustCompile(`: current time \S+ is after \S+`)
 	// aws
-	awsRequestIDRE    = regexp.MustCompile(`(, )*(?i)(request id: )(?:[-[:xdigit:]]+)`)
+	awsRequestIDRE    = regexp.MustCompile(`(, )*(?i)(request ?id: )(?:[-[:xdigit:]]+)`)
 	awsNotAuthorized  = regexp.MustCompile(`(User: arn:aws:sts::)\S+(:assumed-role/[^/]+/)\S+( is not authorized to perform: \S+ on resource: arn:aws:iam::)[^:]+(:\S+)`)
 	awsEncodedMessage = regexp.MustCompile(`(Encoded authorization failure message: )[^,]+,`)
 	// azure

--- a/pkg/controller/utils/errorscrub_test.go
+++ b/pkg/controller/utils/errorscrub_test.go
@@ -54,6 +54,27 @@ func TestErrorScrubber(t *testing.T) {
 			input:    errors.New("failed to reconcile the VPC Endpoint Service: UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure message: CnWuhDtDU8FQVg9qYvdTV1sflohKgfEbSt7r5FKOlWASj-sZd_ThxMgw1vWPaA03t0q-4YxC3ixYib1CpgUy5OxR9rvuTQ24D_CvTl9ZwqTqdG7OZ49nzPRBuYkL6WYrh_m40GVqa7dyZnhdsFADPpGbFngWx6whQqOU83hpGcYUtFuWmuHlMAz8sPsQHviCHZ9WgIWoTS8Rqjpf2BQWKknnF7IVfkAlyhZJGoPNZ5RUxgphGniUfk0G_2mEY8VmVLwzhqAzbJE_GYednXtMfLX9ctEVd1G2c-2bW4lrQpvjxVaZ92oKXhtfkT5zEI_7sw4fa8yqrxfnE6n4XG2M2CqpaT2HphDc8LJpg7lZXhpCCkunG7wtCAiQvF4NwWqENxlCd_k-E_d1FaIEMaUSAoOUXcjJx8W-ObZy0qst64dQPg-kPNHbrnwMh4DGfppWEPaQgLBOa9LN3xkD-5r6fjT5yJWGcTiKYAKjBiW0KAiwULI11_8Ty9l-QY1OMaudbv_0drhKs766YsbTlMTBWZ37trRzMTWmdCCntilfAVjVHWpdNhNlGwvWPB8DMs38I4zONqCUhw8WVbJ0B-b9BgmkD0rpz9-uQ9i3yh8In-YrFgcXy6CgJpKqYnQjy2QhLwJvDLVgf4eckchR7TkDWkjjrXcQ-15aWOnhtUnyRU6MaPRpCwFCj9xigNmVOQfmK63YeoxT9a1SF7XeJA\n\tstatus code: 403, request id: XXX"),
 			expected: `failed to reconcile the VPC Endpoint Service: UnauthorizedOperation: You are not authorized to perform this operation. Encoded authorization failure message: XXX, status code: 403, request id: XXX`,
 		},
+		{
+			name:     "suddenly it is spelled RequestID",
+			input:    errors.New("operation error Resource Groups Tagging API: GetResources, https response error StatusCode: 400, RequestID: 032cc7f0-b1a6-4183-bdbb-a15a23a9e029, api error UnrecognizedClientException: The security token included in the request is invalid."),
+			expected: `operation error Resource Groups Tagging API: GetResources, https response error StatusCode: 400, api error UnrecognizedClientException: The security token included in the request is invalid.`,
+		},
+		{
+			name:     "two request IDs, spelled differently",
+			input:    errors.New(`AccessDenied: Failed to verify the given VPC by calling ec2:DescribeVpcs: You are not authorized to perform this operation. (Service: AmazonEC2; Status Code: 403; Error Code: UnauthorizedOperation; Request ID: 42a5a4ce-9c1a-4916-a62a-72a2e6d9ae59; Proxy: null)\n\tstatus code: 403, request id: 9cc3b1f9-e161-402c-a942-d0ed7c7e5fd4`),
+			expected: `AccessDenied: Failed to verify the given VPC by calling ec2:DescribeVpcs: You are not authorized to perform this operation. (Service: AmazonEC2; Status Code: 403; Error Code: UnauthorizedOperation; ; Proxy: null)\n\tstatus code: 403`,
+		},
+		{
+			name: "embedded newline",
+			input: errors.New(`AccessDenied: Failed to verify the given VPC by calling ec2:DescribeVpcs: You are not authorized to perform this operation. (Service: AmazonEC2; Status Code: 403; Error Code: UnauthorizedOperation; Request ID: 42a5a4ce-9c1a-4916-a62a-72a2e6d9ae59; Proxy: null)
+		status code: 403, request id: 9cc3b1f9-e161-402c-a942-d0ed7c7e5fd4`),
+			expected: `AccessDenied: Failed to verify the given VPC by calling ec2:DescribeVpcs: You are not authorized to perform this operation. (Service: AmazonEC2; Status Code: 403; Error Code: UnauthorizedOperation; ; Proxy: null), 	status code: 403`,
+		},
+		{
+			name:     "request id is at the end",
+			input:    errors.New(`AccessDenied: User: arn:aws:iam::12345:user/test-user is not authorized to perform: route53:ChangeResourceRecordSets on resource: arn:aws:route53:::hostedzone/12345\n\tstatus code: 403, request id: 22bc2e2e-9381-485f-8a46-c7ce8aad2a4d`),
+			expected: `AccessDenied: User: arn:aws:iam::12345:user/test-user is not authorized to perform: route53:ChangeResourceRecordSets on resource: arn:aws:route53:::hostedzone/12345\n\tstatus code: 403`,
+		},
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Possibly as a result of the AWS SDK v2 transition (HIVE-2949 / #2695), or possibly just an arbitrary API change, AWS started spelling the embedded key for request IDs in error messages `RequestID` (it was previously some case variant of `Request ID` -- with a space). This befuddled our regex that was scrubbing such request IDs out of messages we include in status conditions, so those conditions were being updated every reconcile, so their CRs were being requeued immediately, causing thrashing.

Fix the regex to add an optional space.

Also DRY a couple of other spots that were using similar regex-based scrubbing. These may or may not have been causing problems *yet*, but they surely would have at some point. Also tech debt reduction is goodness.