### PR TITLE
OCPBUGS-86058: warn about Authentication CR key naming requirement for STS provisioning

### DIFF
--- a/docs/aws-sts-provisioning.md
+++ b/docs/aws-sts-provisioning.md
@@ -46,14 +46,80 @@ Create a ClusterDeployment normally with the following changes:
   ```
   kubectl create secret generic bound-service-account-signing-key --from-file=bound-service-account-signing-key.key=_output/serviceaccount-signer.private
   ```
-  1. Create a Secret for your installer manifests (credential role Secrets, Authentication config)
+  1. Create a Secret for your installer manifests (credential role Secrets, Authentication config).
+  The recommended approach is `--from-file` pointed at the `ccoctl` output directory, which
+  automatically preserves the original filenames as secret keys:
   ```
   kubectl create secret generic cluster-manifests --from-file=_output/manifests/
   ```
+
+  > **WARNING: Authentication CR key name requirement**
+  >
+  > The secret key for the Authentication CR **must** be exactly
+  > `cluster-authentication-02-config.yaml`. During bootstrap, the
+  > kube-apiserver render step reads this manifest from a hardcoded path
+  > (`/assets/manifests/cluster-authentication-02-config.yaml`). If the
+  > key name in the manifest secret differs from this, the file will not
+  > be found and the kube-apiserver will silently start with the default
+  > `serviceAccountIssuer` (`https://kubernetes.default.svc`) instead of
+  > your custom S3 OIDC issuer. This causes `machine-api-controllers` to
+  > receive tokens with the wrong issuer, and AWS STS rejects them with
+  > `InvalidIdentityToken: Token issuer does not match provider`. Workers
+  > will never provision and the install will time out.
+  >
+  > Using `--from-file=_output/manifests/` as shown above preserves the
+  > canonical filename automatically. If you create the secret manually
+  > (e.g. with `stringData` in YAML), ensure the Authentication CR entry
+  > uses the key `cluster-authentication-02-config.yaml`.
+  >
+  > Other credential manifests (operator Secrets for machine-api, ingress,
+  > image-registry, etc.) are not affected by this requirement — they are
+  > applied by their Kubernetes GVK and content, not by filename.
+
   1. In your InstallConfig set `credentialsMode: Manual`
   1. In your ClusterDeployment set `spec.boundServiceAccountSigningKeySecretRef.name` to point to the Secret created above (`bound-service-account-signing-key`).
   1. In your ClusterDeployment set `spec.provisioning.manifestsSecretRef` to point to the Secret created above (`cluster-manifests`).
   1. Create your ClusterDeployment + InstallConfig to provision your STS cluster.
+
+## Troubleshooting
+
+### Install times out with `InvalidIdentityToken`
+
+If your STS cluster install times out and `machine-api-controllers` logs show:
+
+```
+error assuming role: InvalidIdentityToken: Token issuer does not match provider
+```
+
+The kube-apiserver is likely using the default `serviceAccountIssuer` instead of your custom S3 OIDC issuer.
+
+**Check the issuer on the running cluster:**
+
+```bash
+oc get authentication cluster -o jsonpath='{.spec.serviceAccountIssuer}'
+```
+
+If this returns your S3 OIDC URL (e.g. `https://<name>-oidc.s3.<region>.amazonaws.com`) but the
+kube-apiserver started with `https://kubernetes.default.svc`, the Authentication CR manifest was
+not picked up during bootstrap.
+
+**Verify the manifest secret key names:**
+
+```bash
+oc get secret cluster-manifests -n <namespace> -o jsonpath='{range .data}{@.key}{"\n"}{end}'
+```
+
+Look for `cluster-authentication-02-config.yaml` as an exact key name. If the Authentication CR
+is stored under a different key (e.g. `00-cluster-authentication-config.yaml` or
+`authentication.yaml`), recreate the secret with the correct key name.
+
+The simplest fix is to recreate the manifest secret using `--from-file` pointed at the `ccoctl`
+output directory:
+
+```bash
+oc delete secret cluster-manifests -n <namespace>
+oc create secret generic cluster-manifests -n <namespace> --from-file=_output/manifests/
+```
 
 ## Note: Cleanup AWS resources after uninstalling the cluster
 Make sure you clean up the following resources after you uninstall your cluster. To delete resources created by ccoctl, run

--- a/docs/aws-sts-provisioning.md
+++ b/docs/aws-sts-provisioning.md
@@ -47,34 +47,14 @@ Create a ClusterDeployment normally with the following changes:
   kubectl create secret generic bound-service-account-signing-key --from-file=bound-service-account-signing-key.key=_output/serviceaccount-signer.private
   ```
   1. Create a Secret for your installer manifests (credential role Secrets, Authentication config).
-  The recommended approach is `--from-file` pointed at the `ccoctl` output directory, which
-  automatically preserves the original filenames as secret keys:
+  Use `--from-file` pointed at the `ccoctl` output directory to preserve original filenames as secret keys:
   ```
   kubectl create secret generic cluster-manifests --from-file=_output/manifests/
   ```
 
-  > **WARNING: Authentication CR key name requirement**
-  >
-  > The secret key for the Authentication CR **must** be exactly
-  > `cluster-authentication-02-config.yaml`. During bootstrap, the
-  > kube-apiserver render step reads this manifest from a hardcoded path
-  > (`/assets/manifests/cluster-authentication-02-config.yaml`). If the
-  > key name in the manifest secret differs from this, the file will not
-  > be found and the kube-apiserver will silently start with the default
-  > `serviceAccountIssuer` (`https://kubernetes.default.svc`) instead of
-  > your custom S3 OIDC issuer. This causes `machine-api-controllers` to
-  > receive tokens with the wrong issuer, and AWS STS rejects them with
-  > `InvalidIdentityToken: Token issuer does not match provider`. Workers
-  > will never provision and the install will time out.
-  >
-  > Using `--from-file=_output/manifests/` as shown above preserves the
-  > canonical filename automatically. If you create the secret manually
-  > (e.g. with `stringData` in YAML), ensure the Authentication CR entry
-  > uses the key `cluster-authentication-02-config.yaml`.
-  >
-  > Other credential manifests (operator Secrets for machine-api, ingress,
-  > image-registry, etc.) are not affected by this requirement — they are
-  > applied by their Kubernetes GVK and content, not by filename.
+  > **WARNING:** Altering the original manifest filenames can cause
+  > [silent install failures](#install-times-out-with-invalididentitytoken).
+  > Use `--from-file=<dir>` as shown above.
 
   1. In your InstallConfig set `credentialsMode: Manual`
   1. In your ClusterDeployment set `spec.boundServiceAccountSigningKeySecretRef.name` to point to the Secret created above (`bound-service-account-signing-key`).
@@ -87,11 +67,22 @@ Create a ClusterDeployment normally with the following changes:
 
 If your STS cluster install times out and `machine-api-controllers` logs show:
 
-```
+```text
 error assuming role: InvalidIdentityToken: Token issuer does not match provider
 ```
 
-The kube-apiserver is likely using the default `serviceAccountIssuer` instead of your custom S3 OIDC issuer.
+This typically means the Authentication CR manifest was not picked up during bootstrap.
+
+The secret key for the Authentication CR **must** be exactly
+`cluster-authentication-02-config.yaml`. During bootstrap, the kube-apiserver render step reads
+this manifest from a hardcoded path (`/assets/manifests/cluster-authentication-02-config.yaml`).
+If the key name in the manifest secret differs, the file will not be found and the kube-apiserver
+silently starts with the default `serviceAccountIssuer` (`https://kubernetes.default.svc`)
+instead of your custom S3 OIDC issuer. Tokens issued with the wrong issuer are rejected by AWS
+STS, workers never provision, and the install times out.
+
+Other credential manifests (operator Secrets for machine-api, ingress, image-registry, etc.) are
+not affected — they are applied by their Kubernetes GVK and content, not by filename.
 
 **Check the issuer on the running cluster:**
 
@@ -101,12 +92,12 @@ oc get authentication cluster -o jsonpath='{.spec.serviceAccountIssuer}'
 
 If this returns your S3 OIDC URL (e.g. `https://<name>-oidc.s3.<region>.amazonaws.com`) but the
 kube-apiserver started with `https://kubernetes.default.svc`, the Authentication CR manifest was
-not picked up during bootstrap.
+not loaded during bootstrap.
 
 **Verify the manifest secret key names:**
 
 ```bash
-oc get secret cluster-manifests -n <namespace> -o jsonpath='{range .data}{@.key}{"\n"}{end}'
+oc get secret cluster-manifests -n <namespace> -o go-template='{{range $k, $v := .data}}{{$k}}{{"\n"}}{{end}}'
 ```
 
 Look for `cluster-authentication-02-config.yaml` as an exact key name. If the Authentication CR


### PR DESCRIPTION
## Summary

Clarify the manifest secret key naming requirement for the Authentication CR
when provisioning AWS STS/IRSA clusters via Hive.

When Hive extracts `manifestsSecretRef` entries into the installer's manifest
directory, each secret key becomes the filename on disk. The kube-apiserver
bootstrap render step reads the Authentication CR from a hardcoded path:

```
--cluster-auth-file=/assets/manifests/cluster-authentication-02-config.yaml
```

If the secret key doesn't match this exact filename, the bootstrap kube-apiserver
silently starts with the default `serviceAccountIssuer`
(`https://kubernetes.default.svc`) instead of the custom S3 OIDC issuer. This
causes `machine-api-controllers` to receive tokens with the wrong issuer, and
AWS STS rejects them with `InvalidIdentityToken`. Workers never provision and
the install times out.

Other credential manifests (operator Secrets) are not affected — they are
applied by GVK/content, not by filename. Only the Authentication CR has this
filename dependency.

## Changes

- Added a WARNING callout in the "Create Hive ClusterDeployment" section
  about the required key name `cluster-authentication-02-config.yaml`
- Expanded manifest secret creation guidance with `--from-file` as the
  recommended approach (preserves canonical filenames automatically)
- Added a Troubleshooting section for the common `InvalidIdentityToken`
  failure mode with diagnostic steps and remediation

## Why this matters

A customer experienced repeated STS install timeouts because their
`manifestsSecretRef` used a non-canonical key name for the Authentication CR.
The fix was simply using the correct key name — no code change required.
This documentation change prevents the same misconfiguration for future users.

## Technical detail

The hardcoded filename expectation exists in:
- `installer/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template`:
  `--cluster-auth-file=/assets/manifests/cluster-authentication-02-config.yaml`
- `cluster-kube-apiserver-operator/pkg/cmd/render/render.go`:
  `--cluster-auth-file` flag with silent `os.IsNotExist` handling


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified AWS STS provisioning steps, including creating the installer-manifests Secret from generated installer output
  * Added a prominent warning about required Authentication manifest presence and exact key naming to ensure token issuer validation
  * Added troubleshooting for install timeouts with invalid identity tokens, plus diagnostic commands and guidance to recreate the manifest Secret
<!-- end of auto-generated comment: release notes by coderabbit.ai -->