### PR TITLE
OCPBUGS-99231: konflux push: bigger arm builder

### DIFF
--- a/.tekton/hive-mce-210-push.yaml
+++ b/.tekton/hive-mce-210-push.yaml
@@ -34,7 +34,7 @@ spec:
         - linux/x86_64
         - linux/ppc64le
         - linux/s390x
-        - linux/arm64
+        - linux-mxlarge/arm64
     - name: dockerfile
       value: Dockerfile
     - name: path-context

--- a/.tekton/hive-mce-211-push.yaml
+++ b/.tekton/hive-mce-211-push.yaml
@@ -34,7 +34,7 @@ spec:
         - linux/x86_64
         - linux/ppc64le
         - linux/s390x
-        - linux/arm64
+        - linux-mxlarge/arm64
     - name: dockerfile
       value: Dockerfile
     - name: path-context

--- a/.tekton/hive-mce-217-push.yaml
+++ b/.tekton/hive-mce-217-push.yaml
@@ -34,7 +34,7 @@ spec:
         - linux/x86_64
         - linux/ppc64le
         - linux/s390x
-        - linux/arm64
+        - linux-mxlarge/arm64
     - name: dockerfile
       value: Dockerfile
     - name: path-context

--- a/.tekton/hive-mce-26-push.yaml
+++ b/.tekton/hive-mce-26-push.yaml
@@ -34,7 +34,7 @@ spec:
         - linux/x86_64
         - linux/ppc64le
         - linux/s390x
-        - linux/arm64
+        - linux-mxlarge/arm64
     - name: dockerfile
       value: Dockerfile
     - name: path-context

--- a/.tekton/hive-mce-27-push.yaml
+++ b/.tekton/hive-mce-27-push.yaml
@@ -34,7 +34,7 @@ spec:
         - linux/x86_64
         - linux/ppc64le
         - linux/s390x
-        - linux/arm64
+        - linux-mxlarge/arm64
     - name: dockerfile
       value: Dockerfile
     - name: path-context

--- a/.tekton/hive-mce-28-push.yaml
+++ b/.tekton/hive-mce-28-push.yaml
@@ -34,7 +34,7 @@ spec:
         - linux/x86_64
         - linux/ppc64le
         - linux/s390x
-        - linux/arm64
+        - linux-mxlarge/arm64
     - name: dockerfile
       value: Dockerfile
     - name: path-context

--- a/.tekton/hive-mce-29-push.yaml
+++ b/.tekton/hive-mce-29-push.yaml
@@ -34,7 +34,7 @@ spec:
         - linux/x86_64
         - linux/ppc64le
         - linux/s390x
-        - linux/arm64
+        - linux-mxlarge/arm64
     - name: dockerfile
       value: Dockerfile
     - name: path-context

--- a/.tekton/hive-mce-50-push.yaml
+++ b/.tekton/hive-mce-50-push.yaml
@@ -34,7 +34,7 @@ spec:
         - linux/x86_64
         - linux/ppc64le
         - linux/s390x
-        - linux/arm64
+        - linux-mxlarge/arm64
     - name: dockerfile
       value: Dockerfile
     - name: path-context

--- a/.tekton/hive-mce-51-push.yaml
+++ b/.tekton/hive-mce-51-push.yaml
@@ -34,7 +34,7 @@ spec:
         - linux/x86_64
         - linux/ppc64le
         - linux/s390x
-        - linux/arm64
+        - linux-mxlarge/arm64
     - name: dockerfile
       value: Dockerfile
     - name: path-context

--- a/.tekton/hive-push.yaml
+++ b/.tekton/hive-push.yaml
@@ -34,7 +34,7 @@ spec:
         - linux/x86_64
         - linux/ppc64le
         - linux/s390x
-        - linux/arm64
+        - linux-mxlarge/arm64
     - name: dockerfile
       value: Dockerfile
     - name: path-context


### PR DESCRIPTION
Sounds like you're about to get workout advice.

Alas, no; we're just trying to get around consistent build failures that _seem_ to be due to memory maxing while building arm64. Bump up to the next biggest builder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Updated ARM64 build targets to use the `linux-mxlarge/arm64` platform across push-triggered builds.
  * Standardized platform selection for improved compatibility with the designated build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->