### PR TITLE
HIVE-3148: Adding TEST_TAG so we can group/filter tests 

### DIFF
--- a/test/ote/cmd/extension/main.go
+++ b/test/ote/cmd/extension/main.go
@@ -53,6 +53,9 @@ func main() {
 	if limit := limitTests(); limit != nil {
 		selectFns = append(selectFns, limit)
 	}
+	if fn := tagTests(); fn != nil {
+		selectFns = append(selectFns, fn)
+	}
 	specs, err := g.BuildExtensionTestSpecsFromOpenShiftGinkgoSuite(selectFns...)
 	if err != nil {
 		panic(fmt.Sprintf("couldn't build extension test specs from ginkgo: %+v", err.Error()))
@@ -180,5 +183,15 @@ func shardTests() et.SelectFunction {
 		mine := position%total == index
 		position++
 		return mine
+	}
+}
+
+func tagTests() et.SelectFunction {
+	tag := os.Getenv("TEST_TAG")
+	if tag == "" {
+		return nil
+	}
+	return func(spec *et.ExtensionTestSpec) bool {
+		return strings.Contains(spec.Name, tag)
 	}
 }

--- a/test/ote/cmd/extension/main.go
+++ b/test/ote/cmd/extension/main.go
@@ -47,15 +47,16 @@ func main() {
 	})
 
 	selectFns := []et.SelectFunction{hiveTestsOnly()}
+	if fn := tagTests(); fn != nil {
+		selectFns = append(selectFns, fn)
+	}
 	if shard := shardTests(); shard != nil {
 		selectFns = append(selectFns, shard)
 	}
 	if limit := limitTests(); limit != nil {
 		selectFns = append(selectFns, limit)
 	}
-	if fn := tagTests(); fn != nil {
-		selectFns = append(selectFns, fn)
-	}
+
 	specs, err := g.BuildExtensionTestSpecsFromOpenShiftGinkgoSuite(selectFns...)
 	if err != nil {
 		panic(fmt.Sprintf("couldn't build extension test specs from ginkgo: %+v", err.Error()))

--- a/test/ote/hive/hive_util.go
+++ b/test/ote/hive/hive_util.go
@@ -652,6 +652,15 @@ func (sub *subscription) create(oc *exutil.CLI) {
 
 // Create subscription for Hive if not exist and wait for resource is ready
 func (sub *subscription) createIfNotExist(oc *exutil.CLI) {
+	// If hive-operator is already deployed (e.g. via CI deploy-hive step using kustomize),
+	// skip OLM subscription creation to avoid overwriting the pre-deployed image.
+	deployOutput, _ := oc.AsAdmin().WithoutNamespace().Run("get").Args("deployment", "hive-operator", "-n", sub.namespace).Output()
+	if !strings.Contains(deployOutput, "NotFound") && !strings.Contains(deployOutput, "not found") {
+		e2e.Logf("hive-operator deployment already exists, skipping OLM subscription creation.")
+		newCheck("expect", "get", asAdmin, withoutNamespace, compare, "Running", ok, 5*DefaultTimeout, []string{"pod", "--selector=control-plane=hive-operator", "-n",
+			sub.namespace, "-o=jsonpath={.items[0].status.phase}"}).check(oc)
+		return
+	}
 
 	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("sub", "-n", sub.namespace).Output()
 	if strings.Contains(output, "NotFound") || strings.Contains(output, "No resources") || err != nil {


### PR DESCRIPTION
By introducing TEST_TAG as an environment variable in the release CI configuration, we can group and selectively run Hive tests. This removes the dependency on the private repo for test execution. Instead, periodic jobs in the openshift/release repo can be configured to run Hive tests based on tags, enabling better test organization and scalability (including sharding if needed).

This PR also ensures that when deploying Hive via $IMG from the latest commit in the release repo, the Hive operator version is not unintentionally updated. This behavior was already validated earlier through a merged PR in the private repository.

With this change, most private-repo-based test cases can be deprecated, as periodic jobs in the release repo will handle coverage going forward. A working validation using a fork and PR ([example](https://github.com/openshift/release/pull/79036)) confirms that tests can be filtered using TEST_TAG (e.g., export TEST_TAG=HiveSDRosa) and executed .
Co-authored: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added environment-driven test selection capability for enhanced test filtering.

* **Chores**
  * Improved deployment initialization with existence verification logic to optimize operator setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->