### PR TITLE
e2e: Fix kubeconfig extract

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -196,7 +196,7 @@ function save_hive_logs() {
   oc get cd -A -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}{.spec.clusterMetadata.adminKubeconfigSecretRef.name}{"\n"}{end}' | while read ns cd s; do
     # Skip CDs with no kubeconfig Secret ref set
     [[ -n "$s" ]] || continue
-    oc extract secret/$s -n $ns --to=$tmpd || continue
+    oc extract secret/$s -n $ns --to=$tmpd --confirm=true || continue
     # Nodes
     if oc --kubeconfig=$tmpd/kubeconfig get no -o yaml > $tmpf; then
       mv $tmpf $ARTIFACT_DIR/SPOKE_9exit_${ns}_${cd}_nodes.yaml


### PR DESCRIPTION
When more than one CD exists, `save_hive_logs()` was failing to extract all but the first kubeconfig as the file would already exist. Add the flag to confirm overwrite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in end-to-end tests where log extraction could be interrupted by confirmation prompts, causing test runs to abort. Hive logs are now extracted automatically without requiring manual confirmation during automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->