### PR TITLE
Add MCE-52 tekton files

### DIFF
--- a/.tekton/hive-mce-52-push.yaml
+++ b/.tekton/hive-mce-52-push.yaml
@@ -1,0 +1,81 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift/hive?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: 'false'
+    pipelinesascode.tekton.dev/max-keep-runs: '3'
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "push"
+      && target_branch == "master"
+      && !files.all.all(x, x.matches('^docs/|\\.md$|^(?:.*/)?(?:\\.gitignore|OWNERS|PROJECT|LICENSE)$'))
+  labels:
+    appstudio.openshift.io/application: release-mce-52
+    appstudio.openshift.io/component: hive-mce-52
+    pipelines.appstudio.openshift.io/type: build
+  name: hive-mce-52-on-push
+  namespace: crt-redhat-acm-tenant
+spec:
+  params:
+    - name: git-url
+      value: '{{source_url}}'
+    - name: fetchTags
+      value: 'true'
+    - name: depth
+      value: '0'
+    - name: revision
+      value: '{{revision}}'
+    - name: output-image
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/hive-mce-52:{{revision}}
+    - name: build-platforms
+      value:
+        - linux/x86_64
+        - linux/ppc64le
+        - linux/s390x
+        - linux-mxlarge/arm64
+    - name: dockerfile
+      value: Dockerfile
+    - name: path-context
+      value: .
+    - name: hermetic
+      value: 'true'
+    - name: prefetch-input
+      value: '[{"type": "rpm", "path": "./hack/hermetic"}]'
+    - name: build-args
+      value:
+        - CONTAINER_SUB_MANAGER_OFF=1
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
+        - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
+    - name: build-source-image
+      value: 'true'
+    - name: build-image-index
+      value: 'true'
+    - name: enable-cache-proxy
+      value: 'true'
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: https://github.com/stolostron/konflux-build-catalog.git
+      - name: revision
+        value: main
+      - name: pathInRepo
+        value: pipelines/common.yaml
+  taskRunSpecs:
+    - computeResources:
+        limits:
+          cpu: '4'
+          memory: 20Gi
+        requests:
+          cpu: '1'
+          memory: 16Gi
+      pipelineTaskName: build-images
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-hive-mce-52
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: '{{ git_auth_secret }}'


### PR DESCRIPTION
Assisted-by: Claude Sonnet 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated pipeline for Hive MCE 2.52 push builds.
  * Builds and publishes multi-platform container images and source artifacts.
  * Improves consistency and efficiency of build and release workflows through caching and standardized build settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->