### PR TITLE
OCPBUGS-85813: Ignore unset snowflake fields for fake CDs

### DIFF
--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -1155,9 +1155,7 @@ func (r *ReconcileClusterDeployment) retrofitMetadataJSON(cd *hivev1.ClusterDepl
 			CloudName:                   installertypesazure.CloudEnvironment(cd.Spec.Platform.Azure.CloudName),
 		}
 		if p := cdMetadata.Platform.Azure; p != nil && p.ResourceGroupName != nil {
-			iMetadata.Azure = &installertypesazure.Metadata{
-				ResourceGroupName: *p.ResourceGroupName,
-			}
+			iMetadata.Azure.ResourceGroupName = *p.ResourceGroupName
 		}
 	case cd.Spec.Platform.GCP != nil:
 		// The project ID is embedded in the credentials.
@@ -2300,7 +2298,10 @@ func generateDeprovision(cd *hivev1.ClusterDeployment) (*hivev1.ClusterDeprovisi
 	case cd.Spec.Platform.AWS != nil:
 		// If we haven't discovered the HostedZoneRole yet, fail
 		hzrp := controllerutils.AWSHostedZoneRole(cd)
-		if hzrp == nil {
+		// OCPBUGS-85813: Fake CDs set ClusterMetadata in two phases. In rare race conditions, if
+		// the CD is deleted between those phases, this field can be unset in this code path. It's
+		// safe to ignore it for fake clusters.
+		if hzrp == nil && !controllerutils.IsFakeCluster(cd) {
 			return nil, errors.New("AWS HostedZoneRole unset in ClusterMetadata; refusing to deprovision.")
 		}
 		req.Spec.Platform.AWS = &hivev1.AWSClusterDeprovision{
@@ -2312,7 +2313,10 @@ func generateDeprovision(cd *hivev1.ClusterDeployment) (*hivev1.ClusterDeprovisi
 	case cd.Spec.Platform.Azure != nil:
 		// If we haven't discovered the ResourceGroupName yet, fail
 		rg, err := controllerutils.AzureResourceGroup(cd)
-		if err != nil {
+		// OCPBUGS-85813: Fake CDs set ClusterMetadata in two phases. In rare race conditions, if
+		// the CD is deleted between those phases, this field can be unset in this code path. It's
+		// safe to ignore it for fake clusters.
+		if err != nil && !controllerutils.IsFakeCluster(cd) {
 			return nil, err
 		}
 		req.Spec.Platform.Azure = &hivev1.AzureClusterDeprovision{
@@ -2324,7 +2328,10 @@ func generateDeprovision(cd *hivev1.ClusterDeployment) (*hivev1.ClusterDeprovisi
 	case cd.Spec.Platform.GCP != nil:
 		// If we haven't discovered the NetworkProjectID yet, fail
 		npid := controllerutils.GCPNetworkProjectID(cd)
-		if npid == nil {
+		// OCPBUGS-85813: Fake CDs set ClusterMetadata in two phases. In rare race conditions, if
+		// the CD is deleted between those phases, this field can be unset in this code path. It's
+		// safe to ignore it for fake clusters.
+		if npid == nil && !controllerutils.IsFakeCluster(cd) {
 			return nil, errors.New("GCP NetworkProjectID unset it ClusterMetadata; refusing to deprovision.")
 		}
 		req.Spec.Platform.GCP = &hivev1.GCPClusterDeprovision{


### PR DESCRIPTION
**Background:**

Installer sometimes needs to add fields to the schema of metadata.json. This used to be hard for hive to deal with, as it needs to straddle OCP versions. We made it extensible-for-free via [HIVE-2302](https://redhat.atlassian.net/browse/HIVE-2302) / #2729 by carrying metadata.json opaquely through from provision to deprovision.

However, fake clusters were tricky. The reasons are complex, but it stems from the fact that we generate their metadata without platform specificity because we don't have that information plumbed in at that stage; and installer's participation in the fake cluster flow doesn't include spoofing the metadata at this time. As a result, we have some snowflake code paths that try to retrofit the metadata after the initial (generic) generation.

**The Bug:**

In a tight race, if the CD was deleted in between these two phases of populatiing the fake cluster's metadata, the clusterdeployment controller would refuse to proceed with deprovisioning due to the absence of the values ordinarily populated as described above. The symptom to the user was simply that the CD would remain extant, appearing to still be Provisioning. The hive-controllers logs would show an error like:

```
time="2026-06-15T16:41:29.697Z" level=error msg="Reconciler error" controller=clusterdeployment-controller error="AWS HostedZoneRole unset in ClusterMetadata; refusing to deprovision." name=efried-ds6 namespace=fakewedge object=fakewedge/efried-ds6 reconcileID=49ab3f75-a7dc-42ed-a69d-e60031207ce8
```

**The Workaround:**

Setting `cd.spec.preserveOnDelete: true` causes the clusterdeployment controller to skip the offending code path entirely and let it be garbage collected. Note that this does skip the usual deprovision flow that triggers even for fake clusters. But there's no harm done, as there isn't (or shouldn't be!) any real infrastructure to leak.

**The Fix:**

More snowflake code: The absence of the extra metadata values is now ignored specifically and exclusively for fake CDs.

I should mention that I did spend the better part of a day trying to fix this "properly" by spoofing the metadata
- in one step instead of two
- more completely at the outset
- during the offending deprovision code path

...but it was not fated to be.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Azure cluster metadata preservation during metadata updates.
  * Improved cluster deprovisioning to properly handle test deployments with incomplete metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->