### PR TITLE
HIVE-3171: Network Policies: Phase 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ endif
 # v{major}.{minor}.{commitcount}-{sha}
 SOURCE_GIT_TAG := $(shell hack/version2.sh)
 
-BINDATA_INPUTS :=./config/sharded_controllers/... ./config/hiveadmission/... ./config/controllers/... ./config/rbac/... ./config/configmaps/...
+BINDATA_INPUTS :=./config/sharded_controllers/... ./config/hiveadmission/... ./config/controllers/... ./config/netpol/... ./config/rbac/... ./config/configmaps/...
 $(call add-bindata,operator,$(BINDATA_INPUTS),,assets,pkg/operator/assets/bindata.go)
 
 IMAGE_BUILD_EXTRA_FLAGS := --build-arg BASE_IMAGE=$(BASE_IMAGE) --build-arg EL8_BUILD_IMAGE=$(EL8_BUILD_IMAGE) --build-arg EL9_BUILD_IMAGE=$(EL9_BUILD_IMAGE)

--- a/config/controllers/deployment.yaml
+++ b/config/controllers/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
+    hive.openshift.io/component: hive-controllers
 spec:
   selector:
     matchLabels:
@@ -20,6 +21,7 @@ spec:
       labels:
         control-plane: controller-manager
         controller-tools.k8s.io: "1.0"
+        hive.openshift.io/component: hive-controllers
     spec:
       serviceAccountName: hive-controllers
       volumes:

--- a/config/controllers/hive_controllers_role.yaml
+++ b/config/controllers/hive_controllers_role.yaml
@@ -99,3 +99,15 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/config/hiveadmission/deployment.yaml
+++ b/config/hiveadmission/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     app: hiveadmission
     hiveadmission: "true"
+    hive.openshift.io/component: hiveadmission
 spec:
   replicas: 2
   selector:
@@ -24,6 +25,7 @@ spec:
       labels:
         app: hiveadmission
         hiveadmission: "true"
+        hive.openshift.io/component: hiveadmission
     spec:
       serviceAccountName: hiveadmission
       containers:

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -18,9 +18,10 @@ namespace: hive
 # YAML string, with resources separated by document
 # markers ("---").
 #
-# This kustomize configuration mimic's what is deployed by OLM, essentially *only* what is required
+# This kustomize configuration mimics what is deployed by OLM, essentially *only* what is required
 # for the hive-operator.
 resources:
 - ./operator/operator_role.yaml
 - ./operator/operator_role_binding.yaml
 - ./operator/operator_deployment.yaml
+- ./operator/operator_netpol.yaml

--- a/config/netpol/hive-controllers.yaml
+++ b/config/netpol/hive-controllers.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hive-controllers
+  annotations:
+    hive.openshift.io/netpol-description: "Network policy for all hive controllers, including clustersync and machinepool. These must allow egress to the APIServer and cloud providers. Since we can't identify hostNetwork pods for the former, or specific targets for the latter, we must allow all egress. Ingress must be available from the APIServer for liveness probes; so, similarly, we must allow all ingress."
+spec:
+  egress:
+  - {}
+  ingress:
+  - {}
+  podSelector:
+    matchExpressions:
+      - key: hive.openshift.io/component
+        operator: In
+        values:
+        - hive-controllers
+        - hive-clustersync
+        - hive-machinepool
+  policyTypes:
+  - Egress
+  - Ingress

--- a/config/netpol/hiveadmission.yaml
+++ b/config/netpol/hiveadmission.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hiveadmission
+  annotations:
+    hive.openshift.io/netpol-description: "Network policy for hiveadmission needs both egress to and ingress from the APIServer. Since we can't identify hostNetwork pods, we must allow all."
+spec:
+  egress:
+  - {}
+  ingress:
+  - {}
+  podSelector:
+    matchLabels:
+      hive.openshift.io/component: hiveadmission
+  policyTypes:
+  - Egress
+  - Ingress

--- a/config/operator/operator_deployment.yaml
+++ b/config/operator/operator_deployment.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     control-plane: hive-operator
     controller-tools.k8s.io: "1.0"
+    hive.openshift.io/component: hive-operator
 spec:
   selector:
     matchLabels:
@@ -25,6 +26,7 @@ spec:
       labels:
         control-plane: hive-operator
         controller-tools.k8s.io: "1.0"
+        hive.openshift.io/component: hive-operator
     spec:
       serviceAccountName: hive-operator
       volumes:

--- a/config/operator/operator_netpol.yaml
+++ b/config/operator/operator_netpol.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hive-operator
+  annotations:
+    hive.openshift.io/netpol-description: "Network policy for hive-operator must allow egress to the APIServer. Since we can't identify hostNetwork pods, we must allow all egress."
+spec:
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      hive.openshift.io/component: hive-operator
+  policyTypes:
+  - Egress

--- a/config/operator/operator_role.yaml
+++ b/config/operator/operator_role.yaml
@@ -236,3 +236,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/config/sharded_controllers/statefulset.yaml
+++ b/config/sharded_controllers/statefulset.yaml
@@ -19,6 +19,7 @@ spec:
       labels:
         control-plane: {{.ControllerName}}
         controller-tools.k8s.io: "1.0"
+        hive.openshift.io/component: hive- {{- .ControllerName}}
     spec:
       topologySpreadConstraints: # this forces the pods to be on separate nodes.
       - maxSkew: 1

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -10830,6 +10830,18 @@ objects:
           - get
           - list
           - watch
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - networkpolicies
+        verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
     metadata:
@@ -10848,6 +10860,7 @@ objects:
       labels:
         control-plane: hive-operator
         controller-tools.k8s.io: "1.0"
+        hive.openshift.io/component: hive-operator
       name: hive-operator
     spec:
       replicas: 1
@@ -10863,6 +10876,7 @@ objects:
           labels:
             control-plane: hive-operator
             controller-tools.k8s.io: "1.0"
+            hive.openshift.io/component: hive-operator
         spec:
           containers:
             - command:

--- a/pkg/controller/clusterdeployment/clusterdeployment_controller.go
+++ b/pkg/controller/clusterdeployment/clusterdeployment_controller.go
@@ -19,6 +19,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -526,6 +527,27 @@ func generateOwnershipUniqueKeys(owner hivev1.MetaRuntimeObject) []*controllerut
 				constants.SecretTypeLabel:            constants.SecretTypeKubeAdminCreds,
 			},
 			Controlled: false,
+		},
+		{
+			TypeToList: &networkingv1.NetworkPolicyList{},
+			LabelSelector: map[string]string{
+				constants.JobTypeLabel: constants.JobTypeImageSet,
+			},
+			Controlled: true,
+		},
+		{
+			TypeToList: &networkingv1.NetworkPolicyList{},
+			LabelSelector: map[string]string{
+				constants.JobTypeLabel: constants.JobTypeDeprovision,
+			},
+			Controlled: true,
+		},
+		{
+			TypeToList: &networkingv1.NetworkPolicyList{},
+			LabelSelector: map[string]string{
+				constants.JobTypeLabel: constants.JobTypeProvision,
+			},
+			Controlled: true,
 		},
 	}
 }
@@ -1444,6 +1466,23 @@ func (r *ReconcileClusterDeployment) resolveInstallerImage(cd *hivev1.ClusterDep
 	case apierrors.IsNotFound(err):
 		if areImagesResolved {
 			return nil, r.updateCondition(cd, hivev1.InstallImagesNotResolvedCondition, corev1.ConditionFalse, imagesResolvedReason, imagesResolvedMsg, cdLog)
+		}
+
+		// NOTE: For strict idempotence, we could requeue if the first return is true,
+		// but there's no real benefit and it's more efficient to keep rolling.
+		_, err := controllerutils.EnsureNetworkPolicy(
+			r,
+			r.scheme,
+			constants.JobTypeImageSet,
+			cd,
+			cdLog,
+			// No ingress
+			nil,
+			// Allow all egress (talk to apiserver)
+			[]networkingv1.NetworkPolicyEgressRule{{}},
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to ensure network policy for imageset job")
 		}
 
 		job := imageset.GenerateImageSetJob(cd, releaseImage, controllerutils.InstallServiceAccountName,

--- a/pkg/controller/clusterdeployment/clusterprovisions.go
+++ b/pkg/controller/clusterdeployment/clusterprovisions.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -137,6 +138,23 @@ func (r *ReconcileClusterDeployment) startNewProvision(
 	if err := controllerutils.SetupClusterInstallServiceAccount(r, cd.Namespace, logger); err != nil {
 		logger.WithError(err).Log(controllerutils.LogLevel(err), "error setting up service account and role")
 		return reconcile.Result{}, err
+	}
+
+	// NOTE: For strict idempotence, we could requeue if the first return is true,
+	// but there's no real benefit and it's more efficient to keep rolling.
+	_, err = controllerutils.EnsureNetworkPolicy(
+		r,
+		r.scheme,
+		constants.JobTypeProvision,
+		cd,
+		logger,
+		// No ingress
+		nil,
+		// Allow all egress (talk to apiserver & cloud provider)
+		[]networkingv1.NetworkPolicyEgressRule{{}},
+	)
+	if err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "failed to ensure network policy for provision job")
 	}
 
 	provisionName := apihelpers.GetResourceName(cd.Name, fmt.Sprintf("%d-%s", cd.Status.InstallRestarts, utilrand.String(5)))

--- a/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
+++ b/pkg/controller/clusterdeprovision/clusterdeprovision_controller.go
@@ -7,11 +7,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -169,7 +172,7 @@ func (r *ReconcileClusterDeprovision) Reconcile(ctx context.Context, request rec
 	instance := &hivev1.ClusterDeprovision{}
 	err := r.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// Object not found, return.  Created objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers.
 			rLog.Debug("clusterdeprovision not found, skipping")
@@ -295,6 +298,23 @@ func (r *ReconcileClusterDeprovision) Reconcile(ctx context.Context, request rec
 		return reconcile.Result{}, err
 	}
 
+	// NOTE: For strict idempotence, we could requeue if the first return is true,
+	// but there's no real benefit and it's more efficient to keep rolling.
+	_, err = controllerutils.EnsureNetworkPolicy(
+		r,
+		r.scheme,
+		constants.JobTypeDeprovision,
+		cd,
+		rLog,
+		// No ingress
+		nil,
+		// Allow all egress (talk to apiserver & cloud provider)
+		[]networkingv1.NetworkPolicyEgressRule{{}},
+	)
+	if err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "failed to ensure network policy for deprovision job")
+	}
+
 	// Generate an uninstall job
 	rLog.Debug("generating uninstall job")
 	uninstallJob, err := install.GenerateUninstallerJobForDeprovision(instance,
@@ -334,7 +354,7 @@ func (r *ReconcileClusterDeprovision) Reconcile(ctx context.Context, request rec
 	// Check if uninstall job already exists:
 	existingJob := &batchv1.Job{}
 	err = r.Get(context.TODO(), types.NamespacedName{Name: uninstallJob.Name, Namespace: uninstallJob.Namespace}, existingJob)
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && apierrors.IsNotFound(err) {
 		rLog.Debug("uninstall job does not exist, creating it")
 		err = r.Create(context.TODO(), uninstallJob)
 		if err != nil {

--- a/pkg/controller/utils/netpols.go
+++ b/pkg/controller/utils/netpols.go
@@ -1,0 +1,83 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/openshift/hive/apis/helpers"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/openshift/hive/pkg/constants"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	v1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// EnsureNetworkPolicy makes sure a network policy exists (possibly creating it):
+//   - In the cd's namespace
+//   - Named after the cd and jobType
+//   - Parented to the cd
+//     (Note: Would rather parent to the Job, but then we have a chicken/egg race.)
+//     (...or the Cluster{Dep|P}rovision, but then we would have one for each attempt.)
+//   - With a PodSelector for the jobType's pod
+//   - With the specified ingress and egress (note: We specify both PolicyTypes, so the
+//     caller must be explicit about both)
+//
+// The bool return indicates whether we created it (true) or it already existed (false).
+// If the error return is non-nil, the bool return is meaningless.
+func EnsureNetworkPolicy(cl client.Client, scheme *runtime.Scheme, jobType string, cd *hivev1.ClusterDeployment, logger log.FieldLogger, ingress []v1.NetworkPolicyIngressRule, egress []v1.NetworkPolicyEgressRule) (bool, error) {
+	// CD-specific name, scrubbed for length, with suffix intact
+	name := helpers.GetResourceName(cd.Name, jobType)
+
+	logger = logger.WithField("netpol", cd.Namespace+"/"+name)
+
+	err := cl.Get(context.Background(), types.NamespacedName{Namespace: cd.Namespace, Name: name}, &v1.NetworkPolicy{})
+	if err == nil {
+		// TODO: Should we validate it?
+		logger.Debug("network policy already exists")
+		return false, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return false, errors.Wrap(err, "failed to retrieve network policy")
+	}
+
+	// Not found; create.
+	labels := map[string]string{
+		constants.JobTypeLabel: jobType,
+	}
+	np := &v1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cd.Namespace,
+			Labels:    labels,
+		},
+		Spec: v1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: labels},
+			Ingress:     ingress,
+			Egress:      egress,
+			PolicyTypes: []v1.PolicyType{
+				v1.PolicyTypeEgress,
+				v1.PolicyTypeIngress,
+			},
+		},
+	}
+	if err = controllerutil.SetControllerReference(cd, np, scheme); err != nil {
+		return false, errors.Wrap(err, "failed to set controller reference on network policy")
+	}
+
+	logger.Info("creating network policy")
+	err = cl.Create(context.Background(), np)
+	if apierrors.IsAlreadyExists(err) {
+		// We lost a race, but the important part is that the netpol exists
+		logger.Info("network policy became extant while creating")
+		return false, nil
+	}
+	// err is nil in the green path (create succeeded)
+	return err == nil, err
+}

--- a/pkg/operator/assets/bindata.go
+++ b/pkg/operator/assets/bindata.go
@@ -23,6 +23,8 @@
 // config/controllers/hive_controllers_role_binding.yaml
 // config/controllers/hive_controllers_serviceaccount.yaml
 // config/controllers/service.yaml
+// config/netpol/hive-controllers.yaml
+// config/netpol/hiveadmission.yaml
 // config/rbac/hive_admin_role.yaml
 // config/rbac/hive_admin_role_binding.yaml
 // config/rbac/hive_clusterpool_admin.yaml
@@ -144,6 +146,7 @@ spec:
       labels:
         control-plane: {{.ControllerName}}
         controller-tools.k8s.io: "1.0"
+        hive.openshift.io/component: hive- {{- .ControllerName}}
     spec:
       topologySpreadConstraints: # this forces the pods to be on separate nodes.
       - maxSkew: 1
@@ -501,6 +504,7 @@ metadata:
   labels:
     app: hiveadmission
     hiveadmission: "true"
+    hive.openshift.io/component: hiveadmission
 spec:
   replicas: 2
   selector:
@@ -517,6 +521,7 @@ spec:
       labels:
         app: hiveadmission
         hiveadmission: "true"
+        hive.openshift.io/component: hiveadmission
     spec:
       serviceAccountName: hiveadmission
       containers:
@@ -940,6 +945,7 @@ metadata:
   labels:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
+    hive.openshift.io/component: hive-controllers
 spec:
   selector:
     matchLabels:
@@ -954,6 +960,7 @@ spec:
       labels:
         control-plane: controller-manager
         controller-tools.k8s.io: "1.0"
+        hive.openshift.io/component: hive-controllers
     spec:
       serviceAccountName: hive-controllers
       volumes:
@@ -1127,6 +1134,18 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
 `)
 
 func configControllersHive_controllers_roleYamlBytes() ([]byte, error) {
@@ -1230,6 +1249,79 @@ func configControllersServiceYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "config/controllers/service.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _configNetpolHiveControllersYaml = []byte(`apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hive-controllers
+  annotations:
+    hive.openshift.io/netpol-description: "Network policy for all hive controllers, including clustersync and machinepool. These must allow egress to the APIServer and cloud providers. Since we can't identify hostNetwork pods for the former, or specific targets for the latter, we must allow all egress. Ingress must be available from the APIServer for liveness probes; so, similarly, we must allow all ingress."
+spec:
+  egress:
+  - {}
+  ingress:
+  - {}
+  podSelector:
+    matchExpressions:
+      - key: hive.openshift.io/component
+        operator: In
+        values:
+        - hive-controllers
+        - hive-clustersync
+        - hive-machinepool
+  policyTypes:
+  - Egress
+  - Ingress
+`)
+
+func configNetpolHiveControllersYamlBytes() ([]byte, error) {
+	return _configNetpolHiveControllersYaml, nil
+}
+
+func configNetpolHiveControllersYaml() (*asset, error) {
+	bytes, err := configNetpolHiveControllersYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "config/netpol/hive-controllers.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _configNetpolHiveadmissionYaml = []byte(`apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hiveadmission
+  annotations:
+    hive.openshift.io/netpol-description: "Network policy for hiveadmission needs both egress to and ingress from the APIServer. Since we can't identify hostNetwork pods, we must allow all."
+spec:
+  egress:
+  - {}
+  ingress:
+  - {}
+  podSelector:
+    matchLabels:
+      hive.openshift.io/component: hiveadmission
+  policyTypes:
+  - Egress
+  - Ingress
+`)
+
+func configNetpolHiveadmissionYamlBytes() ([]byte, error) {
+	return _configNetpolHiveadmissionYaml, nil
+}
+
+func configNetpolHiveadmissionYaml() (*asset, error) {
+	bytes, err := configNetpolHiveadmissionYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "config/netpol/hiveadmission.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2207,6 +2299,8 @@ var _bindata = map[string]func() (*asset, error){
 	"config/controllers/hive_controllers_role_binding.yaml":            configControllersHive_controllers_role_bindingYaml,
 	"config/controllers/hive_controllers_serviceaccount.yaml":          configControllersHive_controllers_serviceaccountYaml,
 	"config/controllers/service.yaml":                                  configControllersServiceYaml,
+	"config/netpol/hive-controllers.yaml":                              configNetpolHiveControllersYaml,
+	"config/netpol/hiveadmission.yaml":                                 configNetpolHiveadmissionYaml,
 	"config/rbac/hive_admin_role.yaml":                                 configRbacHive_admin_roleYaml,
 	"config/rbac/hive_admin_role_binding.yaml":                         configRbacHive_admin_role_bindingYaml,
 	"config/rbac/hive_clusterpool_admin.yaml":                          configRbacHive_clusterpool_adminYaml,
@@ -2289,6 +2383,10 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"service-account.yaml":                        {configHiveadmissionServiceAccountYaml, map[string]*bintree{}},
 			"service.yaml":                                {configHiveadmissionServiceYaml, map[string]*bintree{}},
 			"syncset-webhook.yaml":                        {configHiveadmissionSyncsetWebhookYaml, map[string]*bintree{}},
+		}},
+		"netpol": {nil, map[string]*bintree{
+			"hive-controllers.yaml": {configNetpolHiveControllersYaml, map[string]*bintree{}},
+			"hiveadmission.yaml":    {configNetpolHiveadmissionYaml, map[string]*bintree{}},
 		}},
 		"rbac": {nil, map[string]*bintree{
 			"hive_admin_role.yaml":              {configRbacHive_admin_roleYaml, map[string]*bintree{}},

--- a/pkg/operator/hive/hive.go
+++ b/pkg/operator/hive/hive.go
@@ -57,6 +57,8 @@ func (r *ReconcileHiveConfig) deployHive(hLog log.FieldLogger, h resource.Helper
 		"config/configmaps/install-log-regexes-configmap.yaml",
 		"config/rbac/hive_frontend_serviceaccount.yaml",
 		"config/controllers/hive_controllers_serviceaccount.yaml",
+		// NOTE: This policy applies to sharded controllers as well.
+		"config/netpol/hive-controllers.yaml",
 	}
 	// Delete the assets from previous target namespaces
 	assetsToClean := append(namespacedAssets, deploymentAsset)

--- a/pkg/operator/hive/hiveadmission.go
+++ b/pkg/operator/hive/hiveadmission.go
@@ -65,6 +65,7 @@ func (r *ReconcileHiveConfig) deployHiveAdmission(hLog log.FieldLogger, h resour
 	namespacedAssets := []string{
 		"config/hiveadmission/service.yaml",
 		"config/hiveadmission/service-account.yaml",
+		"config/netpol/hiveadmission.yaml",
 	}
 	// In OpenShift, we get the service and kube root CA certs from automatically-generated ConfigMaps
 	if !r.isOpenShift {

--- a/pkg/util/scheme/scheme.go
+++ b/pkg/util/scheme/scheme.go
@@ -12,6 +12,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
 
 	velerov1 "github.com/heptio/velero/pkg/apis/velero/v1"
 	oappsv1 "github.com/openshift/api/apps/v1"
@@ -65,6 +66,7 @@ func init() {
 	)
 	machinev1beta1.AddToScheme(hive_scheme)
 	monitoringv1.AddToScheme(hive_scheme)
+	netv1.AddToScheme(hive_scheme)
 	oappsv1.Install(hive_scheme)
 	orbacv1.Install(hive_scheme)
 	rbacv1.AddToScheme(hive_scheme)


### PR DESCRIPTION
Add network policies for hive components. Unfortunately, most of these end up being allow-all due to limitations identifying the APIServer and external infrastructure providers. There are several layers in play here:
- hive-operator needs its netpol applied alongside its Deployment in order to start up and create the other components. For development, it's tied into `make deploy` via kustomize. For OperatorHub, it's included in the bundle.
- The controllers (hive-controllers, hive-clustersync, hive-machinepool) and hiveadmission get their netpols laid down by hive-operator. The manifests for these are in bindata.
- Netpols for spoke operations (imgset, provision, deprovision) are created by the clusterdeployment controller alongside their respective ClusterDeployments, parented thereto for automatic cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/expanded NetworkPolicy support across the hive operator, controllers, and admission components, including provisioning and deprovisioning workflows.
  * Added and applied new NetworkPolicy manifests for hive-operator, hive-controllers, and hiveadmission.
* **Bug Fixes**
  * Improved reconciliation and ownership handling so NetworkPolicy resources are created and managed reliably during install/uninstall flows.
  * Enhanced OpenShift component labeling for improved consistency across workloads.
* **Chores**
  * Updated RBAC and build/asset generation to include full NetworkPolicy lifecycle permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->