### PR TITLE
HIVE-3192: revendor installer to v1.5.0-alpha.2

### DIFF
--- a/apis/go.mod
+++ b/apis/go.mod
@@ -5,7 +5,6 @@ go 1.26.0
 toolchain go1.26.5
 
 require (
-	github.com/openshift/installer v1.5.0-alpha.1
 	k8s.io/api v0.36.2
 	k8s.io/apimachinery v0.36.2
 )
@@ -17,6 +16,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/openshift/api v0.0.0-20260728120005-8ba0b25b0f29
+	github.com/openshift/installer v1.5.0-alpha.2
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/net v0.55.1-0.20260602153038-42abb857022c // indirect

--- a/apis/go.sum
+++ b/apis/go.sum
@@ -19,8 +19,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/openshift/api v0.0.0-20260728120005-8ba0b25b0f29 h1:WrS2vkQtwJyo5xHJnJfjmHPDasdyKLKwojhMDV3tPto=
 github.com/openshift/api v0.0.0-20260728120005-8ba0b25b0f29/go.mod h1:k6qH5QOVa5GDln2VVm8Jz4NV3Z7R2SATHFLwGS6Wh3M=
-github.com/openshift/installer v1.5.0-alpha.1 h1:Vd+ZAiD6cV5h8fBTPvYnbq42KwScdzhHVF3RFhzHu0w=
-github.com/openshift/installer v1.5.0-alpha.1/go.mod h1:K6syzgcjEQO7QymXOD/CnJTqNNrJVoBX3I1YecYmfck=
+github.com/openshift/installer v1.5.0-alpha.2 h1:5u6TSe3MON6MYvzIWgTyrzWzT21XMT+yJm9DEtxpcmM=
+github.com/openshift/installer v1.5.0-alpha.2/go.mod h1:K6syzgcjEQO7QymXOD/CnJTqNNrJVoBX3I1YecYmfck=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/apis/vendor/modules.txt
+++ b/apis/vendor/modules.txt
@@ -19,7 +19,7 @@ github.com/openshift/api/config/v1
 github.com/openshift/api/machine/v1
 github.com/openshift/api/machine/v1beta1
 github.com/openshift/api/operator/v1
-# github.com/openshift/installer v1.5.0-alpha.1
+# github.com/openshift/installer v1.5.0-alpha.2
 ## explicit; go 1.26.0
 github.com/openshift/installer/pkg/types/vsphere
 # github.com/x448/float16 v0.8.4

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/openshift/cluster-autoscaler-operator v0.0.1-0.20250219201631-227f7537c3b4
 	github.com/openshift/generic-admission-server v1.14.1-0.20260305203524-5df3cca1e3cd
 	github.com/openshift/hive/apis v0.0.0
-	github.com/openshift/installer v1.5.0-alpha.1
+	github.com/openshift/installer v1.5.0-alpha.2
 	github.com/openshift/library-go v0.0.0-20260728221828-f675e9a73816
 	github.com/openshift/machine-api-operator v0.2.1-0.20251128002018-85c00c0d525f
 	github.com/openshift/machine-api-provider-gcp v0.0.1-0.20260113091719-80740861bb2a

--- a/go.sum
+++ b/go.sum
@@ -828,8 +828,8 @@ github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-202510290
 github.com/openshift/cluster-control-plane-machine-set-operator v0.0.0-20251029084908-344babe6a957/go.mod h1:TBlORAAtNZ/Tl86pO7GjNXKsH/g0QAW5GnvYstdOhYI=
 github.com/openshift/generic-admission-server v1.14.1-0.20260305203524-5df3cca1e3cd h1:vmJQouRzbrWIh/klml4SHYpB7U4FEDu6eKt9oqhIVBQ=
 github.com/openshift/generic-admission-server v1.14.1-0.20260305203524-5df3cca1e3cd/go.mod h1:DMfTM7LGbW1IF+h1K3stXiomJmu4l5dTKgrfItEIWrU=
-github.com/openshift/installer v1.5.0-alpha.1 h1:Vd+ZAiD6cV5h8fBTPvYnbq42KwScdzhHVF3RFhzHu0w=
-github.com/openshift/installer v1.5.0-alpha.1/go.mod h1:K6syzgcjEQO7QymXOD/CnJTqNNrJVoBX3I1YecYmfck=
+github.com/openshift/installer v1.5.0-alpha.2 h1:5u6TSe3MON6MYvzIWgTyrzWzT21XMT+yJm9DEtxpcmM=
+github.com/openshift/installer v1.5.0-alpha.2/go.mod h1:K6syzgcjEQO7QymXOD/CnJTqNNrJVoBX3I1YecYmfck=
 github.com/openshift/library-go v0.0.0-20260728221828-f675e9a73816 h1:9wH/CYW5WyblUkRi0/4W3WSeNWbkIQUX+jXax0k4BSc=
 github.com/openshift/library-go v0.0.0-20260728221828-f675e9a73816/go.mod h1:iahMN6YoNSRG1xyRj03YYU5iboJzv+UZFu9S0grJmQc=
 github.com/openshift/machine-api-operator v0.2.1-0.20251128002018-85c00c0d525f h1:nExol3fBEA615EeN7bZ6wvd4EaANOAIgj9aXfdyIja4=

--- a/vendor/github.com/openshift/installer/pkg/asset/installconfig/gcp/validation.go
+++ b/vendor/github.com/openshift/installer/pkg/asset/installconfig/gcp/validation.go
@@ -200,10 +200,11 @@ func validateDiskTypeAvailability(client API, fieldPath *field.Path, project, re
 	dt, dtZones, err := client.GetDiskTypeWithZones(context.TODO(), project, region, diskType)
 	if err != nil {
 		var gerr *googleapi.Error
-		if errors.As(err, &gerr) {
+		if errors.As(err, &gerr) && gerr.Code < 500 {
 			return append(allErrs, field.Invalid(fieldPath.Child("diskType"), diskType, err.Error()))
 		}
-		return append(allErrs, field.InternalError(fieldPath.Child("diskType"), err))
+		logrus.Warnf("could not verify disk type %s availability in %s, skipping API check: %v", diskType, region, err)
+		return allErrs
 	}
 
 	if dt == nil {

--- a/vendor/github.com/openshift/installer/pkg/asset/machines/azure/azuremachines.go
+++ b/vendor/github.com/openshift/installer/pkg/asset/machines/azure/azuremachines.go
@@ -399,6 +399,9 @@ func capzImage(osImage aztypes.OSImage, azEnv aztypes.CloudEnvironment, confiden
 				ThirdPartyImage: false,
 			},
 		}
+	case strings.HasPrefix(rhcosImg, "/subscriptions/"):
+		// An explicit non-marketplace resource path was supplied. Use it as is.
+		return &capz.Image{ID: &rhcosImg}
 	case rhcosImg == "" && !confidentialVM:
 		// hive calls the machines function, but may pass an empty
 		// string for rhcos. In which case, allow MAO to choose default.

--- a/vendor/github.com/openshift/installer/pkg/asset/machines/azure/machines.go
+++ b/vendor/github.com/openshift/installer/pkg/asset/machines/azure/machines.go
@@ -458,5 +458,9 @@ func mapiImage(osImage azure.OSImage, azEnv azure.CloudEnvironment, confidential
 // for MAPI, by removing the /subspcription/ prefix.
 func trimSubscriptionPrefix(image string) string {
 	rgIndex := strings.Index(image, "/resourceGroups/")
+	// Allow invalid inputs to fail downstream
+	if rgIndex < 0 {
+		return image
+	}
 	return image[rgIndex:]
 }

--- a/vendor/github.com/openshift/installer/pkg/asset/manifests/gcp/cloudproviderconfig.go
+++ b/vendor/github.com/openshift/installer/pkg/asset/manifests/gcp/cloudproviderconfig.go
@@ -34,10 +34,12 @@ type global struct {
 	NetworkProjectID string `gcfg:"network-project-id"`
 
 	FirewallManagement string `gcfg:"firewall-rules-management"`
+
+	TokenURL string `gcfg:"token-url"`
 }
 
 // CloudProviderConfig generates the cloud provider config for the GCP platform.
-func CloudProviderConfig(infraID, projectID, subnet, networkProjectID, firewallManagement string) (string, error) {
+func CloudProviderConfig(infraID, projectID, subnet, networkProjectID, firewallManagement, tokenURL string) (string, error) {
 	config := &config{
 		Global: global{
 			ProjectID: projectID,
@@ -59,6 +61,8 @@ func CloudProviderConfig(infraID, projectID, subnet, networkProjectID, firewallM
 			NetworkProjectID: networkProjectID,
 
 			FirewallManagement: firewallManagement,
+
+			TokenURL: tokenURL,
 		},
 	}
 
@@ -82,5 +86,6 @@ external-instance-groups-prefix = {{.Global.ExternalInstanceGroupsPrefix}}
 subnetwork-name = {{.Global.SubnetworkName}}
 {{- if ne .Global.NetworkProjectID "" }}{{"\n"}}network-project-id = {{.Global.NetworkProjectID}}{{ end }}
 {{- if ne .Global.FirewallManagement "" }}{{"\n"}}firewall-rules-management = {{.Global.FirewallManagement}}{{ end }}
+{{- if ne .Global.TokenURL "" }}{{"\n"}}token-url = {{.Global.TokenURL}}{{ end }}
 
 `

--- a/vendor/github.com/openshift/installer/pkg/types/aws/validation/featuregates.go
+++ b/vendor/github.com/openshift/installer/pkg/types/aws/validation/featuregates.go
@@ -44,5 +44,17 @@ func GatedFeatures(c *types.InstallConfig) []featuregates.GatedInstallConfigFeat
 		}
 	}
 
+	// Check if any compute pool has ClusterAPI management configured
+	for idx, compute := range c.Compute {
+		if compute.Management == types.ClusterAPI {
+			gatedFeatures = append(gatedFeatures, featuregates.GatedInstallConfigFeature{
+				FeatureGateName: features.FeatureGateClusterAPIMachineManagementAWS,
+				Condition:       true,
+				Field:           field.NewPath("compute").Index(idx).Child("management"),
+			})
+			break
+		}
+	}
+
 	return gatedFeatures
 }

--- a/vendor/github.com/openshift/installer/pkg/types/azure/validation/platform.go
+++ b/vendor/github.com/openshift/installer/pkg/types/azure/validation/platform.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 
+	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/azure"
 	"github.com/openshift/installer/pkg/types/network"
@@ -162,6 +163,7 @@ func ValidatePlatform(p *azure.Platform, publish types.PublishingStrategy, fldPa
 	}
 
 	allErrs = append(allErrs, validateIPFamily(p.IPFamily, fldPath.Child("ipFamily"))...)
+	allErrs = append(allErrs, validateDualStackMachineNetworks(ic, p.IPFamily)...)
 
 	if p.CloudName == azure.StackCloud && p.AllowSharedKeyAccess != nil && !*p.AllowSharedKeyAccess {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("allowSharedAccessKey"), p.AllowSharedKeyAccess, "disabling shared access key creation is unsupported in Azure stack hub"))
@@ -186,6 +188,98 @@ func validateIPFamily(ipFamily network.IPFamily, fldPath *field.Path) field.Erro
 	default:
 		allErrs = append(allErrs, field.NotSupported(fldPath, ipFamily, validValues))
 	}
+	return allErrs
+}
+
+// validateDualStackMachineNetworks validates Azure IPv6 networking configuration.
+// Azure does not support single-stack IPv6 (IPv6-only). IPv6 can only be used in dual-stack mode with IPv4.
+// Additionally, Azure's subnet splitting logic requires /64 subnets for IPv6, so the parent CIDR must have a broader prefix (prefix length less than /64).
+func validateDualStackMachineNetworks(ic *types.InstallConfig, ipFamily network.IPFamily) field.ErrorList {
+	if ic == nil || ic.Networking == nil {
+		return field.ErrorList{}
+	}
+
+	fldPath := field.NewPath("networking")
+	var allErrs field.ErrorList
+
+	machineNetworks := make([]ipnet.IPNet, len(ic.MachineNetwork))
+	for i, mn := range ic.MachineNetwork {
+		machineNetworks[i] = mn.CIDR
+	}
+
+	hasIPv4 := false
+	hasIPv6 := false
+	ipv6Indices := []int{}
+	ipv6TooLongIndices := []int{}
+	ipv6NotNibbleBoundaryIndices := []int{}
+
+	for i, machineNetwork := range machineNetworks {
+		ip := machineNetwork.IP
+		if len(ip) == 0 {
+			continue
+		}
+
+		if ip.To4() != nil {
+			hasIPv4 = true
+		} else {
+			hasIPv6 = true
+			ipv6Indices = append(ipv6Indices, i)
+
+			prefixLen, bits := machineNetwork.Mask.Size()
+			switch {
+			case bits == 0:
+				allErrs = append(allErrs, field.Invalid(
+					fldPath.Child("machineNetwork").Index(i).Child("cidr"),
+					machineNetworks[i].String(),
+					"CIDR has a non-canonical network mask",
+				))
+			case prefixLen >= 64:
+				ipv6TooLongIndices = append(ipv6TooLongIndices, i)
+			case prefixLen%4 != 0:
+				ipv6NotNibbleBoundaryIndices = append(ipv6NotNibbleBoundaryIndices, i)
+			}
+		}
+	}
+
+	if hasIPv6 && !hasIPv4 {
+		for _, i := range ipv6Indices {
+			allErrs = append(allErrs, field.Invalid(
+				fldPath.Child("machineNetwork").Index(i).Child("cidr"),
+				machineNetworks[i].String(),
+				"single-stack IPv6 is not supported on Azure. IPv6 may only be used with dual-stack networking (both IPv4 and IPv6)",
+			))
+		}
+		return allErrs
+	}
+
+	if ipFamily.DualStackEnabled() && !hasIPv6 {
+		allErrs = append(allErrs, field.Required(
+			fldPath.Child("machineNetwork"),
+			"at least one IPv6 machine network must be specified when dual-stack is enabled",
+		))
+		return allErrs
+	}
+
+	if len(ipv6NotNibbleBoundaryIndices) > 0 {
+		for _, i := range ipv6NotNibbleBoundaryIndices {
+			allErrs = append(allErrs, field.Invalid(
+				fldPath.Child("machineNetwork").Index(i).Child("cidr"),
+				machineNetworks[i].String(),
+				"IPv6 CIDR prefix length must be on a nibble boundary (multiples of 4). Valid prefixes less than /64 are /48, /52, /56, /60",
+			))
+		}
+	}
+
+	if len(ipv6TooLongIndices) > 0 {
+		for _, i := range ipv6TooLongIndices {
+			allErrs = append(allErrs, field.Invalid(
+				fldPath.Child("machineNetwork").Index(i).Child("cidr"),
+				machineNetworks[i].String(),
+				"in dual-stack configurations, IPv6 machine network CIDRs require prefix lengths shorter than /64 on nibble boundaries (e.g., /48, /52, /56, /60). Azure recommends /56 to allow splitting into multiple /64 subnets",
+			))
+		}
+	}
+
 	return allErrs
 }
 

--- a/vendor/github.com/openshift/installer/pkg/types/defaults/machinepools.go
+++ b/vendor/github.com/openshift/installer/pkg/types/defaults/machinepools.go
@@ -40,21 +40,14 @@ func SetMachinePoolDefaults(p *types.MachinePool, platform *types.Platform, fgat
 		}
 	}
 
-	// Set management to ClusterAPI if the appropriate feature gate is enabled and management is unspecified
-	if p.Management == "" {
-		if p.Name == types.MachinePoolControlPlaneRoleName && fgates.Enabled(features.FeatureGateClusterAPIControlPlaneInstall) {
-			p.Management = types.ClusterAPI
-		}
-		if p.Name == types.MachinePoolComputeRoleName && fgates.Enabled(features.FeatureGateClusterAPIComputeInstall) {
-			p.Management = types.ClusterAPI
-		}
-		if p.Name == types.MachinePoolEdgeRoleName && fgates.Enabled(features.FeatureGateClusterAPIComputeInstall) {
-			p.Management = types.ClusterAPI
-		}
-	}
-
 	switch platform.Name() {
 	case aws.Name:
+		if p.Management == "" {
+			if (p.Name == types.MachinePoolComputeRoleName || p.Name == types.MachinePoolEdgeRoleName) &&
+				fgates.Enabled(features.FeatureGateClusterAPIMachineManagementAWS) {
+				p.Management = types.ClusterAPI
+			}
+		}
 		if p.Platform.AWS == nil && platform.AWS.DefaultMachinePlatform != nil {
 			p.Platform.AWS = &aws.MachinePool{}
 		}

--- a/vendor/github.com/openshift/installer/pkg/types/gcp/validation/machinepool.go
+++ b/vendor/github.com/openshift/installer/pkg/types/gcp/validation/machinepool.go
@@ -76,3 +76,30 @@ func ValidateDefaultDiskType(p *gcp.MachinePool, fldPath *field.Path) field.Erro
 
 	return allErrs
 }
+
+// ValidateOSImageForSovereignCloud checks that an OS image is specified for sovereign cloud environments.
+func ValidateOSImageForSovereignCloud(platform *gcp.Platform, pool *gcp.MachinePool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if gcp.GetCloudEnvironment(platform.ProjectID) != gcp.CloudEnvironmentSovereign {
+		return allErrs
+	}
+
+	if pool == nil || pool.OSImage == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("osImage"),
+			"must specify an OS image for sovereign cloud environments (domain-scoped project ID)"))
+		return allErrs
+	}
+
+	osImagePath := fldPath.Child("osImage")
+	if pool.OSImage.Name == "" {
+		allErrs = append(allErrs, field.Required(osImagePath.Child("name"),
+			"must specify an OS image name for sovereign cloud environments"))
+	}
+	if pool.OSImage.Project == "" {
+		allErrs = append(allErrs, field.Required(osImagePath.Child("project"),
+			"must specify an OS image project for sovereign cloud environments"))
+	}
+
+	return allErrs
+}

--- a/vendor/github.com/openshift/installer/pkg/types/validation/featuregates.go
+++ b/vendor/github.com/openshift/installer/pkg/types/validation/featuregates.go
@@ -42,23 +42,6 @@ func validateMachinePoolFeatureGates(c *types.InstallConfig) []featuregates.Gate
 			Field:           field.NewPath("osImageStream"),
 		},
 		{
-			FeatureGateName: features.FeatureGateClusterAPIControlPlaneInstall,
-			Condition:       c.ControlPlane != nil && c.ControlPlane.Management == types.ClusterAPI,
-			Field:           field.NewPath("controlPlane", "management"),
-		},
-		{
-			FeatureGateName: features.FeatureGateClusterAPIComputeInstall,
-			Condition: func() bool {
-				for _, compute := range c.Compute {
-					if compute.Management == types.ClusterAPI {
-						return true
-					}
-				}
-				return false
-			}(),
-			Field: field.NewPath("compute", "management"),
-		},
-		{
 			FeatureGateName: features.FeatureGateConfigurablePKI,
 			Condition:       c.PKI != nil,
 			Field:           field.NewPath("pki"),

--- a/vendor/github.com/openshift/installer/pkg/types/validation/installconfig.go
+++ b/vendor/github.com/openshift/installer/pkg/types/validation/installconfig.go
@@ -439,7 +439,7 @@ func validateNetworkingIPVersion(c *types.InstallConfig) field.ErrorList {
 				allErrs = append(allErrs, field.Invalid(field.NewPath("networking", k), strings.Join(ipnetworksToStrings(addresses[k]), ", "), "dual-stack IPv4/IPv6 requires an IPv4 network in this list"))
 			}
 
-			allErrs = append(allErrs, validateNetworkEntryOrder(p, v, addresses[k], allowV6Primary, field.NewPath("networking", k))...)
+			allErrs = append(allErrs, validateNetworkEntryOrder(p, v, addresses[k], allowV6Primary, k, field.NewPath("networking", k))...)
 		}
 
 	case hasIPv6:
@@ -490,7 +490,7 @@ func validateNetworkingIPVersion(c *types.InstallConfig) field.ErrorList {
 // - IPv4 primary dual-stack: IPv4 CIDR first in list
 // - IPv6 primary dual-stack: IPv6 CIDR first in list
 // Some platforms have an explicit field to define the dual-stack variant, for example, platform.aws.ipFamily on AWS.
-func validateNetworkEntryOrder(p *types.Platform, ipAddressType ipAddressType, networks []ipnet.IPNet, allowV6Primary bool, fldPath *field.Path) field.ErrorList {
+func validateNetworkEntryOrder(p *types.Platform, ipAddressType ipAddressType, networks []ipnet.IPNet, allowV6Primary bool, networkType string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// If missing either IPv4 or IPv6 CIDR, order validation is not applicable
@@ -510,6 +510,14 @@ func validateNetworkEntryOrder(p *types.Platform, ipAddressType ipAddressType, n
 		if ipFamily == network.DualStackIPv6Primary && ipAddressType.Primary == corev1.IPv4Protocol {
 			allErrs = append(allErrs, field.Invalid(fldPath, strings.Join(ipnetworksToStrings(networks), ", "), "DualStackIPv6Primary requires an IPv6 network first in this list"))
 		}
+	case p.Azure != nil:
+		// Azure nodes always have IPv4 as the primary NIC address, so serviceNetwork
+		// must have IPv4 first regardless of ipFamily. The kube-apiserver requires the
+		// primary service IP family to match the node's address family.
+		if networkType == networkTypeService && ipAddressType.Primary != corev1.IPv4Protocol {
+			allErrs = append(allErrs, field.Invalid(fldPath, strings.Join(ipnetworksToStrings(networks), ", "), "Azure requires an IPv4 service network first in this list because node primary addresses are always IPv4"))
+		}
+
 	default:
 		// For platforms that don't support IPv6-primary dual-stack, reject configurations with IPv6 CIDRs listed first.
 		if !allowV6Primary && ipAddressType.Primary != corev1.IPv4Protocol {
@@ -1686,6 +1694,25 @@ func validateGatedFeatures(c *types.InstallConfig) field.ErrorList {
 		fgCheck(gf)
 	}
 
+	return allErrs
+}
+
+func validateMachineManagement(platform *types.Platform, p *types.MachinePool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if p.Management != types.ClusterAPI {
+		return allErrs
+	}
+
+	switch platform.Name() {
+	case aws.Name:
+		// ATM, ClusterAPI management is only supported for worker and edge compute pool
+		if p.Name == types.MachinePoolControlPlaneRoleName {
+			allErrs = append(allErrs, field.Invalid(fldPath, p.Management, fmt.Sprintf("%s machines cannot be managed by Cluster API", p.Name)))
+		}
+	default:
+		allErrs = append(allErrs, field.Invalid(fldPath, p.Management, fmt.Sprintf("machines cannot be managed by Cluster API for platform %s", platform.Name())))
+	}
 	return allErrs
 }
 

--- a/vendor/github.com/openshift/installer/pkg/types/validation/machinepools.go
+++ b/vendor/github.com/openshift/installer/pkg/types/validation/machinepools.go
@@ -79,7 +79,7 @@ func ValidateMachinePool(platform *types.Platform, p *types.MachinePool, fldPath
 	}
 
 	allErrs = append(allErrs, validateDiskSetup(p, fldPath.Child("diskSetup"))...)
-
+	allErrs = append(allErrs, validateMachineManagement(platform, p, fldPath.Child("management"))...)
 	allErrs = append(allErrs, validateMachinePoolPlatform(platform, &p.Platform, p, fldPath.Child("platform"))...)
 	return allErrs
 }
@@ -161,6 +161,9 @@ func validateMachinePoolPlatform(platform *types.Platform, p *types.MachinePoolP
 		validate(azure.Name, p.Azure, func(f *field.Path) field.ErrorList {
 			return azurevalidation.ValidateMachinePool(p.Azure, pool.Name, platform.Azure, pool, f)
 		})
+	}
+	if platform.GCP != nil {
+		allErrs = append(allErrs, gcpvalidation.ValidateOSImageForSovereignCloud(platform.GCP, p.GCP, fldPath.Child("gcp"))...)
 	}
 	if p.GCP != nil {
 		validate(gcp.Name, p.GCP, func(f *field.Path) field.ErrorList { return validateGCPMachinePool(platform, p, pool, f) })

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1917,7 +1917,7 @@ github.com/openshift/hive/apis/hive/v1/vsphere
 github.com/openshift/hive/apis/hivecontracts/v1alpha1
 github.com/openshift/hive/apis/hiveinternal/v1alpha1
 github.com/openshift/hive/apis/scheme
-# github.com/openshift/installer v1.5.0-alpha.1
+# github.com/openshift/installer v1.5.0-alpha.2
 ## explicit; go 1.26.0
 github.com/openshift/installer/data
 github.com/openshift/installer/pkg/asset


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for explicit Azure image resource paths.
  * Added GCP token URL configuration.
  * Added AWS Cluster API machine-management support.
  * Added validation for sovereign-cloud GCP OS images.
  * Added Azure IPv6 and dual-stack network validation.

* **Bug Fixes**
  * Improved handling of cloud API errors during GCP validation.
  * Prevented invalid Azure image paths from causing processing errors.
  * Restricted machine-management settings to supported platforms and pools.
  * Improved Azure service-network ordering validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->