### PR TITLE
OCPBUGS-86779: Fix TestAdmission flake caused by APIService routing delay

### DIFF
--- a/test/e2e/postdeploy/admission/admission_test.go
+++ b/test/e2e/postdeploy/admission/admission_test.go
@@ -2,6 +2,7 @@ package admission
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,8 +68,8 @@ func waitForAdmissionRouting(t *testing.T, c dynamic.Interface, gvr schema.Group
 				"kind":    "DNSZone",
 			},
 			"resource": map[string]interface{}{
-				"group":   "hive.openshift.io",
-				"version": "v1",
+				"group":    "hive.openshift.io",
+				"version":  "v1",
 				"resource": "dnszones",
 			},
 			"operation": "CREATE",
@@ -95,10 +96,7 @@ func waitForAdmissionRouting(t *testing.T, c dynamic.Interface, gvr schema.Group
 				t.Logf("Admission routing not ready yet: %v", err)
 				return false, nil
 			}
-			// Any other error is unexpected; keep retrying to be safe,
-			// but log it so we can diagnose if the probe itself is broken.
-			t.Logf("Unexpected error during admission routing probe: %v", err)
-			return false, nil
+			return false, fmt.Errorf("unexpected error during admission routing probe: %w", err)
 		}
 		return true, nil
 	})

--- a/test/e2e/postdeploy/admission/admission_test.go
+++ b/test/e2e/postdeploy/admission/admission_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	admissionv1 "k8s.io/api/admission/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -46,8 +47,8 @@ func waitForAdmissionAPIService(t *testing.T) bool {
 	return true
 }
 
-func waitForAdmission(t *testing.T) bool {
-	return waitForAdmissionDeployment(t) && waitForAdmissionAPIService(t)
+func waitForAdmission(t *testing.T, c dynamic.Interface, gvr schema.GroupVersionResource) bool {
+	return waitForAdmissionDeployment(t) && waitForAdmissionAPIService(t) && waitForAdmissionRouting(t, c, gvr)
 }
 
 // waitForAdmissionRouting sends a smoke request to the aggregated API endpoint
@@ -92,7 +93,7 @@ func waitForAdmissionRouting(t *testing.T, c dynamic.Interface, gvr schema.Group
 		if err != nil {
 			// The Forbidden error for system:anonymous means kube-apiserver
 			// has not yet wired up routing to the aggregated API server.
-			if strings.Contains(err.Error(), "is forbidden") {
+			if apierrors.IsForbidden(err) && strings.Contains(err.Error(), "system:anonymous") {
 				t.Logf("Admission routing not ready yet: %v", err)
 				return false, nil
 			}
@@ -111,10 +112,7 @@ func waitForAdmissionRouting(t *testing.T, c dynamic.Interface, gvr schema.Group
 func TestAdmission(t *testing.T) {
 	c := common.MustGetDynamicClient()
 	gvr, _ := (&webhook.DNSZoneValidatingAdmissionHook{}).ValidatingResource()
-	if !waitForAdmission(t) {
-		return
-	}
-	if !waitForAdmissionRouting(t, c, gvr) {
+	if !waitForAdmission(t, c, gvr) {
 		return
 	}
 

--- a/test/e2e/postdeploy/admission/admission_test.go
+++ b/test/e2e/postdeploy/admission/admission_test.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
 
 	"github.com/openshift/hive/pkg/util/scheme"
 	webhook "github.com/openshift/hive/pkg/validating-webhooks/hive/v1"
@@ -45,10 +49,74 @@ func waitForAdmission(t *testing.T) bool {
 	return waitForAdmissionDeployment(t) && waitForAdmissionAPIService(t)
 }
 
+// waitForAdmissionRouting sends a smoke request to the aggregated API endpoint
+// in a poll loop, working around a race where kube-apiserver reports the
+// APIService as Available but has not yet fully configured request routing.
+// Until routing is ready the request hits native RBAC and is rejected with
+// Forbidden for system:anonymous.
+func waitForAdmissionRouting(t *testing.T, c dynamic.Interface, gvr schema.GroupVersionResource) bool {
+	// Build a minimal AdmissionReview that the webhook will accept.
+	probe := &unstructured.Unstructured{}
+	probe.SetUnstructuredContent(map[string]interface{}{
+		"apiVersion": "admission.k8s.io/v1",
+		"kind":       "AdmissionReview",
+		"request": map[string]interface{}{
+			"kind": map[string]interface{}{
+				"group":   "hive.openshift.io",
+				"version": "v1",
+				"kind":    "DNSZone",
+			},
+			"resource": map[string]interface{}{
+				"group":   "hive.openshift.io",
+				"version": "v1",
+				"resource": "dnszones",
+			},
+			"operation": "CREATE",
+			"object": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name": "routing-probe",
+				},
+				"spec": map[string]interface{}{
+					"zone": "probe.example.com",
+				},
+			},
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		_, err := c.Resource(gvr).Create(ctx, probe, metav1.CreateOptions{})
+		if err != nil {
+			// The Forbidden error for system:anonymous means kube-apiserver
+			// has not yet wired up routing to the aggregated API server.
+			if strings.Contains(err.Error(), "is forbidden") {
+				t.Logf("Admission routing not ready yet: %v", err)
+				return false, nil
+			}
+			// Any other error is unexpected; keep retrying to be safe,
+			// but log it so we can diagnose if the probe itself is broken.
+			t.Logf("Unexpected error during admission routing probe: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Errorf("Timed out waiting for admission routing to be ready: %v", err)
+		return false
+	}
+	t.Log("Admission routing is ready")
+	return true
+}
+
 func TestAdmission(t *testing.T) {
 	c := common.MustGetDynamicClient()
 	gvr, _ := (&webhook.DNSZoneValidatingAdmissionHook{}).ValidatingResource()
 	if !waitForAdmission(t) {
+		return
+	}
+	if !waitForAdmissionRouting(t, c, gvr) {
 		return
 	}
 


### PR DESCRIPTION
## Summary
Fix intermittent TestAdmission failure caused by kube-apiserver APIService routing not being fully configured even after the APIService reports readiness.

## Root Cause
The test waits for the hiveadmission deployment and APIService to be ready, but there is a gap where the kube-apiserver has not yet wired up request proxying to the aggregated endpoint. During this window, requests hit native RBAC and are rejected with `Forbidden` for `system:anonymous`.

Evidence: first subtest FAILS, but next two subtests PASS within milliseconds — confirming eventual consistency, not a setup failure.

## Fix
Added `waitForAdmissionRouting()` that sends a smoke probe request to the `dnszonevalidators` endpoint in a `wait.PollUntilContextTimeout` loop (1s interval, 2min timeout). Subtests only run once the probe succeeds, confirming routing is fully configured.

## Test Plan
- The fix itself is a test improvement — CI runs will verify the flake is resolved
- `go vet` and `go build` pass on the changed package

Jira: https://redhat.atlassian.net/browse/OCPBUGS-86779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the post-deploy admission end-to-end flow with an additional routing readiness check to confirm the aggregated admission endpoint is reachable.
  * The test now repeatedly polls for readiness within a set timeout and starts the admission review cases only after routing is confirmed.
  * Transient “forbidden” responses during intermediate setup are treated as expected during polling, with clearer logging for unexpected errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->