### PR TITLE
HIVE-3149: Azure: Prefilter SKU list query

### DIFF
--- a/pkg/azureclient/client.go
+++ b/pkg/azureclient/client.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	azenc "github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
 	"github.com/Azure/go-autorest/autorest"
@@ -44,7 +45,7 @@ type Client interface {
 	GetVMCapabilities(ctx context.Context, instanceType, region string) (map[string]string, error)
 
 	// SKU
-	GetVirtualMachineSku(ctx context.Context, name, region string) (*compute.ResourceSku, error)
+	GetVirtualMachineSku(ctx context.Context, name, region string) (*azenc.ResourceSku, error)
 
 	// Images
 	ListImagesByResourceGroup(ctx context.Context, resourceGroupName string) (ImageListResultPage, error)
@@ -54,7 +55,7 @@ type Client interface {
 type ResourceSKUsPage interface {
 	NextWithContext(ctx context.Context) error
 	NotDone() bool
-	Values() []compute.ResourceSku
+	Values() []azenc.ResourceSku
 }
 
 // RecordSetPage is a page of results from listing record sets.
@@ -71,7 +72,7 @@ type ImageListResultPage interface {
 }
 
 type azureClient struct {
-	resourceSKUsClient    *compute.ResourceSkusClient
+	resourceSKUsClient    *azenc.ResourceSkusClient
 	recordSetsClient      *dns.RecordSetsClient
 	zonesClient           *dns.ZonesClient
 	virtualMachinesClient *compute.VirtualMachinesClient
@@ -79,7 +80,7 @@ type azureClient struct {
 }
 
 func (c *azureClient) ListResourceSKUs(ctx context.Context, filter string) (ResourceSKUsPage, error) {
-	page, err := c.resourceSKUsClient.List(ctx, filter)
+	page, err := c.resourceSKUsClient.List(ctx, filter, "false")
 	return &page, err
 }
 
@@ -150,11 +151,13 @@ func (c *azureClient) GetVMCapabilities(ctx context.Context, instanceType, regio
 }
 
 // GetVirtualMachineSku retrieves the resource SKU of a specified virtual machine SKU in the specified region.
-func (c *azureClient) GetVirtualMachineSku(ctx context.Context, name, region string) (*compute.ResourceSku, error) {
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+func (c *azureClient) GetVirtualMachineSku(ctx context.Context, name, region string) (*azenc.ResourceSku, error) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	for page, err := c.resourceSKUsClient.List(ctx, ""); page.NotDone(); err = page.NextWithContext(ctx) {
+	var page azenc.ResourceSkusResultPage
+	var err error
+	for page, err = c.resourceSKUsClient.List(ctx, fmt.Sprintf("location eq '%s'", region), "false"); page.NotDone(); err = page.NextWithContext(ctx) {
 		if err != nil {
 			return nil, errors.Wrap(err, "error fetching SKU pages")
 		}
@@ -164,18 +167,13 @@ func (c *azureClient) GetVirtualMachineSku(ctx context.Context, name, region str
 				continue
 			}
 			// Filter out resources that do not match the provided name
-			if !strings.EqualFold(name, *sku.Name) {
-				continue
-			}
-			// Return the resource from the provided region
-			for _, location := range to.StringSlice(sku.Locations) {
-				if strings.EqualFold(location, region) {
-					return &sku, nil
-				}
+			if strings.EqualFold(name, *sku.Name) {
+				return &sku, nil
 			}
 		}
 	}
-	return nil, nil
+	// err is nil if we didn't find it (page.NotDone() == false above)
+	return nil, err
 }
 
 func (c *azureClient) ListImagesByResourceGroup(ctx context.Context, resourceGroupName string) (ImageListResultPage, error) {
@@ -238,7 +236,7 @@ func newClient(authJSONSource func() ([]byte, error), environmentName string) (*
 		return nil, err
 	}
 
-	resourceSKUsClient := compute.NewResourceSkusClientWithBaseURI(env.ResourceManagerEndpoint, creds.SubscriptionID)
+	resourceSKUsClient := azenc.NewResourceSkusClientWithBaseURI(env.ResourceManagerEndpoint, creds.SubscriptionID)
 	resourceSKUsClient.Authorizer = authorizer
 
 	recordSetsClient := dns.NewRecordSetsClientWithBaseURI(env.ResourceManagerEndpoint, creds.SubscriptionID)

--- a/pkg/azureclient/client.go
+++ b/pkg/azureclient/client.go
@@ -3,10 +3,7 @@ package azureclient
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
-	"strings"
-	"time"
 
 	azenc "github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
@@ -42,10 +39,6 @@ type Client interface {
 	ListAllVirtualMachines(ctx context.Context, statusOnly string) (compute.VirtualMachineListResultPage, error)
 	DeallocateVirtualMachine(ctx context.Context, resourceGroup, name string) (compute.VirtualMachinesDeallocateFuture, error)
 	StartVirtualMachine(ctx context.Context, resourceGroup, name string) (compute.VirtualMachinesStartFuture, error)
-	GetVMCapabilities(ctx context.Context, instanceType, region string) (map[string]string, error)
-
-	// SKU
-	GetVirtualMachineSku(ctx context.Context, name, region string) (*azenc.ResourceSku, error)
 
 	// Images
 	ListImagesByResourceGroup(ctx context.Context, resourceGroupName string) (ImageListResultPage, error)
@@ -130,50 +123,6 @@ func (c *azureClient) DeallocateVirtualMachine(ctx context.Context, resourceGrou
 
 func (c *azureClient) StartVirtualMachine(ctx context.Context, resourceGroup, name string) (compute.VirtualMachinesStartFuture, error) {
 	return c.virtualMachinesClient.Start(ctx, resourceGroup, name)
-}
-
-// GetVMCapabilities retrieves the capabilities of an instance type in a specific region. Returns these values
-// in a map with the capability name as the key and the corresponding value.
-func (c *azureClient) GetVMCapabilities(ctx context.Context, instanceType, region string) (map[string]string, error) {
-	typeMeta, err := c.GetVirtualMachineSku(ctx, instanceType, region)
-	if err != nil {
-		return nil, fmt.Errorf("error connecting to Azure client: %v", err)
-	}
-	if typeMeta == nil {
-		return nil, fmt.Errorf("not found in region %s", region)
-	}
-
-	capabilities := make(map[string]string)
-	for _, capability := range *typeMeta.Capabilities {
-		capabilities[to.String(capability.Name)] = to.String(capability.Value)
-	}
-	return capabilities, nil
-}
-
-// GetVirtualMachineSku retrieves the resource SKU of a specified virtual machine SKU in the specified region.
-func (c *azureClient) GetVirtualMachineSku(ctx context.Context, name, region string) (*azenc.ResourceSku, error) {
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
-	defer cancel()
-
-	var page azenc.ResourceSkusResultPage
-	var err error
-	for page, err = c.resourceSKUsClient.List(ctx, fmt.Sprintf("location eq '%s'", region), "false"); page.NotDone(); err = page.NextWithContext(ctx) {
-		if err != nil {
-			return nil, errors.Wrap(err, "error fetching SKU pages")
-		}
-		for _, sku := range page.Values() {
-			// Filter out resources that are not virtualMachines
-			if !strings.EqualFold("virtualMachines", *sku.ResourceType) {
-				continue
-			}
-			// Filter out resources that do not match the provided name
-			if strings.EqualFold(name, *sku.Name) {
-				return &sku, nil
-			}
-		}
-	}
-	// err is nil if we didn't find it (page.NotDone() == false above)
-	return nil, err
 }
 
 func (c *azureClient) ListImagesByResourceGroup(ctx context.Context, resourceGroupName string) (ImageListResultPage, error) {

--- a/pkg/azureclient/client.go
+++ b/pkg/azureclient/client.go
@@ -3,6 +3,7 @@ package azureclient
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 
 	azenc "github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
@@ -23,7 +24,7 @@ import (
 
 // Client is a wrapper object for actual Azure libraries to allow for easier mocking/testing.
 type Client interface {
-	ListResourceSKUs(ctx context.Context, filter string) (ResourceSKUsPage, error)
+	ListResourceSKUs(ctx context.Context, region string) (ResourceSKUsPage, error)
 
 	// Zones
 	CreateOrUpdateZone(ctx context.Context, resourceGroupName string, zone string) (dns.Zone, error)
@@ -72,8 +73,8 @@ type azureClient struct {
 	imagesClient          *compute.ImagesClient
 }
 
-func (c *azureClient) ListResourceSKUs(ctx context.Context, filter string) (ResourceSKUsPage, error) {
-	page, err := c.resourceSKUsClient.List(ctx, filter, "false")
+func (c *azureClient) ListResourceSKUs(ctx context.Context, region string) (ResourceSKUsPage, error) {
+	page, err := c.resourceSKUsClient.List(ctx, fmt.Sprintf("location eq '%s'", region), "false")
 	return &page, err
 }
 

--- a/pkg/azureclient/mock/client_generated.go
+++ b/pkg/azureclient/mock/client_generated.go
@@ -111,36 +111,6 @@ func (mr *MockClientMockRecorder) DeleteZone(ctx, resourceGroupName, zone interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteZone", reflect.TypeOf((*MockClient)(nil).DeleteZone), ctx, resourceGroupName, zone)
 }
 
-// GetVMCapabilities mocks base method.
-func (m *MockClient) GetVMCapabilities(ctx context.Context, instanceType, region string) (map[string]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVMCapabilities", ctx, instanceType, region)
-	ret0, _ := ret[0].(map[string]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetVMCapabilities indicates an expected call of GetVMCapabilities.
-func (mr *MockClientMockRecorder) GetVMCapabilities(ctx, instanceType, region interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVMCapabilities", reflect.TypeOf((*MockClient)(nil).GetVMCapabilities), ctx, instanceType, region)
-}
-
-// GetVirtualMachineSku mocks base method.
-func (m *MockClient) GetVirtualMachineSku(ctx context.Context, name, region string) (*compute.ResourceSku, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVirtualMachineSku", ctx, name, region)
-	ret0, _ := ret[0].(*compute.ResourceSku)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetVirtualMachineSku indicates an expected call of GetVirtualMachineSku.
-func (mr *MockClientMockRecorder) GetVirtualMachineSku(ctx, name, region interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVirtualMachineSku", reflect.TypeOf((*MockClient)(nil).GetVirtualMachineSku), ctx, name, region)
-}
-
 // GetZone mocks base method.
 func (m *MockClient) GetZone(ctx context.Context, resourceGroupName, zone string) (dns.Zone, error) {
 	m.ctrl.T.Helper()

--- a/pkg/azureclient/mock/client_generated.go
+++ b/pkg/azureclient/mock/client_generated.go
@@ -8,7 +8,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
+	compute "github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
+	compute0 "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 	dns "github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
 	gomock "github.com/golang/mock/gomock"
 	azureclient "github.com/openshift/hive/pkg/azureclient"
@@ -68,10 +69,10 @@ func (mr *MockClientMockRecorder) CreateOrUpdateZone(ctx, resourceGroupName, zon
 }
 
 // DeallocateVirtualMachine mocks base method.
-func (m *MockClient) DeallocateVirtualMachine(ctx context.Context, resourceGroup, name string) (compute.VirtualMachinesDeallocateFuture, error) {
+func (m *MockClient) DeallocateVirtualMachine(ctx context.Context, resourceGroup, name string) (compute0.VirtualMachinesDeallocateFuture, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeallocateVirtualMachine", ctx, resourceGroup, name)
-	ret0, _ := ret[0].(compute.VirtualMachinesDeallocateFuture)
+	ret0, _ := ret[0].(compute0.VirtualMachinesDeallocateFuture)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -156,10 +157,10 @@ func (mr *MockClientMockRecorder) GetZone(ctx, resourceGroupName, zone interface
 }
 
 // ListAllVirtualMachines mocks base method.
-func (m *MockClient) ListAllVirtualMachines(ctx context.Context, statusOnly string) (compute.VirtualMachineListResultPage, error) {
+func (m *MockClient) ListAllVirtualMachines(ctx context.Context, statusOnly string) (compute0.VirtualMachineListResultPage, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAllVirtualMachines", ctx, statusOnly)
-	ret0, _ := ret[0].(compute.VirtualMachineListResultPage)
+	ret0, _ := ret[0].(compute0.VirtualMachineListResultPage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -216,10 +217,10 @@ func (mr *MockClientMockRecorder) ListResourceSKUs(ctx, filter interface{}) *gom
 }
 
 // StartVirtualMachine mocks base method.
-func (m *MockClient) StartVirtualMachine(ctx context.Context, resourceGroup, name string) (compute.VirtualMachinesStartFuture, error) {
+func (m *MockClient) StartVirtualMachine(ctx context.Context, resourceGroup, name string) (compute0.VirtualMachinesStartFuture, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartVirtualMachine", ctx, resourceGroup, name)
-	ret0, _ := ret[0].(compute.VirtualMachinesStartFuture)
+	ret0, _ := ret[0].(compute0.VirtualMachinesStartFuture)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -412,10 +413,10 @@ func (mr *MockImageListResultPageMockRecorder) NotDone() *gomock.Call {
 }
 
 // Values mocks base method.
-func (m *MockImageListResultPage) Values() []compute.Image {
+func (m *MockImageListResultPage) Values() []compute0.Image {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Values")
-	ret0, _ := ret[0].([]compute.Image)
+	ret0, _ := ret[0].([]compute0.Image)
 	return ret0
 }
 

--- a/pkg/controller/machinepool/azureactuator.go
+++ b/pkg/controller/machinepool/azureactuator.go
@@ -201,7 +201,7 @@ func (a *AzureActuator) getZones(region string, instanceType string) ([]string, 
 
 	var res azureclient.ResourceSKUsPage
 	var err error
-	for res, err = a.client.ListResourceSKUs(ctx, ""); err == nil && res.NotDone(); err = res.NextWithContext(ctx) {
+	for res, err = a.client.ListResourceSKUs(ctx, region); err == nil && res.NotDone(); err = res.NextWithContext(ctx) {
 		for _, resSku := range res.Values() {
 			if strings.EqualFold(to.String(resSku.Name), instanceType) {
 				for _, locationInfo := range *resSku.LocationInfo {
@@ -268,7 +268,7 @@ func (a *AzureActuator) getVirtualMachineSku(ctx context.Context, name, region s
 
 	var page azureclient.ResourceSKUsPage
 	var err error
-	for page, err = a.client.ListResourceSKUs(ctx, fmt.Sprintf("location eq '%s'", region)); page.NotDone(); err = page.NextWithContext(ctx) {
+	for page, err = a.client.ListResourceSKUs(ctx, region); page.NotDone(); err = page.NextWithContext(ctx) {
 		if err != nil {
 			return nil, errors.Wrap(err, "error fetching SKU pages")
 		}

--- a/pkg/controller/machinepool/azureactuator.go
+++ b/pkg/controller/machinepool/azureactuator.go
@@ -2,9 +2,11 @@ package machinepool
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
+	azenc "github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -120,7 +122,7 @@ func (a *AzureActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *
 		}
 	}
 
-	capabilities, err := a.client.GetVMCapabilities(context.TODO(), computePool.Platform.Azure.InstanceType, ic.Platform.Azure.Region)
+	capabilities, err := a.getVMCapabilities(context.TODO(), computePool.Platform.Azure.InstanceType, ic.Platform.Azure.Region)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "error retrieving VM capabilities")
 	}
@@ -239,4 +241,48 @@ func (a *AzureActuator) gen2ImageExists(resourceGroupName string) (bool, error) 
 		}
 	}
 	return false, nil
+}
+
+// getVMCapabilities retrieves the capabilities of an instance type in a specific region. Returns these values
+// in a map with the capability name as the key and the corresponding value.
+func (a *AzureActuator) getVMCapabilities(ctx context.Context, instanceType, region string) (map[string]string, error) {
+	typeMeta, err := a.getVirtualMachineSku(ctx, instanceType, region)
+	if err != nil {
+		return nil, fmt.Errorf("error connecting to Azure client: %v", err)
+	}
+	if typeMeta == nil {
+		return nil, fmt.Errorf("not found in region %s", region)
+	}
+
+	capabilities := make(map[string]string)
+	for _, capability := range *typeMeta.Capabilities {
+		capabilities[to.String(capability.Name)] = to.String(capability.Value)
+	}
+	return capabilities, nil
+}
+
+// getVirtualMachineSku retrieves the resource SKU of a specified virtual machine SKU in the specified region.
+func (a *AzureActuator) getVirtualMachineSku(ctx context.Context, name, region string) (*azenc.ResourceSku, error) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	var page azureclient.ResourceSKUsPage
+	var err error
+	for page, err = a.client.ListResourceSKUs(ctx, fmt.Sprintf("location eq '%s'", region)); page.NotDone(); err = page.NextWithContext(ctx) {
+		if err != nil {
+			return nil, errors.Wrap(err, "error fetching SKU pages")
+		}
+		for _, sku := range page.Values() {
+			// Filter out resources that are not virtualMachines
+			if !strings.EqualFold("virtualMachines", *sku.ResourceType) {
+				continue
+			}
+			// Filter out resources that do not match the provided name
+			if strings.EqualFold(name, *sku.Name) {
+				return &sku, nil
+			}
+		}
+	}
+	// err is nil if we didn't find it (page.NotDone() == false above)
+	return nil, err
 }

--- a/pkg/controller/machinepool/azureactuator.go
+++ b/pkg/controller/machinepool/azureactuator.go
@@ -196,7 +196,7 @@ func (a *AzureActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *
 }
 
 func (a *AzureActuator) getZones(region string, instanceType string) ([]string, error) {
-	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.TODO(), 2*time.Minute)
 	defer cancel()
 
 	var res azureclient.ResourceSKUsPage
@@ -251,7 +251,10 @@ func (a *AzureActuator) getVMCapabilities(ctx context.Context, instanceType, reg
 		return nil, fmt.Errorf("error connecting to Azure client: %v", err)
 	}
 	if typeMeta == nil {
-		return nil, fmt.Errorf("not found in region %s", region)
+		return nil, fmt.Errorf("SKU %s not found in region %s", instanceType, region)
+	}
+	if typeMeta.Capabilities == nil {
+		return nil, fmt.Errorf("SKU %s has no Capabilities", instanceType)
 	}
 
 	capabilities := make(map[string]string)
@@ -268,21 +271,18 @@ func (a *AzureActuator) getVirtualMachineSku(ctx context.Context, name, region s
 
 	var page azureclient.ResourceSKUsPage
 	var err error
-	for page, err = a.client.ListResourceSKUs(ctx, region); page.NotDone(); err = page.NextWithContext(ctx) {
-		if err != nil {
-			return nil, errors.Wrap(err, "error fetching SKU pages")
-		}
+	for page, err = a.client.ListResourceSKUs(ctx, region); err == nil && page.NotDone(); err = page.NextWithContext(ctx) {
 		for _, sku := range page.Values() {
 			// Filter out resources that are not virtualMachines
-			if !strings.EqualFold("virtualMachines", *sku.ResourceType) {
+			if !strings.EqualFold("virtualMachines", to.String(sku.ResourceType)) {
 				continue
 			}
 			// Filter out resources that do not match the provided name
-			if strings.EqualFold(name, *sku.Name) {
+			if strings.EqualFold(name, to.String(sku.Name)) {
 				return &sku, nil
 			}
 		}
 	}
 	// err is nil if we didn't find it (page.NotDone() == false above)
-	return nil, err
+	return nil, errors.Wrap(err, "error fetching SKU pages")
 }

--- a/pkg/controller/machinepool/azureactuator_test.go
+++ b/pkg/controller/machinepool/azureactuator_test.go
@@ -348,7 +348,7 @@ func validateAzureMachineSets(t *testing.T, mSets []*machineapi.MachineSet, expe
 
 func mockListResourceSKUs(mockCtrl *gomock.Controller, client *mockazure.MockClient, zones []string) {
 	page := mockazure.NewMockResourceSKUsPage(mockCtrl)
-	client.EXPECT().ListResourceSKUs(gomock.Any(), "").Return(page, nil)
+	client.EXPECT().ListResourceSKUs(gomock.Any(), testRegion).Return(page, nil)
 	page.EXPECT().NotDone().Return(true)
 	page.EXPECT().Values().Return(
 		[]azenc.ResourceSku{
@@ -367,7 +367,7 @@ func mockListResourceSKUs(mockCtrl *gomock.Controller, client *mockazure.MockCli
 
 func mockGetVMCapabilities(mockCtrl *gomock.Controller, client *mockazure.MockClient, hyperVGenerations string) {
 	page := mockazure.NewMockResourceSKUsPage(mockCtrl)
-	client.EXPECT().ListResourceSKUs(gomock.Any(), fmt.Sprintf("location eq '%s'", testRegion)).Return(page, nil)
+	client.EXPECT().ListResourceSKUs(gomock.Any(), testRegion).Return(page, nil)
 	page.EXPECT().NotDone().Return(true)
 	page.EXPECT().Values().Return(
 		[]azenc.ResourceSku{

--- a/pkg/controller/machinepool/azureactuator_test.go
+++ b/pkg/controller/machinepool/azureactuator_test.go
@@ -41,8 +41,8 @@ func TestAzureActuator(t *testing.T) {
 			clusterDeployment: testAzureClusterDeployment(),
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1"})
-				mockGetVMCapabilities(client, "V1,V2")
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
@@ -54,8 +54,8 @@ func TestAzureActuator(t *testing.T) {
 			clusterDeployment: testAzureClusterDeployment(),
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(client, "V1,V2")
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
@@ -73,7 +73,7 @@ func TestAzureActuator(t *testing.T) {
 				return pool
 			}(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
-				mockGetVMCapabilities(client, "V1,V2")
+				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
@@ -87,8 +87,8 @@ func TestAzureActuator(t *testing.T) {
 			clusterDeployment: testAzureClusterDeployment(),
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(client, "V1,V2")
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
@@ -117,8 +117,8 @@ func TestAzureActuator(t *testing.T) {
 				return pool
 			}(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(client, "V1,V2")
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
@@ -143,8 +143,8 @@ func TestAzureActuator(t *testing.T) {
 				return p
 			}(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(client, "V1,V2")
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
@@ -158,8 +158,8 @@ func TestAzureActuator(t *testing.T) {
 			clusterDeployment: testAzureClusterDeployment(),
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3", "zone4", "zone5"})
-				mockGetVMCapabilities(client, "V1,V2")
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
@@ -175,8 +175,8 @@ func TestAzureActuator(t *testing.T) {
 			clusterDeployment: testAzureClusterDeployment(),
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
 				mockListResourceSKUs(mockCtrl, client, []string{})
-				mockGetVMCapabilities(client, "V1,V2")
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
@@ -189,8 +189,8 @@ func TestAzureActuator(t *testing.T) {
 			clusterDeployment: testAzureClusterDeployment(),
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(client, "V1,V2")
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
@@ -208,8 +208,8 @@ func TestAzureActuator(t *testing.T) {
 			clusterDeployment: testAzureClusterDeployment(),
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockGetVMCapabilities(mockCtrl, client, "V1")
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(client, "V1")
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1), testAzureImage(compute.HyperVGenerationTypesV2)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
@@ -227,8 +227,8 @@ func TestAzureActuator(t *testing.T) {
 			clusterDeployment: testAzureClusterDeployment(),
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(client, "V1,V2")
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1), testAzureImage(compute.HyperVGenerationTypesV2)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
@@ -246,8 +246,8 @@ func TestAzureActuator(t *testing.T) {
 			clusterDeployment: testAzureClusterDeployment(),
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockGetVMCapabilities(mockCtrl, client, "V2")
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
-				mockGetVMCapabilities(client, "V2")
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1), testAzureImage(compute.HyperVGenerationTypesV2)})
 			},
 			expectedMachineSetReplicas: map[string]int64{
@@ -274,7 +274,7 @@ func TestAzureActuator(t *testing.T) {
 				return mp
 			}(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
-				mockGetVMCapabilities(client, "V1,V2")
+				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
 				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 			},
 			expectedMachineSetReplicas: map[string]int64{
@@ -365,11 +365,24 @@ func mockListResourceSKUs(mockCtrl *gomock.Controller, client *mockazure.MockCli
 	)
 }
 
-func mockGetVMCapabilities(client *mockazure.MockClient, hyperVGenerations string) {
-	capabilities := map[string]string{
-		"HyperVGenerations": hyperVGenerations,
-	}
-	client.EXPECT().GetVMCapabilities(gomock.Any(), gomock.Any(), gomock.Any()).Return(capabilities, nil)
+func mockGetVMCapabilities(mockCtrl *gomock.Controller, client *mockazure.MockClient, hyperVGenerations string) {
+	page := mockazure.NewMockResourceSKUsPage(mockCtrl)
+	client.EXPECT().ListResourceSKUs(gomock.Any(), fmt.Sprintf("location eq '%s'", testRegion)).Return(page, nil)
+	page.EXPECT().NotDone().Return(true)
+	page.EXPECT().Values().Return(
+		[]azenc.ResourceSku{
+			{
+				ResourceType: ptr.To("virtualMachines"),
+				Name:         ptr.To(testInstanceType),
+				Capabilities: &[]azenc.ResourceSkuCapabilities{
+					{
+						Name:  ptr.To("HyperVGenerations"),
+						Value: ptr.To(hyperVGenerations),
+					},
+				},
+			},
+		},
+	)
 }
 
 func mockListImagesByResourceGroup(client *mockazure.MockClient, images []compute.Image) {

--- a/pkg/controller/machinepool/azureactuator_test.go
+++ b/pkg/controller/machinepool/azureactuator_test.go
@@ -33,8 +33,9 @@ func TestAzureActuator(t *testing.T) {
 		expectedMachineSetReplicas  map[string]int64
 		expectedImage               *machineapi.Image
 		extraProviderSpecValidation providerSpecValidator
-		expectedErr                 bool
-		expectedLogs                []string
+		// Error message (sub)string. If empty, no error is expected.
+		expectedErr  string
+		expectedLogs []string
 	}{
 		{
 			name:              "generate single machineset for single zone",
@@ -42,8 +43,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListResourceSKUs(mockCtrl, client, []string{"zone1"})
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
+				mockListResourceSKUs(mockCtrl, client, []string{"zone1"})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 3,
@@ -55,8 +56,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
+				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -88,8 +89,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
+				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -118,8 +119,8 @@ func TestAzureActuator(t *testing.T) {
 			}(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
+				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -144,8 +145,8 @@ func TestAzureActuator(t *testing.T) {
 			}(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
+				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 2,
@@ -159,8 +160,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3", "zone4", "zone5"})
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
+				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3", "zone4", "zone5"})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -176,8 +177,49 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListResourceSKUs(mockCtrl, client, []string{})
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
+				mockListResourceSKUs(mockCtrl, client, []string{})
+			},
+			expectedMachineSetReplicas: map[string]int64{
+				generateAzureMachineSetName(""): 3, // Non-zoned deployment
+			},
+			expectedLogs: []string{"No availability zones detected for region. Using non-zoned deployment."},
+		},
+		{
+			name:              "getZones: no SKUs in region",
+			clusterDeployment: testAzureClusterDeployment(),
+			pool:              testAzurePool(),
+			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockGetVMCapabilities(mockCtrl, client, "N/A")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
+				page := mockazure.NewMockResourceSKUsPage(mockCtrl)
+				client.EXPECT().ListResourceSKUs(gomock.Any(), testRegion).Return(page, nil)
+				page.EXPECT().NotDone().Return(false)
+			},
+			expectedMachineSetReplicas: map[string]int64{
+				generateAzureMachineSetName(""): 3, // Non-zoned deployment
+			},
+			expectedLogs: []string{"No availability zones detected for region. Using non-zoned deployment."},
+		},
+		{
+			name:              "getZones: no matching SKUs in region",
+			clusterDeployment: testAzureClusterDeployment(),
+			pool:              testAzurePool(),
+			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockGetVMCapabilities(mockCtrl, client, "N/A")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
+				page := mockazure.NewMockResourceSKUsPage(mockCtrl)
+				client.EXPECT().ListResourceSKUs(gomock.Any(), testRegion).Return(page, nil)
+				page.EXPECT().NotDone().Return(true)
+				page.EXPECT().Values().Return(
+					[]azenc.ResourceSku{
+						{
+							Name: ptr.To("not-my-instance-type"),
+						},
+					},
+				)
+				page.EXPECT().NextWithContext(gomock.Any()).Return(nil)
+				page.EXPECT().NotDone().Return(false)
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName(""): 3, // Non-zoned deployment
@@ -190,8 +232,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
+				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -209,8 +251,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockGetVMCapabilities(mockCtrl, client, "V1")
-				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1), testAzureImage(compute.HyperVGenerationTypesV2)})
+				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -228,8 +270,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockGetVMCapabilities(mockCtrl, client, "V1,V2")
-				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1), testAzureImage(compute.HyperVGenerationTypesV2)})
+				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -247,8 +289,8 @@ func TestAzureActuator(t *testing.T) {
 			pool:              testAzurePool(),
 			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
 				mockGetVMCapabilities(mockCtrl, client, "V2")
-				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1), testAzureImage(compute.HyperVGenerationTypesV2)})
+				mockListResourceSKUs(mockCtrl, client, []string{"zone1", "zone2", "zone3"})
 			},
 			expectedMachineSetReplicas: map[string]int64{
 				generateAzureMachineSetName("zone1"): 1,
@@ -290,6 +332,236 @@ func TestAzureActuator(t *testing.T) {
 				Type:      "MarketplaceWithPlan",
 			},
 		},
+		{
+			name:              "getVMCapabilities: no SKUs in region",
+			clusterDeployment: testAzureClusterDeployment(),
+			pool:              testAzurePool(),
+			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				page := mockazure.NewMockResourceSKUsPage(mockCtrl)
+				client.EXPECT().ListResourceSKUs(gomock.Any(), testRegion).Return(page, nil)
+				page.EXPECT().NotDone().Return(false)
+			},
+			expectedErr: "error retrieving VM capabilities: SKU test-instance-type not found in region test-region",
+		},
+		{
+			name:              "getVMCapabilities: no Capabilities in SKU",
+			clusterDeployment: testAzureClusterDeployment(),
+			pool:              testAzurePool(),
+			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				page := mockazure.NewMockResourceSKUsPage(mockCtrl)
+				client.EXPECT().ListResourceSKUs(gomock.Any(), testRegion).Return(page, nil)
+				page.EXPECT().NotDone().Return(true)
+				page.EXPECT().Values().Return(
+					[]azenc.ResourceSku{
+						{
+							ResourceType: ptr.To("virtualMachines"),
+							Name:         ptr.To(testInstanceType),
+						},
+					},
+				)
+			},
+			expectedErr: "error retrieving VM capabilities: SKU test-instance-type has no Capabilities",
+		},
+		{
+			name:              "getVMCapabilities: no matching SKUs in region",
+			clusterDeployment: testAzureClusterDeployment(),
+			pool:              testAzurePool(),
+			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				page := mockazure.NewMockResourceSKUsPage(mockCtrl)
+				client.EXPECT().ListResourceSKUs(gomock.Any(), testRegion).Return(page, nil)
+				page.EXPECT().NotDone().Return(true)
+				page.EXPECT().Values().Return(
+					[]azenc.ResourceSku{
+						{
+							ResourceType: ptr.To("virtualMachines"),
+							Name:         ptr.To("not-my-instance-type"),
+							Capabilities: &[]azenc.ResourceSkuCapabilities{
+								{
+									Name:  ptr.To("HyperVGenerations"),
+									Value: ptr.To("N/A"),
+								},
+							},
+						},
+					},
+				)
+				page.EXPECT().NextWithContext(gomock.Any()).Return(nil)
+				page.EXPECT().NotDone().Return(false)
+			},
+			expectedErr: "error retrieving VM capabilities: SKU test-instance-type not found in region test-region",
+		},
+		{
+			name:              "getVMCapabilities: no virtualMachines in region",
+			clusterDeployment: testAzureClusterDeployment(),
+			pool:              testAzurePool(),
+			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				page := mockazure.NewMockResourceSKUsPage(mockCtrl)
+				client.EXPECT().ListResourceSKUs(gomock.Any(), testRegion).Return(page, nil)
+				page.EXPECT().NotDone().Return(true)
+				page.EXPECT().Values().Return(
+					[]azenc.ResourceSku{
+						{
+							ResourceType: ptr.To("notVirtualMachines"),
+							Name:         ptr.To(testInstanceType),
+							Capabilities: &[]azenc.ResourceSkuCapabilities{
+								{
+									Name:  ptr.To("HyperVGenerations"),
+									Value: ptr.To("N/A"),
+								},
+							},
+						},
+					},
+				)
+				page.EXPECT().NextWithContext(gomock.Any()).Return(nil)
+				page.EXPECT().NotDone().Return(false)
+			},
+			expectedErr: "error retrieving VM capabilities: SKU test-instance-type not found in region test-region",
+		},
+		{
+			name:              "getVMCapabilities: nil ResourceType",
+			clusterDeployment: testAzureClusterDeployment(),
+			pool:              testAzurePool(),
+			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				page := mockazure.NewMockResourceSKUsPage(mockCtrl)
+				client.EXPECT().ListResourceSKUs(gomock.Any(), testRegion).Return(page, nil)
+				page.EXPECT().NotDone().Return(true)
+				page.EXPECT().Values().Return(
+					[]azenc.ResourceSku{
+						{
+							Name: ptr.To(testInstanceType),
+							Capabilities: &[]azenc.ResourceSkuCapabilities{
+								{
+									Name:  ptr.To("HyperVGenerations"),
+									Value: ptr.To("N/A"),
+								},
+							},
+						},
+					},
+				)
+				page.EXPECT().NextWithContext(gomock.Any()).Return(nil)
+				page.EXPECT().NotDone().Return(false)
+			},
+			expectedErr: "error retrieving VM capabilities: SKU test-instance-type not found in region test-region",
+		},
+		{
+			name:              "getVMCapabilities: nil Name",
+			clusterDeployment: testAzureClusterDeployment(),
+			pool:              testAzurePool(),
+			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				page := mockazure.NewMockResourceSKUsPage(mockCtrl)
+				client.EXPECT().ListResourceSKUs(gomock.Any(), testRegion).Return(page, nil)
+				page.EXPECT().NotDone().Return(true)
+				page.EXPECT().Values().Return(
+					[]azenc.ResourceSku{
+						{
+							ResourceType: ptr.To("virtualMachines"),
+							Capabilities: &[]azenc.ResourceSkuCapabilities{
+								{
+									Name:  ptr.To("HyperVGenerations"),
+									Value: ptr.To("N/A"),
+								},
+							},
+						},
+					},
+				)
+				page.EXPECT().NextWithContext(gomock.Any()).Return(nil)
+				page.EXPECT().NotDone().Return(false)
+			},
+			expectedErr: "error retrieving VM capabilities: SKU test-instance-type not found in region test-region",
+		},
+		{
+			name:              "getVMCapabilities: error on initial call",
+			clusterDeployment: testAzureClusterDeployment(),
+			pool:              testAzurePool(),
+			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockazure.NewMockResourceSKUsPage(mockCtrl)
+				client.EXPECT().ListResourceSKUs(gomock.Any(), testRegion).Return(nil, fmt.Errorf("SDK error"))
+			},
+			expectedErr: "error retrieving VM capabilities: error connecting to Azure client: error fetching SKU pages: SDK error",
+		},
+		{
+			name:              "getVMCapabilities: error getting second page",
+			clusterDeployment: testAzureClusterDeployment(),
+			pool:              testAzurePool(),
+			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				page := mockazure.NewMockResourceSKUsPage(mockCtrl)
+				client.EXPECT().ListResourceSKUs(gomock.Any(), testRegion).Return(page, nil)
+				page.EXPECT().NotDone().Return(true)
+				page.EXPECT().Values().Return(
+					[]azenc.ResourceSku{
+						{
+							ResourceType: ptr.To("virtualMachines"),
+							Name:         ptr.To("not-my-instance-type"),
+							Capabilities: &[]azenc.ResourceSkuCapabilities{
+								{
+									Name:  ptr.To("HyperVGenerations"),
+									Value: ptr.To("N/A"),
+								},
+							},
+						},
+					},
+				)
+				page.EXPECT().NextWithContext(gomock.Any()).Return(fmt.Errorf("SDK error"))
+			},
+			expectedErr: "error retrieving VM capabilities: error connecting to Azure client: error fetching SKU pages: SDK error",
+		},
+		{
+			name:              "getImagesByResourceGroup errors on initial call",
+			clusterDeployment: testAzureClusterDeployment(),
+			pool:              testAzurePool(),
+			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockGetVMCapabilities(mockCtrl, client, "N/A")
+				client.EXPECT().ListImagesByResourceGroup(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("SDK error"))
+
+			},
+			expectedErr: "error listing images by resourceGroup: foo-12345-rg: SDK error",
+		},
+		{
+			name:              "getImagesByResourceGroup errors getting second page",
+			clusterDeployment: testAzureClusterDeployment(),
+			pool:              testAzurePool(),
+			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockGetVMCapabilities(mockCtrl, client, "N/A")
+				pages := mockazure.NewMockImageListResultPage(mockCtrl)
+				client.EXPECT().ListImagesByResourceGroup(gomock.Any(), gomock.Any()).Return(pages, nil)
+				pages.EXPECT().NotDone().Return(true)
+				pages.EXPECT().Values().Return([]compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
+				pages.EXPECT().NextWithContext(gomock.Any()).Return(fmt.Errorf("SDK error"))
+			},
+			expectedErr: "error listing images by resourceGroup: foo-12345-rg: SDK error",
+		},
+		{
+			name:              "getZones: error on initial call",
+			clusterDeployment: testAzureClusterDeployment(),
+			pool:              testAzurePool(),
+			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockGetVMCapabilities(mockCtrl, client, "N/A")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
+				mockazure.NewMockResourceSKUsPage(mockCtrl)
+				client.EXPECT().ListResourceSKUs(gomock.Any(), testRegion).Return(nil, fmt.Errorf("SDK error"))
+			},
+			expectedErr: "compute pool not providing list of zones and failed to fetch list of zones: SDK error",
+		},
+		{
+			name:              "getZones: error getting second page",
+			clusterDeployment: testAzureClusterDeployment(),
+			pool:              testAzurePool(),
+			mockAzureClient: func(mockCtrl *gomock.Controller, client *mockazure.MockClient) {
+				mockGetVMCapabilities(mockCtrl, client, "N/A")
+				mockListImagesByResourceGroup(client, []compute.Image{testAzureImage(compute.HyperVGenerationTypesV1)})
+				page := mockazure.NewMockResourceSKUsPage(mockCtrl)
+				client.EXPECT().ListResourceSKUs(gomock.Any(), testRegion).Return(page, nil)
+				page.EXPECT().NotDone().Return(true)
+				page.EXPECT().Values().Return(
+					[]azenc.ResourceSku{
+						{
+							Name: ptr.To("not-my-instance-type"),
+						},
+					},
+				)
+				page.EXPECT().NextWithContext(gomock.Any()).Return(fmt.Errorf("SDK error"))
+			},
+			expectedErr: "compute pool not providing list of zones and failed to fetch list of zones: SDK error",
+		},
 	}
 
 	for _, test := range tests {
@@ -310,8 +582,10 @@ func TestAzureActuator(t *testing.T) {
 
 			generatedMachineSets, _, err := actuator.GenerateMachineSets(test.clusterDeployment, test.pool, actuator.logger)
 
-			if test.expectedErr {
-				assert.Error(t, err, "expected error for test case")
+			if test.expectedErr != "" {
+				if assert.Error(t, err, "expected error for test case") {
+					assert.Contains(t, err.Error(), test.expectedErr, "Error %q did not contain substring %q", err.Error(), test.expectedErr)
+				}
 			} else {
 				assert.NoError(t, err, "unexpected error for test case")
 				validateAzureMachineSets(t, generatedMachineSets, test.expectedMachineSetReplicas, test.expectedImage, test.extraProviderSpecValidation)

--- a/pkg/controller/machinepool/azureactuator_test.go
+++ b/pkg/controller/machinepool/azureactuator_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openshift/hive/pkg/constants"
 
+	azenc "github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -350,10 +351,10 @@ func mockListResourceSKUs(mockCtrl *gomock.Controller, client *mockazure.MockCli
 	client.EXPECT().ListResourceSKUs(gomock.Any(), "").Return(page, nil)
 	page.EXPECT().NotDone().Return(true)
 	page.EXPECT().Values().Return(
-		[]compute.ResourceSku{
+		[]azenc.ResourceSku{
 			{
 				Name: ptr.To(testInstanceType),
-				LocationInfo: &[]compute.ResourceSkuLocationInfo{
+				LocationInfo: &[]azenc.ResourceSkuLocationInfo{
 					{
 						Location: ptr.To(testRegion),
 						Zones:    &zones,


### PR DESCRIPTION
Here we refactor our GetVirtualMachineSku() function to more closely match the modern version of its upstream (installer) counterpart:
- Use a more recent client package for the `List()` call to ensure the `location` filter is available.
- Add the `location` filter to limit the results by region on the server side. This should greatly reduce both the latency and the size (number of pages) of the response.
- Correct the error checking path for the scenario where no SKUs exist in the region. Previously this error was getting swallowed by the loop logic.
- Increase the timeout from 30s to 2m. This may or may not be necessary in light of the filtering improvement.

Note one deviation from the upstream logic: we've removed the section where we were ensuring the result is in the desired region, as this should already be accounted for by the location filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Switched to the newer Azure SKU client, now querying SKUs by region with server-side filtering and a longer timeout for SKU paging.
* **Bug Fixes**
  * More robust VM capability and zone discovery with better handling of missing SKUs, mismatched data, and paging errors.
* **Tests**
  * Expanded test coverage for zoneless deployments, zone-selection failures, pagination, and multiple SKU/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->