### PR TITLE
HIVE-3194: Switch to PQC base images

### DIFF
--- a/.tekton/hive-mce-210-push.yaml
+++ b/.tekton/hive-mce-210-push.yaml
@@ -48,7 +48,7 @@ spec:
         - CONTAINER_SUB_MANAGER_OFF=1
         - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
         - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
-        - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
+        - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'
     - name: build-image-index

--- a/.tekton/hive-mce-211-push.yaml
+++ b/.tekton/hive-mce-211-push.yaml
@@ -48,7 +48,7 @@ spec:
         - CONTAINER_SUB_MANAGER_OFF=1
         - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
         - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
-        - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
+        - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'
     - name: build-image-index

--- a/.tekton/hive-mce-217-push.yaml
+++ b/.tekton/hive-mce-217-push.yaml
@@ -48,7 +48,7 @@ spec:
         - CONTAINER_SUB_MANAGER_OFF=1
         - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
         - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
-        - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
+        - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'
     - name: build-image-index

--- a/.tekton/hive-mce-26-push.yaml
+++ b/.tekton/hive-mce-26-push.yaml
@@ -48,7 +48,7 @@ spec:
         - CONTAINER_SUB_MANAGER_OFF=1
         - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
         - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
-        - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
+        - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'
     - name: build-image-index

--- a/.tekton/hive-mce-28-push.yaml
+++ b/.tekton/hive-mce-28-push.yaml
@@ -48,7 +48,7 @@ spec:
         - CONTAINER_SUB_MANAGER_OFF=1
         - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
         - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
-        - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
+        - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'
     - name: build-image-index

--- a/.tekton/hive-mce-29-push.yaml
+++ b/.tekton/hive-mce-29-push.yaml
@@ -48,7 +48,7 @@ spec:
         - CONTAINER_SUB_MANAGER_OFF=1
         - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
         - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
-        - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
+        - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'
     - name: build-image-index

--- a/.tekton/hive-mce-50-push.yaml
+++ b/.tekton/hive-mce-50-push.yaml
@@ -48,7 +48,7 @@ spec:
         - CONTAINER_SUB_MANAGER_OFF=1
         - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
         - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
-        - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
+        - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'
     - name: build-image-index

--- a/.tekton/hive-mce-51-push.yaml
+++ b/.tekton/hive-mce-51-push.yaml
@@ -48,7 +48,7 @@ spec:
         - CONTAINER_SUB_MANAGER_OFF=1
         - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
         - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
-        - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
+        - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'
     - name: build-image-index

--- a/.tekton/hive-mce-52-push.yaml
+++ b/.tekton/hive-mce-52-push.yaml
@@ -48,7 +48,7 @@ spec:
         - CONTAINER_SUB_MANAGER_OFF=1
         - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
         - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
-        - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
+        - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'
     - name: build-image-index

--- a/.tekton/hive-pull-request.yaml
+++ b/.tekton/hive-pull-request.yaml
@@ -49,7 +49,7 @@ spec:
         - CONTAINER_SUB_MANAGER_OFF=1
         - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
         - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
-        - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
+        - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'
     - name: build-image-index

--- a/.tekton/hive-push.yaml
+++ b/.tekton/hive-push.yaml
@@ -48,7 +48,7 @@ spec:
         - CONTAINER_SUB_MANAGER_OFF=1
         - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
         - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
-        - BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
+        - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'
     - name: build-image-index

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG CONTAINER_SUB_MANAGER_OFF=0
 ARG EL8_BUILD_IMAGE=${EL8_BUILD_IMAGE:-registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.26-openshift-4.23}
 ARG EL9_BUILD_IMAGE=${EL9_BUILD_IMAGE:-registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23}
-ARG BASE_IMAGE=${BASE_IMAGE:-registry.access.redhat.com/ubi9/ubi-minimal:latest}
+ARG BASE_IMAGE=${BASE_IMAGE:-registry.redhat.io/ubi9/ubi-minimal-pqc:latest}
 
 FROM ${EL8_BUILD_IMAGE} as builder_rhel8
 ARG GO=${GO:-go}

--- a/Dockerfile.ote
+++ b/Dockerfile.ote
@@ -1,5 +1,5 @@
 ARG OTE_BUILD_IMAGE=registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23
-ARG BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
+ARG BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 FROM ${OTE_BUILD_IMAGE} as builder
 RUN mkdir -p /go/src/github.com/openshift/hive

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: vendor update test build
 # These images need to be synced with the default values in the Dockerfile.
 EL8_BUILD_IMAGE ?= registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.26-openshift-4.23
 EL9_BUILD_IMAGE ?= registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-4.23
-BASE_IMAGE ?= registry.ci.openshift.org/ocp/4.21:base-rhel9
+BASE_IMAGE ?= registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 # In openshift ci (Prow), we need to set $HOME to a writable directory else tests will fail
 # because they don't have permissions to create /.local or /.cache directories


### PR DESCRIPTION
Not-Involved: AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated build and runtime environments to use Red Hat’s PQC-enabled UBI 9 minimal base image.
  - Standardized image sourcing through Red Hat’s registry across development, pull-request, and release builds.
  - Updated default local build configuration to use the RHEL 9.8 ELS PQC-minimal image.
  - Ensured consistent base-image configuration across automated and local build workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->