### PR TITLE
Bump golang to 1.26.3

### DIFF
--- a/.tekton/hive-mce-210-pull-request.yaml
+++ b/.tekton/hive-mce-210-pull-request.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-210-push.yaml
+++ b/.tekton/hive-mce-210-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-211-pull-request.yaml
+++ b/.tekton/hive-mce-211-pull-request.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-211-push.yaml
+++ b/.tekton/hive-mce-211-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-217-pull-request.yaml
+++ b/.tekton/hive-mce-217-pull-request.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-217-push.yaml
+++ b/.tekton/hive-mce-217-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-26-pull-request.yaml
+++ b/.tekton/hive-mce-26-pull-request.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-26-push.yaml
+++ b/.tekton/hive-mce-26-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-27-pull-request.yaml
+++ b/.tekton/hive-mce-27-pull-request.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-27-push.yaml
+++ b/.tekton/hive-mce-27-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-28-pull-request.yaml
+++ b/.tekton/hive-mce-28-pull-request.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-28-push.yaml
+++ b/.tekton/hive-mce-28-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-29-pull-request.yaml
+++ b/.tekton/hive-mce-29-pull-request.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-29-push.yaml
+++ b/.tekton/hive-mce-29-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-50-pull-request.yaml
+++ b/.tekton/hive-mce-50-pull-request.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-50-push.yaml
+++ b/.tekton/hive-mce-50-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-51-pull-request.yaml
+++ b/.tekton/hive-mce-51-pull-request.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-51-push.yaml
+++ b/.tekton/hive-mce-51-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-pull-request.yaml
+++ b/.tekton/hive-pull-request.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-push.yaml
+++ b/.tekton/hive-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604242241.p0.g2aa6a05.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.25.9-202604271511.p0.g207b799.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g9708ae8.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.3-202605271342.p0.g50c85bb.el9
         - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
     - name: build-source-image
       value: 'true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG CONTAINER_SUB_MANAGER_OFF=0
-ARG EL8_BUILD_IMAGE=${EL8_BUILD_IMAGE:-registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25-openshift-4.21}
-ARG EL9_BUILD_IMAGE=${EL9_BUILD_IMAGE:-registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21}
+ARG EL8_BUILD_IMAGE=${EL8_BUILD_IMAGE:-registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.26-openshift-4.23}
+ARG EL9_BUILD_IMAGE=${EL9_BUILD_IMAGE:-registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23}
 ARG BASE_IMAGE=${BASE_IMAGE:-registry.access.redhat.com/ubi9/ubi-minimal:latest}
 
 FROM ${EL8_BUILD_IMAGE} as builder_rhel8

--- a/Dockerfile.ote
+++ b/Dockerfile.ote
@@ -1,4 +1,4 @@
-ARG OTE_BUILD_IMAGE=registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22
+ARG OTE_BUILD_IMAGE=registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23
 ARG BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 FROM ${OTE_BUILD_IMAGE} as builder

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ SHELL := /bin/bash
 all: vendor update test build
 
 # These images need to be synced with the default values in the Dockerfile.
-EL8_BUILD_IMAGE ?= registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.25-openshift-4.21
-EL9_BUILD_IMAGE ?= registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21
+EL8_BUILD_IMAGE ?= registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.26-openshift-4.23
+EL9_BUILD_IMAGE ?= registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23
 BASE_IMAGE ?= registry.ci.openshift.org/ocp/4.21:base-rhel9
 
 # In openshift ci (Prow), we need to set $HOME to a writable directory else tests will fail

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -1,8 +1,8 @@
 module github.com/openshift/hive/apis
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.9
+toolchain go1.26.3
 
 require (
 	github.com/openshift/api v0.0.0-20260318185450-1f2fa3f09f4e

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/openshift/hive
 
-go 1.25.0
+go 1.26.0
 
-toolchain go1.25.9
+toolchain go1.26.3
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible

--- a/hack/ubi-build-deps.sh
+++ b/hack/ubi-build-deps.sh
@@ -4,8 +4,8 @@ dnf install -y \
 	golang \
 	make
 
-# Since go 1.25.x is not available in ubi8, let's go upstream
-go install golang.org/dl/go1.25.9@latest
-/root/go/bin/go1.25.9 download
+# Since go 1.26.x is not available in ubi8, let's go upstream
+go install golang.org/dl/go1.26.3@latest
+/root/go/bin/go1.26.3 download
 rm /usr/bin/go
-ln -s /root/go/bin/go1.25.9 /usr/bin/go
+ln -s /root/go/bin/go1.26.3 /usr/bin/go

--- a/test/ote/go.mod
+++ b/test/ote/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/hive/test/ote
 
-go 1.25.0
+go 1.26.0
 
 require (
 	cloud.google.com/go/compute v1.38.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1908,7 +1908,7 @@ github.com/openshift/generic-admission-server/pkg/cmd/server
 github.com/openshift/generic-admission-server/pkg/registry/admissionreview
 github.com/openshift/generic-admission-server/pkg/registry/admissionreview/generated
 # github.com/openshift/hive/apis v0.0.0 => ./apis
-## explicit; go 1.25.0
+## explicit; go 1.26.0
 github.com/openshift/hive/apis
 github.com/openshift/hive/apis/helpers
 github.com/openshift/hive/apis/hive/v1


### PR DESCRIPTION
Note that this PR is not expected to make `security` pass, as there are still several vulns that require even newer golangs, which are not yet available to us. However, 1.26.3 is still newer than 1.25.9 (patch status equivalent to 1.25.10) so this still moves the ball forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Go toolchain to 1.26.3 (including module/toolchain metadata and OTE-related Go module settings).
  * Refreshed local and container build defaults to newer Go 1.26–based builder images for EL8 and EL9.
  * Updated Tekton PipelineRun build arguments for EL8/EL9 to use the newer Go builder image tags (including OTE).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->