### PR TITLE
HIVE-2881: skip unstable flaky tests for now

### DIFF
--- a/test/ote/hive/hive_aws.go
+++ b/test/ote/hive/hive_aws.go
@@ -3487,7 +3487,7 @@ spec:
 
 	// Author: fxie@redhat.com mihuang@redhat.com
 	// ./bin/extended-platform-tests run all --dry-run|grep "41212"|./bin/extended-platform-tests run --timeout 80m -f -
-	g.It("[Level0] Author:fxie-NonHyperShiftHOST-Longduration-NonPreRelease-ConnectedOnly-High-41212-High-43751-Medium-57403-[HiveSDRosa] [AWSGov] Hive supports to install private cluster [Disruptive]", func() {
+	g.XIt("[Level0] Author:fxie-NonHyperShiftHOST-Longduration-NonPreRelease-ConnectedOnly-High-41212-High-43751-Medium-57403-[HiveSDRosa] [AWSGov] Hive supports to install private cluster [Disruptive]", func() {
 		// Settings
 		var (
 			testCaseID = "41212"
@@ -6521,7 +6521,7 @@ spec:
 
 	//author: mihuang@redhat.com
 	//example: ./bin/extended-platform-tests run all --dry-run|grep "40825"|./bin/extended-platform-tests run --timeout 60m -f -
-	g.It("[Level0] Author:mihuang-NonHyperShiftHOST-Longduration-NonPreRelease-ConnectedOnly-High-40825-[HiveSDRosa] Support AWS AssumeRole credentials cluster. [Disruptive]", func() {
+	g.XIt("[Level0] Author:mihuang-NonHyperShiftHOST-Longduration-NonPreRelease-ConnectedOnly-High-40825-[HiveSDRosa] Support AWS AssumeRole credentials cluster. [Disruptive]", func() {
 		testCaseID := "40825"
 		cdName := "cluster-" + testCaseID + "-" + getRandomString()[:ClusterSuffixLen]
 		randomSuffix := getRandomString()[:3]


### PR DESCRIPTION
There are two tests which are not passing , but failing at bootstrap , if we can skip them for now , that would help us with the stable signal rosa job using OTE.I am unable to fix the tests for now , also they are longduration.

@2uasimojo 

Added [Jira](https://redhat.atlassian.net/browse/HIVE-3165) to keep track.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled test cases for AWS Hive private cluster installation and AWS AssumeRole credentials configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->