### PR TITLE
HIVE-3132: Switch to Admission v1

### DIFF
--- a/config/hiveadmission/clusterdeployment-webhook.yaml
+++ b/config/hiveadmission/clusterdeployment-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
 webhooks:
 - name: clusterdeploymentvalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/config/hiveadmission/clusterdeploymentcustomization-webhook.yaml
+++ b/config/hiveadmission/clusterdeploymentcustomization-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
 webhooks:
 - name: clusterdeploymentcustomizationvalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/config/hiveadmission/clusterimageset-webhook.yaml
+++ b/config/hiveadmission/clusterimageset-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
 webhooks:
 - name: clusterimagesetvalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/config/hiveadmission/clusterpool-webhook.yaml
+++ b/config/hiveadmission/clusterpool-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
 webhooks:
 - name: clusterpoolvalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/config/hiveadmission/clusterprovision-webhook.yaml
+++ b/config/hiveadmission/clusterprovision-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
 webhooks:
 - name: clusterprovisionvalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/config/hiveadmission/dnszones-webhook.yaml
+++ b/config/hiveadmission/dnszones-webhook.yaml
@@ -7,7 +7,7 @@ metadata:
 webhooks:
 - name: dnszonevalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/config/hiveadmission/machinepool-webhook.yaml
+++ b/config/hiveadmission/machinepool-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
 webhooks:
 - name: machinepoolvalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/config/hiveadmission/selectorsyncset-webhook.yaml
+++ b/config/hiveadmission/selectorsyncset-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
 webhooks:
 - name: selectorsyncsetvalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/config/hiveadmission/syncset-webhook.yaml
+++ b/config/hiveadmission/syncset-webhook.yaml
@@ -6,7 +6,7 @@ metadata:
 webhooks:
 - name: syncsetvalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -278,7 +278,7 @@ metadata:
 webhooks:
 - name: clusterdeploymentvalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
@@ -323,7 +323,7 @@ metadata:
 webhooks:
 - name: clusterdeploymentcustomizationvalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
@@ -367,7 +367,7 @@ metadata:
 webhooks:
 - name: clusterimagesetvalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
@@ -411,7 +411,7 @@ metadata:
 webhooks:
 - name: clusterpoolvalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
@@ -455,7 +455,7 @@ metadata:
 webhooks:
 - name: clusterprovisionvalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
@@ -584,7 +584,7 @@ metadata:
 webhooks:
 - name: dnszonevalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
@@ -728,7 +728,7 @@ metadata:
 webhooks:
 - name: machinepoolvalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
@@ -797,7 +797,7 @@ metadata:
 webhooks:
 - name: selectorsyncsetvalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API
@@ -896,7 +896,7 @@ metadata:
 webhooks:
 - name: syncsetvalidators.admission.hive.openshift.io
   admissionReviewVersions:
-  - v1beta1
+  - v1
   clientConfig:
     service:
       # reach the webhook via the registered aggregated API

--- a/pkg/util/scheme/scheme.go
+++ b/pkg/util/scheme/scheme.go
@@ -25,7 +25,7 @@ import (
 	autoscalingv1beta1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis/autoscaling/v1beta1"
 	"github.com/openshift/hive/apis"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	crv1alpha1 "k8s.io/cluster-registry/pkg/apis/clusterregistry/v1alpha1"
@@ -43,7 +43,7 @@ var hive_scheme *runtime.Scheme
 func init() {
 	hive_scheme = runtime.NewScheme()
 	admissionregistrationv1.AddToScheme(hive_scheme)
-	admissionv1beta1.AddToScheme(hive_scheme)
+	admissionv1.AddToScheme(hive_scheme)
 	apis.AddToScheme(hive_scheme)
 	apiextv1.AddToScheme(hive_scheme)
 	appsv1.AddToScheme(hive_scheme)

--- a/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook.go
+++ b/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	log "github.com/sirupsen/logrus"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -139,7 +139,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) Initialize(kubeClientConfig *
 
 // Validate is called by generic-admission-server when the registered REST resource above is called with an admission request.
 // Usually it's the kube apiserver that is making the admission validation request.
-func (a *ClusterDeploymentValidatingAdmissionHook) Validate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *ClusterDeploymentValidatingAdmissionHook) Validate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -152,7 +152,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) Validate(admissionSpec *admis
 		contextLogger.Info("Skipping validation for request")
 		// The request object isn't something that this validator should validate.
 		// Therefore, we say that it's Allowed.
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
@@ -160,15 +160,15 @@ func (a *ClusterDeploymentValidatingAdmissionHook) Validate(admissionSpec *admis
 	contextLogger.Info("Validating request")
 
 	switch admissionSpec.Operation {
-	case admissionv1beta1.Create:
+	case admissionv1.Create:
 		return a.validateCreate(admissionSpec)
-	case admissionv1beta1.Update:
+	case admissionv1.Update:
 		return a.validateUpdate(admissionSpec)
-	case admissionv1beta1.Delete:
+	case admissionv1.Delete:
 		return a.validateDelete(admissionSpec)
 	default:
 		contextLogger.Info("Successful validation")
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
@@ -176,7 +176,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) Validate(admissionSpec *admis
 
 // shouldValidate explicitly checks if the request should validated. For example, this webhook may have accidentally been registered to check
 // the validity of some other type of object with a different GVR.
-func (a *ClusterDeploymentValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1beta1.AdmissionRequest) bool {
+func (a *ClusterDeploymentValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1.AdmissionRequest) bool {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -218,7 +218,7 @@ func creationHooksDisabled(o metav1.Object) bool {
 }
 
 // validateCreate specifically validates create operations for ClusterDeployment objects.
-func (a *ClusterDeploymentValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *ClusterDeploymentValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -235,7 +235,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateCreate(admissionSpec 
 	cd := &hivev1.ClusterDeployment{}
 	if err := a.decoder.DecodeRaw(admissionSpec.Object, cd); err != nil {
 		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -254,7 +254,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateCreate(admissionSpec 
 	if len(cd.Name) > validation.DNS1123LabelMaxLength {
 		message := fmt.Sprintf("Invalid cluster deployment name (.meta.name): %s", validation.MaxLenError(validation.DNS1123LabelMaxLength))
 		contextLogger.Error(message)
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -266,7 +266,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateCreate(admissionSpec 
 	if len(cd.Spec.ClusterName) > validation.DNS1123LabelMaxLength {
 		message := fmt.Sprintf("Invalid cluster name (.spec.clusterName): %s", validation.MaxLenError(validation.DNS1123LabelMaxLength))
 		contextLogger.Error(message)
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -288,7 +288,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateCreate(admissionSpec 
 	if cd.Spec.ManageDNS {
 		if !validateDomain(cd.Spec.BaseDomain, a.validManagedDomains) {
 			message := "The base domain must be a child of one of the managed domains for ClusterDeployments with manageDNS set to true"
-			return &admissionv1beta1.AdmissionResponse{
+			return &admissionv1.AdmissionResponse{
 				Allowed: false,
 				Result: &metav1.Status{
 					Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -362,7 +362,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateCreate(admissionSpec 
 
 	if len(allErrs) > 0 {
 		status := errors.NewInvalid(schemaGVK(admissionSpec.Kind).GroupKind(), admissionSpec.Name, allErrs).Status()
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result:  &status,
 		}
@@ -370,7 +370,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateCreate(admissionSpec 
 
 	// If we get here, then all checks passed, so the object is valid.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
@@ -441,11 +441,11 @@ func validateAgentInstallStrategy(specPath *field.Path, cd *hivev1.ClusterDeploy
 }
 */
 
-func validatefeatureGates(decoder admission.Decoder, admissionSpec *admissionv1beta1.AdmissionRequest, fs *featureSet, contextLogger *log.Entry) *admissionv1beta1.AdmissionResponse {
+func validatefeatureGates(decoder admission.Decoder, admissionSpec *admissionv1.AdmissionRequest, fs *featureSet, contextLogger *log.Entry) *admissionv1.AdmissionResponse {
 	obj := &unstructured.Unstructured{}
 	if err := decoder.DecodeRaw(admissionSpec.Object, obj); err != nil {
 		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -462,7 +462,7 @@ func validatefeatureGates(decoder admission.Decoder, admissionSpec *admissionv1b
 
 	if len(errs) > 0 && len(errs.ToAggregate().Errors()) > 0 {
 		status := errors.NewInvalid(schemaGVK(admissionSpec.Kind).GroupKind(), admissionSpec.Name, errs).Status()
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result:  &status,
 		}
@@ -627,7 +627,7 @@ func validateCanManageDNSForClusterPlatform(specPath *field.Path, spec hivev1.Cl
 }
 
 // validateUpdate specifically validates update operations for ClusterDeployment objects.
-func (a *ClusterDeploymentValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *ClusterDeploymentValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -644,7 +644,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateUpdate(admissionSpec 
 	cd := &hivev1.ClusterDeployment{}
 	if err := a.decoder.DecodeRaw(admissionSpec.Object, cd); err != nil {
 		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -659,7 +659,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateUpdate(admissionSpec 
 	oldObject := &hivev1.ClusterDeployment{}
 	if err := a.decoder.DecodeRaw(admissionSpec.OldObject, oldObject); err != nil {
 		contextLogger.Errorf("Failed unmarshaling OldObject: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -676,7 +676,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateUpdate(admissionSpec 
 		message := fmt.Sprintf("Attempted to change ClusterDeployment.Spec which is immutable except for %s fields. Unsupported change: \n%s", strings.Join(mutableFields, ","), unsupportedDiff)
 		contextLogger.Infof("Failed validation: %v", message)
 
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -696,7 +696,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateUpdate(admissionSpec 
 		message := "Previously defined a list of ingress objects, must provide a default ingress object"
 		contextLogger.Infof("Failed validation: %v", message)
 
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -785,7 +785,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateUpdate(admissionSpec 
 	if len(allErrs) > 0 {
 		contextLogger.WithError(allErrs.ToAggregate()).Info("failed validation")
 		status := errors.NewInvalid(schemaGVK(admissionSpec.Kind).GroupKind(), admissionSpec.Name, allErrs).Status()
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result:  &status,
 		}
@@ -793,13 +793,13 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateUpdate(admissionSpec 
 
 	// If we get here, then all checks passed, so the object is valid.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
 
 // validateDelete specifically validates delete operations for ClusterDeployment objects.
-func (a *ClusterDeploymentValidatingAdmissionHook) validateDelete(request *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *ClusterDeploymentValidatingAdmissionHook) validateDelete(request *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	logger := log.WithFields(log.Fields{
 		"operation": request.Operation,
 		"group":     request.Resource.Group,
@@ -811,7 +811,7 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateDelete(request *admis
 	oldObject := &hivev1.ClusterDeployment{}
 	if err := a.decoder.DecodeRaw(request.OldObject, oldObject); err != nil {
 		logger.Errorf("Failed unmarshaling Object: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -839,14 +839,14 @@ func (a *ClusterDeploymentValidatingAdmissionHook) validateDelete(request *admis
 	if len(allErrs) > 0 {
 		logger.WithError(allErrs.ToAggregate()).Info("failed validation")
 		status := errors.NewInvalid(schemaGVK(request.Kind).GroupKind(), request.Name, allErrs).Status()
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result:  &status,
 		}
 	}
 
 	logger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
@@ -975,12 +975,12 @@ func validateDomain(domain string, validDomains []string) bool {
 	return matchFound
 }
 
-func validateIngress(cd *hivev1.ClusterDeployment, contextLogger *log.Entry) *admissionv1beta1.AdmissionResponse {
+func validateIngress(cd *hivev1.ClusterDeployment, contextLogger *log.Entry) *admissionv1.AdmissionResponse {
 	if !validateIngressList(&cd.Spec) {
 		message := "Ingress list must include a default entry"
 		contextLogger.Infof("Failed validation: %v", message)
 
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -992,7 +992,7 @@ func validateIngress(cd *hivev1.ClusterDeployment, contextLogger *log.Entry) *ad
 	if !validateIngressDomainsNotWildcard(&cd.Spec) {
 		message := "Ingress domains must not lead with *"
 		contextLogger.Infof("Failed validation: %v", message)
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -1004,7 +1004,7 @@ func validateIngress(cd *hivev1.ClusterDeployment, contextLogger *log.Entry) *ad
 	if !validateIngressDomainsShareClusterDomain(&cd.Spec) {
 		message := "Ingress domains must share the same domain as the cluster"
 		contextLogger.Infof("Failed validation: %v", message)
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -1016,7 +1016,7 @@ func validateIngress(cd *hivev1.ClusterDeployment, contextLogger *log.Entry) *ad
 	if !validateIngressServingCertificateExists(&cd.Spec) {
 		message := "Ingress has serving certificate that does not exist in certificate bundle"
 		contextLogger.Infof("Failed validation: %v", message)
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -1029,12 +1029,12 @@ func validateIngress(cd *hivev1.ClusterDeployment, contextLogger *log.Entry) *ad
 	return nil
 }
 
-func validateCertificateBundles(cd *hivev1.ClusterDeployment, contextLogger *log.Entry) *admissionv1beta1.AdmissionResponse {
+func validateCertificateBundles(cd *hivev1.ClusterDeployment, contextLogger *log.Entry) *admissionv1.AdmissionResponse {
 	for _, certBundle := range cd.Spec.CertificateBundles {
 		if certBundle.Name == "" {
 			message := "Certificate bundle is missing a name"
 			contextLogger.Infof("Failed validation: %v", message)
-			return &admissionv1beta1.AdmissionResponse{
+			return &admissionv1.AdmissionResponse{
 				Allowed: false,
 				Result: &metav1.Status{
 					Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -1045,7 +1045,7 @@ func validateCertificateBundles(cd *hivev1.ClusterDeployment, contextLogger *log
 		if certBundle.CertificateSecretRef.Name == "" {
 			message := "Certificate bundle is missing a secret reference"
 			contextLogger.Infof("Failed validation: %v", message)
-			return &admissionv1beta1.AdmissionResponse{
+			return &admissionv1.AdmissionResponse{
 				Allowed: false,
 				Result: &metav1.Status{
 					Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,

--- a/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/clusterdeployment_validating_admission_hook_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -232,7 +232,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 		newObjectRaw        []byte
 		oldObject           *hivev1.ClusterDeployment
 		oldObjectRaw        []byte
-		operation           admissionv1beta1.Operation
+		operation           admissionv1.Operation
 		expectedAllowed     bool
 		gvr                 *metav1.GroupVersionResource
 		enabledFeatureGates []string
@@ -242,28 +242,28 @@ func TestClusterDeploymentValidate(t *testing.T) {
 		{
 			name:            "Test valid create",
 			newObject:       validAWSClusterDeployment(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test Delete Operation is allowed even with mismatch objects",
 			oldObject:       validAWSClusterDeployment(),
 			newObject:       validClusterDeploymentDifferentImmutableValue(),
-			operation:       admissionv1beta1.Delete,
+			operation:       admissionv1.Delete,
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test Update Operation is allowed with same data",
 			oldObject:       validAWSClusterDeployment(),
 			newObject:       validClusterDeploymentSameValues(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test Update Operation is allowed with different mutable data",
 			oldObject:       validAWSClusterDeployment(),
 			newObject:       validClusterDeploymentDifferentMutableValue(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -274,7 +274,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Provisioning.InstallConfigSecretRef = nil
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -286,7 +286,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -297,19 +297,19 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				return cd
 			}(),
 			newObject:       validAWSClusterDeployment(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test create with ClusterPoolReference",
 			newObject:       validAWSClusterDeploymentFromPool("pool-ns", "mypool", "", ""),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test create with Claimed ClusterPoolReference",
 			newObject:       validAWSClusterDeploymentFromPool("pool-ns", "mypool", "test-claim", ""),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -319,70 +319,70 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Labels = map[string]string{constants.DisableCreationWebHookForDisasterRecovery: "true"}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test update with removed ClusterPoolReference",
 			oldObject:       validAWSClusterDeploymentFromPool("pool-ns", "mypool", "", ""),
 			newObject:       validAWSClusterDeployment(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test update with added ClusterPoolReference",
 			oldObject:       validAWSClusterDeployment(),
 			newObject:       validAWSClusterDeploymentFromPool("pool-ns", "mypool", "", "foo"),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test update with modified ClusterPoolReference Namespace",
 			oldObject:       validAWSClusterDeploymentFromPool("pool-ns", "mypool", "", ""),
 			newObject:       validAWSClusterDeploymentFromPool("new-pool-ns", "mypool", "", ""),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test update with modified ClusterPoolReference PoolName",
 			oldObject:       validAWSClusterDeploymentFromPool("pool-ns", "mypool", "", "foo"),
 			newObject:       validAWSClusterDeploymentFromPool("pool-ns", "new-mypool", "", "foo"),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test update with added ClusterPoolReference CustomizationRef",
 			oldObject:       validAWSClusterDeploymentFromPool("pool-ns", "mypool", "", ""),
 			newObject:       validAWSClusterDeploymentFromPool("new-pool-ns", "new-mypool", "", "foo"),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test update with modified ClusterPoolReference CustomizationRef",
 			oldObject:       validAWSClusterDeploymentFromPool("pool-ns", "mypool", "", "foo"),
 			newObject:       validAWSClusterDeploymentFromPool("new-pool-ns", "new-mypool", "", "bar"),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test update with claimed ClusterPoolReference",
 			oldObject:       validAWSClusterDeploymentFromPool("pool-ns", "mypool", "", ""),
 			newObject:       validAWSClusterDeploymentFromPool("pool-ns", "mypool", "test-claim", ""),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test update with unclaimed ClusterPoolReference",
 			oldObject:       validAWSClusterDeploymentFromPool("pool-ns", "mypool", "test-claim", "foo"),
 			newObject:       validAWSClusterDeploymentFromPool("pool-ns", "mypool", "", "foo"),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test update with changed claim",
 			oldObject:       validAWSClusterDeploymentFromPool("pool-ns", "mypool", "test-claim", ""),
 			newObject:       validAWSClusterDeploymentFromPool("pool-ns", "mypool", "other-claim", ""),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
@@ -393,7 +393,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Installed = true
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
@@ -414,7 +414,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
@@ -425,32 +425,32 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.PreserveOnDelete = true
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test Update Operation is NOT allowed with different immutable data",
 			oldObject:       validAWSClusterDeployment(),
 			newObject:       validClusterDeploymentDifferentImmutableValue(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test unable to marshal new object during create",
 			newObjectRaw:    []byte{0},
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test unable to marshal new object during update",
 			newObjectRaw:    []byte{0},
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test unable to marshal old object during update",
 			oldObjectRaw:    []byte{0},
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
@@ -485,13 +485,13 @@ func TestClusterDeploymentValidate(t *testing.T) {
 			name:            "Test going from previously defined list of ingress to empty ingress list",
 			oldObject:       validClusterDeploymentWithIngress(),
 			newObject:       validAWSClusterDeployment(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test new clusterdeployment with ingress list with default defined",
 			newObject:       validClusterDeploymentWithIngress(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
@@ -501,7 +501,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Ingress[0].Name = "notdefault"
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -511,14 +511,14 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Provisioning.SSHPrivateKeySecretRef = &corev1.LocalObjectReference{Name: ""}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test updating existing empty ingress to populated ingress",
 			oldObject:       validAWSClusterDeployment(),
 			newObject:       validClusterDeploymentWithIngress(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -529,31 +529,31 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Ingress[0].Name = "notdefault"
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test valid managed domain",
 			newObject:       clusterDeploymentWithManagedDomain("bar.foo.aaa.com"),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test base domain is not child of a managed domain",
 			newObject:       clusterDeploymentWithManagedDomain("bar.bad-domain.com"),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test base domain is not direct child of a managed domain",
 			newObject:       clusterDeploymentWithManagedDomain("baz.foo.bbb.com"),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test base domain is not same as one of the managed domains",
 			newObject:       clusterDeploymentWithManagedDomain("foo.aaa.com"),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -564,7 +564,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.BaseDomain = "bar.foo.aaa.com"
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
@@ -575,7 +575,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.BaseDomain = "bar.foo.aaa.com"
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
@@ -590,7 +590,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -610,7 +610,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -626,7 +626,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				*cd.Spec.InstallAttemptsLimit = 1
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -636,7 +636,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Ingress[0].Domain = "*.apps.sameclustername.example.com"
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -646,7 +646,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Ingress[0].Domain = "apps.sameclustername.NOTexample.com"
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -656,7 +656,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Name = "this-is-a-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-name"
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -666,7 +666,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.ClusterName = "this-is-a-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-name"
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -692,7 +692,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -716,7 +716,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -741,7 +741,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -772,7 +772,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -802,7 +802,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
@@ -827,7 +827,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -854,13 +854,13 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Azure create valid",
 			newObject:       validAzureClusterDeployment(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
@@ -870,7 +870,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Platform.Azure.Region = ""
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -880,7 +880,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Platform.Azure.CredentialsSecretRef.Name = ""
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -891,7 +891,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.ManageDNS = false
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
@@ -902,7 +902,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.ManageDNS = true
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -913,7 +913,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Platform.Azure.Region = ""
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
@@ -939,7 +939,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -963,7 +963,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -988,7 +988,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -1019,7 +1019,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -1050,7 +1050,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		// TODO: ensure Azure clusterDeployments have necessary info for
@@ -1082,7 +1082,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Platform.AWS = awsCD.Spec.Platform.AWS
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -1092,7 +1092,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Platform.Azure = nil
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -1108,7 +1108,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
@@ -1124,7 +1124,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -1139,7 +1139,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
@@ -1153,7 +1153,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -1167,7 +1167,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -1177,7 +1177,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Provisioning.InstallConfigSecretRef = nil
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -1192,7 +1192,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -1208,7 +1208,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -1232,7 +1232,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					Kind:    "AgentClusterInstall",
 				}},
 			}},
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -1256,7 +1256,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 					Kind:    "FakeClusterInstall",
 				}},
 			}},
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
@@ -1266,13 +1266,13 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Provisioning = nil
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
 			name:            "valid GCP clusterdeployment",
 			newObject:       validGCPClusterDeployment(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
@@ -1283,7 +1283,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Platform.GCP.DiscardLocalSsdOnHibernate = ptr.To(true)
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -1294,7 +1294,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				return cd
 			}(),
 			newObject:       validGCPClusterDeployment(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -1309,7 +1309,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Platform.GCP.DiscardLocalSsdOnHibernate = ptr.To(false)
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -1335,7 +1335,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -1359,7 +1359,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -1384,7 +1384,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -1415,7 +1415,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -1445,7 +1445,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
@@ -1467,7 +1467,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -1487,7 +1487,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -1508,7 +1508,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -1531,7 +1531,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -1551,7 +1551,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.ClusterMetadata = &hivev1.ClusterMetadata{}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
@@ -1573,7 +1573,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
@@ -1583,13 +1583,13 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Provisioning = nil
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
 			name:            "OpenStack create valid",
 			newObject:       validOpenStackClusterDeployment(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
@@ -1599,7 +1599,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Platform.OpenStack.CertificatesSecretRef = &corev1.LocalObjectReference{Name: ""}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -1609,13 +1609,13 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Platform.OpenStack.CertificatesSecretRef = &corev1.LocalObjectReference{Name: "openstack-certificates"}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid delete",
 			oldObject:       validAWSClusterDeployment(),
-			operation:       admissionv1beta1.Delete,
+			operation:       admissionv1.Delete,
 			expectedAllowed: true,
 		},
 		{
@@ -1628,7 +1628,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Annotations[constants.ProtectedDeleteAnnotation] = "true"
 				return cd
 			}(),
-			operation:       admissionv1beta1.Delete,
+			operation:       admissionv1.Delete,
 			expectedAllowed: false,
 		},
 		{
@@ -1641,25 +1641,25 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Annotations[constants.ProtectedDeleteAnnotation] = "false"
 				return cd
 			}(),
-			operation:       admissionv1beta1.Delete,
+			operation:       admissionv1.Delete,
 			expectedAllowed: true,
 		},
 		{
 			name:            "vSphere create valid",
 			newObject:       validVSphereClusterDeployment(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
 			name:            "Nutanix create valid",
 			newObject:       validNutanixClusterDeployment(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
 			name:            "IBMCloud create valid",
 			newObject:       validIBMCloudClusterDeployment(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
@@ -1670,7 +1670,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Provisioning.ManifestsSecretRef = nil
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -1680,7 +1680,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Platform.Nutanix.CredentialsSecretRef.Name = "" // Simulating a missing required field
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -1690,7 +1690,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Platform.Nutanix.PrismCentral.Address = "" // Simulating a missing required field
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -1700,7 +1700,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Platform.Nutanix.PrismCentral.Port = 0 // Simulating a missing required field
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -1713,7 +1713,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Provisioning.ManifestsSecretRef = &corev1.LocalObjectReference{Name: "bar"}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -1726,7 +1726,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Provisioning.ManifestsSecretRef = &corev1.LocalObjectReference{Name: "bar"}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
@@ -1736,7 +1736,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Platform.AWS.PrivateLink = &hivev1aws.PrivateLinkAccess{}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
@@ -1746,7 +1746,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Platform.AWS.PrivateLink = &hivev1aws.PrivateLinkAccess{Enabled: true}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -1756,7 +1756,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Platform.AWS.PrivateLink = &hivev1aws.PrivateLinkAccess{Enabled: true}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 			awsPrivateLink:  &hivev1.AWSPrivateLinkConfig{},
 		},
@@ -1767,7 +1767,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Platform.AWS.PrivateLink = &hivev1aws.PrivateLinkAccess{Enabled: true}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 			awsPrivateLink: &hivev1.AWSPrivateLinkConfig{
 				EndpointVPCInventory: []hivev1.AWSPrivateLinkInventory{{
@@ -1785,7 +1785,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				cd.Spec.Platform.AWS.PrivateLink = &hivev1aws.PrivateLinkAccess{Enabled: true}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 			awsPrivateLink: &hivev1.AWSPrivateLinkConfig{
 				EndpointVPCInventory: []hivev1.AWSPrivateLinkInventory{{
@@ -1814,7 +1814,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -1832,7 +1832,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				}
 				return cd
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 			awsPrivateLink: &hivev1.AWSPrivateLinkConfig{
 				EndpointVPCInventory: []hivev1.AWSPrivateLinkInventory{{
@@ -1881,7 +1881,7 @@ func TestClusterDeploymentValidate(t *testing.T) {
 				tc.oldObjectRaw, _ = json.Marshal(tc.oldObject)
 			}
 
-			request := &admissionv1beta1.AdmissionRequest{
+			request := &admissionv1.AdmissionRequest{
 				Operation: tc.operation,
 				Resource:  *tc.gvr,
 				Object: runtime.RawExtension{

--- a/pkg/validating-webhooks/hive/v1/clusterdeploymentcustomization_validating_admission_hook.go
+++ b/pkg/validating-webhooks/hive/v1/clusterdeploymentcustomization_validating_admission_hook.go
@@ -6,7 +6,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -69,7 +69,7 @@ func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) Initialize(kubeC
 
 // Validate is called by generic-admission-server when the registered REST resource above is called with an admission request.
 // Usually it's the kube apiserver that is making the admission validation request.
-func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) Validate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) Validate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -82,7 +82,7 @@ func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) Validate(admissi
 		contextLogger.Info("Skipping validation for request")
 		// The request object isn't something that this validator should validate.
 		// Therefore, we say that it's Allowed.
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
@@ -90,13 +90,13 @@ func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) Validate(admissi
 	contextLogger.Info("Validating request")
 
 	switch admissionSpec.Operation {
-	case admissionv1beta1.Create:
+	case admissionv1.Create:
 		return a.validateCreate(admissionSpec)
-	case admissionv1beta1.Update:
+	case admissionv1.Update:
 		return a.validateUpdate(admissionSpec)
 	default:
 		contextLogger.Info("Successful validation")
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
@@ -104,7 +104,7 @@ func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) Validate(admissi
 
 // shouldValidate explicitly checks if the request should validated. For example, this webhook may have accidentally been registered to check
 // the validity of some other type of object with a different GVR.
-func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1beta1.AdmissionRequest) bool {
+func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1.AdmissionRequest) bool {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -134,7 +134,7 @@ func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) shouldValidate(a
 }
 
 // validateCreate specifically validates create operations for ClusterDeploymentCustomization objects.
-func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -146,7 +146,7 @@ func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) validateCreate(a
 	cdc := &hivev1.ClusterDeploymentCustomization{}
 	if err := a.decoder.DecodeRaw(admissionSpec.Object, cdc); err != nil {
 		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -163,7 +163,7 @@ func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) validateCreate(a
 	if len(cdc.Name) > validation.DNS1123LabelMaxLength {
 		message := fmt.Sprintf("Invalid cluster deployment customization name (.meta.name): %s", validation.MaxLenError(validation.DNS1123LabelMaxLength))
 		contextLogger.Error(message)
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -174,13 +174,13 @@ func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) validateCreate(a
 
 	// If we get here, then all checks passed, so the object is valid.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
 
 // validateUpdate specifically validates update operations for ClusterDeployment objects.
-func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -192,7 +192,7 @@ func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) validateUpdate(a
 	newObject := &hivev1.ClusterDeploymentCustomization{}
 	if err := a.decoder.DecodeRaw(admissionSpec.Object, newObject); err != nil {
 		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -207,7 +207,7 @@ func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) validateUpdate(a
 	oldObject := &hivev1.ClusterDeploymentCustomization{}
 	if err := a.decoder.DecodeRaw(admissionSpec.OldObject, oldObject); err != nil {
 		contextLogger.Errorf("Failed unmarshaling OldObject: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -221,7 +221,7 @@ func (a *ClusterDeploymentCustomizationValidatingAdmissionHook) validateUpdate(a
 
 	// If we get here, then all checks passed, so the object is valid.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }

--- a/pkg/validating-webhooks/hive/v1/clusterimageset_validating_admission_hook.go
+++ b/pkg/validating-webhooks/hive/v1/clusterimageset_validating_admission_hook.go
@@ -8,7 +8,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -67,7 +67,7 @@ func (a *ClusterImageSetValidatingAdmissionHook) Initialize(kubeClientConfig *re
 
 // Validate is called by generic-admission-server when the registered REST resource above is called with an admission request.
 // Usually it's the kube apiserver that is making the admission validation request.
-func (a *ClusterImageSetValidatingAdmissionHook) Validate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *ClusterImageSetValidatingAdmissionHook) Validate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -80,31 +80,31 @@ func (a *ClusterImageSetValidatingAdmissionHook) Validate(admissionSpec *admissi
 		contextLogger.Info("Skipping validation for request")
 		// The request object isn't something that this validator should validate.
 		// Therefore, we say that it's allowed.
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
 
 	contextLogger.Info("Validating request")
 
-	if admissionSpec.Operation == admissionv1beta1.Create {
+	if admissionSpec.Operation == admissionv1.Create {
 		return a.validateCreate(admissionSpec)
 	}
 
-	if admissionSpec.Operation == admissionv1beta1.Update {
+	if admissionSpec.Operation == admissionv1.Update {
 		return a.validateUpdate(admissionSpec)
 	}
 
 	// We're only validating creates and updates at this time, so all other operations are explicitly allowed.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
 
 // shouldValidate explicitly checks if the request should validated. For example, this webhook may have accidentally been registered to check
 // the validity of some other type of object with a different GVR.
-func (a *ClusterImageSetValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1beta1.AdmissionRequest) bool {
+func (a *ClusterImageSetValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1.AdmissionRequest) bool {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -134,7 +134,7 @@ func (a *ClusterImageSetValidatingAdmissionHook) shouldValidate(admissionSpec *a
 }
 
 // validateCreate specifically validates create operations for ClusterImageSet objects.
-func (a *ClusterImageSetValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *ClusterImageSetValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -146,7 +146,7 @@ func (a *ClusterImageSetValidatingAdmissionHook) validateCreate(admissionSpec *a
 	newObject := &hivev1.ClusterImageSet{}
 	if err := a.decoder.DecodeRaw(admissionSpec.Object, newObject); err != nil {
 		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -166,7 +166,7 @@ func (a *ClusterImageSetValidatingAdmissionHook) validateCreate(admissionSpec *a
 	if len(allErrs) > 0 {
 		contextLogger.WithError(allErrs.ToAggregate()).Info("failed validation")
 		status := errors.NewInvalid(schemaGVK(admissionSpec.Kind).GroupKind(), admissionSpec.Name, allErrs).Status()
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result:  &status,
 		}
@@ -174,13 +174,13 @@ func (a *ClusterImageSetValidatingAdmissionHook) validateCreate(admissionSpec *a
 
 	// If we get here, then all checks passed, so the object is valid.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
 
 // validateUpdate specifically validates update operations for ClusterImageSet objects.
-func (a *ClusterImageSetValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *ClusterImageSetValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -192,7 +192,7 @@ func (a *ClusterImageSetValidatingAdmissionHook) validateUpdate(admissionSpec *a
 	newObject := &hivev1.ClusterImageSet{}
 	if err := a.decoder.DecodeRaw(admissionSpec.Object, newObject); err != nil {
 		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -207,7 +207,7 @@ func (a *ClusterImageSetValidatingAdmissionHook) validateUpdate(admissionSpec *a
 	oldObject := &hivev1.ClusterImageSet{}
 	if err := a.decoder.DecodeRaw(admissionSpec.OldObject, oldObject); err != nil {
 		contextLogger.Errorf("Failed unmarshaling OldObject: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -227,7 +227,7 @@ func (a *ClusterImageSetValidatingAdmissionHook) validateUpdate(admissionSpec *a
 	if len(allErrs) > 0 {
 		contextLogger.WithError(allErrs.ToAggregate()).Info("failed validation")
 		status := errors.NewInvalid(schemaGVK(admissionSpec.Kind).GroupKind(), admissionSpec.Name, allErrs).Status()
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result:  &status,
 		}
@@ -235,7 +235,7 @@ func (a *ClusterImageSetValidatingAdmissionHook) validateUpdate(admissionSpec *a
 
 	// If we get here, then all checks passed, so the object is valid.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }

--- a/pkg/validating-webhooks/hive/v1/clusterimageset_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/clusterimageset_validating_admission_hook_test.go
@@ -6,7 +6,7 @@ import (
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/stretchr/testify/assert"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -48,7 +48,7 @@ func TestClusterImageSetValidate(t *testing.T) {
 		oldSpec         hivev1.ClusterImageSetSpec
 		newObjectRaw    []byte
 		oldObjectRaw    []byte
-		operation       admissionv1beta1.Operation
+		operation       admissionv1.Operation
 		expectedAllowed bool
 		gvr             *metav1.GroupVersionResource
 	}{
@@ -57,7 +57,7 @@ func TestClusterImageSetValidate(t *testing.T) {
 			newSpec: hivev1.ClusterImageSetSpec{
 				ReleaseImage: "image:tag",
 			},
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
@@ -65,7 +65,7 @@ func TestClusterImageSetValidate(t *testing.T) {
 			newSpec: hivev1.ClusterImageSetSpec{
 				ReleaseImage: "image@sha256:abc",
 			},
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
@@ -73,7 +73,7 @@ func TestClusterImageSetValidate(t *testing.T) {
 			newSpec: hivev1.ClusterImageSetSpec{
 				ReleaseImage: "image@SHA256:abc",
 			},
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -81,31 +81,31 @@ func TestClusterImageSetValidate(t *testing.T) {
 			newSpec: hivev1.ClusterImageSetSpec{
 				ReleaseImage: "image@sh256:abc##",
 			},
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test empty ClusterImageSet.Spec value",
 			newSpec:         hivev1.ClusterImageSetSpec{},
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test unable to marshal new object during create",
 			newObjectRaw:    []byte{0},
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test unable to marshal new object during update",
 			newObjectRaw:    []byte{0},
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test unable to marshal old object during update",
 			oldObjectRaw:    []byte{0},
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
@@ -116,12 +116,12 @@ func TestClusterImageSetValidate(t *testing.T) {
 			oldSpec: hivev1.ClusterImageSetSpec{
 				ReleaseImage: "b:tag",
 			},
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test that we don't validate deletes",
-			operation:       admissionv1beta1.Delete,
+			operation:       admissionv1.Delete,
 			expectedAllowed: true,
 		},
 		{
@@ -180,7 +180,7 @@ func TestClusterImageSetValidate(t *testing.T) {
 				}
 			}
 
-			request := &admissionv1beta1.AdmissionRequest{
+			request := &admissionv1.AdmissionRequest{
 				Operation: tc.operation,
 				Resource:  *tc.gvr,
 				Object: runtime.RawExtension{

--- a/pkg/validating-webhooks/hive/v1/clusterpool_validating_admission_hook.go
+++ b/pkg/validating-webhooks/hive/v1/clusterpool_validating_admission_hook.go
@@ -6,7 +6,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -71,7 +71,7 @@ func (a *ClusterPoolValidatingAdmissionHook) Initialize(kubeClientConfig *rest.C
 
 // Validate is called by generic-admission-server when the registered REST resource above is called with an admission request.
 // Usually it's the kube apiserver that is making the admission validation request.
-func (a *ClusterPoolValidatingAdmissionHook) Validate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *ClusterPoolValidatingAdmissionHook) Validate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -84,7 +84,7 @@ func (a *ClusterPoolValidatingAdmissionHook) Validate(admissionSpec *admissionv1
 		contextLogger.Info("Skipping validation for request")
 		// The request object isn't something that this validator should validate.
 		// Therefore, we say that it's Allowed.
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
@@ -92,13 +92,13 @@ func (a *ClusterPoolValidatingAdmissionHook) Validate(admissionSpec *admissionv1
 	contextLogger.Info("Validating request")
 
 	switch admissionSpec.Operation {
-	case admissionv1beta1.Create:
+	case admissionv1.Create:
 		return a.validateCreate(admissionSpec)
-	case admissionv1beta1.Update:
+	case admissionv1.Update:
 		return a.validateUpdate(admissionSpec)
 	default:
 		contextLogger.Info("Successful validation")
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
@@ -106,7 +106,7 @@ func (a *ClusterPoolValidatingAdmissionHook) Validate(admissionSpec *admissionv1
 
 // shouldValidate explicitly checks if the request should validated. For example, this webhook may have accidentally been registered to check
 // the validity of some other type of object with a different GVR.
-func (a *ClusterPoolValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1beta1.AdmissionRequest) bool {
+func (a *ClusterPoolValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1.AdmissionRequest) bool {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -136,7 +136,7 @@ func (a *ClusterPoolValidatingAdmissionHook) shouldValidate(admissionSpec *admis
 }
 
 // validateCreate specifically validates create operations for ClusterPool objects.
-func (a *ClusterPoolValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *ClusterPoolValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -148,7 +148,7 @@ func (a *ClusterPoolValidatingAdmissionHook) validateCreate(admissionSpec *admis
 	newObject := &hivev1.ClusterPool{}
 	if err := a.decoder.DecodeRaw(admissionSpec.Object, newObject); err != nil {
 		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -165,7 +165,7 @@ func (a *ClusterPoolValidatingAdmissionHook) validateCreate(admissionSpec *admis
 	if len(newObject.Name) > validation.DNS1123LabelMaxLength {
 		message := fmt.Sprintf("Invalid cluster pool name (.meta.name): %s", validation.MaxLenError(validation.DNS1123LabelMaxLength))
 		contextLogger.Error(message)
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -181,7 +181,7 @@ func (a *ClusterPoolValidatingAdmissionHook) validateCreate(admissionSpec *admis
 
 	if len(allErrs) > 0 {
 		status := errors.NewInvalid(schemaGVK(admissionSpec.Kind).GroupKind(), admissionSpec.Name, allErrs).Status()
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result:  &status,
 		}
@@ -189,13 +189,13 @@ func (a *ClusterPoolValidatingAdmissionHook) validateCreate(admissionSpec *admis
 
 	// If we get here, then all checks passed, so the object is valid.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
 
 // validateUpdate specifically validates update operations for ClusterDeployment objects.
-func (a *ClusterPoolValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *ClusterPoolValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -207,7 +207,7 @@ func (a *ClusterPoolValidatingAdmissionHook) validateUpdate(admissionSpec *admis
 	newObject := &hivev1.ClusterPool{}
 	if err := a.decoder.DecodeRaw(admissionSpec.Object, newObject); err != nil {
 		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -222,7 +222,7 @@ func (a *ClusterPoolValidatingAdmissionHook) validateUpdate(admissionSpec *admis
 	oldObject := &hivev1.ClusterPool{}
 	if err := a.decoder.DecodeRaw(admissionSpec.OldObject, oldObject); err != nil {
 		contextLogger.Errorf("Failed unmarshaling OldObject: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -242,7 +242,7 @@ func (a *ClusterPoolValidatingAdmissionHook) validateUpdate(admissionSpec *admis
 	if len(allErrs) > 0 {
 		contextLogger.WithError(allErrs.ToAggregate()).Info("failed validation")
 		status := errors.NewInvalid(schemaGVK(admissionSpec.Kind).GroupKind(), admissionSpec.Name, allErrs).Status()
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result:  &status,
 		}
@@ -250,7 +250,7 @@ func (a *ClusterPoolValidatingAdmissionHook) validateUpdate(admissionSpec *admis
 
 	// If we get here, then all checks passed, so the object is valid.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }

--- a/pkg/validating-webhooks/hive/v1/clusterpool_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/clusterpool_validating_admission_hook_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -74,21 +74,21 @@ func TestClusterPoolValidate(t *testing.T) {
 		newObjectRaw    []byte
 		oldObject       *hivev1.ClusterPool
 		oldObjectRaw    []byte
-		operation       admissionv1beta1.Operation
+		operation       admissionv1.Operation
 		expectedAllowed bool
 		gvr             *metav1.GroupVersionResource
 	}{
 		{
 			name:            "Test valid create",
 			newObject:       validAWSClusterPool(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test Update Operation is allowed with same data",
 			oldObject:       validAWSClusterPool(),
 			newObject:       validAWSClusterPool(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
@@ -99,25 +99,25 @@ func TestClusterPoolValidate(t *testing.T) {
 				pool.Spec.BaseDomain = "anotherbasedomain.example.com"
 				return pool
 			}(),
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test unable to marshal new object during create",
 			newObjectRaw:    []byte{0},
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test unable to marshal new object during update",
 			newObjectRaw:    []byte{0},
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test unable to marshal old object during update",
 			oldObjectRaw:    []byte{0},
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
@@ -150,13 +150,13 @@ func TestClusterPoolValidate(t *testing.T) {
 		{
 			name:            "Azure create valid",
 			newObject:       validAzureClusterPool(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
 			name:            "OpenStack unsupported platform",
 			newObject:       invalidOpenStackClusterPool(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -166,7 +166,7 @@ func TestClusterPoolValidate(t *testing.T) {
 				cd.Spec.Platform.Azure.Region = ""
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -176,7 +176,7 @@ func TestClusterPoolValidate(t *testing.T) {
 				cd.Spec.Platform.Azure.CredentialsSecretRef.Name = ""
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -186,7 +186,7 @@ func TestClusterPoolValidate(t *testing.T) {
 				cd.Spec.Platform.Azure.BaseDomainResourceGroupName = ""
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
@@ -197,7 +197,7 @@ func TestClusterPoolValidate(t *testing.T) {
 				cd.Spec.Platform.AWS = awsCD.Spec.Platform.AWS
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
@@ -207,19 +207,19 @@ func TestClusterPoolValidate(t *testing.T) {
 				cd.Spec.Platform.Azure = nil
 				return cd
 			}(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
 			name:            "valid GCP clusterdeployment",
 			newObject:       validGCPClusterPool(),
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid delete",
 			oldObject:       validAWSClusterPool(),
-			operation:       admissionv1beta1.Delete,
+			operation:       admissionv1.Delete,
 			expectedAllowed: true,
 		},
 	}
@@ -247,7 +247,7 @@ func TestClusterPoolValidate(t *testing.T) {
 				tc.oldObjectRaw, _ = json.Marshal(tc.oldObject)
 			}
 
-			request := &admissionv1beta1.AdmissionRequest{
+			request := &admissionv1.AdmissionRequest{
 				Operation: tc.operation,
 				Resource:  *tc.gvr,
 				Object: runtime.RawExtension{

--- a/pkg/validating-webhooks/hive/v1/clusterprovision_validating_admission_hook.go
+++ b/pkg/validating-webhooks/hive/v1/clusterprovision_validating_admission_hook.go
@@ -6,7 +6,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -84,7 +84,7 @@ func (a *ClusterProvisionValidatingAdmissionHook) Initialize(kubeClientConfig *r
 
 // Validate is called by generic-admission-server when the registered REST resource above is called with an admission request.
 // Usually it's the kube apiserver that is making the admission validation request.
-func (a *ClusterProvisionValidatingAdmissionHook) Validate(request *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *ClusterProvisionValidatingAdmissionHook) Validate(request *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	logger := log.WithFields(log.Fields{
 		"operation": request.Operation,
 		"group":     request.Resource.Group,
@@ -97,7 +97,7 @@ func (a *ClusterProvisionValidatingAdmissionHook) Validate(request *admissionv1b
 		logger.Info("Skipping validation for request")
 		// The request object isn't something that this validator should validate.
 		// Therefore, we say that it's allowed.
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
@@ -105,13 +105,13 @@ func (a *ClusterProvisionValidatingAdmissionHook) Validate(request *admissionv1b
 	logger.Info("Validating request")
 
 	switch request.Operation {
-	case admissionv1beta1.Create:
+	case admissionv1.Create:
 		return a.validateCreateRequest(request, logger)
-	case admissionv1beta1.Update:
+	case admissionv1.Update:
 		return a.validateUpdateRequest(request, logger)
 	default:
 		logger.Info("Successful validation")
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
@@ -119,7 +119,7 @@ func (a *ClusterProvisionValidatingAdmissionHook) Validate(request *admissionv1b
 
 // shouldValidate explicitly checks if the request should validated. For example, this webhook may have accidentally been registered to check
 // the validity of some other type of object with a different GVR.
-func (a *ClusterProvisionValidatingAdmissionHook) shouldValidate(request *admissionv1beta1.AdmissionRequest, logger log.FieldLogger) bool {
+func (a *ClusterProvisionValidatingAdmissionHook) shouldValidate(request *admissionv1.AdmissionRequest, logger log.FieldLogger) bool {
 	logger = logger.WithField("method", "shouldValidate")
 
 	if request.Resource.Group != clusterProvisionGroup {
@@ -143,7 +143,7 @@ func (a *ClusterProvisionValidatingAdmissionHook) shouldValidate(request *admiss
 }
 
 // validateCreateRequest specifically validates create operations for ClusterProvision objects.
-func (a *ClusterProvisionValidatingAdmissionHook) validateCreateRequest(request *admissionv1beta1.AdmissionRequest, logger log.FieldLogger) *admissionv1beta1.AdmissionResponse {
+func (a *ClusterProvisionValidatingAdmissionHook) validateCreateRequest(request *admissionv1.AdmissionRequest, logger log.FieldLogger) *admissionv1.AdmissionResponse {
 	logger = logger.WithField("method", "validateCreateRequest")
 
 	newObject, resp := a.decode(request.Object, logger.WithField("decode", "Object"))
@@ -158,7 +158,7 @@ func (a *ClusterProvisionValidatingAdmissionHook) validateCreateRequest(request 
 	if allErrs := validateClusterProvisionCreate(newObject); len(allErrs) > 0 {
 		logger.WithError(allErrs.ToAggregate()).Info("failed validation")
 		status := errors.NewInvalid(schemaGVK(request.Kind).GroupKind(), request.Name, allErrs).Status()
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result:  &status,
 		}
@@ -166,13 +166,13 @@ func (a *ClusterProvisionValidatingAdmissionHook) validateCreateRequest(request 
 
 	// If we get here, then all checks passed, so the object is valid.
 	logger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
 
 // validateUpdateRequest specifically validates update operations for ClusterProvision objects.
-func (a *ClusterProvisionValidatingAdmissionHook) validateUpdateRequest(request *admissionv1beta1.AdmissionRequest, logger log.FieldLogger) *admissionv1beta1.AdmissionResponse {
+func (a *ClusterProvisionValidatingAdmissionHook) validateUpdateRequest(request *admissionv1.AdmissionRequest, logger log.FieldLogger) *admissionv1.AdmissionResponse {
 	logger = logger.WithField("method", "validateUpdateRequest")
 
 	newObject, resp := a.decode(request.Object, logger.WithField("decode", "Object"))
@@ -192,7 +192,7 @@ func (a *ClusterProvisionValidatingAdmissionHook) validateUpdateRequest(request 
 	if allErrs := validateClusterProvisionUpdate(oldObject, newObject); len(allErrs) > 0 {
 		logger.WithError(allErrs.ToAggregate()).Info("failed validation")
 		status := errors.NewInvalid(schemaGVK(request.Kind).GroupKind(), request.Name, allErrs).Status()
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result:  &status,
 		}
@@ -200,16 +200,16 @@ func (a *ClusterProvisionValidatingAdmissionHook) validateUpdateRequest(request 
 
 	// If we get here, then all checks passed, so the object is valid.
 	logger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
 
-func (a *ClusterProvisionValidatingAdmissionHook) decode(raw runtime.RawExtension, logger log.FieldLogger) (*hivev1.ClusterProvision, *admissionv1beta1.AdmissionResponse) {
+func (a *ClusterProvisionValidatingAdmissionHook) decode(raw runtime.RawExtension, logger log.FieldLogger) (*hivev1.ClusterProvision, *admissionv1.AdmissionResponse) {
 	obj := &hivev1.ClusterProvision{}
 	if err := a.decoder.DecodeRaw(raw, obj); err != nil {
 		logger.WithError(err).Error("failed to decode")
-		return nil, &admissionv1beta1.AdmissionResponse{
+		return nil, &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,

--- a/pkg/validating-webhooks/hive/v1/clusterprovision_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/clusterprovision_validating_admission_hook_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -56,13 +56,13 @@ func Test_ClusterProvisionAdmission_Validate_Kind(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cut := NewClusterProvisionValidatingAdmissionHook(*createDecoder())
 			cut.Initialize(nil, nil)
-			request := &admissionv1beta1.AdmissionRequest{
+			request := &admissionv1.AdmissionRequest{
 				Resource: metav1.GroupVersionResource{
 					Group:    tc.group,
 					Version:  tc.version,
 					Resource: tc.resource,
 				},
-				Operation: admissionv1beta1.Create,
+				Operation: admissionv1.Create,
 			}
 			response := cut.Validate(request)
 			assert.Equal(t, tc.expectToSkip, response.Allowed)
@@ -73,20 +73,20 @@ func Test_ClusterProvisionAdmission_Validate_Kind(t *testing.T) {
 func Test_ClusterProvisionAdmission_Validate_Operation(t *testing.T) {
 	cases := []struct {
 		name         string
-		operation    admissionv1beta1.Operation
+		operation    admissionv1.Operation
 		expectToSkip bool
 	}{
 		{
 			name:      "create",
-			operation: admissionv1beta1.Create,
+			operation: admissionv1.Create,
 		},
 		{
 			name:      "update",
-			operation: admissionv1beta1.Update,
+			operation: admissionv1.Update,
 		},
 		{
 			name:         "other",
-			operation:    admissionv1beta1.Operation("other"),
+			operation:    admissionv1.Operation("other"),
 			expectToSkip: true,
 		},
 	}
@@ -94,7 +94,7 @@ func Test_ClusterProvisionAdmission_Validate_Operation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cut := NewClusterProvisionValidatingAdmissionHook(*createDecoder())
 			cut.Initialize(nil, nil)
-			request := &admissionv1beta1.AdmissionRequest{
+			request := &admissionv1.AdmissionRequest{
 				Resource: metav1.GroupVersionResource{
 					Group:    clusterProvisionGroup,
 					Version:  clusterProvisionVersion,
@@ -254,13 +254,13 @@ func Test_ClusterProvisionAdmission_Validate_Create(t *testing.T) {
 			if !assert.NoError(t, err, "unexpected error marshalling provision") {
 				return
 			}
-			request := &admissionv1beta1.AdmissionRequest{
+			request := &admissionv1.AdmissionRequest{
 				Resource: metav1.GroupVersionResource{
 					Group:    clusterProvisionGroup,
 					Version:  clusterProvisionVersion,
 					Resource: clusterProvisionResource,
 				},
-				Operation: admissionv1beta1.Create,
+				Operation: admissionv1.Create,
 				Object:    runtime.RawExtension{Raw: rawProvision},
 			}
 			response := cut.Validate(request)
@@ -489,13 +489,13 @@ func Test_ClusterProvisionAdmission_Validate_Update(t *testing.T) {
 			if !assert.NoError(t, err, "unexpected error marshalling new provision") {
 				return
 			}
-			request := &admissionv1beta1.AdmissionRequest{
+			request := &admissionv1.AdmissionRequest{
 				Resource: metav1.GroupVersionResource{
 					Group:    clusterProvisionGroup,
 					Version:  clusterProvisionVersion,
 					Resource: clusterProvisionResource,
 				},
-				Operation: admissionv1beta1.Update,
+				Operation: admissionv1.Update,
 				Object:    runtime.RawExtension{Raw: newAsJSON},
 				OldObject: runtime.RawExtension{Raw: oldAsJSON},
 			}
@@ -546,13 +546,13 @@ func Test_ClusterProvisionAdmission_Validate_Update_StageTransition(t *testing.T
 					if !assert.NoError(t, err, "unexpected error marshalling new provision") {
 						return
 					}
-					request := &admissionv1beta1.AdmissionRequest{
+					request := &admissionv1.AdmissionRequest{
 						Resource: metav1.GroupVersionResource{
 							Group:    clusterProvisionGroup,
 							Version:  clusterProvisionVersion,
 							Resource: clusterProvisionResource,
 						},
-						Operation: admissionv1beta1.Update,
+						Operation: admissionv1.Update,
 						Object:    runtime.RawExtension{Raw: newAsJSON},
 						OldObject: runtime.RawExtension{Raw: oldAsJSON},
 					}

--- a/pkg/validating-webhooks/hive/v1/dnszone_validating_admission_hook.go
+++ b/pkg/validating-webhooks/hive/v1/dnszone_validating_admission_hook.go
@@ -7,7 +7,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dnsvalidation "k8s.io/apimachinery/pkg/util/validation"
@@ -64,7 +64,7 @@ func (a *DNSZoneValidatingAdmissionHook) Initialize(kubeClientConfig *rest.Confi
 
 // Validate is called by generic-admission-server when the registered REST resource above is called with an admission request.
 // Usually it's the kube apiserver that is making the admission validation request.
-func (a *DNSZoneValidatingAdmissionHook) Validate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *DNSZoneValidatingAdmissionHook) Validate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -77,31 +77,31 @@ func (a *DNSZoneValidatingAdmissionHook) Validate(admissionSpec *admissionv1beta
 		contextLogger.Info("Skipping validation for request")
 		// The request object isn't something that this validator should validate.
 		// Therefore, we say that it's allowed.
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
 
 	contextLogger.Info("Validating request")
 
-	if admissionSpec.Operation == admissionv1beta1.Create {
+	if admissionSpec.Operation == admissionv1.Create {
 		return a.validateCreate(admissionSpec)
 	}
 
-	if admissionSpec.Operation == admissionv1beta1.Update {
+	if admissionSpec.Operation == admissionv1.Update {
 		return a.validateUpdate(admissionSpec)
 	}
 
 	// We're only validating creates and updates at this time, so all other operations are explicitly allowed.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
 
 // shouldValidate explicitly checks if the request should validated. For example, this webhook may have accidentally been registered to check
 // the validity of some other type of object with a different GVR.
-func (a *DNSZoneValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1beta1.AdmissionRequest) bool {
+func (a *DNSZoneValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1.AdmissionRequest) bool {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -131,7 +131,7 @@ func (a *DNSZoneValidatingAdmissionHook) shouldValidate(admissionSpec *admission
 }
 
 // validateCreate specifically validates create operations for DNSZone objects.
-func (a *DNSZoneValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *DNSZoneValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -143,7 +143,7 @@ func (a *DNSZoneValidatingAdmissionHook) validateCreate(admissionSpec *admission
 	newObject := &hivev1.DNSZone{}
 	if err := a.decoder.DecodeRaw(admissionSpec.Object, newObject); err != nil {
 		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -159,7 +159,7 @@ func (a *DNSZoneValidatingAdmissionHook) validateCreate(admissionSpec *admission
 	if len(strErrs) != 0 {
 		message := fmt.Sprintf("Failed validation: %v", strings.Join(strErrs, ";"))
 		contextLogger.Info(message)
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -170,13 +170,13 @@ func (a *DNSZoneValidatingAdmissionHook) validateCreate(admissionSpec *admission
 
 	// If we get here, then all checks passed, so the object is valid.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
 
 // validateUpdate specifically validates update operations for DNSZone objects.
-func (a *DNSZoneValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *DNSZoneValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -188,7 +188,7 @@ func (a *DNSZoneValidatingAdmissionHook) validateUpdate(admissionSpec *admission
 	newObject := &hivev1.DNSZone{}
 	if err := a.decoder.DecodeRaw(admissionSpec.Object, newObject); err != nil {
 		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -203,7 +203,7 @@ func (a *DNSZoneValidatingAdmissionHook) validateUpdate(admissionSpec *admission
 	oldObject := &hivev1.DNSZone{}
 	if err := a.decoder.DecodeRaw(admissionSpec.OldObject, oldObject); err != nil {
 		contextLogger.Errorf("Failed unmarshaling OldObject: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -219,7 +219,7 @@ func (a *DNSZoneValidatingAdmissionHook) validateUpdate(admissionSpec *admission
 		message := "DNSZone.Spec.Zone is immutable"
 		contextLogger.Infof("Failed validation: %v", message)
 
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -230,7 +230,7 @@ func (a *DNSZoneValidatingAdmissionHook) validateUpdate(admissionSpec *admission
 
 	// If we get here, then all checks passed, so the object is valid.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }

--- a/pkg/validating-webhooks/hive/v1/dnszone_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/dnszone_validating_admission_hook_test.go
@@ -6,7 +6,7 @@ import (
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/stretchr/testify/assert"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -48,51 +48,51 @@ func TestDNSZoneValidate(t *testing.T) {
 		oldZoneStr      string
 		newObjectRaw    []byte
 		oldObjectRaw    []byte
-		operation       admissionv1beta1.Operation
+		operation       admissionv1.Operation
 		expectedAllowed bool
 		gvr             *metav1.GroupVersionResource
 	}{
 		{
 			name:            "Test valid DNSZone.Spec.Zone",
 			newZoneStr:      "this.is.a.valid.zone",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test empty DNSZone.Spec.Zone value",
 			newZoneStr:      "",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test invalid DNSZone.Spec.Zone",
 			newZoneStr:      "this_is_not_a_valid_zone",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test unable to marshal new object during create",
 			newObjectRaw:    []byte{0},
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test unable to marshal new object during update",
 			newObjectRaw:    []byte{0},
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test unable to marshal old object during update",
 			oldObjectRaw:    []byte{0},
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			expectedAllowed: false,
 		},
 		{
 			name:       "Test DNSZone.Spec.Zone is immutable (updates not allowed)",
 			newZoneStr: "this.is.a.new.valid.zone",
 			oldZoneStr: "this.is.a.valid.zone",
-			operation:  admissionv1beta1.Update,
+			operation:  admissionv1.Update,
 
 			expectedAllowed: false,
 		},
@@ -100,13 +100,13 @@ func TestDNSZoneValidate(t *testing.T) {
 			name:       "Test other updates allowed",
 			newZoneStr: "this.is.a.valid.zone",
 			oldZoneStr: "this.is.a.valid.zone",
-			operation:  admissionv1beta1.Update,
+			operation:  admissionv1.Update,
 
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test that we don't validate deletes",
-			operation:       admissionv1beta1.Delete,
+			operation:       admissionv1.Delete,
 			expectedAllowed: true,
 		},
 		{
@@ -169,7 +169,7 @@ func TestDNSZoneValidate(t *testing.T) {
 				}
 			}
 
-			request := &admissionv1beta1.AdmissionRequest{
+			request := &admissionv1.AdmissionRequest{
 				Operation: tc.operation,
 				Resource:  *tc.gvr,
 				Object: runtime.RawExtension{

--- a/pkg/validating-webhooks/hive/v1/machinepool_validating_admission_hook.go
+++ b/pkg/validating-webhooks/hive/v1/machinepool_validating_admission_hook.go
@@ -7,7 +7,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,7 +81,7 @@ func (a *MachinePoolValidatingAdmissionHook) Initialize(kubeClientConfig *rest.C
 
 // Validate is called by generic-admission-server when the registered REST resource above is called with an admission request.
 // Usually it's the kube apiserver that is making the admission validation request.
-func (a *MachinePoolValidatingAdmissionHook) Validate(request *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *MachinePoolValidatingAdmissionHook) Validate(request *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	logger := log.WithFields(log.Fields{
 		"operation": request.Operation,
 		"group":     request.Resource.Group,
@@ -94,7 +94,7 @@ func (a *MachinePoolValidatingAdmissionHook) Validate(request *admissionv1beta1.
 		logger.Info("Skipping validation for request")
 		// The request object isn't something that this validator should validate.
 		// Therefore, we say that it's allowed.
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
@@ -102,13 +102,13 @@ func (a *MachinePoolValidatingAdmissionHook) Validate(request *admissionv1beta1.
 	logger.Info("Validating request")
 
 	switch request.Operation {
-	case admissionv1beta1.Create:
+	case admissionv1.Create:
 		return a.validateCreateRequest(request, logger)
-	case admissionv1beta1.Update:
+	case admissionv1.Update:
 		return a.validateUpdateRequest(request, logger)
 	default:
 		logger.Info("Successful validation")
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
@@ -116,7 +116,7 @@ func (a *MachinePoolValidatingAdmissionHook) Validate(request *admissionv1beta1.
 
 // shouldValidate explicitly checks if the request should validated. For example, this webhook may have accidentally been registered to check
 // the validity of some other type of object with a different GVR.
-func (a *MachinePoolValidatingAdmissionHook) shouldValidate(request *admissionv1beta1.AdmissionRequest, logger log.FieldLogger) bool {
+func (a *MachinePoolValidatingAdmissionHook) shouldValidate(request *admissionv1.AdmissionRequest, logger log.FieldLogger) bool {
 	logger = logger.WithField("method", "shouldValidate")
 
 	if request.Resource.Group != machinePoolGroup {
@@ -140,7 +140,7 @@ func (a *MachinePoolValidatingAdmissionHook) shouldValidate(request *admissionv1
 }
 
 // validateCreateRequest specifically validates create operations for MachinePool objects.
-func (a *MachinePoolValidatingAdmissionHook) validateCreateRequest(request *admissionv1beta1.AdmissionRequest, logger log.FieldLogger) *admissionv1beta1.AdmissionResponse {
+func (a *MachinePoolValidatingAdmissionHook) validateCreateRequest(request *admissionv1.AdmissionRequest, logger log.FieldLogger) *admissionv1.AdmissionResponse {
 	logger = logger.WithField("method", "validateCreateRequest")
 
 	newObject, resp := a.decode(request.Object, logger.WithField("decode", "Object"))
@@ -155,7 +155,7 @@ func (a *MachinePoolValidatingAdmissionHook) validateCreateRequest(request *admi
 	if allErrs := validateMachinePoolCreate(newObject); len(allErrs) > 0 {
 		logger.WithError(allErrs.ToAggregate()).Info("failed validation")
 		status := errors.NewInvalid(schemaGVK(request.Kind).GroupKind(), request.Name, allErrs).Status()
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result:  &status,
 		}
@@ -163,13 +163,13 @@ func (a *MachinePoolValidatingAdmissionHook) validateCreateRequest(request *admi
 
 	// If we get here, then all checks passed, so the object is valid.
 	logger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
 
 // validateUpdateRequest specifically validates update operations for MachinePool objects.
-func (a *MachinePoolValidatingAdmissionHook) validateUpdateRequest(request *admissionv1beta1.AdmissionRequest, logger log.FieldLogger) *admissionv1beta1.AdmissionResponse {
+func (a *MachinePoolValidatingAdmissionHook) validateUpdateRequest(request *admissionv1.AdmissionRequest, logger log.FieldLogger) *admissionv1.AdmissionResponse {
 	logger = logger.WithField("method", "validateUpdateRequest")
 
 	newObject, resp := a.decode(request.Object, logger.WithField("decode", "Object"))
@@ -189,7 +189,7 @@ func (a *MachinePoolValidatingAdmissionHook) validateUpdateRequest(request *admi
 	if allErrs := validateMachinePoolUpdate(oldObject, newObject); len(allErrs) > 0 {
 		logger.WithError(allErrs.ToAggregate()).Info("failed validation")
 		status := errors.NewInvalid(schemaGVK(request.Kind).GroupKind(), request.Name, allErrs).Status()
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result:  &status,
 		}
@@ -197,16 +197,16 @@ func (a *MachinePoolValidatingAdmissionHook) validateUpdateRequest(request *admi
 
 	// If we get here, then all checks passed, so the object is valid.
 	logger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
 
-func (a *MachinePoolValidatingAdmissionHook) decode(raw runtime.RawExtension, logger log.FieldLogger) (*hivev1.MachinePool, *admissionv1beta1.AdmissionResponse) {
+func (a *MachinePoolValidatingAdmissionHook) decode(raw runtime.RawExtension, logger log.FieldLogger) (*hivev1.MachinePool, *admissionv1.AdmissionResponse) {
 	obj := &hivev1.MachinePool{}
 	if err := a.decoder.DecodeRaw(raw, obj); err != nil {
 		logger.WithError(err).Error("failed to decode")
-		return nil, &admissionv1beta1.AdmissionResponse{
+		return nil, &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,

--- a/pkg/validating-webhooks/hive/v1/machinepool_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/machinepool_validating_admission_hook_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -61,13 +61,13 @@ func Test_MachinePoolAdmission_Validate_Kind(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cut := NewMachinePoolValidatingAdmissionHook(*createDecoder())
 			cut.Initialize(nil, nil)
-			request := &admissionv1beta1.AdmissionRequest{
+			request := &admissionv1.AdmissionRequest{
 				Resource: metav1.GroupVersionResource{
 					Group:    tc.group,
 					Version:  tc.version,
 					Resource: tc.resource,
 				},
-				Operation: admissionv1beta1.Create,
+				Operation: admissionv1.Create,
 			}
 			response := cut.Validate(request)
 			assert.Equal(t, tc.expectToSkip, response.Allowed)
@@ -78,20 +78,20 @@ func Test_MachinePoolAdmission_Validate_Kind(t *testing.T) {
 func Test_MachinePoolAdmission_Validate_Operation(t *testing.T) {
 	cases := []struct {
 		name         string
-		operation    admissionv1beta1.Operation
+		operation    admissionv1.Operation
 		expectToSkip bool
 	}{
 		{
 			name:      "create",
-			operation: admissionv1beta1.Create,
+			operation: admissionv1.Create,
 		},
 		{
 			name:      "update",
-			operation: admissionv1beta1.Update,
+			operation: admissionv1.Update,
 		},
 		{
 			name:         "other",
-			operation:    admissionv1beta1.Operation("other"),
+			operation:    admissionv1.Operation("other"),
 			expectToSkip: true,
 		},
 	}
@@ -99,7 +99,7 @@ func Test_MachinePoolAdmission_Validate_Operation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cut := NewMachinePoolValidatingAdmissionHook(*createDecoder())
 			cut.Initialize(nil, nil)
-			request := &admissionv1beta1.AdmissionRequest{
+			request := &admissionv1.AdmissionRequest{
 				Resource: metav1.GroupVersionResource{
 					Group:    machinePoolGroup,
 					Version:  machinePoolVersion,
@@ -499,13 +499,13 @@ func Test_MachinePoolAdmission_Validate_Create(t *testing.T) {
 			if !assert.NoError(t, err, "unexpected error marshalling provision") {
 				return
 			}
-			request := &admissionv1beta1.AdmissionRequest{
+			request := &admissionv1.AdmissionRequest{
 				Resource: metav1.GroupVersionResource{
 					Group:    machinePoolGroup,
 					Version:  machinePoolVersion,
 					Resource: machinePoolResource,
 				},
-				Operation: admissionv1beta1.Create,
+				Operation: admissionv1.Create,
 				Object:    runtime.RawExtension{Raw: rawProvision},
 			}
 			response := cut.Validate(request)
@@ -616,13 +616,13 @@ func Test_MachinePoolAdmission_Validate_Update(t *testing.T) {
 			if !assert.NoError(t, err, "unexpected error marshalling new provision") {
 				return
 			}
-			request := &admissionv1beta1.AdmissionRequest{
+			request := &admissionv1.AdmissionRequest{
 				Resource: metav1.GroupVersionResource{
 					Group:    machinePoolGroup,
 					Version:  machinePoolVersion,
 					Resource: machinePoolResource,
 				},
-				Operation: admissionv1beta1.Update,
+				Operation: admissionv1.Update,
 				Object:    runtime.RawExtension{Raw: newAsJSON},
 				OldObject: runtime.RawExtension{Raw: oldAsJSON},
 			}

--- a/pkg/validating-webhooks/hive/v1/selector_syncset_validating_admission_hook.go
+++ b/pkg/validating-webhooks/hive/v1/selector_syncset_validating_admission_hook.go
@@ -5,7 +5,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -63,7 +63,7 @@ func (a *SelectorSyncSetValidatingAdmissionHook) Initialize(kubeClientConfig *re
 
 // Validate is called by generic-admission-server when the registered REST resource above is called with an admission request.
 // Usually it's the kube apiserver that is making the admission validation request.
-func (a *SelectorSyncSetValidatingAdmissionHook) Validate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *SelectorSyncSetValidatingAdmissionHook) Validate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -76,31 +76,31 @@ func (a *SelectorSyncSetValidatingAdmissionHook) Validate(admissionSpec *admissi
 		contextLogger.Info("Skipping validation for request")
 		// The request object isn't something that this validator should validate.
 		// Therefore, we say that it's allowed.
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
 
 	contextLogger.Info("Validating request")
 
-	if admissionSpec.Operation == admissionv1beta1.Create {
+	if admissionSpec.Operation == admissionv1.Create {
 		return a.validateCreate(admissionSpec)
 	}
 
-	if admissionSpec.Operation == admissionv1beta1.Update {
+	if admissionSpec.Operation == admissionv1.Update {
 		return a.validateUpdate(admissionSpec)
 	}
 
 	// We're only validating creates and updates at this time, so all other operations are explicitly allowed.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
 
 // shouldValidate explicitly checks if the request should validated. For example, this webhook may have accidentally been registered to check
 // the validity of some other type of object with a different GVR.
-func (a *SelectorSyncSetValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1beta1.AdmissionRequest) bool {
+func (a *SelectorSyncSetValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1.AdmissionRequest) bool {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -130,7 +130,7 @@ func (a *SelectorSyncSetValidatingAdmissionHook) shouldValidate(admissionSpec *a
 }
 
 // validateCreate specifically validates create operations for SelectorSyncSet objects.
-func (a *SelectorSyncSetValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *SelectorSyncSetValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -142,7 +142,7 @@ func (a *SelectorSyncSetValidatingAdmissionHook) validateCreate(admissionSpec *a
 	newObject := &hivev1.SelectorSyncSet{}
 	if err := a.decoder.DecodeRaw(admissionSpec.Object, newObject); err != nil {
 		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -163,7 +163,7 @@ func (a *SelectorSyncSetValidatingAdmissionHook) validateCreate(admissionSpec *a
 	if len(allErrs) > 0 {
 		statusError := errors.NewInvalid(newObject.GroupVersionKind().GroupKind(), newObject.Name, allErrs).Status()
 		contextLogger.Info(statusError.Message)
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result:  &statusError,
 		}
@@ -171,13 +171,13 @@ func (a *SelectorSyncSetValidatingAdmissionHook) validateCreate(admissionSpec *a
 
 	// If we get here, then all checks passed, so the object is valid.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
 
 // validateUpdate specifically validates update operations for SelectorSyncSet objects.
-func (a *SelectorSyncSetValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *SelectorSyncSetValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -189,7 +189,7 @@ func (a *SelectorSyncSetValidatingAdmissionHook) validateUpdate(admissionSpec *a
 	newObject := &hivev1.SelectorSyncSet{}
 	if err := a.decoder.DecodeRaw(admissionSpec.Object, newObject); err != nil {
 		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -210,7 +210,7 @@ func (a *SelectorSyncSetValidatingAdmissionHook) validateUpdate(admissionSpec *a
 	if len(allErrs) > 0 {
 		statusError := errors.NewInvalid(newObject.GroupVersionKind().GroupKind(), newObject.Name, allErrs).Status()
 		contextLogger.Info(statusError.Message)
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result:  &statusError,
 		}
@@ -218,7 +218,7 @@ func (a *SelectorSyncSetValidatingAdmissionHook) validateUpdate(admissionSpec *a
 
 	// If we get here, then all checks passed, so the object is valid.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }

--- a/pkg/validating-webhooks/hive/v1/selector_syncset_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/selector_syncset_validating_admission_hook_test.go
@@ -6,7 +6,7 @@ import (
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/stretchr/testify/assert"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -44,73 +44,73 @@ func TestSelectorSyncSetInitialize(t *testing.T) {
 func TestSelectorSyncSetValidate(t *testing.T) {
 	cases := []struct {
 		name            string
-		operation       admissionv1beta1.Operation
+		operation       admissionv1.Operation
 		expectedAllowed bool
 		selectorSyncSet *hivev1.SelectorSyncSet
 	}{
 		{
 			name:            "Test valid patch type create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			selectorSyncSet: testValidPatchSelectorSyncSet(),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test invalid patch type create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			selectorSyncSet: testInvalidPatchSelectorSyncSet(),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test valid patch type update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			selectorSyncSet: testValidPatchSelectorSyncSet(),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test invalid patch type update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			selectorSyncSet: testInvalidPatchSelectorSyncSet(),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test create syncset with no patches",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			selectorSyncSet: testSelectorSyncSet(),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test update syncset with no patches",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			selectorSyncSet: testSelectorSyncSet(),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid SecretReference create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			selectorSyncSet: testSecretReferenceSelectorSyncSet(),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid SecretReference update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			selectorSyncSet: testSecretReferenceSelectorSyncSet(),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid SecretReference create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			selectorSyncSet: testSecretReferenceSelectorSyncSet(),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid SecretReference update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			selectorSyncSet: testSecretReferenceSelectorSyncSet(),
 			expectedAllowed: true,
 		},
 		{
 			name:      "Test invalid SecretReference no source name create",
-			operation: admissionv1beta1.Create,
+			operation: admissionv1.Create,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSecretReferenceSelectorSyncSet()
 				ss.Spec.Secrets[0].SourceRef.Name = ""
@@ -120,7 +120,7 @@ func TestSelectorSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test invalid SecretReference no target name create",
-			operation: admissionv1beta1.Create,
+			operation: admissionv1.Create,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSecretReferenceSelectorSyncSet()
 				ss.Spec.Secrets[0].TargetRef.Name = ""
@@ -130,7 +130,7 @@ func TestSelectorSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test invalid SecretReference no source name update",
-			operation: admissionv1beta1.Update,
+			operation: admissionv1.Update,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSecretReferenceSelectorSyncSet()
 				ss.Spec.Secrets[0].SourceRef.Name = ""
@@ -140,7 +140,7 @@ func TestSelectorSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test invalid SecretReference no target name update",
-			operation: admissionv1beta1.Update,
+			operation: admissionv1.Update,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSecretReferenceSelectorSyncSet()
 				ss.Spec.Secrets[0].TargetRef.Name = ""
@@ -150,7 +150,7 @@ func TestSelectorSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test valid empty string resourceApplyMode create",
-			operation: admissionv1beta1.Create,
+			operation: admissionv1.Create,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSelectorSyncSet()
 				ss.Spec.ResourceApplyMode = ""
@@ -160,7 +160,7 @@ func TestSelectorSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test valid empty string resourceApplyMode update",
-			operation: admissionv1beta1.Update,
+			operation: admissionv1.Update,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSelectorSyncSet()
 				ss.Spec.ResourceApplyMode = ""
@@ -170,7 +170,7 @@ func TestSelectorSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test valid Upsert resourceApplyMode create",
-			operation: admissionv1beta1.Create,
+			operation: admissionv1.Create,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSelectorSyncSet()
 				ss.Spec.ResourceApplyMode = "Upsert"
@@ -180,7 +180,7 @@ func TestSelectorSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test valid Upsert resourceApplyMode update",
-			operation: admissionv1beta1.Update,
+			operation: admissionv1.Update,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSelectorSyncSet()
 				ss.Spec.ResourceApplyMode = "Upsert"
@@ -190,7 +190,7 @@ func TestSelectorSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test valid Sync resourceApplyMode create",
-			operation: admissionv1beta1.Create,
+			operation: admissionv1.Create,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSelectorSyncSet()
 				ss.Spec.ResourceApplyMode = "Sync"
@@ -200,7 +200,7 @@ func TestSelectorSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test valid Sync resourceApplyMode update",
-			operation: admissionv1beta1.Update,
+			operation: admissionv1.Update,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSelectorSyncSet()
 				ss.Spec.ResourceApplyMode = "Sync"
@@ -210,7 +210,7 @@ func TestSelectorSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test invalid resourceApplyMode create",
-			operation: admissionv1beta1.Create,
+			operation: admissionv1.Create,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSelectorSyncSet()
 				ss.Spec.ResourceApplyMode = "sync"
@@ -220,7 +220,7 @@ func TestSelectorSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test invalid resourceApplyMode update",
-			operation: admissionv1beta1.Update,
+			operation: admissionv1.Update,
 			selectorSyncSet: func() *hivev1.SelectorSyncSet {
 				ss := testSelectorSyncSet()
 				ss.Spec.ResourceApplyMode = "sync"
@@ -230,128 +230,128 @@ func TestSelectorSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:            "Test invalid unmarshalable TypeMeta Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": 798786}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test valid Role authorization.k8s.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "Role"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid Role authorization.k8s.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "Role"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test invalid Role authorization.openshift.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "Role"}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test invalid Role authorization.openshift.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "Role"}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test valid RoleBinding authorization.k8s.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "RoleBinding"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid RoleBinding authorization.k8s.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "RoleBinding"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test invalid RoleBinding authorization.openshift.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "RoleBinding"}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test invalid RoleBinding authorization.openshift.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "RoleBinding"}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test valid ClusterRole authorization.k8s.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "ClusterRole"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid ClusterRole authorization.k8s.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "ClusterRole"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test invalid ClusterRole authorization.openshift.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "ClusterRole"}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test invalid ClusterRole authorization.openshift.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "ClusterRole"}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test valid ClusterRoleBinding authorization.k8s.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "ClusterRoleBinding"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid ClusterRoleBinding authorization.k8s.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "ClusterRoleBinding"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test invalid ClusterRoleBinding authorization.openshift.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "ClusterRoleBinding"}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test invalid ClusterRoleBinding authorization.openshift.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "ClusterRoleBinding"}`),
 			expectedAllowed: false,
 		},
 
 		{
 			name:            "Test valid SubjectAccessReview authorization.k8s.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "SubjectAccessReview"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid SubjectAccessReview authorization.k8s.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "SubjectAccessReview"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test invalid SubjectAccessReview authorization.openshift.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "SubjectAccessReview"}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test invalid SubjectAccessReview authorization.openshift.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			selectorSyncSet: testSelectorSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "SubjectAccessReview"}`),
 			expectedAllowed: false,
 		},
@@ -370,7 +370,7 @@ func TestSelectorSyncSetValidate(t *testing.T) {
 				Resource: "selectorsyncsets",
 			}
 
-			request := &admissionv1beta1.AdmissionRequest{
+			request := &admissionv1.AdmissionRequest{
 				Operation: tc.operation,
 				Resource:  gvr,
 				Object: runtime.RawExtension{

--- a/pkg/validating-webhooks/hive/v1/syncset_validating_admission_hook.go
+++ b/pkg/validating-webhooks/hive/v1/syncset_validating_admission_hook.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -95,7 +95,7 @@ func (a *SyncSetValidatingAdmissionHook) Initialize(kubeClientConfig *rest.Confi
 
 // Validate is called by generic-admission-server when the registered REST resource above is called with an admission request.
 // Usually it's the kube apiserver that is making the admission validation request.
-func (a *SyncSetValidatingAdmissionHook) Validate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *SyncSetValidatingAdmissionHook) Validate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -108,31 +108,31 @@ func (a *SyncSetValidatingAdmissionHook) Validate(admissionSpec *admissionv1beta
 		contextLogger.Info("Skipping validation for request")
 		// The request object isn't something that this validator should validate.
 		// Therefore, we say that it's allowed.
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: true,
 		}
 	}
 
 	contextLogger.Info("Validating request")
 
-	if admissionSpec.Operation == admissionv1beta1.Create {
+	if admissionSpec.Operation == admissionv1.Create {
 		return a.validateCreate(admissionSpec)
 	}
 
-	if admissionSpec.Operation == admissionv1beta1.Update {
+	if admissionSpec.Operation == admissionv1.Update {
 		return a.validateUpdate(admissionSpec)
 	}
 
 	// We're only validating creates and updates at this time, so all other operations are explicitly allowed.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
 
 // shouldValidate explicitly checks if the request should validated. For example, this webhook may have accidentally been registered to check
 // the validity of some other type of object with a different GVR.
-func (a *SyncSetValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1beta1.AdmissionRequest) bool {
+func (a *SyncSetValidatingAdmissionHook) shouldValidate(admissionSpec *admissionv1.AdmissionRequest) bool {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -162,7 +162,7 @@ func (a *SyncSetValidatingAdmissionHook) shouldValidate(admissionSpec *admission
 }
 
 // validateCreate specifically validates create operations for SyncSet objects.
-func (a *SyncSetValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *SyncSetValidatingAdmissionHook) validateCreate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -174,7 +174,7 @@ func (a *SyncSetValidatingAdmissionHook) validateCreate(admissionSpec *admission
 	newObject := &hivev1.SyncSet{}
 	if err := a.decoder.DecodeRaw(admissionSpec.Object, newObject); err != nil {
 		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -196,7 +196,7 @@ func (a *SyncSetValidatingAdmissionHook) validateCreate(admissionSpec *admission
 	if len(allErrs) > 0 {
 		statusError := errors.NewInvalid(newObject.GroupVersionKind().GroupKind(), newObject.Name, allErrs).Status()
 		contextLogger.Info(statusError.Message)
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result:  &statusError,
 		}
@@ -204,13 +204,13 @@ func (a *SyncSetValidatingAdmissionHook) validateCreate(admissionSpec *admission
 
 	// If we get here, then all checks passed, so the object is valid.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }
 
 // validateUpdate specifically validates update operations for SyncSet objects.
-func (a *SyncSetValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+func (a *SyncSetValidatingAdmissionHook) validateUpdate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	contextLogger := log.WithFields(log.Fields{
 		"operation": admissionSpec.Operation,
 		"group":     admissionSpec.Resource.Group,
@@ -222,7 +222,7 @@ func (a *SyncSetValidatingAdmissionHook) validateUpdate(admissionSpec *admission
 	newObject := &hivev1.SyncSet{}
 	if err := a.decoder.DecodeRaw(admissionSpec.Object, newObject); err != nil {
 		contextLogger.Errorf("Failed unmarshaling Object: %v", err.Error())
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
@@ -244,7 +244,7 @@ func (a *SyncSetValidatingAdmissionHook) validateUpdate(admissionSpec *admission
 	if len(allErrs) > 0 {
 		statusError := errors.NewInvalid(newObject.GroupVersionKind().GroupKind(), newObject.Name, allErrs).Status()
 		contextLogger.Info(statusError.Message)
-		return &admissionv1beta1.AdmissionResponse{
+		return &admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result:  &statusError,
 		}
@@ -252,7 +252,7 @@ func (a *SyncSetValidatingAdmissionHook) validateUpdate(admissionSpec *admission
 
 	// If we get here, then all checks passed, so the object is valid.
 	contextLogger.Info("Successful validation")
-	return &admissionv1beta1.AdmissionResponse{
+	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 	}
 }

--- a/pkg/validating-webhooks/hive/v1/syncset_validating_admission_hook_test.go
+++ b/pkg/validating-webhooks/hive/v1/syncset_validating_admission_hook_test.go
@@ -14,7 +14,7 @@ import (
 	machinev1 "github.com/openshift/api/machine/v1"
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	hivev1nutanix "github.com/openshift/hive/apis/hive/v1/nutanix"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -54,73 +54,73 @@ func TestSyncSetInitialize(t *testing.T) {
 func TestSyncSetValidate(t *testing.T) {
 	cases := []struct {
 		name            string
-		operation       admissionv1beta1.Operation
+		operation       admissionv1.Operation
 		expectedAllowed bool
 		syncSet         *hivev1.SyncSet
 	}{
 		{
 			name:            "Test valid patch type create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			syncSet:         testValidPatchSyncSet(),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test invalid patch type create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			syncSet:         testInvalidPatchSyncSet(),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test empty patch type create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			syncSet:         testPatchSyncSet(""),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid patch type update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			syncSet:         testValidPatchSyncSet(),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test invalid patch type update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			syncSet:         testInvalidPatchSyncSet(),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test empty patch type update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			syncSet:         testPatchSyncSet(""),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test create with no patches",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			syncSet:         testSyncSet(),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test update with no patches",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			syncSet:         testSyncSet(),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid SecretReference create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			syncSet:         testSecretReferenceSyncSet(),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid SecretReference update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			syncSet:         testSecretReferenceSyncSet(),
 			expectedAllowed: true,
 		},
 		{
 			name:      "Test invalid SecretReference no source name create",
-			operation: admissionv1beta1.Create,
+			operation: admissionv1.Create,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSecretReferenceSyncSet()
 				ss.Spec.Secrets[0].SourceRef.Name = ""
@@ -130,7 +130,7 @@ func TestSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test invalid SecretReference source not in SyncSet namespace",
-			operation: admissionv1beta1.Create,
+			operation: admissionv1.Create,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSecretReferenceSyncSet()
 				ss.Spec.Secrets[0].SourceRef.Namespace = "anotherns"
@@ -140,7 +140,7 @@ func TestSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test valid SecretReference source has empty namespace",
-			operation: admissionv1beta1.Create,
+			operation: admissionv1.Create,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSecretReferenceSyncSet()
 				ss.Spec.Secrets[0].SourceRef.Namespace = ""
@@ -150,7 +150,7 @@ func TestSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test invalid SecretReference no target name create",
-			operation: admissionv1beta1.Create,
+			operation: admissionv1.Create,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSecretReferenceSyncSet()
 				ss.Spec.Secrets[0].TargetRef.Name = ""
@@ -160,7 +160,7 @@ func TestSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test invalid SecretReference no source name update",
-			operation: admissionv1beta1.Update,
+			operation: admissionv1.Update,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSecretReferenceSyncSet()
 				ss.Spec.Secrets[0].SourceRef.Name = ""
@@ -170,7 +170,7 @@ func TestSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test invalid SecretReference no target name update",
-			operation: admissionv1beta1.Update,
+			operation: admissionv1.Update,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSecretReferenceSyncSet()
 				ss.Spec.Secrets[0].TargetRef.Name = ""
@@ -180,7 +180,7 @@ func TestSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test valid empty string resourceApplyMode create",
-			operation: admissionv1beta1.Create,
+			operation: admissionv1.Create,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSyncSet()
 				ss.Spec.ResourceApplyMode = ""
@@ -190,7 +190,7 @@ func TestSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test valid empty string resourceApplyMode update",
-			operation: admissionv1beta1.Update,
+			operation: admissionv1.Update,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSyncSet()
 				ss.Spec.ResourceApplyMode = ""
@@ -200,7 +200,7 @@ func TestSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test valid Upsert resourceApplyMode create",
-			operation: admissionv1beta1.Create,
+			operation: admissionv1.Create,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSyncSet()
 				ss.Spec.ResourceApplyMode = "Upsert"
@@ -210,7 +210,7 @@ func TestSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test valid Upsert resourceApplyMode update",
-			operation: admissionv1beta1.Update,
+			operation: admissionv1.Update,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSyncSet()
 				ss.Spec.ResourceApplyMode = "Upsert"
@@ -220,7 +220,7 @@ func TestSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test valid Sync resourceApplyMode create",
-			operation: admissionv1beta1.Create,
+			operation: admissionv1.Create,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSyncSet()
 				ss.Spec.ResourceApplyMode = "Sync"
@@ -230,7 +230,7 @@ func TestSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test valid Sync resourceApplyMode update",
-			operation: admissionv1beta1.Update,
+			operation: admissionv1.Update,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSyncSet()
 				ss.Spec.ResourceApplyMode = "Sync"
@@ -240,7 +240,7 @@ func TestSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test invalid resourceApplyMode create",
-			operation: admissionv1beta1.Create,
+			operation: admissionv1.Create,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSyncSet()
 				ss.Spec.ResourceApplyMode = "sync"
@@ -250,7 +250,7 @@ func TestSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:      "Test invalid resourceApplyMode update",
-			operation: admissionv1beta1.Update,
+			operation: admissionv1.Update,
 			syncSet: func() *hivev1.SyncSet {
 				ss := testSyncSet()
 				ss.Spec.ResourceApplyMode = "sync"
@@ -260,134 +260,134 @@ func TestSyncSetValidate(t *testing.T) {
 		},
 		{
 			name:            "Test invalid unmarshalable Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": 798786}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test missing Kind Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "v1"}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test valid Role authorization.k8s.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "Role"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid Role authorization.k8s.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "Role"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test invalid Role authorization.openshift.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "Role"}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test invalid Role authorization.openshift.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "Role"}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test valid RoleBinding authorization.k8s.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "RoleBinding"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid RoleBinding authorization.k8s.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "RoleBinding"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test invalid RoleBinding authorization.openshift.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "RoleBinding"}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test invalid RoleBinding authorization.openshift.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "RoleBinding"}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test valid ClusterRole authorization.k8s.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "ClusterRole"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid ClusterRole authorization.k8s.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "ClusterRole"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test invalid ClusterRole authorization.openshift.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "ClusterRole"}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test invalid ClusterRole authorization.openshift.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "ClusterRole"}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test valid ClusterRoleBinding authorization.k8s.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "ClusterRoleBinding"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid ClusterRoleBinding authorization.k8s.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "ClusterRoleBinding"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test invalid ClusterRoleBinding authorization.openshift.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "ClusterRoleBinding"}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test invalid ClusterRoleBinding authorization.openshift.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "ClusterRoleBinding"}`),
 			expectedAllowed: false,
 		},
 
 		{
 			name:            "Test valid SubjectAccessReview authorization.k8s.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "SubjectAccessReview"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test valid SubjectAccessReview authorization.k8s.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.k8s.io/v1", "kind": "SubjectAccessReview"}`),
 			expectedAllowed: true,
 		},
 		{
 			name:            "Test invalid SubjectAccessReview authorization.openshift.io Resource create",
-			operation:       admissionv1beta1.Create,
+			operation:       admissionv1.Create,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "SubjectAccessReview"}`),
 			expectedAllowed: false,
 		},
 		{
 			name:            "Test invalid SubjectAccessReview authorization.openshift.io Resource update",
-			operation:       admissionv1beta1.Update,
+			operation:       admissionv1.Update,
 			syncSet:         testSyncSetWithResources(`{"apiVersion": "authorization.openshift.io/v1", "kind": "SubjectAccessReview"}`),
 			expectedAllowed: false,
 		},
@@ -406,7 +406,7 @@ func TestSyncSetValidate(t *testing.T) {
 				Resource: "syncsets",
 			}
 
-			request := &admissionv1beta1.AdmissionRequest{
+			request := &admissionv1.AdmissionRequest{
 				Operation: tc.operation,
 				Resource:  gvr,
 				Object: runtime.RawExtension{

--- a/test/e2e/postdeploy/admission/admission_test.go
+++ b/test/e2e/postdeploy/admission/admission_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -90,7 +90,7 @@ func TestAdmission(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected create error: %v", err)
 			}
-			reviewResult := &admissionv1beta1.AdmissionReview{}
+			reviewResult := &admissionv1.AdmissionReview{}
 			scheme := scheme.GetScheme()
 			err = scheme.Convert(result, reviewResult, nil)
 			if err != nil {

--- a/test/e2e/postdeploy/admission/testdata/hiveadmission-review-failure.json
+++ b/test/e2e/postdeploy/admission/testdata/hiveadmission-review-failure.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "admission.k8s.io/v1beta1",
+  "apiVersion": "admission.k8s.io/v1",
   "kind": "AdmissionReview",
   "request": {
     "kind": {

--- a/test/e2e/postdeploy/admission/testdata/hiveadmission-review-success.json
+++ b/test/e2e/postdeploy/admission/testdata/hiveadmission-review-success.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "admission.k8s.io/v1beta1",
+  "apiVersion": "admission.k8s.io/v1",
   "kind": "AdmissionReview",
   "request": {
     "kind": {

--- a/test/e2e/postdeploy/admission/testdata/hiveadmission-review-update-failure.json
+++ b/test/e2e/postdeploy/admission/testdata/hiveadmission-review-update-failure.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "admission.k8s.io/v1beta1",
+  "apiVersion": "admission.k8s.io/v1",
   "kind": "AdmissionReview",
   "request": {
     "kind": {


### PR DESCRIPTION
v1beta1 has been deprecated, and the last k8s that didn't support v1 (1.16, I think) has been "out of support", for long enough that we should be safe to move fully to v1 now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated admission integrations to Kubernetes AdmissionReview v1 for broader cluster compatibility.
* **New Features**
  * Added validation support for ClusterDeploymentCustomization resources.
* **Bug Fixes / Behavior**
  * ClusterPool webhook no longer runs on DELETE (now only CREATE/UPDATE), reducing unnecessary validation on deletes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->