### PR TITLE
RFE-9669: Add spec.platform.aws.amiID to MachinePool

### DIFF
--- a/apis/hive/v1/aws/machinepool.go
+++ b/apis/hive/v1/aws/machinepool.go
@@ -43,6 +43,11 @@ type MachinePoolPlatform struct {
 	// this field taking precedence when keys collide.
 	// +optional
 	UserTags map[string]string `json:"userTags,omitempty"`
+
+	// AMIID is the AMI to use for machines in this pool. When omitted, Hive falls back to its
+	// existing behavior of determining an appropriate boot image for the platform.
+	// +optional
+	AMIID *string `json:"amiID,omitempty"`
 }
 
 // SpotMarketOptions defines the options available to a user when configuring

--- a/apis/hive/v1/aws/zz_generated.deepcopy.go
+++ b/apis/hive/v1/aws/zz_generated.deepcopy.go
@@ -89,6 +89,11 @@ func (in *MachinePoolPlatform) DeepCopyInto(out *MachinePoolPlatform) {
 			(*out)[key] = val
 		}
 	}
+	if in.AMIID != nil {
+		in, out := &in.AMIID, &out.AMIID
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/config/crds/hive.openshift.io_machinepools.yaml
+++ b/config/crds/hive.openshift.io_machinepools.yaml
@@ -120,6 +120,11 @@ spec:
                           items:
                             type: string
                           type: array
+                        amiID:
+                          description: |-
+                            AMIID is the AMI to use for machines in this pool. When omitted, Hive falls back to its
+                            existing behavior of determining an appropriate boot image for the platform.
+                          type: string
                         metadataService:
                           description: EC2MetadataOptions defines metadata service interaction options for EC2 instances in the machine pool.
                           properties:

--- a/docs/using-hive.md
+++ b/docs/using-hive.md
@@ -954,6 +954,26 @@ The `spec.replicas` and `spec.autoscaling` configurations cannot be configured s
 
 The `spec.autoscaling.maxReplicas` is an optional field. If it is not configured, then nodes will be auto-scaled without restriction based on resource utilization needs.
 
+#### Customizing VM boot image
+
+By default, we try to determine an appropriate boot image for VMs defined through MachinePools.
+For some platforms, a specific image can be supplied in the MachinePool spec.
+For example, for AWS, the AMI ID can be specified using `spec.platform.aws.amiID` field.
+
+```yaml
+apiVersion: hive.openshift.io/v1
+kind: MachinePool
+metadata:
+  name: mycluster-worker
+  namespace: mynamespace
+spec:
+  clusterDeploymentRef:
+    name: mycluster
+  name: worker
+  platform:
+    aws:
+      amiID: ami-01234567890123456
+```
 ##### Integration with Horizontal Pod Autoscalers
 
 A `MachinePool` configured to auto-scaling mode creates a `ClusterAutoscaler` on the deployed cluster. `ClusterAutoscalers` can co-exist and work with Horiztonal Pod Autoscalers to ensure that there are enough available nodes to meet the auto-scaled pod replica count requirements. See excerpt from OpenShift [documentation](https://docs.openshift.com/container-platform/4.8/machine_management/applying-autoscaling.html):

--- a/hack/app-sre/saas-template.yaml
+++ b/hack/app-sre/saas-template.yaml
@@ -8055,6 +8055,11 @@ objects:
                               items:
                                 type: string
                               type: array
+                            amiID:
+                              description: |-
+                                AMIID is the AMI to use for machines in this pool. When omitted, Hive falls back to its
+                                existing behavior of determining an appropriate boot image for the platform.
+                              type: string
                             metadataService:
                               description: EC2MetadataOptions defines metadata service interaction options for EC2 instances in the machine pool.
                               properties:

--- a/pkg/controller/machinepool/awsactuator.go
+++ b/pkg/controller/machinepool/awsactuator.go
@@ -62,9 +62,13 @@ func NewAWSActuator(
 		logger.WithError(err).Warn("failed to create AWS client")
 		return nil, err
 	}
-	amiID := pool.Annotations[hivev1.MachinePoolImageIDOverrideAnnotation]
-	if amiID != "" {
-		log.Infof("using AMI override from %s annotation: %s", hivev1.MachinePoolImageIDOverrideAnnotation, amiID)
+	var amiID string
+	if pool.Spec.Platform.AWS != nil && pool.Spec.Platform.AWS.AMIID != nil && *pool.Spec.Platform.AWS.AMIID != "" {
+		amiID = *pool.Spec.Platform.AWS.AMIID
+		logger.WithField("AMIID", amiID).Info("using AMI from spec.platform.aws.amiID")
+	} else if override := pool.Annotations[hivev1.MachinePoolImageIDOverrideAnnotation]; override != "" {
+		amiID = override
+		logger.WithField("AMIID", amiID).Infof("using AMI override from %s annotation", hivev1.MachinePoolImageIDOverrideAnnotation)
 	} else {
 		refByTag, err := masterAMIRefByTag(masterMachine)
 		if err != nil {

--- a/vendor/github.com/openshift/hive/apis/hive/v1/aws/machinepool.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/aws/machinepool.go
@@ -43,6 +43,11 @@ type MachinePoolPlatform struct {
 	// this field taking precedence when keys collide.
 	// +optional
 	UserTags map[string]string `json:"userTags,omitempty"`
+
+	// AMIID is the AMI to use for machines in this pool. When omitted, Hive falls back to its
+	// existing behavior of determining an appropriate boot image for the platform.
+	// +optional
+	AMIID *string `json:"amiID,omitempty"`
 }
 
 // SpotMarketOptions defines the options available to a user when configuring

--- a/vendor/github.com/openshift/hive/apis/hive/v1/aws/zz_generated.deepcopy.go
+++ b/vendor/github.com/openshift/hive/apis/hive/v1/aws/zz_generated.deepcopy.go
@@ -89,6 +89,11 @@ func (in *MachinePoolPlatform) DeepCopyInto(out *MachinePoolPlatform) {
 			(*out)[key] = val
 		}
 	}
+	if in.AMIID != nil {
+		in, out := &in.AMIID, &out.AMIID
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Allow specifying a custom AMI directly on a MachinePool's AWS platform spec, rather than only through the existing, explicitly-unsupported hive.openshift.io/image-id-override annotation.

- Add AMIID *string to apis/hive/v1/aws.MachinePoolPlatform.
- In pkg/controller/machinepool/awsactuator.go, resolve the AMI in this order: spec.platform.aws.amiID, then the hive.openshift.io/image-id-override annotation (unchanged), then the existing master-machine lookup fallback.
- Regenerate deepcopy, CRD manifests, and the app-sre SaaS template via make update.

Assisted-by: Claude (Anthropic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AWS machine pools can now specify a custom worker boot image via the optional `spec.platform.aws.amiID`.
* **Bug Fixes**
  * AMI/boot image selection now uses a clearer precedence: `spec.platform.aws.amiID`, then the existing cluster annotation (when set), then the existing master-based AMI resolution.
  * Improved handling to prevent boot image ID pointer aliasing during updates.
* **Documentation**
  * Added a “Machine Pools” section explaining custom VM boot images, including an AWS `amiID` example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->