### PR TITLE
HIVE-2946: Remove empty vSphere dataDisks from install-config

### DIFF
--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -2034,7 +2034,10 @@ func removeUnsupportedVSphereDataDisks(ic *installertypes.InstallConfig, icData 
 
 	modifiedBytes, err := yamlutils.ApplyPatches(icData, patches)
 	if err != nil {
-		return nil, errors.Wrap(err, "error removing unsupported vSphere dataDisks field from install-config")
+		// Best-effort cleanup to suppress warnings on older payloads.
+		// Aborting the install would be worse than the original warning.
+		log.WithError(err).Warn("failed to remove empty vSphere dataDisks from install-config; proceeding with original data")
+		return icData, nil
 	}
 	return modifiedBytes, nil
 }

--- a/pkg/installmanager/installmanager.go
+++ b/pkg/installmanager/installmanager.go
@@ -1980,7 +1980,63 @@ func (m *InstallManager) pasteInInstallConfigSecrets(cd *hivev1.ClusterDeploymen
 	if err := injectProviderAdditionalBundle(&ic, cd, m.getPlatformCertificateDir(cd)); err != nil {
 		return nil, err
 	}
-	return yaml.Marshal(ic)
+
+	updatedICData, err := yaml.Marshal(ic)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not marshal InstallConfig")
+	}
+
+	updatedICData, err = removeUnsupportedVSphereDataDisks(&ic, updatedICData)
+	if err != nil {
+		return nil, err
+	}
+
+	return updatedICData, nil
+}
+
+// removeUnsupportedVSphereDataDisks strips empty vSphere dataDisks fields that can be
+// added by marshal/unmarshal cycles when using installer types that do not set omitempty.
+// Older installer payloads treat this field as unknown and emit a warning.
+func removeUnsupportedVSphereDataDisks(ic *installertypes.InstallConfig, icData []byte) ([]byte, error) {
+	if ic == nil {
+		return icData, nil
+	}
+
+	patches := make([]hivev1.PatchEntity, 0)
+
+	if ic.ControlPlane != nil && ic.ControlPlane.Platform.VSphere != nil && len(ic.ControlPlane.Platform.VSphere.DataDisks) == 0 {
+		patches = append(patches, hivev1.PatchEntity{
+			Op:   "remove",
+			Path: "/controlPlane/platform/vsphere/dataDisks",
+		})
+	}
+
+	if ic.Arbiter != nil && ic.Arbiter.Platform.VSphere != nil && len(ic.Arbiter.Platform.VSphere.DataDisks) == 0 {
+		patches = append(patches, hivev1.PatchEntity{
+			Op:   "remove",
+			Path: "/arbiter/platform/vsphere/dataDisks",
+		})
+	}
+
+	for i, compute := range ic.Compute {
+		if compute.Platform.VSphere == nil || len(compute.Platform.VSphere.DataDisks) > 0 {
+			continue
+		}
+		patches = append(patches, hivev1.PatchEntity{
+			Op:   "remove",
+			Path: fmt.Sprintf("/compute/%d/platform/vsphere/dataDisks", i),
+		})
+	}
+
+	if len(patches) == 0 {
+		return icData, nil
+	}
+
+	modifiedBytes, err := yamlutils.ApplyPatches(icData, patches)
+	if err != nil {
+		return nil, errors.Wrap(err, "error removing unsupported vSphere dataDisks field from install-config")
+	}
+	return modifiedBytes, nil
 }
 
 func pasteInPullSecret(ic *installertypes.InstallConfig, pullSecretFile string) error {

--- a/pkg/installmanager/installmanager_test.go
+++ b/pkg/installmanager/installmanager_test.go
@@ -28,6 +28,7 @@ import (
 
 	machineapi "github.com/openshift/api/machine/v1beta1"
 	installertypes "github.com/openshift/installer/pkg/types"
+	installertypesvsphere "github.com/openshift/installer/pkg/types/vsphere"
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 	"github.com/openshift/hive/apis/hive/v1/aws"
@@ -816,6 +817,68 @@ func Test_nutanix_injectProviderCredentials(t *testing.T) {
 			assert.Equal(t, string(expected), string(actual), "unexpected InstallConfig output")
 		})
 	}
+}
+
+func Test_removeUnsupportedVSphereDataDisks(t *testing.T) {
+	t.Run("removes empty vSphere dataDisks from compute and controlPlane", func(t *testing.T) {
+		ic := installertypes.InstallConfig{
+			ControlPlane: &installertypes.MachinePool{
+				Name: "master",
+				Platform: installertypes.MachinePoolPlatform{
+					VSphere: &installertypesvsphere.MachinePool{
+						NumCPUs: 4,
+					},
+				},
+			},
+			Compute: []installertypes.MachinePool{
+				{
+					Name: "worker",
+					Platform: installertypes.MachinePoolPlatform{
+						VSphere: &installertypesvsphere.MachinePool{
+							NumCPUs: 2,
+						},
+					},
+				},
+			},
+		}
+
+		icData, err := yaml.Marshal(ic)
+		require.NoError(t, err)
+		require.Contains(t, string(icData), "dataDisks")
+
+		modified, err := removeUnsupportedVSphereDataDisks(&ic, icData)
+		require.NoError(t, err)
+		assert.NotContains(t, string(modified), "dataDisks")
+	})
+
+	t.Run("preserves vSphere dataDisks when explicitly set", func(t *testing.T) {
+		ic := installertypes.InstallConfig{
+			Compute: []installertypes.MachinePool{
+				{
+					Name: "worker",
+					Platform: installertypes.MachinePoolPlatform{
+						VSphere: &installertypesvsphere.MachinePool{
+							NumCPUs: 2,
+							DataDisks: []installertypesvsphere.DataDisk{
+								{
+									Name:    "disk1",
+									SizeGiB: 10,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		icData, err := yaml.Marshal(ic)
+		require.NoError(t, err)
+
+		modified, err := removeUnsupportedVSphereDataDisks(&ic, icData)
+		require.NoError(t, err)
+		assert.Contains(t, string(modified), "dataDisks")
+		assert.Contains(t, string(modified), "disk1")
+	})
 }
 
 func Test_nutanix_injectProviderAdditionalBundle(t *testing.T) {


### PR DESCRIPTION
## Summary
- remove empty vSphere `dataDisks` keys from install-config after install-manager mutates secrets, avoiding unknown-field warnings on older payloads
- keep explicitly configured `dataDisks` intact so newer payload behavior is preserved
- add focused unit tests for both removal and preservation scenarios

## Test plan
- [x] `go test ./pkg/installmanager -run 'Test_removeUnsupportedVSphereDataDisks|Test_pasteInPullSecret'`
- [ ] Run broader Hive CI jobs
- [x] Confirm warning is absent in ACM vSphere 4.18 flow


Made with [Cursor](https://cursor.com)