### PR TITLE
pkg/install: use a functional check for hiveutil

### DIFF
--- a/pkg/install/generate.go
+++ b/pkg/install/generate.go
@@ -394,7 +394,7 @@ func InstallerPodSpec(
 			Command:         []string{"/bin/sh", "-c"},
 			// Large file copy here has shown to cause problems in clusters under load, safer to copy then rename to the file the install manager is waiting for
 			// so it doesn't try to run a partially copied binary.
-			Args:         []string{fmt.Sprintf("cp -v /bin/openshift-install /output/openshift-install.tmp && mv /output/openshift-install.tmp /output/openshift-install && major_version=$(sed -n 's/.*release \\([0-9]*\\).*/\\1/p' /etc/redhat-release) && ln -s /output/hiveutil.rhel${major_version} /output/hiveutil && /output/hiveutil install-manager --work-dir /output --log-level debug %s %s", cd.Namespace, provisionName)},
+			Args:         []string{fmt.Sprintf("cp -v /bin/openshift-install /output/openshift-install.tmp && mv /output/openshift-install.tmp /output/openshift-install && if /output/hiveutil.rhel9 version >/dev/null 2>&1; then ln -s /output/hiveutil.rhel9 /output/hiveutil; elif /output/hiveutil.rhel8 version >/dev/null 2>&1; then ln -s /output/hiveutil.rhel8 /output/hiveutil; else echo 'FATAL: neither hiveutil.rhel9 nor hiveutil.rhel8 can execute on this image' >&2; exit 1; fi && /output/hiveutil install-manager --work-dir /output --log-level debug %s %s", cd.Namespace, provisionName)},
 			VolumeMounts: volumeMounts,
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{


### PR DESCRIPTION
We would like to support copying the hiveutil image into containers that are not strictly RHEL. So, instead of hard-coding a check for `/etc/redhat-release` and assuming that things will work implicitly, we can just check the binaries directly and use the one that doesn't have linker errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer compatibility by selecting the first executable `hiveutil` binary available.
  * Added a clear fatal error when no compatible binary can be executed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->