### PR TITLE
ACM-35041: Snowflake OpenStack failure domain matching

### DIFF
--- a/pkg/controller/machinepool/machinepool_controller.go
+++ b/pkg/controller/machinepool/machinepool_controller.go
@@ -733,6 +733,16 @@ func matchFailureDomains(gMS *machineapi.MachineSet, rMS machineapi.MachineSet, 
 		return rfd.AWS().Placement.AvailabilityZone == gfd.AWS().Placement.AvailabilityZone, nil
 	}
 
+	// SNOWFLAKE! ACM-35041: Hive's OpenStack MachinePool API has no AvailabilityZone field, so
+	// the generated failure domain always has an empty compute AZ (and always an empty root volume
+	// AZ). Since Hive generates at most one MachineSet per OpenStack MachinePool, the label match
+	// (already confirmed by the caller) is sufficient to identify the same machines.
+	if rfdtype == configv1.OpenStackPlatformType {
+		if gfd.OpenStack().AvailabilityZone == "" {
+			return true, nil
+		}
+	}
+
 	// Otherwise the FailureDomain should be unambiguous and we can just compare them.
 	equal := rfd.Equal(gfd)
 	if !equal {

--- a/pkg/controller/machinepool/openstackactuator_test.go
+++ b/pkg/controller/machinepool/openstackactuator_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 
+	configv1 "github.com/openshift/api/config/v1"
 	machinev1alpha1 "github.com/openshift/api/machine/v1alpha1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 
@@ -285,4 +286,94 @@ func testOSPClusterDeployment() *hivev1.ClusterDeployment {
 		},
 	}
 	return cd
+}
+
+// TestOpenStackMatchMachineSets verifies the ACM-35041 snowflake: because Hive's OpenStack
+// MachinePool API has no AvailabilityZone field, the generated failure domain always has an
+// empty AZ. The match should succeed on the label alone so that replica-count changes are
+// propagated to existing MachineSets that were created by the installer with a real AZ.
+func TestOpenStackMatchMachineSets(t *testing.T) {
+	infra := &configv1.Infrastructure{
+		Spec: configv1.InfrastructureSpec{
+			PlatformSpec: configv1.PlatformSpec{
+				Type: configv1.OpenStackPlatformType,
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		generated   *machinev1beta1.MachineSet
+		remote      *machinev1beta1.MachineSet
+		expectMatch bool
+		expectErr   bool
+	}{
+		{
+			name:        "generated empty AZ matches remote with real AZ (no root volume)",
+			generated:   testOpenStackMachineSet("", nil),
+			remote:      testOpenStackMachineSet("nova-az1", nil),
+			expectMatch: true,
+		},
+		{
+			name:      "generated empty AZ matches remote with real AZ and root volume",
+			generated: testOpenStackMachineSet("", nil),
+			remote: testOpenStackMachineSet("nova-az1", &machinev1alpha1.RootVolume{
+				VolumeType: "san3000-gen3",
+				Zone:       "nova-az1",
+			}),
+			expectMatch: true,
+		},
+		{
+			name:        "both empty AZ match",
+			generated:   testOpenStackMachineSet("", nil),
+			remote:      testOpenStackMachineSet("", nil),
+			expectMatch: true,
+		},
+		{
+			name:      "labels do not match",
+			generated: testOpenStackMachineSet("", nil),
+			remote: func() *machinev1beta1.MachineSet {
+				ms := testOpenStackMachineSet("nova-az1", nil)
+				ms.Labels[machinePoolNameLabel] = "different-pool"
+				return ms
+			}(),
+			expectMatch: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			match, err := matchMachineSets(test.generated, *test.remote, infra, log.New())
+			if test.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expectMatch, match)
+			}
+		})
+	}
+}
+
+func testOpenStackMachineSet(az string, rootVolume *machinev1alpha1.RootVolume) *machinev1beta1.MachineSet {
+	return &machinev1beta1.MachineSet{
+		ObjectMeta: v1.ObjectMeta{
+			Labels: map[string]string{
+				machinePoolNameLabel: "a-pool",
+			},
+		},
+		Spec: machinev1beta1.MachineSetSpec{
+			Template: machinev1beta1.MachineTemplateSpec{
+				Spec: machinev1beta1.MachineSpec{
+					ProviderSpec: machinev1beta1.ProviderSpec{
+						Value: &runtime.RawExtension{
+							Object: &machinev1alpha1.OpenstackProviderSpec{
+								AvailabilityZone: az,
+								RootVolume:       rootVolume,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
Hive's OpenStack MachinePool API has no AvailabilityZone field, so the generated failure domain always has an empty compute AZ. After [HIVE-2254](https://redhat.atlassian.net/browse/HIVE-2254) switched MachineSet matching to label + failure-domain comparison, OpenStack could no longer match a Hive-generated MachineSet (AZ: "") against the existing remote MachineSet with a real AZ created by the installer. This caused Hive to attempt creating a duplicate MachineSet, which then failed, leaving replica-count changes from MachinePool updates stuck forever.

Add a snowflake in matchFailureDomains() (parallel to the existing AWS and IBMCloud snowflakes): when the platform is OpenStack and the generated failure domain has an empty compute AZ, return true after the caller-verified label match. This is safe because Hive generates exactly one MachineSet per OpenStack MachinePool and the providerSpec is not overwritten without the OverrideMachinePoolPlatformAnnotation. The snowflake naturally becomes inert once AvailabilityZone support is added to the Hive OpenStack MachinePool API.

Also add tests for OpenStack MachineSet matching.

Assisted-by: Claude Sonnet 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OpenStack failure-domain matching when the generated compute availability zone is empty.
  - OpenStack MachineSets now match correctly across supported root-volume configurations while continuing to reject label mismatches.

- **Tests**
  - Added coverage for OpenStack MachineSet matching scenarios, including availability zones, root volumes, and label differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->