### PR TITLE
HIVE-3199: Bump golang builders to 1.26.7

### DIFF
--- a/.tekton/hive-mce-210-push.yaml
+++ b/.tekton/hive-mce-210-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el9
         - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-211-push.yaml
+++ b/.tekton/hive-mce-211-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el9
         - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-217-push.yaml
+++ b/.tekton/hive-mce-217-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el9
         - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-26-push.yaml
+++ b/.tekton/hive-mce-26-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el9
         - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-28-push.yaml
+++ b/.tekton/hive-mce-28-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el9
         - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-29-push.yaml
+++ b/.tekton/hive-mce-29-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el9
         - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-50-push.yaml
+++ b/.tekton/hive-mce-50-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el9
         - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-51-push.yaml
+++ b/.tekton/hive-mce-51-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el9
         - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-mce-52-push.yaml
+++ b/.tekton/hive-mce-52-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el9
         - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-pull-request.yaml
+++ b/.tekton/hive-pull-request.yaml
@@ -47,8 +47,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el9
         - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'

--- a/.tekton/hive-push.yaml
+++ b/.tekton/hive-push.yaml
@@ -46,8 +46,8 @@ spec:
     - name: build-args
       value:
         - CONTAINER_SUB_MANAGER_OFF=1
-        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607271835.p0.g5a9ab9d.el8
-        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.5-202607161515.p0.g48af02f.el9
+        - EL8_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el8
+        - EL9_BUILD_IMAGE=brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.26.7-202608270918.p0.gedd1cdd.assembly.stream.el9
         - BASE_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
     - name: build-source-image
       value: 'true'

--- a/apis/go.mod
+++ b/apis/go.mod
@@ -2,7 +2,7 @@ module github.com/openshift/hive/apis
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.7
 
 require (
 	k8s.io/api v0.36.2

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/openshift/hive
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.7
 
 require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible

--- a/hack/ubi-build-deps.sh
+++ b/hack/ubi-build-deps.sh
@@ -5,7 +5,7 @@ dnf install -y \
 	make
 
 # Since go 1.26.x is not available in ubi8, let's go upstream
-go install golang.org/dl/go1.26.5@latest
-/root/go/bin/go1.26.5 download
+go install golang.org/dl/go1.26.7@latest
+/root/go/bin/go1.26.7 download
 rm /usr/bin/go
-ln -s /root/go/bin/go1.26.5 /usr/bin/go
+ln -s /root/go/bin/go1.26.7 /usr/bin/go


### PR DESCRIPTION
Various CVEs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project to use Go 1.26.7.
  * Refreshed build environments and tooling to align with the updated Go version.
  * Updated pull-request and continuous integration build configurations for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->