### PR TITLE
No-jira: Standard_D2s_v3: instance type doesn't meet requirements of 16 GB min Memory

### DIFF
--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -528,7 +528,7 @@ For Azure, replace the contents of `compute.platform` and `controlPlane.platform
     azure:
       osDisk:
         diskSizeGB: 128
-      type: Standard_D2s_v3
+      type: Standard_D4s_v3
 ```
 
 and replace the contents of `platform` with:
@@ -806,7 +806,7 @@ For Azure, replace the contents of `spec.platform` with:
 azure:
   osDisk:
     diskSizeGB: 128
-  type: Standard_D2s_v3
+  type: Standard_D4s_v3
 ```
 
 For GCP, replace the contents of `spec.platform` with:


### PR DESCRIPTION
PTAL when time permits small nit in readme , while doing Azure clusterdeployment , got below error - 

` Invalid value: \"Standard_D2s_v3\": instance type does not meet minimum resource requirements of 4 vCPUsAvailable, controlPlane.platform.azure.type: Invalid value: \"Standard_D2s_v3\": instance type does not meet minimum resource requirements of 16 GB Memory]`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Azure installation example to use larger VM sizing for compute and control plane nodes (example values changed from Standard_D2s_v3 to Standard_D4s_v3), ensuring example configs reflect increased resource sizing for installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->