### PR TITLE
OCPBUGS-105520: VSphere: Clear upconverted deprecated fields

### DIFF
--- a/pkg/controller/utils/vsphereutils/vsphere.go
+++ b/pkg/controller/utils/vsphereutils/vsphere.go
@@ -30,5 +30,22 @@ func ConvertDeprecatedFields(platform *hivevsphere.Platform) error {
 	}
 
 	platform.Infrastructure = dummyInstallConfig.Platform.VSphere
+	// ConvertInstallConfig copies legacy names onto the installer Platform and
+	// leaves them there. infrastructure.folder is CRD-validated as a full
+	// inventory path (^/.*?/vm/.*?); a non-pathed leftover fails KAS
+	// (OCPBUGS-105520). Drop all deprecated fields — topology already holds
+	// the upconverted values.
+	infra := platform.Infrastructure
+	infra.DeprecatedVCenter = ""
+	infra.DeprecatedUsername = ""
+	infra.DeprecatedPassword = ""
+	infra.DeprecatedDatacenter = ""
+	infra.DeprecatedDefaultDatastore = ""
+	infra.DeprecatedFolder = ""
+	infra.DeprecatedCluster = ""
+	infra.DeprecatedResourcePool = ""
+	infra.DeprecatedAPIVIP = ""
+	infra.DeprecatedIngressVIP = ""
+	infra.DeprecatedNetwork = ""
 	return nil
 }

--- a/pkg/controller/utils/vsphereutils/vsphereutils_test.go
+++ b/pkg/controller/utils/vsphereutils/vsphereutils_test.go
@@ -53,6 +53,40 @@ func TestConvertDeprecatedFields(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Already-absolute folder values must still land on topology.folder.
+			Name:                       "pathed folder",
+			DeprecatedVCenter:          "my_vcenter",
+			DeprecatedDatacenter:       "my_datacenter",
+			DeprecatedDefaultDatastore: "my_datastore",
+			DeprecatedFolder:           "/my_datacenter/vm/my_folder",
+			DeprecatedCluster:          "my_cluster",
+			DeprecatedNetwork:          "my_network",
+			Expected: &installervsphere.Platform{
+				VCenters: []installervsphere.VCenter{
+					{
+						Server:      "my_vcenter",
+						Port:        443,
+						Datacenters: []string{"my_datacenter"},
+					},
+				},
+				FailureDomains: []installervsphere.FailureDomain{
+					{
+						Name:   "generated-failure-domain",
+						Region: "generated-region",
+						Zone:   "generated-zone",
+						Server: "my_vcenter",
+						Topology: installervsphere.Topology{
+							Datacenter:     "my_datacenter",
+							ComputeCluster: "/my_datacenter/host/my_cluster",
+							Networks:       []string{"my_network"},
+							Datastore:      "/my_datacenter/datastore/my_datastore",
+							Folder:         "/my_datacenter/vm/my_folder",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -66,12 +100,14 @@ func TestConvertDeprecatedFields(t *testing.T) {
 				DeprecatedNetwork:          test.DeprecatedNetwork,
 			}
 
-			test.Expected.DeprecatedVCenter = test.DeprecatedVCenter
-			test.Expected.DeprecatedDatacenter = test.DeprecatedDatacenter
-			test.Expected.DeprecatedDefaultDatastore = test.DeprecatedDefaultDatastore
-			test.Expected.DeprecatedFolder = test.DeprecatedFolder
-			test.Expected.DeprecatedCluster = test.DeprecatedCluster
-			test.Expected.DeprecatedNetwork = test.DeprecatedNetwork
+			// OCPBUGS-105520: leftover infrastructure.folder (and siblings) must
+			// be cleared rather than copied from the hive Platform fields.
+			test.Expected.DeprecatedVCenter = ""
+			test.Expected.DeprecatedDatacenter = ""
+			test.Expected.DeprecatedDefaultDatastore = ""
+			test.Expected.DeprecatedFolder = ""
+			test.Expected.DeprecatedCluster = ""
+			test.Expected.DeprecatedNetwork = ""
 
 			err := ConvertDeprecatedFields(platform)
 			require.NoError(t, err)


### PR DESCRIPTION
[HIVE-2391](https://redhat.atlassian.net/browse/HIVE-2391) (adding zonal support for vsphere) included code to upconvert old-style, deprecated single-failure-domain infrastructure fields into the new per-FD shape. Part of that work included swapping the hive-side data structure, which was previously an in-repo copy of the upstream, to a reference to the real upstream struct. In so doing, we inherited a kubebuilder validation for the `folder` field that requires it to be a fully-qualified path _in both places_ (the deprecated field and the per-FD field). However, our upconversion was leaving the deprecated fields populated, as they are ignored downstream if the new-shape fields are populated. This resulted in the KAS rejecting ClusterDeployment updates in scenarios where the deprecated folder field contained a non-fully-qualified path.

To fix this, and similar potential future issues, we explicitly clear all the deprecated fields after the upconversion.

Assisted-By: claude/grok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deprecated vSphere infrastructure settings are now cleared after conversion.
  * Converted credentials, VIPs, topology values, and folder paths are retained in the current configuration.
  * Absolute folder paths are preserved correctly during conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->