### PR TITLE
OCPBUGS-85791: Check more errors when copying private image secret

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -2522,7 +2522,21 @@ func (r *ReconcileClusterDeployment) ensurePrivateImagePullSecret(cd *hivev1.Clu
 	src := types.NamespacedName{Name: secretName, Namespace: srcNamespace}
 	dest := types.NamespacedName{Name: secretName, Namespace: destNamespace}
 
-	return controllerutils.CopySecret(r, src, dest, cd, r.scheme)
+	requeue, err := controllerutils.CopySecret(r, src, dest, cd, r.scheme)
+	if err != nil {
+		deleted, err2 := r.namespaceTerminated(cd.Namespace)
+		if deleted {
+			cdLog.Warn("detected deleted namespace; skipping private image pull secret copy")
+			return false, nil
+		}
+		if err2 != nil {
+			cdLog.WithError(err).Warn("Error copying private image pull secret")
+			cdLog.WithError(err2).Warn("Error checking whether target namespace is marked for deletion")
+			return false, errors.Wrapf(err2, "Failed to discover whether namespace %s is marked for deletion", cd.Namespace)
+		}
+		return false, errors.Wrap(err, "Error copying private image pull secret")
+	}
+	return requeue, nil
 }
 
 func configureTrustedCABundleConfigMap(cm *corev1.ConfigMap) bool {
@@ -2569,6 +2583,7 @@ func (r *ReconcileClusterDeployment) ensureTrustedCABundleConfigMap(cd *hivev1.C
 				msg := "Failed to create the trusted CA bundle ConfigMap"
 				if err2 != nil {
 					cdLog.WithError(err).Warn(msg)
+					cdLog.WithError(err2).Warn("Error checking whether target namespace is marked for deletion")
 					return errors.Wrapf(err2, "Failed to discover whether namespace %s is marked for deletion", cd.Namespace)
 				}
 				return errors.Wrap(err, msg)

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller_test.go
@@ -5597,3 +5597,105 @@ func (testReleaseVerifier) Verifiers() map[string]openpgp.EntityList {
 
 func (testReleaseVerifier) AddStore(_ store.Store) {
 }
+
+func TestEnsurePrivateImagePullSecret(t *testing.T) {
+	const (
+		privateSecretName = "hive-private-pull-secret"
+		hiveNamespace     = "hive"
+	)
+
+	cases := []struct {
+		name            string
+		existing        []runtime.Object
+		setEnv          bool
+		expectRequeue   bool
+		expectError     bool
+		expectErrSubstr string
+	}{
+		{
+			name:   "no-op when env var is unset",
+			setEnv: false,
+			existing: []runtime.Object{
+				testEmptyClusterDeployment(),
+			},
+		},
+		{
+			name:   "success when source secret exists",
+			setEnv: true,
+			existing: []runtime.Object{
+				testEmptyClusterDeployment(),
+				testSecretWithNamespace(corev1.SecretTypeDockerConfigJson, privateSecretName, hiveNamespace, ".dockerconfigjson", "{}"),
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}},
+			},
+			expectRequeue: true,
+		},
+		{
+			name:   "copy fails, namespace is terminating",
+			setEnv: true,
+			existing: []runtime.Object{
+				testEmptyClusterDeployment(),
+				// No source secret -> CopySecret will fail
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+					Name:              testNamespace,
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					Finalizers:        []string{"kubernetes"},
+				}},
+			},
+			expectRequeue: false,
+			expectError:   false,
+		},
+		{
+			name:   "copy fails, namespace is active",
+			setEnv: true,
+			existing: []runtime.Object{
+				testEmptyClusterDeployment(),
+				// No source secret -> CopySecret will fail
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}},
+			},
+			expectRequeue:   false,
+			expectError:     true,
+			expectErrSubstr: "Error copying private image pull secret",
+		},
+		{
+			name:   "copy fails, namespace lookup also fails",
+			setEnv: true,
+			existing: []runtime.Object{
+				testEmptyClusterDeployment(),
+				// No source secret -> CopySecret will fail
+				// No namespace object -> namespaceTerminated will also fail
+			},
+			expectRequeue:   false,
+			expectError:     true,
+			expectErrSubstr: "Failed to discover whether namespace",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.setEnv {
+				t.Setenv(constants.HivePrivateImagePullSecret, privateSecretName)
+			} else {
+				t.Setenv(constants.HivePrivateImagePullSecret, "")
+			}
+			t.Setenv("HIVE_NS", hiveNamespace)
+
+			fakeClient := testfake.NewFakeClientBuilder().WithRuntimeObjects(tc.existing...).Build()
+			rcd := &ReconcileClusterDeployment{
+				Client:          fakeClient,
+				scheme:          scheme.GetScheme(),
+				sharedPodConfig: &controllerutils.SharedPodConfig{},
+			}
+			cd := testEmptyClusterDeployment()
+			cdLog := log.WithField("test", tc.name)
+
+			requeue, err := rcd.ensurePrivateImagePullSecret(cd, cdLog)
+			if tc.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectErrSubstr)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expectRequeue, requeue)
+		})
+	}
+}


### PR DESCRIPTION
xref OCPBUGS-85791

/assign @suhanime 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved private image pull secret reconciliation for terminating target namespaces by safely skipping copy failures while preserving the helper’s requeue behavior.
  * Refined warning logging when namespace deletion checks fail during trusted CA bundle config map reconciliation.
* **Tests**
  * Added table-driven unit tests for private image pull secret behavior (env unset, copy success, copy failure with terminating/active namespaces, and termination check discovery failures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->