### PR TITLE
HIVE-2671: add netpols to e2e env

### DIFF
--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -129,13 +129,19 @@ function wait_for_namespace {
   exit 1
 }
 
-# apply_deny_all_netpol pre-creates namespace $1 (idempotently) and applies a
-# deny-all NetworkPolicy to it. This exercises Hive's non-OLM network policy
-# coverage: if any required netpol is absent or misconfigured, pods in that
-# namespace cannot communicate and the subsequent e2e tests will fail.
+# apply_deny_all_netpol applies a deny-all NetworkPolicy to namespace $1. By
+# default it also (idempotently) pre-creates the namespace; pass "false" as $2 to
+# skip that step -- e.g. from watch_clusterpool_namespaces, where the namespace
+# already exists and re-creating a just-reaped one would be wrong.
+# This exercises Hive's non-OLM network policy coverage: if any required netpol is
+# absent or misconfigured, pods in that namespace cannot communicate and the
+# subsequent e2e tests will fail.
 function apply_deny_all_netpol {
   local ns=$1
-  oc create namespace "${ns}" --dry-run=client -o yaml | oc apply -f -
+  local create_ns=${2:-true}
+  if [[ "$create_ns" == "true" ]]; then
+    oc create namespace "${ns}" --dry-run=client -o yaml | oc apply -f -
+  fi
   oc apply -f - <<EOF
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -150,24 +156,25 @@ spec:
 EOF
 }
 
-# watch_clusterpool_namespaces runs as a background process, polling every 2s
-# for namespaces labeled hive.openshift.io/cluster-pool-name (created at
-# runtime by the clusterpool controller) and applying a deny-all NetworkPolicy
-# to each one it hasn't processed yet. Start it with & and capture the PID;
-# kill the PID in the EXIT trap.
+# watch_clusterpool_namespaces runs as a background process, watching for
+# namespaces labeled hive.openshift.io/cluster-pool-name (created at runtime by
+# the clusterpool controller) and applying a deny-all NetworkPolicy to each one.
+# Start it with & and capture the PID; kill the PID in the EXIT trap.
+#
+# `-w` streams namespaces as they appear, which narrows (though can't fully close)
+# the race between namespace creation and NetworkPolicy application.
 function watch_clusterpool_namespaces {
-  local seen=""
-  while true; do
-    while read -r ns; do
-      [[ -z "$ns" ]] && continue
-      if [[ " $seen " != *" $ns "* ]]; then
-        apply_deny_all_netpol "$ns"
-        seen="$seen $ns"
-      fi
-    done < <(oc get namespace -l 'hive.openshift.io/cluster-pool-name' \
-      -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null)
-    sleep 2
-  done
+  local -A seen
+  oc get namespace -l 'hive.openshift.io/cluster-pool-name' -o name --no-headers -w 2>/dev/null \
+    | while IFS=/ read -r _ ns; do
+        [[ -z "$ns" ]] && continue
+        [[ -n "${seen[$ns]}" ]] && continue
+        # The namespace already exists (we're reacting to it), so don't re-create it.
+        # Under set -e a failed apply aborts the whole test, which is what we want:
+        # a clusterpool CD must never provision without the deny-all policy.
+        apply_deny_all_netpol "$ns" false
+        seen[$ns]=1
+      done
 }
 
 function get_osp_resources() {

--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -150,6 +150,26 @@ spec:
 EOF
 }
 
+# watch_clusterpool_namespaces runs as a background process, polling every 2s
+# for namespaces labeled hive.openshift.io/cluster-pool-name (created at
+# runtime by the clusterpool controller) and applying a deny-all NetworkPolicy
+# to each one it hasn't processed yet. Start it with & and capture the PID;
+# kill the PID in the EXIT trap.
+function watch_clusterpool_namespaces {
+  local seen=""
+  while true; do
+    while read -r ns; do
+      [[ -z "$ns" ]] && continue
+      if [[ " $seen " != *" $ns "* ]]; then
+        apply_deny_all_netpol "$ns"
+        seen="$seen $ns"
+      fi
+    done < <(oc get namespace -l 'hive.openshift.io/cluster-pool-name' \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null)
+    sleep 2
+  done
+}
+
 function get_osp_resources() {
   local resource_path=$1
 

--- a/hack/e2e-common.sh
+++ b/hack/e2e-common.sh
@@ -129,6 +129,27 @@ function wait_for_namespace {
   exit 1
 }
 
+# apply_deny_all_netpol pre-creates namespace $1 (idempotently) and applies a
+# deny-all NetworkPolicy to it. This exercises Hive's non-OLM network policy
+# coverage: if any required netpol is absent or misconfigured, pods in that
+# namespace cannot communicate and the subsequent e2e tests will fail.
+function apply_deny_all_netpol {
+  local ns=$1
+  oc create namespace "${ns}" --dry-run=client -o yaml | oc apply -f -
+  oc apply -f - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-all
+  namespace: ${ns}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+EOF
+}
+
 function get_osp_resources() {
   local resource_path=$1
 
@@ -214,6 +235,16 @@ function save_hive_logs() {
 # The consumer of this lib can set up its own exit trap, but this basic one will at least help
 # debug e.g. problems from `make deploy` and managed DNS setup.
 trap 'set +e; kill %1; save_hive_logs' EXIT
+
+# Pre-apply deny-all network policies to both hive namespaces and the cluster
+# namespace. make deploy then lays down the operator netpol (egress for
+# hive-operator pods) and the operator lays down controller/admission netpols
+# in HIVE_NS. For CLUSTER_NAMESPACE, hive controllers lay down per-job allow
+# netpols (imageset/provision/deprovision) before each job starts. If any
+# netpol is missing or misconfigured, the e2e tests that follow will fail.
+apply_deny_all_netpol "${HIVE_OPERATOR_NS}"
+apply_deny_all_netpol "${HIVE_NS}"
+apply_deny_all_netpol "${CLUSTER_NAMESPACE}"
 
 # Install Hive
 IMG="${HIVE_IMAGE}" make deploy

--- a/hack/e2e-pool-test.sh
+++ b/hack/e2e-pool-test.sh
@@ -14,6 +14,11 @@ for deployment in hive-controllers hiveadmission; do
   oc wait --for=condition=Available --timeout=2m deploy/$deployment -n $HIVE_NS
 done
 
+# Start background watcher to apply deny-all netpols to clusterpool namespaces
+# as they are created at runtime by the controller.
+watch_clusterpool_namespaces &
+NETPOL_WATCHER_PID=$!
+
 function create_imageset() {
   local is_name=$1
   echo "Creating imageset $is_name"
@@ -98,6 +103,7 @@ REAL_POOL_NAME=$CLUSTER_NAME
 
 function cleanup() {
   echo "!EXIT TRAP!"
+  kill "$NETPOL_WATCHER_PID" 2>/dev/null || true
   capture_manifests CLEANUP_000
   # Let's save the logs now in case any of the following fail
   echo "Saving hive logs before cleanup"

--- a/hack/e2e-test.sh
+++ b/hack/e2e-test.sh
@@ -55,6 +55,9 @@ export HIVE_NS=hive-e2e-two
 oc patch hiveconfig hive -n $HIVE_OPERATOR_NS --type=merge -p '{"spec":{"targetNamespace": "'$HIVE_NS'"}}'
 # Wait for hive-operator to roll out the new namespace
 wait_for_namespace $HIVE_NS 60
+# Apply deny-all to the new target namespace so netpol coverage is exercised
+# on the migration path as well.
+apply_deny_all_netpol "${HIVE_NS}"
 # 3) If USE_MANAGED_DNS=true, "Move" the managed DNS creds secret to the new namespace. (In real
 #    life the user would be responsible for making sure the secret referenced by hiveconfig exists
 #    in the new target namespace -- either by moving the secret or creating a new one and updating


### PR DESCRIPTION
verifies https://github.com/openshift/hive/pull/2923

Adds baseline deny-all networkpolicy objects to e2e so that the defensive policies from #2923 are required to maintain functionality. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for network isolation across operator, Hive, cluster, and cluster-pool namespaces.
  * Added validation that namespace migration paths continue to work when ingress and egress traffic are denied by default.
  * Added coverage for automatically applying isolation policies to newly created cluster-pool namespaces.
  * Improved test monitoring and cleanup to ensure isolation policies are applied consistently throughout test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->