### PR TITLE
Fix StatefulSet reconcile hotloop from server-defaulted fields

### DIFF
--- a/config/sharded_controllers/statefulset.yaml
+++ b/config/sharded_controllers/statefulset.yaml
@@ -10,6 +10,15 @@ metadata:
     control-plane: {{.ControllerName}}
     controller-tools.k8s.io: "1.0"
 spec:
+  podManagementPolicy: OrderedReady
+  revisionHistoryLimit: 10
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: 0
   selector:
     matchLabels:
       control-plane: {{.ControllerName}}

--- a/pkg/operator/hive/sharded_controllers_test.go
+++ b/pkg/operator/hive/sharded_controllers_test.go
@@ -1,0 +1,49 @@
+package hive
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+
+	controllerutils "github.com/openshift/hive/pkg/controller/utils"
+	"github.com/openshift/hive/pkg/operator/assets"
+)
+
+func TestStatefulSetTemplateIncludesDefaultableFields(t *testing.T) {
+	for _, controllerName := range []string{"clustersync", "machinepool"} {
+		t.Run(controllerName, func(t *testing.T) {
+			templateValues := map[string]string{
+				"ControllerName": controllerName,
+			}
+			processed, err := controllerutils.ProcessAssetTemplate(
+				assets.MustAsset("config/sharded_controllers/statefulset.yaml"),
+				templateValues,
+			)
+			if err != nil {
+				t.Fatalf("failed to process template: %v", err)
+			}
+
+			ss := readRuntimeObjectOrDie[*appsv1.StatefulSet](appsv1.SchemeGroupVersion, processed)
+
+			if ss.Spec.PodManagementPolicy != appsv1.OrderedReadyPodManagement {
+				t.Errorf("expected PodManagementPolicy=%q, got %q",
+					appsv1.OrderedReadyPodManagement, ss.Spec.PodManagementPolicy)
+			}
+
+			if ss.Spec.RevisionHistoryLimit == nil || *ss.Spec.RevisionHistoryLimit != 10 {
+				t.Errorf("expected RevisionHistoryLimit=10, got %v", ss.Spec.RevisionHistoryLimit)
+			}
+
+			if ss.Spec.UpdateStrategy.Type != appsv1.RollingUpdateStatefulSetStrategyType {
+				t.Errorf("expected UpdateStrategy.Type=%q, got %q",
+					appsv1.RollingUpdateStatefulSetStrategyType, ss.Spec.UpdateStrategy.Type)
+			}
+
+			if ss.Spec.UpdateStrategy.RollingUpdate == nil ||
+				ss.Spec.UpdateStrategy.RollingUpdate.Partition == nil ||
+				*ss.Spec.UpdateStrategy.RollingUpdate.Partition != 0 {
+				t.Error("expected UpdateStrategy.RollingUpdate.Partition=0")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The hive-operator enters an infinite reconcile loop (~8s cycles, 6-7 CPU cores) because the `clustersync` and `machinepool` StatefulSet templates omit fields that the kube-apiserver defaults on every apply:

- `updateStrategy` (defaults to `{type: RollingUpdate, rollingUpdate: {partition: 0}}`)
- `revisionHistoryLimit` (defaults to `10`)
- `podManagementPolicy` (defaults to `OrderedReady`)
- `persistentVolumeClaimRetentionPolicy` (defaults to `{whenDeleted: Retain, whenScaled: Retain}`)

The client-side three-way merge in `ApplyRuntimeObject()` computes a non-empty patch each cycle because `last-applied-configuration` has the omitted fields while the live object has the server-defaulted values. The apply returns `"configured"` instead of `"unchanged"`, triggering a watch event that re-queues reconciliation immediately.

### Collateral damage

The continuous API server churn causes `assisted-service` to lose its leader election lease (15s duration), resulting in CrashLoopBackOff. We observed **300+ restarts** in production on ACM/MCE v2.17.1.

## Fix

Explicitly set all server-defaultable fields in `config/sharded_controllers/statefulset.yaml` to match what the API server would default them to. This breaks the diff loop because the desired state now matches the live state after defaulting.

This is the same approach used by:
- [prometheus-operator#5712](https://github.com/prometheus-operator/prometheus-operator/issues/5712) — `revisionHistoryLimit` defaulting loop
- [OLM BZ#1888073](https://bugzilla.redhat.com/show_bug.cgi?id=1888073) — no-op hotloop

## Changes

- `config/sharded_controllers/statefulset.yaml` — add `podManagementPolicy`, `revisionHistoryLimit`, `persistentVolumeClaimRetentionPolicy`, and `updateStrategy` with their default values
- `pkg/operator/hive/sharded_controllers_test.go` — new test verifying the rendered template includes all defaultable fields

## Workaround (for affected users)

Scale the hive-operator to 0 replicas. The hive-managed components (controllers, clustersync, machinepool, hiveadmission) continue running fine without the operator:

```bash
oc scale deployment hive-operator -n multicluster-engine --replicas=0
```

## Test plan

- [ ] Unit test `TestStatefulSetTemplateIncludesDefaultableFields` passes
- [ ] Deploy on a cluster with ACM/MCE, verify hive-operator logs show `applied (unchanged)` for both StatefulSets after initial reconcile
- [ ] Verify assisted-service maintains its leader lease without restarts
- [ ] Verify `hive-operator` CPU usage drops from 6-7 cores to near-zero idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Stateful workloads now start and update in a predictable order.
  * Persistent storage claims are retained when pods are deleted or scaled down.
  * Rolling updates are configured to proceed from the beginning of the workload.
* **Tests**
  * Added coverage to verify these Kubernetes workload settings for supported sharded controllers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->