### PR TITLE
OCPBUGS-78995: Azure MachinePool: Fix image gallery discovery

### DIFF
--- a/pkg/controller/machinepool/azureactuator.go
+++ b/pkg/controller/machinepool/azureactuator.go
@@ -127,6 +127,12 @@ func (a *AzureActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *
 		return nil, false, errors.Wrap(err, "error retrieving VM capabilities")
 	}
 
+	// If we leave the rhcosImg empty, installer supplies a default marketplace image.
+	// If we set it to *any value*, installer will use the well-known gallery image URN format that
+	// varies only by HyperVGeneration, which we'll compute below. The value of rhcosImg itself is
+	// *not used*.
+	rhcosImg := ""
+
 	if osImage := pool.Spec.Platform.Azure.OSImage; osImage != nil && osImage.Publisher != "" {
 		var plan = installertypesazure.ImageWithPurchasePlan // default value
 		if osImage.Plan != "" {
@@ -141,24 +147,35 @@ func (a *AzureActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *
 			Version:   osImage.Version,
 		}
 	} else {
-		// An image was not provided so check if the installer created a "gen2" image
-		// to determine if we should allow resultant machinesets to consume a "gen2" image.
-		gen2ImageExists, err := a.gen2ImageExists(ic.Platform.Azure.ClusterResourceGroupName(cd.Spec.ClusterMetadata.InfraID))
+		// An image was not provided. If a gallery image exists at all, we need to assume the spoke
+		// is old and doesn't have marketplace images. If that's the case, we want to use a gen2
+		// image if available (and compatible with our VM size). If no gen2 image is available, we
+		// dummy down our VM capabilities to force using the gen1 image.
+		// If no gallery image exists, we'll trigger the path in MachineSets() that uses a default
+		// marketplace image.
+		gallery, gen2, err := a.galleryImageExistsAndIsGen2(ic.Platform.Azure.ClusterResourceGroupName(cd.Spec.ClusterMetadata.InfraID))
 		if err != nil {
 			return nil, false, err
 		}
-		if !gen2ImageExists {
-			// Modify capabilities to ensure that a V1 image is chosen by installazure.MachineSets()
-			// because a V2 image does not exist.
-			// The HyperVGeneration is germane to the instance/disk type and affects the image used
-			// for the instance. "-gen-2" will be appended to the image name by installazure.MachineSets()
-			// when the HyperVGenerations capability (comma separated list of HyperVGenerations) includes "V2".
-			//
-			// capabilities := map[string]string{
-			//   "HyperVGenerations": "V1,V2",
-			// }
-			//
-			if _, ok := capabilities["HyperVGenerations"]; ok {
+		if gallery {
+			// signal that the installer code should use the gallery URN. This is pretty hacky and
+			// non-future-proof; include a breadcrumb to flag possible future regressions.
+			rhcosImg = "gallery (if you are seeing this string in a Machine[Set], please report a hive bug)"
+			if !gen2 {
+				// Ensure that a V1 image is chosen by installazure.MachineSets() because a V2
+				// image does not exist.
+				// A VM size is capable of running V1, V2, or both, as indicated in its capabilities map:
+				//
+				// capabilities := map[string]string{
+				//   "HyperVGenerations": "V1,V2",
+				// }
+				//
+				// An image is V1 xor V2.
+				// Installer code will assume the highest version in the capabilities map; so if no
+				// V2 image exists, make sure it chooses V1.
+				// (There is still a failure mode here if the VM size doesn't support V1. In that
+				// case, the Machine will fail with an appropriate message, and the user should
+				// choose a VM size that does.)
 				capabilities["HyperVGenerations"] = "V1"
 			}
 		}
@@ -177,14 +194,11 @@ func (a *AzureActuator) GenerateMachineSets(cd *hivev1.ClusterDeployment, pool *
 		}
 	}
 
-	// If we leave the imageID, the image is determined by the installer
-	const imageID = ""
-
 	installerMachineSets, err := installazure.MachineSets(
 		cd.Spec.ClusterMetadata.InfraID,
 		installconfig.MakeAsset(ic),
 		computePool,
-		imageID,
+		rhcosImg,
 		workerRole,
 		workerUserDataName,
 		capabilities,
@@ -230,17 +244,25 @@ func (a *AzureActuator) getImagesByResourceGroup(resourceGroupName string) ([]co
 	return images, err
 }
 
-func (a *AzureActuator) gen2ImageExists(resourceGroupName string) (bool, error) {
+// galleryImageExistsAndIsGen2 looks for gallery images in the specified RG.
+// The first return indicates that we found *any* such images. If this is false, the caller should
+// use marketplace images.
+// The second return, only relevant if the first is true, indicates whether any of the found images
+// are gen2. If this is false, the caller must assume gen1, validate compatibility with the VM
+// size, and request gen1 accordingly.
+func (a *AzureActuator) galleryImageExistsAndIsGen2(resourceGroupName string) (bool, bool, error) {
 	images, err := a.getImagesByResourceGroup(resourceGroupName)
 	if err != nil {
-		return false, errors.Wrapf(err, "error listing images by resourceGroup: %s", resourceGroupName)
+		// We get 200/[] rather than 404 if there are none, right?
+		return false, false, errors.Wrapf(err, "error listing images by resourceGroup: %s", resourceGroupName)
 	}
+	found := len(images) != 0
 	for _, image := range images {
 		if image.ImageProperties.HyperVGeneration == compute.HyperVGenerationTypesV2 {
-			return true, nil
+			return found, true, nil
 		}
 	}
-	return false, nil
+	return found, false, nil
 }
 
 // getVMCapabilities retrieves the capabilities of an instance type in a specific region. Returns these values

--- a/vendor/github.com/openshift/installer/pkg/asset/installconfig/azure/capabilities.go
+++ b/vendor/github.com/openshift/installer/pkg/asset/installconfig/azure/capabilities.go
@@ -6,6 +6,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/azure"
 )
 
@@ -45,4 +46,13 @@ func GetHyperVGenerationVersions(capabilities map[string]string) (sets.Set[strin
 func GetVMNetworkingCapability(capabilities map[string]string) bool {
 	val, ok := capabilities[string(azure.AcceleratedNetworkingEnabled)]
 	return ok && strings.EqualFold(val, "True")
+}
+
+func GetArchitecture(capabilities map[string]string) types.Architecture {
+	val, ok := capabilities["CpuArchitectureType"]
+	if ok && val == "Arm64" {
+		return types.ArchitectureARM64
+	}
+	// If not ARM, assume x86. We already validated that it's one or the other.
+	return types.ArchitectureAMD64
 }

--- a/vendor/github.com/openshift/installer/pkg/asset/machines/azure/azuremachines.go
+++ b/vendor/github.com/openshift/installer/pkg/asset/machines/azure/azuremachines.go
@@ -61,7 +61,7 @@ func GenerateMachines(clusterID, resourceGroup, subscriptionID string, session *
 		return nil, fmt.Errorf("failed to create machineapi.TagSpecifications from UserTags: %w", err)
 	}
 	confidentialVM := mpool.Settings != nil && mpool.Settings.SecurityType != ""
-	image := capzImage(mpool.OSImage, in.Environment, confidentialVM, in.HyperVGen, resourceGroup, subscriptionID, clusterID, in.RHCOS)
+	image := capzImage(mpool.OSImage, in.Environment, confidentialVM, in.Pool.Architecture, in.HyperVGen, resourceGroup, subscriptionID, clusterID, in.RHCOS)
 	// Set up OSDisk
 	osDisk := capz.OSDisk{
 		OSType:     "Linux",
@@ -361,7 +361,7 @@ func bootDiagStorageURIBuilder(diag *aztypes.BootDiagnostics, storageEndpointSuf
 	return ""
 }
 
-func capzImage(osImage aztypes.OSImage, azEnv aztypes.CloudEnvironment, confidentialVM bool, gen, rg, sub, infraID, rhcosImg string) *capz.Image {
+func capzImage(osImage aztypes.OSImage, azEnv aztypes.CloudEnvironment, confidentialVM bool, arch types.Architecture, gen, rg, sub, infraID, rhcosImg string) *capz.Image {
 	switch {
 	case osImage.Publisher != "":
 		return &capz.Image{
@@ -394,9 +394,26 @@ func capzImage(osImage aztypes.OSImage, azEnv aztypes.CloudEnvironment, confiden
 			},
 		}
 	case rhcosImg == "" && !confidentialVM:
-		// hive calls the machines function, but may pass an empty
-		// string for rhcos. In which case, allow MAO to choose default.
-		return &capz.Image{} // can't be nil or mapiImage will panic
+		// Hardcode the "oldest" image from marketplace-rhcos.json. MCO should update this.
+		sku := "420-arm"
+		if arch != types.ArchitectureARM64 {
+			if gen == "V2" {
+				sku = "420-v2"
+			} else {
+				sku = "aro_420"
+			}
+		}
+		return &capz.Image{
+			Marketplace: &capz.AzureMarketplaceImage{
+				ImagePlan: capz.ImagePlan{
+					Publisher: "azureopenshift",
+					Offer:     "aro4",
+					SKU:       sku,
+				},
+				Version:         "9.6.20251015",
+				ThirdPartyImage: false,
+			},
+		}
 	default: // Installer-created image gallery, for OKD && confidential VMs.
 		// image gallery names cannot have dashes
 		galleryName := strings.ReplaceAll(infraID, "-", "_")

--- a/vendor/github.com/openshift/installer/pkg/asset/machines/azure/machines.go
+++ b/vendor/github.com/openshift/installer/pkg/asset/machines/azure/machines.go
@@ -180,7 +180,7 @@ func provider(platform *azure.Platform, mpool *azure.MachinePool, osImage string
 	rg := platform.ClusterResourceGroupName(clusterID)
 
 	confidentialVM := mpool.Settings != nil && mpool.Settings.SecurityType != ""
-	image := mapiImage(mpool.OSImage, platform.CloudName, confidentialVM, hyperVGen, rg, session.Credentials.SubscriptionID, clusterID, osImage)
+	image := mapiImage(mpool.OSImage, platform.CloudName, confidentialVM, icazure.GetArchitecture(capabilities), hyperVGen, rg, session.Credentials.SubscriptionID, clusterID, osImage)
 
 	if mpool.OSDisk.DiskType == "" {
 		mpool.OSDisk.DiskType = "Premium_LRS"
@@ -431,9 +431,9 @@ func generateSecurityProfile(mpool *azure.MachinePool) *machineapi.SecurityProfi
 	return securityProfile
 }
 
-func mapiImage(osImage azure.OSImage, azEnv azure.CloudEnvironment, confidentialVM bool, gen, rg, sub, infraID, rhcosImg string) machineapi.Image {
+func mapiImage(osImage azure.OSImage, azEnv azure.CloudEnvironment, confidentialVM bool, arch types.Architecture, gen, rg, sub, infraID, rhcosImg string) machineapi.Image {
 	mImg := machineapi.Image{}
-	cImg := capzImage(osImage, azEnv, confidentialVM, gen, rg, sub, infraID, rhcosImg)
+	cImg := capzImage(osImage, azEnv, confidentialVM, arch, gen, rg, sub, infraID, rhcosImg)
 
 	if cImg.ID != nil {
 		mImg.ResourceID = trimSubscriptionPrefix(*cImg.ID)


### PR DESCRIPTION
Around 4.20, installer started using marketplace images. The logic in our azure MachinePool actuator was never updated for that, which was causing problems with downstream image defaulting.

This is part of a two-part fix (the other part in installer, picked up via the latest revendor) to force the installer code to use gallery images iff they exist; and otherwise use a default marketplace image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Azure machine image selection for ARM64 and AMD64 architectures.
  * Added support for automatically selecting compatible marketplace images based on VM generation.
  * Azure deployments can now use available gallery images, including appropriate Gen1 or Gen2 variants.

* **Bug Fixes**
  * Improved fallback behavior when gallery images are unavailable.
  * Prevented incompatible image selections for Azure VM capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->