### PR TITLE
Fix vendor directory inconsistency for Konflux hermetic builds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -361,7 +361,7 @@ require (
 	github.com/ryanrolds/sqlclosecheck v0.5.1 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sanposhiho/wastedassign/v2 v2.1.0 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3-0.20260305113123-180cde331deb // indirect
 	github.com/securego/gosec/v2 v2.22.2 // indirect
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd // indirect

--- a/go.sum
+++ b/go.sum
@@ -908,8 +908,8 @@ github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDc
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
 github.com/sanposhiho/wastedassign/v2 v2.1.0 h1:crurBF7fJKIORrV85u9UUpePDYGWnwvv3+A96WvwXT0=
 github.com/sanposhiho/wastedassign/v2 v2.1.0/go.mod h1:+oSmSC+9bQ+VUAxA66nBb0Z7N8CK7mscKTDYC6aIek4=
-github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
-github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3-0.20260305113123-180cde331deb h1:gBKmvepO0IIyV3orONHHq+aOYjvDu7GFrJ9sXQ8RNSg=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3-0.20260305113123-180cde331deb/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sashamelentyev/interfacebloat v1.1.0 h1:xdRdJp0irL086OyW1H/RTZTr1h/tMEOsumirXcOJqAw=
 github.com/sashamelentyev/interfacebloat v1.1.0/go.mod h1:+Y9yU5YdTkrNvoX0xHc84dxiN1iBi9+G8zZIhPVoNjQ=
 github.com/sashamelentyev/usestdlibvars v1.28.0 h1:jZnudE2zKCtYlGzLVreNp5pmCdOxXUzwsMDBkR21cyQ=

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/format.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/format.go
@@ -318,7 +318,7 @@ func validateEmail(v any) error {
 		return LocalizableError("local part more than 64 characters long")
 	}
 
-	if len(local) > 1 && strings.HasPrefix(local, `"`) && strings.HasPrefix(local, `"`) {
+	if len(local) > 1 && strings.HasPrefix(local, `"`) && strings.HasSuffix(local, `"`) {
 		// quoted
 		local := local[1 : len(local)-1]
 		if strings.IndexByte(local, '\\') != -1 || strings.IndexByte(local, '"') != -1 {

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/go.work.sum
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/go.work.sum
@@ -1,4 +1,4 @@
-github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/objcompiler.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/objcompiler.go
@@ -355,9 +355,13 @@ func (c *objCompiler) enqueueRef(pname string) (*Schema, error) {
 	if ref == nil {
 		return nil, nil
 	}
+	return c.enqueueRefVal(*ref)
+}
+
+func (c *objCompiler) enqueueRefVal(ref string) (*Schema, error) {
 	baseURL := c.res.id
 	// baseURL := c.r.baseURL(c.up.ptr)
-	uf, err := baseURL.join(*ref)
+	uf, err := baseURL.join(ref)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/schema.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/schema.go
@@ -1,8 +1,25 @@
+/*
+Package jsonschema provides json-schema compilation and validation.
+
+The schema is compiled against the version specified in "$schema" property.
+If "$schema" property is missing, it uses latest draft which currently implemented
+by this library.
+
+You can force to use specific draft,  when "$schema" is missing, as follows:
+
+	compiler := jsonschema.NewCompiler()
+	compiler.DefaultDraft(jsonschema.Draft4)
+
+This package supports loading json-schema from filePath and fileURL.
+
+see examples for usage.
+*/
 package jsonschema
 
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"math/big"
 )
 
@@ -110,12 +127,22 @@ const (
 )
 
 func typeOf(v any) jsonType {
-	switch v.(type) {
+	switch v := v.(type) {
 	case nil:
 		return nullType
 	case bool:
 		return booleanType
-	case json.Number, float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+	case float64:
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return invalidType
+		}
+		return numberType
+	case float32:
+		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+			return invalidType
+		}
+		return numberType
+	case json.Number, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
 		return numberType
 	case string:
 		return stringType

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/util.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/util.go
@@ -320,6 +320,9 @@ func equals(v1, v2 any) (bool, ErrorKind) {
 		v2, ok := v2.(string)
 		return ok && v1 == v2, nil
 	case json.Number, float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		if typeOf(v2) != numberType {
+			return false, nil
+		}
 		num1, ok1 := new(big.Rat).SetString(fmt.Sprint(v1))
 		num2, ok2 := new(big.Rat).SetString(fmt.Sprint(v2))
 		return ok1 && ok2 && num1.Cmp(num2) == 0, nil

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/validator.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/validator.go
@@ -375,7 +375,7 @@ func (vd *validator) arrValidate(arr []any) {
 				}
 			case *Schema:
 				for i, item := range arr[evaluated:] {
-					vd.addErr(vd.validateVal(additional, item, strconv.Itoa(i)))
+					vd.addErr(vd.validateVal(additional, item, strconv.Itoa(evaluated+i)))
 				}
 			}
 		}
@@ -390,7 +390,7 @@ func (vd *validator) arrValidate(arr []any) {
 		// items2020 --
 		if s.Items2020 != nil {
 			for i, item := range arr[evaluated:] {
-				vd.addErr(vd.validateVal(s.Items2020, item, strconv.Itoa(i)))
+				vd.addErr(vd.validateVal(s.Items2020, item, strconv.Itoa(evaluated+i)))
 			}
 		}
 	}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/vocab.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/vocab.go
@@ -14,6 +14,10 @@ func (ctx *CompilerContext) Enqueue(schPath []string) *Schema {
 	return ctx.c.enqueuePtr(ptr)
 }
 
+func (ctx *CompilerContext) EnqueueRef(ref string) (*Schema, error) {
+	return ctx.c.enqueueRefVal(ref)
+}
+
 // Vocabulary defines a set of keywords, their syntax and
 // their semantics.
 type Vocabulary struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2186,7 +2186,7 @@ github.com/sagikazarmark/locafero
 # github.com/sanposhiho/wastedassign/v2 v2.1.0
 ## explicit; go 1.18
 github.com/sanposhiho/wastedassign/v2
-# github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
+# github.com/santhosh-tekuri/jsonschema/v6 v6.0.3-0.20260305113123-180cde331deb
 ## explicit; go 1.21
 github.com/santhosh-tekuri/jsonschema/v6
 github.com/santhosh-tekuri/jsonschema/v6/kind


### PR DESCRIPTION
Original description: (removed)
Hermeto (Konflux's dependency pre-fetcher) validates in strict mode that the vendor directory matches go.mod. After running go mod vendor, it detects vendor/github.com/santhosh-tekuri/jsonschema/v6/.swp which exists in the upstream module but was excluded from the repo by .gitignore's *.swp rule.

Add negation rules (!vendor/**/*.swp, !vendor/**/*.swo) to .gitignore and commit the missing vendored file so Hermeto's strict validation passes.

-----
Revised description:
- Instead of adding the suspicious .swp binary and modifying .gitignore, the fix now bumps github.com/santhosh-tekuri/jsonschema/v6 from v6.0.2 to pseudo-version v6.0.3-0.20260305113123-180cde331deb (commit 180cde3)
- This commit from the upstream repo removes the accidentally included .swp file entirely (per jsonschema PR #254)
- After go mod vendor, the .swp file is no longer produced, so Hermeto's strict validation passes without needing any .gitignore workarounds

This matches the same approach used in managed-serviceaccount PR #536. 

-----
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON Schema validation for quoted email addresses.
  * Corrected handling of non-finite numbers such as `NaN` and infinity.
  * Prevented invalid numeric comparisons.
  * Fixed array validation error locations for tuple and prefix items.
  * Improved schema reference resolution.

* **Dependency Updates**
  * Updated the bundled JSON Schema validation library to a newer version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->