### PR TITLE
Add omitempty to HibernationConfig json tag

### DIFF
--- a/apis/hive/v1/clusterpool_types.go
+++ b/apis/hive/v1/clusterpool_types.go
@@ -91,7 +91,7 @@ type ClusterPoolSpec struct {
 
 	// HibernationConfig configures the hibernation/resume behavior of ClusterDeployments owned by the ClusterPool.
 	// +optional
-	HibernationConfig *HibernationConfig `json:"hibernationConfig"`
+	HibernationConfig *HibernationConfig `json:"hibernationConfig,omitempty"`
 
 	// Inventory maintains a list of entries consumed by the ClusterPool
 	// to customize the default ClusterDeployment.

--- a/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/clusterpool_types.go
@@ -91,7 +91,7 @@ type ClusterPoolSpec struct {
 
 	// HibernationConfig configures the hibernation/resume behavior of ClusterDeployments owned by the ClusterPool.
 	// +optional
-	HibernationConfig *HibernationConfig `json:"hibernationConfig"`
+	HibernationConfig *HibernationConfig `json:"hibernationConfig,omitempty"`
 
 	// Inventory maintains a list of entries consumed by the ClusterPool
 	// to customize the default ClusterDeployment.


### PR DESCRIPTION
- Add `omitempty` to `ClusterPoolSpec.HibernationConfig` JSON tag for consistency with other optional fields in `clusterpool_types.go`
- Sync vendored copy under `vendor/github.com/openshift/hive/apis`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON output for cluster pool settings so empty hibernation configuration is no longer included when it isn’t set.
  * This makes exported configuration cleaner and avoids showing blank fields in responses or manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->